### PR TITLE
fix(build): resolve TypeScript regressions and add PR build gates

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,6 +8,33 @@ permissions:
   contents: read
 
 jobs:
+  build-checks:
+    name: TypeScript and build checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Run root build
+        run: npm run build
+
+      - name: Install functions dependencies
+        run: npm ci
+        working-directory: functions
+
+      - name: Run functions build
+        run: npm run build
+        working-directory: functions
+
   frontend-tests:
     name: Frontend targeted tests
     runs-on: ubuntu-latest

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -49,6 +49,7 @@ import {
   adminDeleteBookingLineRef,
   adminDeleteBookingRef,
   TicketAudience,
+  GuestTicketRequestStatus,
 } from "@dataconnect/generated";
 import type { UUIDString } from "@dataconnect/generated";
 import type {
@@ -394,7 +395,10 @@ export default function SectionEventsManager({ sectionId, sectionName, onBack }:
   const eventBookings: EventBookingAdminRow[] = eventBookingsData?.event?.bookings ?? [];
   const ticketOrders: TicketOrderAdminRow[] = ticketOrdersData?.event?.ticketOrders ?? [];
 
-  const handleReviewRequest = async (request: GuestTicketRequestAdminRow & { bookingId: string }, status: "APPROVED" | "REJECTED") => {
+  const handleReviewRequest = async (
+    request: GuestTicketRequestAdminRow & { bookingId: string },
+    status: GuestTicketRequestStatus.APPROVED | GuestTicketRequestStatus.REJECTED
+  ) => {
     setReviewingRequestId(request.id);
     setError(null);
     try {
@@ -555,7 +559,7 @@ export default function SectionEventsManager({ sectionId, sectionName, onBack }:
                               variant="outlined"
                               color="success"
                               disabled={reviewingRequestId === req.id}
-                              onClick={() => void handleReviewRequest(req, "APPROVED")}
+                              onClick={() => void handleReviewRequest(req, GuestTicketRequestStatus.APPROVED)}
                             >
                               Approve
                             </Button>
@@ -564,7 +568,7 @@ export default function SectionEventsManager({ sectionId, sectionName, onBack }:
                               variant="outlined"
                               color="error"
                               disabled={reviewingRequestId === req.id}
-                              onClick={() => void handleReviewRequest(req, "REJECTED")}
+                              onClick={() => void handleReviewRequest(req, GuestTicketRequestStatus.REJECTED)}
                             >
                               Reject
                             </Button>

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -145,7 +145,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     let alive = true;
     void (async () => {
       try {
-        const merged = await getSectionMembersMerged({ sectionId: section.id });
+        const merged = await getSectionMembersMerged(section.id);
         if (!alive) return;
         const options = (merged.members ?? [])
           .filter((m) => m.id !== currentUserData?.user?.id)


### PR DESCRIPTION
## Summary
- fix TypeScript mismatch in guest request moderation status handling (`GuestTicketRequestStatus` enum usage)
- fix callable argument mismatch in `EventBookingWizard` (`getSectionMembersMerged` expects a string section id)
- extend `.github/workflows/pr-tests.yml` with a dedicated `build-checks` job running root and functions builds on every PR

## Test plan
- [x] npm run build
- [x] cd functions && npm run build
- [x] npm run test -- SectionEventsManager --run

## Related
- Closes #36
- Part of #64

Made with [Cursor](https://cursor.com)