### PR TITLE
docs(structure): define repository layout and cleanup conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,60 @@
-# React + TypeScript + Vite
+# SODC Web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+SODC Web is a React + Firebase application for section membership, event booking, moderation, and payments.
 
-Currently, two official plugins are available:
+## Repository layout
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- `src/`: frontend application code (features, shared components, hooks, utilities)
+- `functions/src/`: Firebase Functions backend (callables, webhooks, server-side rules)
+- `dataconnect/`: Data Connect schema and GraphQL operations
+- `docs/`: architecture and operational documentation
 
-## React Compiler
+Detailed structure conventions live in:
+- `docs/architecture/repo-structure.md`
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+## Generated code
 
-## Expanding the ESLint configuration
+These folders are generated from Data Connect operations and should not be hand-edited in normal flow:
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+- `src/dataconnect-generated/`
+- `functions/src/dataconnect-admin-generated/`
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+After `.gql` changes, regenerate SDKs with:
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```sh
+npx firebase dataconnect:sdk:generate
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Local development
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Frontend:
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```sh
+npm install
+npm run dev
+```
+
+Functions:
+
+```sh
+cd functions
+npm install
+npm run build
+```
+
+## Test commands
+
+Frontend tests:
+
+```sh
+npm run test
+```
+
+Functions tests:
+
+```sh
+cd functions
+npm run test
 ```
 
 ## Dev-only reset helper (emulator)

--- a/docs/architecture/repo-structure.md
+++ b/docs/architecture/repo-structure.md
@@ -1,0 +1,41 @@
+# Repository Structure Conventions
+
+This document defines where code should live and how to keep structure changes low-risk.
+
+## Directory ownership
+
+- `src/features/`: product-domain frontend code (admin, sections, users, auth).
+- `src/shared/`: reusable UI and utilities shared across features.
+- `src/constants/`: route/auth/static app constants.
+- `functions/src/`: backend logic and entry points for callable/onRequest functions.
+- `dataconnect/schema/`: source-of-truth data model.
+- `dataconnect/api/`: source-of-truth GraphQL operations.
+- `docs/architecture/`: technical architecture and process docs.
+
+## Testing layout
+
+- Frontend tests live near domain code in `src/**/__tests__/`.
+- Functions/backend tests live in `functions/src/__tests__/`.
+- Permission and auth contract tests should be backend-owned by default, even when they validate Data Connect operation directives.
+
+## Generated artifacts
+
+Generated SDKs should remain isolated and treated as build outputs:
+
+- `src/dataconnect-generated/`
+- `functions/src/dataconnect-admin-generated/`
+
+Rules:
+
+1. Prefer updating `.gql` sources, then regenerate.
+2. Avoid manual edits in generated folders unless handling a documented emergency unblock.
+3. If generated output changes, include source operation/schema changes in the same PR when possible.
+
+## Safe cleanup rules
+
+When performing structure cleanup:
+
+1. Prefer small, scoped PRs.
+2. Avoid broad moves and behavior changes in one step.
+3. Preserve import boundaries (`features` -> `shared`, not the reverse for domain-specific logic).
+4. Keep tests updated in the same PR as file moves/refactors.


### PR DESCRIPTION
## Summary
- replace template README content with project-specific repository guidance
- add `docs/architecture/repo-structure.md` with directory ownership and safe cleanup conventions
- document generated artifact handling and testing layout boundaries

## Test plan
- [x] Documentation-only change (no runtime behavior changes)
- [x] Verify referenced paths and commands are valid

## Related
- Closes #65
- Part of #64

Made with [Cursor](https://cursor.com)