### PR TITLE
feat(admin): route header admin action to current context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { ErrorBoundary } from "./shared/components/ErrorBoundary";
 import Header from "./shared/components/Header";
 import HomePage from "./shared/components/HomePage";
 import AppSideNav from "./shared/components/AppSideNav";
+import { PageHeaderAdminActionProvider } from "./shared/components/PageHeader";
 import { colors } from "./config/colors";
 import { ROUTES } from "./constants";
 import CheckoutStatusNotice from "./features/sections/components/CheckoutStatusNotice";
@@ -235,6 +236,14 @@ function AppContent() {
     return Array.from(sectionMap.values()).sort((a, b) => a.label.localeCompare(b.label));
   }, [userSectionsData]);
 
+  const pageHeaderAdminAction = useMemo(
+    () => ({
+      visible: Boolean(user && isEnabled && isAdmin),
+      onClick: () => navigate(ROUTES.MANAGE_USERS),
+    }),
+    [isAdmin, isEnabled, navigate, user]
+  );
+
   const header = (
     <Header
       user={user}
@@ -454,91 +463,93 @@ function AppContent() {
           }}
         >
           <Box sx={{ width: "100%", maxWidth: "1200px" }}>
-        {checkoutQueryState && (
-          <Box
-            sx={{
-              maxWidth: { sm: "700px" },
-              mx: "auto",
-              px: { xs: 3, sm: 4 },
-            }}
-          >
-            <CheckoutStatusNotice
-              checkoutState={checkoutQueryState.checkout}
-              orderId={checkoutQueryState.orderId}
-              onDismiss={handleDismissCheckoutStatus}
-            />
-          </Box>
-        )}
-        <Routes>
-          <Route path={ROUTES.HOME} element={<HomePage />} />
-          <Route
-            path={ROUTES.ACCOUNT}
-            element={
-              <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
-                <Suspense fallback={<LoadingFallback />}>
-                  <AuthGate userData={userData} onBack={() => navigate(ROUTES.HOME)} />
-                </Suspense>
-              </Box>
-            }
-          />
-          <Route
-            path={ROUTES.PROFILE}
-            element={
-              <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
-                {user ? (
-                  <Suspense fallback={<LoadingFallback />}>
-                    <Profile key={user.uid} userData={userData} userEmail={user?.email || ""} onBack={() => navigate(ROUTES.HOME)} onUpdate={handleProfileUpdate} />
-                  </Suspense>
-                ) : (
-                  <Navigate to={ROUTES.ACCOUNT} replace />
-                )}
-              </Box>
-            }
-          />
-          <Route path={ROUTES.PERMISSIONS} element={<Navigate to={ROUTES.MANAGE_USERS} replace />} />
-          <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
-          <Route path={ROUTES.APPROVE_USERS} element={renderAdminOnly("Approve Users", <Suspense fallback={<LoadingFallback />}><ApproveUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
-          <Route path={ROUTES.USER_GROUPS} element={renderAdminOnly("User Groups", <Suspense fallback={<LoadingFallback />}><UserGroups onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
-          <Route
-            path={ROUTES.AUDIT_LOGS}
-            element={renderAdminOnly(
-              "Audit Logs",
-              <ErrorBoundary title="Audit Logs" onBack={() => navigate(ROUTES.HOME)}>
-                <Suspense fallback={<LoadingFallback />}>
-                  <AuditLogs onBack={() => navigate(ROUTES.HOME)} />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-          />
-          <Route
-            path={ROUTES.MANAGE_SECTIONS}
-            element={renderAdminOnly(
-              "Manage Sections",
-              <ErrorBoundary title="Manage Sections" onBack={() => navigate(ROUTES.HOME)}>
-                <Suspense fallback={<LoadingFallback />}>
-                  <ManageSections onBack={() => navigate(ROUTES.HOME)} />
-                </Suspense>
-              </ErrorBoundary>
-            )}
-          />
-          <Route
-            path={ROUTES.SECTIONS}
-            element={
-              user && isEnabled ? (
-                <Suspense fallback={<LoadingFallback />}>
-                  <SectionsList onBack={() => navigate(ROUTES.HOME)} onSelectSection={(sectionId) => navigate(`/sections/${sectionId}`)} />
-                </Suspense>
-              ) : (
-                <Navigate to={ROUTES.ACCOUNT} replace />
-              )
-            }
-          />
-          <Route
-            path={ROUTES.SECTION_DETAIL}
-            element={user && isEnabled ? <Suspense fallback={<LoadingFallback />}><SectionDetailRoute /></Suspense> : <Navigate to={ROUTES.ACCOUNT} replace />}
-          />
-          <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
-        </Routes>
+            <PageHeaderAdminActionProvider value={pageHeaderAdminAction}>
+              {checkoutQueryState && (
+                <Box
+                  sx={{
+                    maxWidth: { sm: "700px" },
+                    mx: "auto",
+                    px: { xs: 3, sm: 4 },
+                  }}
+                >
+                  <CheckoutStatusNotice
+                    checkoutState={checkoutQueryState.checkout}
+                    orderId={checkoutQueryState.orderId}
+                    onDismiss={handleDismissCheckoutStatus}
+                  />
+                </Box>
+              )}
+              <Routes>
+                <Route path={ROUTES.HOME} element={<HomePage />} />
+                <Route
+                  path={ROUTES.ACCOUNT}
+                  element={
+                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                      <Suspense fallback={<LoadingFallback />}>
+                        <AuthGate userData={userData} onBack={() => navigate(ROUTES.HOME)} />
+                      </Suspense>
+                    </Box>
+                  }
+                />
+                <Route
+                  path={ROUTES.PROFILE}
+                  element={
+                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                      {user ? (
+                        <Suspense fallback={<LoadingFallback />}>
+                          <Profile key={user.uid} userData={userData} userEmail={user?.email || ""} onBack={() => navigate(ROUTES.HOME)} onUpdate={handleProfileUpdate} />
+                        </Suspense>
+                      ) : (
+                        <Navigate to={ROUTES.ACCOUNT} replace />
+                      )}
+                    </Box>
+                  }
+                />
+                <Route path={ROUTES.PERMISSIONS} element={<Navigate to={ROUTES.MANAGE_USERS} replace />} />
+                <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.APPROVE_USERS} element={renderAdminOnly("Approve Users", <Suspense fallback={<LoadingFallback />}><ApproveUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.USER_GROUPS} element={renderAdminOnly("User Groups", <Suspense fallback={<LoadingFallback />}><UserGroups onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
+                <Route
+                  path={ROUTES.AUDIT_LOGS}
+                  element={renderAdminOnly(
+                    "Audit Logs",
+                    <ErrorBoundary title="Audit Logs" onBack={() => navigate(ROUTES.HOME)}>
+                      <Suspense fallback={<LoadingFallback />}>
+                        <AuditLogs onBack={() => navigate(ROUTES.HOME)} />
+                      </Suspense>
+                    </ErrorBoundary>
+                  )}
+                />
+                <Route
+                  path={ROUTES.MANAGE_SECTIONS}
+                  element={renderAdminOnly(
+                    "Manage Sections",
+                    <ErrorBoundary title="Manage Sections" onBack={() => navigate(ROUTES.HOME)}>
+                      <Suspense fallback={<LoadingFallback />}>
+                        <ManageSections onBack={() => navigate(ROUTES.HOME)} />
+                      </Suspense>
+                    </ErrorBoundary>
+                  )}
+                />
+                <Route
+                  path={ROUTES.SECTIONS}
+                  element={
+                    user && isEnabled ? (
+                      <Suspense fallback={<LoadingFallback />}>
+                        <SectionsList onBack={() => navigate(ROUTES.HOME)} onSelectSection={(sectionId) => navigate(`/sections/${sectionId}`)} />
+                      </Suspense>
+                    ) : (
+                      <Navigate to={ROUTES.ACCOUNT} replace />
+                    )
+                  }
+                />
+                <Route
+                  path={ROUTES.SECTION_DETAIL}
+                  element={user && isEnabled ? <Suspense fallback={<LoadingFallback />}><SectionDetailRoute /></Suspense> : <Navigate to={ROUTES.ACCOUNT} replace />}
+                />
+                <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
+              </Routes>
+            </PageHeaderAdminActionProvider>
           </Box>
         </Box>
       </Box>

--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Box,
   Typography,
@@ -56,6 +56,7 @@ import { colors } from "../../../config/colors";
 import PageHeader from "../../../shared/components/PageHeader";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
+import { useLocation } from "react-router-dom";
 import "../../../shared/components/PageContainer.css";
 
 const SECTION_PURPOSE_ORDER: SectionUserGroupPurpose[] = [
@@ -102,7 +103,18 @@ interface SectionWithDetails {
   updatedAt: string;
 }
 
+interface ManageSectionsLocationState {
+  managedSection?: {
+    id: string;
+    name: string;
+  };
+  eventId?: string;
+  editSectionId?: string;
+}
+
 export default function ManageSections({ onBack }: ManageSectionsProps) {
+  const location = useLocation();
+  const initialState = location.state as ManageSectionsLocationState | null;
   const isAdmin = useAdminClaim(auth.currentUser);
   const [sections, setSections] = useState<SectionWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
@@ -130,8 +142,10 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
   const [selectedPurpose, setSelectedPurpose] = useState<SectionUserGroupPurpose>(SectionUserGroupPurpose.ACCESS);
   const [addingUserGroup, setAddingUserGroup] = useState(false);
   const [removingUserGroupId, setRemovingUserGroupId] = useState<string | null>(null);
-  const [managedSectionId, setManagedSectionId] = useState<string | null>(null);
-  const [managedSectionName, setManagedSectionName] = useState("");
+  const [managedSectionId, setManagedSectionId] = useState<string | null>(initialState?.managedSection?.id ?? null);
+  const [managedSectionName, setManagedSectionName] = useState(initialState?.managedSection?.name ?? "");
+  const initialEventIdRef = useRef(initialState?.eventId ?? null);
+  const initialEditSectionIdRef = useRef(initialState?.editSectionId ?? null);
 
   const fetchSections = useCallback(async () => {
     setLoading(true);
@@ -233,6 +247,21 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     // Fetch user groups when editing
     await fetchSectionUserGroups(section.id);
   };
+
+  useEffect(() => {
+    const editSectionId = initialEditSectionIdRef.current;
+    if (!editSectionId || loading || managedSectionId) {
+      return;
+    }
+
+    const section = sections.find((item) => item.id === editSectionId);
+    if (!section) {
+      return;
+    }
+
+    initialEditSectionIdRef.current = null;
+    void handleEdit(section);
+  }, [handleEdit, loading, managedSectionId, sections]);
 
   const handleDelete = async (section: SectionWithDetails) => {
     if (!confirm(`Are you sure you want to delete the section "${section.name}"? This will remove all user group associations.`)) {
@@ -352,9 +381,11 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       <SectionEventsManager
         sectionId={managedSectionId}
         sectionName={managedSectionName}
+        initialEventId={initialEventIdRef.current}
         onBack={() => {
           setManagedSectionId(null);
           setManagedSectionName("");
+          initialEventIdRef.current = null;
         }}
       />
     );

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -95,10 +95,11 @@ function fromDatetimeLocal(s: string): string {
 interface SectionEventsManagerProps {
   sectionId: string;
   sectionName: string;
+  initialEventId?: string | null;
   onBack: () => void;
 }
 
-export default function SectionEventsManager({ sectionId, sectionName, onBack }: SectionEventsManagerProps) {
+export default function SectionEventsManager({ sectionId, sectionName, initialEventId, onBack }: SectionEventsManagerProps) {
   const { data: eventsData, isLoading: loadingEvents, isError: errorEvents, refetch: refetchEvents } = useGetEventsForSection(
     dataConnect,
     { sectionId: sectionId as UUIDString }
@@ -118,7 +119,7 @@ export default function SectionEventsManager({ sectionId, sectionName, onBack }:
   const [deletingEventId, setDeletingEventId] = useState<string | null>(null);
 
   // Ticket types: which event we're managing ticket types for
-  const [ticketTypesEventId, setTicketTypesEventId] = useState<string | null>(null);
+  const [ticketTypesEventId, setTicketTypesEventId] = useState<string | null>(initialEventId ?? null);
   const { data: eventDetailData, isLoading: loadingEventDetail, refetch: refetchEventDetail } = useGetEventById(
     dataConnect,
     { id: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -31,6 +31,9 @@ import {
 import EventBookingWizard from "./EventBookingWizard";
 import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
+import { ROUTES } from "../../../constants";
+import { useAdminClaim } from "../../users/hooks/useAdminClaim";
+import { useNavigate } from "react-router-dom";
 import { createTicketCheckoutSession, getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
 import type { GetSectionByIdData, UUIDString } from "@dataconnect/generated";
 import { TicketAudience } from "@dataconnect/generated";
@@ -43,6 +46,7 @@ interface SectionDetailProps {
 }
 
 export default function SectionDetail({ sectionId, onBack }: SectionDetailProps) {
+  const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState("");
   const [page, setPage] = useState(1);
   const [snackbar, setSnackbar] = useState<{ open: boolean; message: string; severity: "success" | "error" }>({
@@ -58,6 +62,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [startingCheckoutId, setStartingCheckoutId] = useState<string | null>(null);
 
   const currentUser = auth.currentUser;
+  const isAdmin = useAdminClaim(currentUser);
 
   // Get section details (for user group info and subscribability)
   const {
@@ -161,6 +166,12 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       userUserGroupIds.filter((id) => memberGroups.some((g) => g.id === id))
     );
   }, [sectionData, currentUser, userUserGroupIds, sectionPurposeLinks, memberGroups]);
+
+  const canModerateSection = useMemo(() => {
+    return sectionPurposeLinks.some(
+      (link) => link.purpose === "MODERATOR" && userUserGroupIds.includes(link.userGroup.id)
+    );
+  }, [sectionPurposeLinks, userUserGroupIds]);
 
   const allMembers = sectionMembers;
   const refetchMembers = fetchMembers;
@@ -327,10 +338,31 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
 
   const section = sectionData.section;
   const isMembers = isMembersSection(section as any);
+  const sectionAdminAction = {
+    visible: Boolean(currentUser && (isAdmin || canModerateSection)),
+    onClick: () => {
+      if (isMembers) {
+        navigate(ROUTES.MANAGE_SECTIONS, {
+          state: { editSectionId: section.id },
+        });
+        return;
+      }
+
+      navigate(ROUTES.MANAGE_SECTIONS, {
+        state: {
+          managedSection: {
+            id: section.id,
+            name: section.name,
+          },
+          eventId: selectedEventId ?? undefined,
+        },
+      });
+    },
+  };
 
   return (
     <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
-      <PageHeader title={section.name} onBack={onBack} />
+      <PageHeader title={section.name} onBack={onBack} adminAction={sectionAdminAction} />
       
       <Box sx={{ mt: 3, mb: 3 }}>
         <Typography variant="h6" sx={{ mb: 1 }}>

--- a/src/shared/components/PageHeader.css
+++ b/src/shared/components/PageHeader.css
@@ -2,10 +2,18 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
   margin-bottom: 24px;
 }
 
 .page-header-title {
   color: #1A2F5A;
+}
+
+.page-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
 }
 

--- a/src/shared/components/PageHeader.tsx
+++ b/src/shared/components/PageHeader.tsx
@@ -1,20 +1,56 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { AdminPanelSettings } from "@mui/icons-material";
 import { Box, Button, Typography } from "@mui/material";
 import "./PageHeader.css";
+
+export interface PageHeaderAdminAction {
+  visible: boolean;
+  onClick: () => void;
+}
+
+const PageHeaderAdminActionContext = createContext<PageHeaderAdminAction>({
+  visible: false,
+  onClick: () => {},
+});
 
 interface PageHeaderProps {
   title: string;
   onBack: () => void;
+  adminAction?: PageHeaderAdminAction;
 }
 
-export default function PageHeader({ title, onBack }: PageHeaderProps) {
+interface PageHeaderAdminActionProviderProps {
+  value: PageHeaderAdminAction;
+  children: ReactNode;
+}
+
+export function PageHeaderAdminActionProvider({ value, children }: PageHeaderAdminActionProviderProps) {
+  return (
+    <PageHeaderAdminActionContext.Provider value={value}>
+      {children}
+    </PageHeaderAdminActionContext.Provider>
+  );
+}
+
+export default function PageHeader({ title, onBack, adminAction: adminActionOverride }: PageHeaderProps) {
+  const contextAdminAction = useContext(PageHeaderAdminActionContext);
+  const adminAction = adminActionOverride ?? contextAdminAction;
+
   return (
     <Box className="page-header">
       <Typography variant="h4" className="page-header-title">
         {title}
       </Typography>
-      <Button variant="outlined" onClick={onBack}>
-        Back
-      </Button>
+      <Box className="page-header-actions">
+        {adminAction.visible && (
+          <Button variant="contained" startIcon={<AdminPanelSettings />} onClick={adminAction.onClick}>
+            Admin
+          </Button>
+        )}
+        <Button variant="outlined" onClick={onBack}>
+          Back
+        </Button>
+      </Box>
     </Box>
   );
 }

--- a/src/shared/components/__tests__/PageHeader.test.tsx
+++ b/src/shared/components/__tests__/PageHeader.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../../test-utils';
-import PageHeader from '../PageHeader';
+import PageHeader, { PageHeaderAdminActionProvider } from '../PageHeader';
 
 describe('PageHeader', () => {
   it('should render title', () => {
@@ -29,6 +29,59 @@ describe('PageHeader', () => {
     await user.click(backButton);
     
     expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('should render admin action when provided', () => {
+    const onBack = vi.fn();
+    const onAdminClick = vi.fn();
+
+    render(
+      <PageHeaderAdminActionProvider value={{ visible: true, onClick: onAdminClick }}>
+        <PageHeader title="Test Page" onBack={onBack} />
+      </PageHeaderAdminActionProvider>
+    );
+
+    expect(screen.getByRole('button', { name: /admin/i })).toBeInTheDocument();
+  });
+
+  it('should call admin action when admin button is clicked', async () => {
+    const onBack = vi.fn();
+    const onAdminClick = vi.fn();
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    render(
+      <PageHeaderAdminActionProvider value={{ visible: true, onClick: onAdminClick }}>
+        <PageHeader title="Test Page" onBack={onBack} />
+      </PageHeaderAdminActionProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: /admin/i }));
+
+    expect(onAdminClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should prefer page admin action over provider action', async () => {
+    const onBack = vi.fn();
+    const onProviderAdminClick = vi.fn();
+    const onPageAdminClick = vi.fn();
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    render(
+      <PageHeaderAdminActionProvider value={{ visible: true, onClick: onProviderAdminClick }}>
+        <PageHeader
+          title="Test Page"
+          onBack={onBack}
+          adminAction={{ visible: true, onClick: onPageAdminClick }}
+        />
+      </PageHeaderAdminActionProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: /admin/i }));
+
+    expect(onPageAdminClick).toHaveBeenCalledTimes(1);
+    expect(onProviderAdminClick).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add a shared PageHeader admin action with page-level overrides.
- Route the Admin button from section detail pages to the relevant Manage Sections context.
- Preserve default admin entry for global pages and add PageHeader tests for provider/override behavior.

## Test plan
- npm run test:run -- src/shared/components/__tests__/PageHeader.test.tsx
- npm run build


Made with [Cursor](https://cursor.com)