### PR TITLE
Fix: Add missing purpose parameter when removing access group from section

### DIFF
--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -297,7 +297,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     }
   };
 
-  const handleRemoveAccessGroup = async (accessGroupId: string) => {
+  const handleRemoveAccessGroup = async (accessGroupId: string, purpose: SectionAccessGroupPurpose) => {
     if (!editingSection) {
       return;
     }
@@ -312,6 +312,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       const ref = revokeAccessGroupFromSectionRef(dataConnect, {
         sectionId: editingSection.id,
         accessGroupId: accessGroupId,
+        purpose: purpose,
       });
       await executeMutation(ref);
       


### PR DESCRIPTION
## Problem
The `RevokeAccessGroupFromSection` mutation requires three parameters (`sectionId`, `accessGroupId`, and `purpose`) to identify the correct record to delete. The `handleRemoveAccessGroup` function was only passing two parameters, causing an error when removing access groups from sections.

## Solution
- Updated `handleRemoveAccessGroup` function signature to accept `purpose` parameter
- Added `purpose` to the `revokeAccessGroupFromSectionRef` mutation call

## Changes
- `src/features/admin/components/ManageSections.tsx`: Updated function to pass all required parameters to the mutation

## Testing
✅ Verified the function call site already passes both parameters
✅ No linting errors
✅ Function signature now matches the mutation requirements

Fixes #9