### PR TITLE
[#15] Simplify issue templates and extract examples

### DIFF
--- a/.cursor/commands/commit.md
+++ b/.cursor/commands/commit.md
@@ -1,0 +1,11 @@
+# Git: Add, Commit (AI), Push
+
+Stage all changed files, including new files.  Include files in IDE directories, unless in .gitignore
+
+Generate a concise, high-quality git commit message based on the staged changes.
+
+Create the commit using that message.
+
+Push the current branch to origin.
+
+If there are no changes to commit, do nothing.

--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,20 @@
+# PR: Update Draft Pull Request
+
+Ensure all local changes are committed and pushed to the current branch.
+
+Check whether an open pull request already exists for the current branch.
+
+If a pull request exists:
+- Update the pull request title and description to reflect the latest commits.
+- Summarise what has changed since the last update.
+- Keep the pull request as a draft.
+
+If no pull request exists:
+- Create a new draft pull request targeting the default branch.
+- Generate a clear, concise title.
+- Generate a well-structured description including:
+  - Summary of changes
+  - Why the change is needed
+  - Any notable impacts or follow-ups
+
+Do not merge or mark the pull request as ready for review.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -6,14 +6,13 @@ labels: ''
 assignees: ''
 ---
 
+> 💡 **Need examples?** See [ISSUE_TEMPLATE_EXAMPLES.md](../ISSUE_TEMPLATE_EXAMPLES.md) for examples of how to fill out each section.
+
 ## Description
 
 **What is the bug?**
 
 Provide a clear, concise description of the bug. What happened vs. what you expected to happen?
-
-**Example:**
-> When clicking the "Save" button on the profile page, the form data is not being saved and no error message is displayed. The page appears to do nothing when the button is clicked.
 
 ---
 
@@ -28,13 +27,6 @@ List the steps that lead to the bug:
 3. Scroll down to '...'
 4. See error
 
-**Example:**
-1. Log in as a user with MEMBER status
-2. Navigate to Profile page
-3. Change email address field
-4. Click "Save" button
-5. Observe that no save confirmation appears and changes are not persisted
-
 ---
 
 ## Expected Behavior
@@ -43,9 +35,6 @@ List the steps that lead to the bug:
 
 Describe what you expected to happen.
 
-**Example:**
-> After clicking "Save", I expected to see a success message and the email address should be updated in my profile.
-
 ---
 
 ## Actual Behavior
@@ -53,48 +42,6 @@ Describe what you expected to happen.
 **What actually happens?**
 
 Describe what actually happens when you follow the steps.
-
-**Example:**
-> The button appears to be clicked (visual feedback), but no network request is made, no success/error message appears, and the email address remains unchanged after page refresh.
-
----
-
-## Environment
-
-**Where and how did this occur?**
-
-- **Browser**: [e.g., Chrome 120, Firefox 121, Safari 17]
-- **OS**: [e.g., macOS 14.2, Windows 11, Linux]
-- **User Role**: [e.g., Admin, Member, Pending]
-- **Access Groups**: [e.g., Status-based only, Manual groups, Multiple groups]
-- **Environment**: [e.g., Production, Staging, Local/Dev]
-
----
-
-## Screenshots/Logs
-
-**Visual evidence or error messages**
-
-If applicable, add screenshots or error logs to help explain the problem.
-
-**Example:**
-```
-Error in console:
-Uncaught TypeError: Cannot read property 'save' of undefined
-    at ProfileForm.saveProfile (Profile.tsx:45)
-```
-
----
-
-## Technical Details
-
-**Any relevant technical information?**
-
-- Network requests (if applicable)
-- Console errors
-- DataConnect query/response issues
-- Authentication/authorization problems
-- Related to specific access groups or permissions
 
 ---
 
@@ -108,71 +55,3 @@ List specific, testable criteria for the fix:
 - [ ] No regression - [related functionality still works]
 - [ ] Error handling - [appropriate error messages if applicable]
 - [ ] Edge cases handled - [specific edge cases to test]
-
-**Example:**
-- [ ] Save button successfully saves profile changes
-- [ ] Success message appears after save
-- [ ] Changes persist after page refresh
-- [ ] Appropriate error message shown if save fails
-- [ ] Works for users with different access group configurations
-
----
-
-## Technical Considerations
-
-**Any constraints, dependencies, or technical notes?**
-
-Include information about:
-- Database/schema implications
-- API/GraphQL query issues
-- Authentication/authorization concerns
-- Performance considerations
-- Integration points affected
-
-**Example:**
-> - Issue appears to be in the `saveProfile` mutation call
-> - May be related to DataConnect auth expressions
-> - Need to verify user has UPDATE permission for profile
-> - Check if mutation is being called with correct parameters
-
----
-
-## Testing Notes
-
-**What should be tested? Any special test scenarios?**
-
-Describe test cases, edge cases, and any specific testing requirements.
-
-**Security Tests (Must Pass):**
-- [ ] Verify fix doesn't introduce security vulnerabilities
-- [ ] Verify proper authorization checks are in place
-- [ ] Verify no data leakage or unauthorized access
-
-**Functionality Tests:**
-- [ ] Bug is fixed in the reported scenario
-- [ ] Related functionality still works correctly
-- [ ] Edge cases are handled appropriately
-- [ ] Works across different user roles and access groups
-
----
-
-## Implementation Plan
-
-**To be filled in during planning phase**
-
-This section will be populated after discussion with Cursor/AI to develop the fix strategy. The plan should include:
-- Root cause analysis
-- High-level approach to fix
-- File/component changes needed
-- Step-by-step implementation order
-- Any architectural decisions
-
----
-
-## Related Issues
-
-Link to any related issues, PRs, or discussions.
-
-**Example:**
-> Related to #42 (Profile page improvements)
-> Possibly related to #38 (DataConnect mutation issues)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request
-    url: https://github.com/YOUR_ORG/YOUR_REPO/issues/new?template=feature.md
+    url: https://github.com/rafsodc/sodc-web/issues/new?template=feature.md
     about: Request a new feature or enhancement
   - name: Bug Report
-    url: https://github.com/YOUR_ORG/YOUR_REPO/issues/new?template=bug.md
+    url: https://github.com/rafsodc/sodc-web/issues/new?template=bug.md
     about: Report a bug or issue
+  - name: Template Examples
+    url: https://github.com/rafsodc/sodc-web/blob/main/.github/ISSUE_TEMPLATE_EXAMPLES.md
+    about: See examples for filling out issue templates

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -6,14 +6,13 @@ labels: ''
 assignees: ''
 ---
 
+> 💡 **Need examples?** See [ISSUE_TEMPLATE_EXAMPLES.md](../ISSUE_TEMPLATE_EXAMPLES.md) for examples of how to fill out each section.
+
 ## Description
 
 **What needs to be implemented?**
 
 Provide a clear, concise description of the feature or enhancement. Be specific about what the feature should do and who will use it.
-
-**Example:**
-> Add ability for users to filter sections by access group membership. Users should be able to see only sections they have access to, with an optional toggle to show all sections. This will help users navigate the sections list more efficiently, especially as the number of sections grows.
 
 ---
 
@@ -23,9 +22,6 @@ Provide a clear, concise description of the feature or enhancement. Be specific 
 
 Explain the background, motivation, or use case that led to this request. Include any relevant user stories or scenarios.
 
-**Example:**
-> Currently, users see all sections in the sections list, including ones they don't have access to. This creates confusion and makes it harder to find relevant sections. As we add more event-specific sections, the list will become cluttered. Users have requested a way to filter to only see sections they can actually access. This aligns with our goal of improving user experience and reducing cognitive load.
-
 ---
 
 ## Acceptance Criteria
@@ -34,82 +30,6 @@ Explain the background, motivation, or use case that led to this request. Includ
 
 List specific, testable criteria. Each criterion should map to a logical unit of work that can be implemented and tested independently. Use checkboxes to track progress.
 
-**Example:**
-- [ ] Add a filter toggle button to the sections list page (e.g., "Show only my sections")
-- [ ] When filter is enabled, only display sections where user has VIEW access via their access groups
-- [ ] Filter state persists across page navigation (use localStorage or query params)
-- [ ] Filter toggle is visible and accessible to all enabled users
-- [ ] Filter respects existing section access control (no security bypass)
-- [ ] Empty state message shown when filter results in no sections
-- [ ] Filter works correctly with both status-based and manual access groups
-
----
-
-## Technical Considerations
-
-**Any constraints, dependencies, or technical notes?**
-
-Include information about:
-- Database/schema changes needed
-- API/GraphQL query modifications
-- Authentication/authorization requirements
-- Performance considerations
-- Integration points with existing features
-- Breaking changes
-
-**Example:**
-> - No schema changes required - we can use existing `GetSectionsForUser` query which already filters by access groups
-> - Need to modify `SectionsList` component to add filter UI and state management
-> - Should leverage existing `useGetSectionsForUser` hook from `src/features/sections/`
-> - Consider using React Query's caching to avoid unnecessary refetches when toggling filter
-> - Filter state should be stored in URL query params (e.g., `?filter=mine`) for shareability
-> - Must ensure filter doesn't bypass any existing auth expressions in DataConnect queries
-> - Test with users who have multiple access groups (status-based + manual)
-
----
-
-## Testing Notes
-
-**What should be tested? Any special test scenarios?**
-
-Describe test cases, edge cases, and any specific testing requirements. Consider both Security and Functionality test categories.
-
-**Example:**
-
-**Security Tests (Must Pass):**
-- [ ] Verify users cannot see sections they don't have access to, even if filter is disabled
-- [ ] Verify filter doesn't expose any section data through API calls
-- [ ] Verify filter respects DataConnect auth expressions (`auth.token.enabled == true`)
-- [ ] Test with users who have restricted membership status (PENDING, RESIGNED) - should see no sections
-
-**Functionality Tests:**
-- [ ] Filter toggle shows/hides sections correctly
-- [ ] Filter state persists when navigating away and back
-- [ ] Filter works with users who have multiple access groups
-- [ ] Filter works with users who have only status-based access groups
-- [ ] Filter works with users who have only manual access groups
-- [ ] Empty state displays correctly when filter results in no sections
-- [ ] Filter can be toggled on/off multiple times without issues
-- [ ] URL query param updates correctly when filter is toggled
-- [ ] Page loads with filter enabled if query param is present
-
----
-
-## Implementation Plan
-
-**To be filled in during planning phase**
-
-This section will be populated after discussion with Cursor/AI to develop the implementation strategy. The plan should include:
-- High-level approach
-- File/component changes needed
-- Step-by-step implementation order
-- Any architectural decisions
-
----
-
-## Related Issues
-
-Link to any related issues, PRs, or discussions.
-
-**Example:**
-> Related to #12 (Improve sections navigation UX)
+- [ ] [First criterion]
+- [ ] [Second criterion]
+- [ ] [Additional criteria...]

--- a/.github/ISSUE_TEMPLATE_EXAMPLES.md
+++ b/.github/ISSUE_TEMPLATE_EXAMPLES.md
@@ -1,0 +1,129 @@
+# Issue Template Examples
+
+This file contains examples for filling out issue templates. These examples are provided as reference to help you understand what kind of information to include in each section.
+
+## Bug Report Examples
+
+### Description Example
+
+> When clicking the "Save" button on the profile page, the form data is not being saved and no error message is displayed. The page appears to do nothing when the button is clicked.
+
+### Steps to Reproduce Example
+
+1. Log in as a user with MEMBER status
+2. Navigate to Profile page
+3. Change email address field
+4. Click "Save" button
+5. Observe that no save confirmation appears and changes are not persisted
+
+### Expected Behavior Example
+
+> After clicking "Save", I expected to see a success message and the email address should be updated in my profile.
+
+### Actual Behavior Example
+
+> The button appears to be clicked (visual feedback), but no network request is made, no success/error message appears, and the email address remains unchanged after page refresh.
+
+### Environment Example
+
+- **Browser**: Chrome 120, Firefox 121, Safari 17
+- **OS**: macOS 14.2, Windows 11, Linux
+- **User Role**: Admin, Member, Pending
+- **Access Groups**: Status-based only, Manual groups, Multiple groups
+- **Environment**: Production, Staging, Local/Dev
+
+### Screenshots/Logs Example
+
+```
+Error in console:
+Uncaught TypeError: Cannot read property 'save' of undefined
+    at ProfileForm.saveProfile (Profile.tsx:45)
+```
+
+### Acceptance Criteria Example
+
+- [ ] Save button successfully saves profile changes
+- [ ] Success message appears after save
+- [ ] Changes persist after page refresh
+- [ ] Appropriate error message shown if save fails
+- [ ] Works for users with different access group configurations
+
+### Technical Considerations Example
+
+> - Issue appears to be in the `saveProfile` mutation call
+> - May be related to DataConnect auth expressions
+> - Need to verify user has UPDATE permission for profile
+> - Check if mutation is being called with correct parameters
+
+### Testing Notes Example
+
+**Security Tests (Must Pass):**
+- [ ] Verify fix doesn't introduce security vulnerabilities
+- [ ] Verify proper authorization checks are in place
+- [ ] Verify no data leakage or unauthorized access
+
+**Functionality Tests:**
+- [ ] Bug is fixed in the reported scenario
+- [ ] Related functionality still works correctly
+- [ ] Edge cases are handled appropriately
+- [ ] Works across different user roles and access groups
+
+### Related Issues Example
+
+> Related to #42 (Profile page improvements)
+> Possibly related to #38 (DataConnect mutation issues)
+
+---
+
+## Feature Request Examples
+
+### Description Example
+
+> Add ability for users to filter sections by access group membership. Users should be able to see only sections they have access to, with an optional toggle to show all sections. This will help users navigate the sections list more efficiently, especially as the number of sections grows.
+
+### Context Example
+
+> Currently, users see all sections in the sections list, including ones they don't have access to. This creates confusion and makes it harder to find relevant sections. As we add more event-specific sections, the list will become cluttered. Users have requested a way to filter to only see sections they can actually access. This aligns with our goal of improving user experience and reducing cognitive load.
+
+### Acceptance Criteria Example
+
+- [ ] Add a filter toggle button to the sections list page (e.g., "Show only my sections")
+- [ ] When filter is enabled, only display sections where user has VIEW access via their access groups
+- [ ] Filter state persists across page navigation (use localStorage or query params)
+- [ ] Filter toggle is visible and accessible to all enabled users
+- [ ] Filter respects existing section access control (no security bypass)
+- [ ] Empty state message shown when filter results in no sections
+- [ ] Filter works correctly with both status-based and manual access groups
+
+### Technical Considerations Example
+
+> - No schema changes required - we can use existing `GetSectionsForUser` query which already filters by access groups
+> - Need to modify `SectionsList` component to add filter UI and state management
+> - Should leverage existing `useGetSectionsForUser` hook from `src/features/sections/`
+> - Consider using React Query's caching to avoid unnecessary refetches when toggling filter
+> - Filter state should be stored in URL query params (e.g., `?filter=mine`) for shareability
+> - Must ensure filter doesn't bypass any existing auth expressions in DataConnect queries
+> - Test with users who have multiple access groups (status-based + manual)
+
+### Testing Notes Example
+
+**Security Tests (Must Pass):**
+- [ ] Verify users cannot see sections they don't have access to, even if filter is disabled
+- [ ] Verify filter doesn't expose any section data through API calls
+- [ ] Verify filter respects DataConnect auth expressions (`auth.token.enabled == true`)
+- [ ] Test with users who have restricted membership status (PENDING, RESIGNED) - should see no sections
+
+**Functionality Tests:**
+- [ ] Filter toggle shows/hides sections correctly
+- [ ] Filter state persists when navigating away and back
+- [ ] Filter works with users who have multiple access groups
+- [ ] Filter works with users who have only status-based access groups
+- [ ] Filter works with users who have only manual access groups
+- [ ] Empty state displays correctly when filter results in no sections
+- [ ] Filter can be toggled on/off multiple times without issues
+- [ ] URL query param updates correctly when filter is toggled
+- [ ] Page loads with filter enabled if query param is present
+
+### Related Issues Example
+
+> Related to #12 (Improve sections navigation UX)


### PR DESCRIPTION
Implements issue #15 - Issue Templates

## Summary of Changes

This PR simplifies the issue templates by removing examples and developer-only sections, making them more user-friendly and less intimidating to complete.

### Changes Made

- **Simplified bug.md**: Reduced from 179 to 57 lines (68% reduction)
  - Kept only essential user-provided sections: Description, Steps to Reproduce, Expected/Actual Behavior, Acceptance Criteria
  - Removed: Environment, Screenshots/Logs, Technical Details, Technical Considerations, Testing Notes, Implementation Plan, Related Issues

- **Simplified feature.md**: Reduced from 115 to 35 lines (70% reduction)
  - Kept only essential sections: Description, Context, Acceptance Criteria
  - Removed: Technical Considerations, Testing Notes, Implementation Plan, Related Issues

- **Created ISSUE_TEMPLATE_EXAMPLES.md**: Extracted all examples to a reference file organized by template type and section

- **Updated config.yml**: 
  - Replaced placeholder URLs with actual repo (rafsodc/sodc-web)
  - Added Template Examples contact link

- **Added Cursor command definitions**: 
  - commit.md: Command for staging, committing, and pushing
  - pr.md: Command for updating/creating draft PRs

## Why This Change Is Needed

Issue templates were excessively long (179 and 115 lines), making them intimidating and a chore for users to complete. By simplifying them and moving examples to a reference file, users are more likely to complete the templates while still having access to examples when needed.

## Notable Impacts

- Developers will now add technical details, testing notes, and implementation plans in comments during the planning phase (as intended by the workflow)
- Examples are still accessible via the contact link in config.yml
- Templates are now ~70% shorter and more user-friendly
- All examples preserved in the examples file for reference

## Related Issue

Closes #15