### PR TITLE
test(coverage): close high-risk admin and auth guard gaps

### DIFF
--- a/functions/src/__tests__/authGuards.test.ts
+++ b/functions/src/__tests__/authGuards.test.ts
@@ -20,6 +20,10 @@ describe("auth guard helpers", () => {
     expect(() => requireEnabled(req as unknown as never)).toThrow("Account must be enabled");
   });
 
+  it("requireEnabled rejects unauthenticated calls", () => {
+    expect(() => requireEnabled({ auth: null } as unknown as never)).toThrow("Sign in required");
+  });
+
   it("requireEnabled accepts users with enabled claim", () => {
     const req: RequestLike = { auth: { uid: "u1", token: { enabled: true } } };
     expect(() => requireEnabled(req as unknown as never)).not.toThrow();
@@ -28,6 +32,10 @@ describe("auth guard helpers", () => {
   it("requireAdmin rejects non-admin calls", () => {
     const req: RequestLike = { auth: { uid: "u1", token: { admin: false } } };
     expect(() => requireAdmin(req as unknown as never)).toThrow("Admins only");
+  });
+
+  it("requireAdmin rejects unauthenticated calls", () => {
+    expect(() => requireAdmin({ auth: null } as unknown as never)).toThrow("Sign in required");
   });
 
   it("requireAdmin accepts admin calls", () => {

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -121,6 +121,21 @@ describe("SectionEventsManager", () => {
     expect(screen.getByRole("button", { name: /ticket types/i })).toBeInTheDocument();
   });
 
+  it("renders error message when events query fails", async () => {
+    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load events/i)).toBeInTheDocument();
+    });
+  });
+
   it("renders moderation queue and approves a pending request", async () => {
     const user = userEvent.setup();
     vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
@@ -243,5 +258,44 @@ describe("SectionEventsManager", () => {
     expect(screen.getByText("Jamie Guest")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /approve/i }));
     await waitFor(() => expect(executeMutation).toHaveBeenCalled());
+  });
+
+  it("shows empty-state alerts for moderation, booking audit, and payment activity", async () => {
+    const user = userEvent.setup();
+    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+      data: {
+        section: {
+          id: sectionId,
+          events: [
+            {
+              id: "ev-1",
+              title: "Annual Dinner",
+              startDateTime: "2025-03-01T18:00:00Z",
+              endDateTime: "2025-03-01T22:00:00Z",
+              bookingStartDateTime: "2025-02-01T00:00:00Z",
+              bookingEndDateTime: "2025-02-28T23:59:59Z",
+              location: "Main Hall",
+              guestOfHonour: "Jane Doe",
+            },
+          ],
+        },
+      } as any,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
+      data: { event: { id: "ev-1", ticketTypes: [] } } as any,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as any);
+
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+    await user.click(screen.getByRole("button", { name: /ticket types/i }));
+
+    expect(screen.getByText(/no guest ticket requests for this filter/i)).toBeInTheDocument();
+    expect(screen.getByText(/no bookings found for this event/i)).toBeInTheDocument();
+    expect(screen.getByText(/no payment orders found for this event/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add unauthenticated negative-path coverage for `requireEnabled` and `requireAdmin`
- add admin UI coverage for events-query error fallback in `SectionEventsManager`
- add empty-state coverage for moderation queue, booking audit activity, and payment activity tables

## Test plan
- [x] cd functions && npm run test -- authGuards dataconnectAuthContracts --run
- [x] npm run test -- SectionEventsManager --run

## Related
- Closes #66
- Part of #64

Made with [Cursor](https://cursor.com)