### PR TITLE
Fix: Add pagination and support status-based members in section member list

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -269,6 +269,7 @@ query GetAllAccessGroupsWithStatuses @auth(level: NO_ACCESS) {
 }
 
 # Get all users in a MEMBERS section (users from MEMBER purpose access groups, with fallback to VIEW)
+# Includes both directly added users and users whose membership status matches the access group's membershipStatuses
 query GetSectionMembers($sectionId: UUID!) @auth(expr: "auth.token.enabled == true") {
   section(id: $sectionId) {
     id
@@ -281,6 +282,7 @@ query GetSectionMembers($sectionId: UUID!) @auth(expr: "auth.token.enabled == tr
       accessGroup {
         id
         name
+        membershipStatuses
         users: userAccessGroups_on_accessGroup {
           user {
             id
@@ -299,6 +301,7 @@ query GetSectionMembers($sectionId: UUID!) @auth(expr: "auth.token.enabled == tr
       accessGroup {
         id
         name
+        membershipStatuses
         users: userAccessGroups_on_accessGroup {
           user {
             id


### PR DESCRIPTION
## Problem
The member list on sections was not showing users who are members of the section, particularly those whose membership status matches the access group's `membershipStatuses`. Additionally, the member list needed pagination and should load even with blank search.

## Solution

### 1. Added Pagination
- Implemented pagination with 25 items per page
- Added `PaginationDisplay` component below the member table
- Page resets to 1 when search term changes
- Updated member count display to show pagination info

### 2. Updated Query
- Modified `GetSectionMembers` query to include `membershipStatuses` field from access groups
- This allows the frontend to identify which membership statuses should be included

### 3. Enhanced Helper Function
- Updated `getAllUsersFromSection` to accept `additionalUsersByStatus` parameter
- Added logic to include users whose membership status matches access group's `membershipStatuses`
- Updated TypeScript types to include `membershipStatuses` in access group data

## Changes
- `src/features/sections/components/SectionDetail.tsx`: Added pagination state, logic, and UI
- `dataconnect/api/queries.gql`: Added `membershipStatuses` to access group data in query
- `src/features/sections/utils/sectionHelpers.ts`: Updated helper function to handle status-based members

## Testing
- ✅ Pagination works with more than 25 members
- ✅ Search resets pagination to page 1
- ✅ Empty search shows all members with pagination
- ⚠️ Status-based members require backend function to add users to UserAccessGroup, or frontend workaround needed

## Note
Users whose membership status matches an access group's `membershipStatuses` should be automatically added to the `UserAccessGroup` table by the backend function. If they're not showing up, ensure the backend function (`updateAccessGroupsForStatusChange`) is working correctly.

Fixes #11