### PR TITLE
test(security): extend function guard and auth contract coverage

### DIFF
--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -32,6 +32,8 @@ describe("Data Connect auth contracts", () => {
     const queries = readApiFile("queries.gql");
     const bookingMutations = readApiFile("booking-mutations.gql");
     const adminSdk = readApiFile("admin-mutations.gql");
+    const userMutations = readApiFile("user-mutations.gql");
+    const groupMutations = readApiFile("user-group-mutations.gql");
 
     assertAuth(queries, [
       { op: "query ListEventBookingsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
@@ -54,6 +56,20 @@ describe("Data Connect auth contracts", () => {
       { op: "query GetBookingsForBookerAndEvent", mustInclude: "@auth(level: NO_ACCESS)" },
       { op: "mutation UpdateBookingStatusFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
       { op: "mutation UpdateBookingPreferencesFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
+    ]);
+
+    assertAuth(userMutations, [
+      { op: "mutation CreateUserProfile", mustInclude: "@auth(level: USER)" },
+      { op: "mutation UpsertUser", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
+      { op: "mutation UpdateUser", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+    ]);
+
+    assertAuth(groupMutations, [
+      { op: "mutation CreateSection", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateUserGroup", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation GrantUserGroupToSectionForPurpose", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateEvent", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateTicketType", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
     ]);
   });
 

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+function readSource(fileName: string): string {
+  return fs.readFileSync(path.resolve(process.cwd(), "src", fileName), "utf8");
+}
+
+function assertOnCallGuard(source: string, functionName: string, guardCall: string): void {
+  const exportIdx = source.indexOf(`export const ${functionName} = onCall`);
+  expect(exportIdx).toBeGreaterThanOrEqual(0);
+  const guardIdx = source.indexOf(guardCall, exportIdx);
+  expect(guardIdx).toBeGreaterThan(exportIdx);
+  expect(guardIdx - exportIdx).toBeLessThan(400);
+}
+
+describe("function entry guard contracts", () => {
+  it("enforces expected auth guards on callable entry points", () => {
+    const admin = readSource("admin.ts");
+    assertOnCallGuard(admin, "grantAdmin", "requireAdmin(request);");
+    assertOnCallGuard(admin, "revokeAdmin", "requireAdmin(request);");
+    assertOnCallGuard(admin, "listAdminUsers", "requireAdmin(request);");
+
+    const users = readSource("users.ts");
+    assertOnCallGuard(users, "updateDisplayName", "requireAuth(request);");
+    assertOnCallGuard(users, "updateUserDisplayName", "requireAdmin(request);");
+    assertOnCallGuard(users, "searchUsers", "requireAdmin(request);");
+
+    const membership = readSource("membershipStatus.ts");
+    assertOnCallGuard(membership, "updateMembershipStatus", "requireAuth(request);");
+
+    const sections = readSource("sections.ts");
+    assertOnCallGuard(sections, "getSectionMembersMerged", "requireAuth(request);");
+
+    const bookings = readSource("bookings.ts");
+    assertOnCallGuard(bookings, "submitEventBooking", "requireEnabled(request);");
+
+    const payments = readSource("payments.ts");
+    assertOnCallGuard(payments, "createTicketCheckoutSession", "requireEnabled(request);");
+  });
+
+  it("keeps Stripe webhook signature verification in place", () => {
+    const payments = readSource("payments.ts");
+    expect(payments).toContain("stripe-signature");
+    expect(payments).toContain("constructEvent(req.rawBody, signature, webhookSecret)");
+  });
+});


### PR DESCRIPTION
## Summary
- add callable entry-guard contract tests to ensure each function enforces the expected auth helper at entry
- add webhook security contract checks for Stripe signature verification
- extend Data Connect critical auth contract assertions to include user and user-group mutation sets

## Test plan
- [x] cd functions && npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts --run

## Related
- Closes #67
- Part of #64

Made with [Cursor](https://cursor.com)