### PR TITLE
fix(routing): preserve deep links until auth resolves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,16 +42,27 @@ const LoadingFallback = () => (
 function SectionDetailRoute() {
   const { sectionId } = useParams<{ sectionId: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
   if (!sectionId) {
     return <Navigate to={ROUTES.SECTIONS} replace />;
   }
-  return <SectionDetail sectionId={sectionId} onBack={() => navigate(ROUTES.SECTIONS)} />;
+
+  const handleBack = () => {
+    if (window.history.state?.idx > 0 || location.key !== "default") {
+      navigate(-1);
+      return;
+    }
+    navigate(ROUTES.SECTIONS, { replace: true });
+  };
+
+  return <SectionDetail sectionId={sectionId} onBack={handleBack} />;
 }
 
 function AppContent() {
   const navigate = useNavigate();
   const location = useLocation();
   const [user, setUser] = useState<User | null>(null);
+  const [authInitialized, setAuthInitialized] = useState(false);
   const [emailCheckTrigger, setEmailCheckTrigger] = useState(0);
   const [logoutSuccess, setLogoutSuccess] = useState(false);
   const [checkoutQueryState, setCheckoutQueryState] = useState<{
@@ -68,7 +79,7 @@ function AppContent() {
   const { data: userSectionsData } = useGetSectionsForUser(dataConnect, { enabled: !!user && isEnabled });
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(location.search);
     const checkout = params.get("checkout");
     if (checkout !== "success" && checkout !== "cancel") {
       return;
@@ -77,7 +88,7 @@ function AppContent() {
       checkout,
       orderId: params.get("orderId"),
     });
-  }, []);
+  }, [location.search]);
 
   useEffect(() => {
     const handleOnline = () => setIsOnline(true);
@@ -96,6 +107,7 @@ function AppContent() {
       const isNowLoggedOut = u === null;
       
       setUser(u);
+      setAuthInitialized(true);
       
       if (wasLoggedIn && isNowLoggedOut) {
         navigate(ROUTES.ACCOUNT);
@@ -379,11 +391,20 @@ function AppContent() {
   };
 
   const handleDismissCheckoutStatus = () => {
-    const url = new URL(window.location.href);
-    url.searchParams.delete("checkout");
-    url.searchParams.delete("orderId");
-    navigate(`${url.pathname}${url.search}${url.hash}`, { replace: true });
+    const params = new URLSearchParams(location.search);
+    params.delete("checkout");
+    params.delete("orderId");
+    const search = params.toString();
+    navigate(`${location.pathname}${search ? `?${search}` : ""}${location.hash}`, { replace: true });
     setCheckoutQueryState(null);
+  };
+
+  const navigateBackOr = (fallbackRoute: string) => {
+    if (window.history.state?.idx > 0 || location.key !== "default") {
+      navigate(-1);
+      return;
+    }
+    navigate(fallbackRoute, { replace: true });
   };
 
   const adminLinks = isAdmin
@@ -397,6 +418,9 @@ function AppContent() {
     : [];
 
   const renderAdminOnly = (title: string, element: ReactElement) => {
+    if (!authInitialized) {
+      return <LoadingFallback />;
+    }
     if (user && isAdmin) {
       return element;
     }
@@ -417,6 +441,13 @@ function AppContent() {
         </Button>
       </Box>
     );
+  };
+
+  const protectedRoute = (element: ReactElement) => {
+    if (!authInitialized) {
+      return <LoadingFallback />;
+    }
+    return user && isEnabled ? element : <Navigate to={ROUTES.ACCOUNT} replace />;
   };
 
   return (
@@ -486,7 +517,7 @@ function AppContent() {
                   element={
                     <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
                       <Suspense fallback={<LoadingFallback />}>
-                        <AuthGate userData={userData} onBack={() => navigate(ROUTES.HOME)} />
+                        <AuthGate userData={userData} onBack={() => navigateBackOr(ROUTES.HOME)} />
                       </Suspense>
                     </Box>
                   }
@@ -497,7 +528,7 @@ function AppContent() {
                     <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
                       {user ? (
                         <Suspense fallback={<LoadingFallback />}>
-                          <Profile key={user.uid} userData={userData} userEmail={user?.email || ""} onBack={() => navigate(ROUTES.HOME)} onUpdate={handleProfileUpdate} />
+                          <Profile key={user.uid} userData={userData} userEmail={user?.email || ""} onBack={() => navigateBackOr(ROUTES.HOME)} onUpdate={handleProfileUpdate} />
                         </Suspense>
                       ) : (
                         <Navigate to={ROUTES.ACCOUNT} replace />
@@ -506,16 +537,16 @@ function AppContent() {
                   }
                 />
                 <Route path={ROUTES.PERMISSIONS} element={<Navigate to={ROUTES.MANAGE_USERS} replace />} />
-                <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
-                <Route path={ROUTES.APPROVE_USERS} element={renderAdminOnly("Approve Users", <Suspense fallback={<LoadingFallback />}><ApproveUsers onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
-                <Route path={ROUTES.USER_GROUPS} element={renderAdminOnly("User Groups", <Suspense fallback={<LoadingFallback />}><UserGroups onBack={() => navigate(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.APPROVE_USERS} element={renderAdminOnly("Approve Users", <Suspense fallback={<LoadingFallback />}><ApproveUsers onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.USER_GROUPS} element={renderAdminOnly("User Groups", <Suspense fallback={<LoadingFallback />}><UserGroups onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
                 <Route
                   path={ROUTES.AUDIT_LOGS}
                   element={renderAdminOnly(
                     "Audit Logs",
-                    <ErrorBoundary title="Audit Logs" onBack={() => navigate(ROUTES.HOME)}>
+                    <ErrorBoundary title="Audit Logs" onBack={() => navigateBackOr(ROUTES.HOME)}>
                       <Suspense fallback={<LoadingFallback />}>
-                        <AuditLogs onBack={() => navigate(ROUTES.HOME)} />
+                        <AuditLogs onBack={() => navigateBackOr(ROUTES.HOME)} />
                       </Suspense>
                     </ErrorBoundary>
                   )}
@@ -524,28 +555,24 @@ function AppContent() {
                   path={ROUTES.MANAGE_SECTIONS}
                   element={renderAdminOnly(
                     "Manage Sections",
-                    <ErrorBoundary title="Manage Sections" onBack={() => navigate(ROUTES.HOME)}>
+                    <ErrorBoundary title="Manage Sections" onBack={() => navigateBackOr(ROUTES.HOME)}>
                       <Suspense fallback={<LoadingFallback />}>
-                        <ManageSections onBack={() => navigate(ROUTES.HOME)} />
+                        <ManageSections onBack={() => navigateBackOr(ROUTES.HOME)} />
                       </Suspense>
                     </ErrorBoundary>
                   )}
                 />
                 <Route
                   path={ROUTES.SECTIONS}
-                  element={
-                    user && isEnabled ? (
+                  element={protectedRoute(
                       <Suspense fallback={<LoadingFallback />}>
-                        <SectionsList onBack={() => navigate(ROUTES.HOME)} onSelectSection={(sectionId) => navigate(`/sections/${sectionId}`)} />
+                        <SectionsList onBack={() => navigateBackOr(ROUTES.HOME)} onSelectSection={(sectionId) => navigate(`/sections/${sectionId}`)} />
                       </Suspense>
-                    ) : (
-                      <Navigate to={ROUTES.ACCOUNT} replace />
-                    )
-                  }
+                  )}
                 />
                 <Route
                   path={ROUTES.SECTION_DETAIL}
-                  element={user && isEnabled ? <Suspense fallback={<LoadingFallback />}><SectionDetailRoute /></Suspense> : <Navigate to={ROUTES.ACCOUNT} replace />}
+                  element={protectedRoute(<Suspense fallback={<LoadingFallback />}><SectionDetailRoute /></Suspense>)}
                 />
                 <Route path="*" element={<Navigate to={ROUTES.HOME} replace />} />
               </Routes>

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { render, screen, waitFor } from "../test-utils";
+import userEvent from "@testing-library/user-event";
+import type { User } from "firebase/auth";
+import App from "../App";
+import { ROUTES } from "../constants";
+import { createMockUser } from "../test-utils/mocks/firebase";
+
+let currentUser: User | null = null;
+let enabledClaim = false;
+let adminClaim = false;
+
+const mockSectionsData = {
+  user: {
+    id: "user-1",
+    membershipStatus: "REGULAR",
+    userGroups: [
+      {
+        userGroup: {
+          id: "group-1",
+          purposeLinks: [
+            {
+              purpose: "ACCESS",
+              section: { id: "section-1", name: "Signals" },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  allUserGroups: [],
+};
+
+vi.mock("firebase/auth", () => ({
+  onAuthStateChanged: vi.fn((_auth, callback) => {
+    callback(currentUser);
+    return vi.fn();
+  }),
+  onIdTokenChanged: vi.fn((_auth, callback) => {
+    callback(currentUser);
+    return vi.fn();
+  }),
+  reload: vi.fn().mockResolvedValue(undefined),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../config/firebase", () => ({
+  auth: {
+    get currentUser() {
+      return currentUser;
+    },
+  },
+  dataConnect: {},
+  firebaseApp: {},
+}));
+
+vi.mock("../features/users/hooks/useUserData", () => ({
+  useUserData: vi.fn((user: User | null) => ({
+    userData: user
+      ? {
+          id: user.uid,
+          firstName: "Test",
+          lastName: "User",
+          email: user.email ?? "test@example.com",
+          serviceNumber: "123",
+          membershipStatus: "REGULAR",
+          createdAt: "2024-01-01",
+          updatedAt: "2024-01-01",
+        }
+      : null,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock("../features/users/hooks/useEnabledClaim", () => ({
+  useEnabledClaim: vi.fn((user: User | null) => Boolean(user && enabledClaim)),
+}));
+
+vi.mock("../features/users/hooks/useAdminClaim", () => ({
+  useAdminClaim: vi.fn((user: User | null) => Boolean(user && adminClaim)),
+}));
+
+vi.mock("@dataconnect/generated/react", () => ({
+  useGetSectionsForUser: vi.fn(() => ({
+    data: mockSectionsData,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  })),
+  useGetMyTicketOrderById: vi.fn(() => ({
+    data: {
+      user: {
+        ticketOrders: [
+          {
+            status: "PAID",
+            ticketType: { title: "Dinner ticket" },
+          },
+        ],
+      },
+    },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock("../shared/components/Header", () => ({
+  default: ({ onAccountClick, onProfileClick }: { onAccountClick: () => void; onProfileClick?: () => void }) => (
+    <header>
+      <button onClick={onAccountClick}>Account</button>
+      <button onClick={onProfileClick}>Profile</button>
+    </header>
+  ),
+}));
+
+vi.mock("../shared/components/HomePage", () => ({
+  default: () => <h1>Home Page</h1>,
+}));
+
+vi.mock("../features/auth/components/AuthGate", () => ({
+  default: ({ onBack }: { onBack?: () => void }) => (
+    <div>
+      <h1>Account Page</h1>
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock("../features/profile/components/Profile", () => ({
+  default: ({ onBack }: { onBack: () => void }) => (
+    <div>
+      <h1>Profile Page</h1>
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock("../features/sections/components/SectionsList", () => ({
+  default: ({ onBack, onSelectSection }: { onBack: () => void; onSelectSection: (sectionId: string) => void }) => (
+    <div>
+      <h1>Sections Page</h1>
+      <button onClick={onBack}>Back</button>
+      <button onClick={() => onSelectSection("section-1")}>Open Section</button>
+    </div>
+  ),
+}));
+
+vi.mock("../features/sections/components/SectionDetail", () => ({
+  default: ({ sectionId, onBack }: { sectionId: string; onBack: () => void }) => (
+    <div>
+      <h1>Section Detail {sectionId}</h1>
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock("../features/admin/components/ManageUsers", () => ({
+  default: ({ onBack }: { onBack: () => void }) => (
+    <div>
+      <h1>Manage Users Page</h1>
+      <button onClick={onBack}>Back</button>
+    </div>
+  ),
+}));
+
+vi.mock("../features/admin/components/ApproveUsers", () => ({
+  default: () => <h1>Approvals Page</h1>,
+}));
+
+vi.mock("../features/admin/components/UserGroups", () => ({
+  default: () => <h1>User Groups Page</h1>,
+}));
+
+vi.mock("../features/admin/components/AuditLogs", () => ({
+  default: () => <h1>Audit Logs Page</h1>,
+}));
+
+vi.mock("../features/admin/components/ManageSections", () => ({
+  default: () => <h1>Manage Sections Page</h1>,
+}));
+
+vi.mock("../features/users/components/AccountStatusMessage", () => ({
+  default: () => <h1>Account Status Page</h1>,
+}));
+
+vi.mock("../features/auth/components/ProfileCompletion", () => ({
+  default: () => <h1>Profile Completion Page</h1>,
+}));
+
+vi.mock("../features/auth/components/EmailVerificationMessage", () => ({
+  default: () => <h1>Email Verification Page</h1>,
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function renderApp(initialEntries: string[]) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <App />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+}
+
+describe("App routing", () => {
+  beforeEach(() => {
+    currentUser = null;
+    enabledClaim = false;
+    adminClaim = false;
+    vi.clearAllMocks();
+  });
+
+  it("renders the account page from a direct deep link", async () => {
+    renderApp([ROUTES.ACCOUNT]);
+
+    expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.ACCOUNT);
+  });
+
+  it("redirects unauthenticated section deep links to account", async () => {
+    renderApp(["/sections/section-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.ACCOUNT));
+  });
+
+  it("renders section detail from a direct deep link for enabled users", async () => {
+    currentUser = createMockUser({ uid: "user-1" });
+    enabledClaim = true;
+
+    renderApp(["/sections/section-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent("/sections/section-1");
+  });
+
+  it("uses browser history for section detail Back when history exists", async () => {
+    currentUser = createMockUser({ uid: "user-1" });
+    enabledClaim = true;
+    const user = userEvent.setup();
+
+    renderApp([ROUTES.HOME, "/sections/section-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
+  });
+
+  it("falls back to sections when section detail has no prior history", async () => {
+    currentUser = createMockUser({ uid: "user-1" });
+    enabledClaim = true;
+    const user = userEvent.setup();
+
+    renderApp(["/sections/section-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(await screen.findByRole("heading", { name: "Sections Page" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.SECTIONS));
+  });
+
+  it("renders access denied for non-admin admin deep links", async () => {
+    currentUser = createMockUser({ uid: "user-1" });
+    enabledClaim = true;
+
+    renderApp([ROUTES.MANAGE_USERS]);
+
+    expect(await screen.findByText(/access denied/i)).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.MANAGE_USERS);
+  });
+
+  it("renders admin pages for admin deep links", async () => {
+    currentUser = createMockUser({ uid: "admin-1" });
+    enabledClaim = true;
+    adminClaim = true;
+
+    renderApp([ROUTES.MANAGE_USERS]);
+
+    expect(await screen.findByRole("heading", { name: "Manage Users Page" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.MANAGE_USERS);
+  });
+
+  it("cleans checkout query params with replace when dismissed", async () => {
+    currentUser = createMockUser({ uid: "user-1" });
+    enabledClaim = true;
+    const user = userEvent.setup();
+
+    renderApp(["/?checkout=success&orderId=00000000-0000-0000-0000-000000000001"]);
+
+    expect(await screen.findByText(/payment confirmed/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /close/i }));
+
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
+  });
+});


### PR DESCRIPTION
## Summary
- Gate protected route redirects until Firebase auth has initialized so direct deep links don't bounce to `/account` prematurely.
- Make Back actions history-aware with safe fallback routes for direct loads.
- Use React Router location for checkout query state and add App-level routing regression tests.

## Test plan
- npm run test:run -- src/__tests__/App.routing.test.tsx src/constants/__tests__/routes.test.ts src/shared/components/__tests__/PageHeader.test.tsx
- npm run build

Closes #80

Made with [Cursor](https://cursor.com)