### PR TITLE
test(functions): add permission guard and auth contract regression tests

### DIFF
--- a/functions/src/__tests__/authGuards.test.ts
+++ b/functions/src/__tests__/authGuards.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { HttpsError } from "firebase-functions/v2/https";
+import { requireAdmin, requireAuth, requireEnabled } from "../helpers";
+
+type RequestLike = {
+  auth?: {
+    uid: string;
+    token: Record<string, unknown>;
+  } | null;
+};
+
+describe("auth guard helpers", () => {
+  it("requireAuth rejects unauthenticated calls", () => {
+    expect(() => requireAuth({ auth: null } as unknown as never)).toThrow(HttpsError);
+    expect(() => requireAuth({} as unknown as never)).toThrow("Sign in required");
+  });
+
+  it("requireEnabled rejects users without enabled claim", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { enabled: false } } };
+    expect(() => requireEnabled(req as unknown as never)).toThrow("Account must be enabled");
+  });
+
+  it("requireEnabled accepts users with enabled claim", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { enabled: true } } };
+    expect(() => requireEnabled(req as unknown as never)).not.toThrow();
+  });
+
+  it("requireAdmin rejects non-admin calls", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: false } } };
+    expect(() => requireAdmin(req as unknown as never)).toThrow("Admins only");
+  });
+
+  it("requireAdmin accepts admin calls", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: true } } };
+    expect(() => requireAdmin(req as unknown as never)).not.toThrow();
+  });
+});

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+type AuthExpectation = {
+  op: string;
+  mustInclude: string;
+};
+
+function readApiFile(fileName: string): string {
+  const p = path.resolve(process.cwd(), "..", "dataconnect", "api", fileName);
+  return fs.readFileSync(p, "utf8");
+}
+
+function extractOperationBlock(source: string, operationName: string): string {
+  const idx = source.indexOf(operationName);
+  if (idx < 0) throw new Error(`Operation not found: ${operationName}`);
+  const start = source.lastIndexOf("\n", idx);
+  const end = source.indexOf("\n}", idx);
+  return source.slice(start >= 0 ? start : 0, end >= 0 ? end + 2 : source.length);
+}
+
+function assertAuth(source: string, checks: AuthExpectation[]): void {
+  for (const check of checks) {
+    const block = extractOperationBlock(source, check.op);
+    expect(block).toContain(check.mustInclude);
+  }
+}
+
+describe("Data Connect auth contracts", () => {
+  it("Phase A: critical booking/payment/admin operations keep strict auth", () => {
+    const queries = readApiFile("queries.gql");
+    const bookingMutations = readApiFile("booking-mutations.gql");
+    const adminSdk = readApiFile("admin-mutations.gql");
+
+    assertAuth(queries, [
+      { op: "query ListEventBookingsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "query ListGuestTicketRequestsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "query ListTicketOrdersForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "query GetMyTicketOrderById", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
+    ]);
+
+    assertAuth(bookingMutations, [
+      { op: "mutation CreateGuestTicketRequest", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
+      { op: "mutation AdminReviewGuestTicketRequest", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+    ]);
+
+    assertAuth(adminSdk, [
+      { op: "query GetUserForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "query GetTicketTypeForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "mutation CreateTicketOrderForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "query GetTicketOrderForWebhook", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "mutation MarkTicketOrderPaidFromWebhook", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "query GetBookingsForBookerAndEvent", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "mutation UpdateBookingStatusFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "mutation UpdateBookingPreferencesFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
+    ]);
+  });
+
+  it("Phase B: all operations declare an @auth directive", () => {
+    const apiDir = path.resolve(process.cwd(), "..", "dataconnect", "api");
+    const files = fs.readdirSync(apiDir).filter((f) => f.endsWith(".gql"));
+
+    const opHeader = /(query|mutation)\s+([A-Za-z0-9_]+)/g;
+    for (const file of files) {
+      const source = fs.readFileSync(path.join(apiDir, file), "utf8");
+      const matches = [...source.matchAll(opHeader)];
+      if (matches.length === 0) continue;
+      for (const m of matches) {
+        const start = m.index ?? 0;
+        const end = source.indexOf("{", start);
+        const header = source.slice(start, end >= 0 ? end : start + 400);
+        expect(header).toContain("@auth(");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for backend callable guard helpers (`requireAuth`, `requireEnabled`, `requireAdmin`)
- add Data Connect auth contract tests for critical booking/payment/admin operations
- add full-sweep check that operation headers in `dataconnect/api/*.gql` include `@auth(...)`

## Test plan
- [x] cd functions && npm run test -- authGuards dataconnectAuthContracts --run

## Related
- Part of #64
- Advances #67

Made with [Cursor](https://cursor.com)