### PR TITLE
Add permission-aware side navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Header from "./shared/components/Header";
 import HomePage from "./shared/components/HomePage";
 import AppSideNav from "./shared/components/AppSideNav";
 import { PageHeaderAdminActionProvider } from "./shared/components/PageHeader";
+import { buildNavigationLinks } from "./shared/navigation/buildNavigationLinks";
 import { colors } from "./config/colors";
 import { ROUTES } from "./constants";
 import CheckoutStatusNotice from "./features/sections/components/CheckoutStatusNotice";
@@ -206,47 +207,10 @@ function AppContent() {
   const needsProfileCompletion = user && user.emailVerified && !isEnabled && 
     profileExists === false && !checkingProfileRef.current;
 
-  const sectionsLinks = useMemo(() => {
-    if (!userSectionsData?.user?.userGroups) {
-      return [];
-    }
-
-    const sectionMap = new Map<string, { label: string; to: string }>();
-    const addSection = (section: { id: string; name: string }) => {
-      if (!section?.id || sectionMap.has(section.id)) {
-        return;
-      }
-      sectionMap.set(section.id, { label: section.name || "Untitled section", to: `/sections/${section.id}` });
-    };
-
-    for (const groupRelation of userSectionsData.user.userGroups) {
-      const userGroup = groupRelation?.userGroup;
-      if (!userGroup?.purposeLinks) {
-        continue;
-      }
-      for (const purposeLink of userGroup.purposeLinks) {
-        if ((purposeLink.purpose === "ACCESS" || purposeLink.purpose === "MODERATOR") && purposeLink.section) {
-          addSection({ id: purposeLink.section.id, name: purposeLink.section.name });
-        }
-      }
-    }
-
-    const userStatus = userSectionsData.user.membershipStatus;
-    if (userStatus && userSectionsData.allUserGroups) {
-      for (const userGroup of userSectionsData.allUserGroups) {
-        if (!userGroup?.membershipStatuses?.includes(userStatus) || !userGroup?.purposeLinks) {
-          continue;
-        }
-        for (const purposeLink of userGroup.purposeLinks) {
-          if ((purposeLink.purpose === "ACCESS" || purposeLink.purpose === "MODERATOR") && purposeLink.section) {
-            addSection({ id: purposeLink.section.id, name: purposeLink.section.name });
-          }
-        }
-      }
-    }
-
-    return Array.from(sectionMap.values()).sort((a, b) => a.label.localeCompare(b.label));
-  }, [userSectionsData]);
+  const navigationLinks = useMemo(
+    () => buildNavigationLinks({ isEnabled, isAdmin, sectionsData: userSectionsData }),
+    [isAdmin, isEnabled, userSectionsData]
+  );
 
   const pageHeaderAdminAction = useMemo(
     () => ({
@@ -255,6 +219,14 @@ function AppContent() {
     }),
     [isAdmin, isEnabled, navigate, user]
   );
+  const selectedAdminSectionId =
+    location.pathname === ROUTES.MANAGE_SECTIONS
+      ? ((location.state as { managedSection?: { id?: string } } | null)?.managedSection?.id ?? null)
+      : null;
+  const selectedAdminUserGroupId =
+    location.pathname === ROUTES.USER_GROUPS
+      ? ((location.state as { expandedGroupId?: string } | null)?.expandedGroupId ?? null)
+      : null;
 
   const header = (
     <Header
@@ -407,16 +379,6 @@ function AppContent() {
     navigate(fallbackRoute, { replace: true });
   };
 
-  const adminLinks = isAdmin
-    ? [
-        { label: "Manage Users", to: ROUTES.MANAGE_USERS },
-        { label: "Approvals", to: ROUTES.APPROVE_USERS },
-        { label: "User Groups", to: ROUTES.USER_GROUPS },
-        { label: "Audit Logs", to: ROUTES.AUDIT_LOGS },
-        { label: "Manage Sections", to: ROUTES.MANAGE_SECTIONS },
-      ]
-    : [];
-
   const renderAdminOnly = (title: string, element: ReactElement) => {
     if (!authInitialized) {
       return <LoadingFallback />;
@@ -477,9 +439,11 @@ function AppContent() {
       >
         {user && isEnabled ? (
           <AppSideNav
-            sections={sectionsLinks}
-            adminLinks={adminLinks}
+            sections={navigationLinks.sections}
+            adminLinks={navigationLinks.admin}
             pathname={location.pathname}
+            selectedAdminSectionId={selectedAdminSectionId}
+            selectedAdminUserGroupId={selectedAdminUserGroupId}
             mobileOpen={mobileNavOpen}
             onMobileClose={() => setMobileNavOpen(false)}
           />

--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -147,6 +147,24 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
   const initialEventIdRef = useRef(initialState?.eventId ?? null);
   const initialEditSectionIdRef = useRef(initialState?.editSectionId ?? null);
 
+  useEffect(() => {
+    const state = location.state as ManageSectionsLocationState | null;
+    if (state?.managedSection) {
+      setManagedSectionId(state.managedSection.id);
+      setManagedSectionName(state.managedSection.name);
+      initialEventIdRef.current = state.eventId ?? null;
+      return;
+    }
+    if (state?.editSectionId) {
+      initialEditSectionIdRef.current = state.editSectionId;
+      return;
+    }
+    setManagedSectionId(null);
+    setManagedSectionName("");
+    initialEventIdRef.current = null;
+    initialEditSectionIdRef.current = null;
+  }, [location.state]);
+
   const fetchSections = useCallback(async () => {
     setLoading(true);
     setError(null);

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -63,6 +63,7 @@ import {
 import { searchUsers } from "../../users/utils/searchUsers";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
+import { useLocation } from "react-router-dom";
 import "../../../shared/components/PageContainer.css";
 
 interface UserGroupsProps {
@@ -80,7 +81,12 @@ interface UserGroupWithDetails {
   sectionCount?: number;
 }
 
+interface UserGroupsLocationState {
+  expandedGroupId?: string | null;
+}
+
 export default function UserGroups({ onBack }: UserGroupsProps) {
+  const location = useLocation();
   const isAdmin = useAdminClaim(auth.currentUser);
   const [userGroups, setUserGroups] = useState<UserGroupWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
@@ -164,6 +170,16 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   useEffect(() => {
     fetchUserGroupsList();
   }, [fetchUserGroupsList]);
+
+  useEffect(() => {
+    const expandedGroupId = (location.state as UserGroupsLocationState | null)?.expandedGroupId;
+    if (!expandedGroupId) {
+      setExpandedGroupId(null);
+      return;
+    }
+    setExpandedGroupId(expandedGroupId);
+    fetchGroupDetails(expandedGroupId);
+  }, [fetchGroupDetails, location.state]);
 
   useEffect(() => {
     if (!isAdmin) return;

--- a/src/shared/components/AppSideNav.tsx
+++ b/src/shared/components/AppSideNav.tsx
@@ -1,19 +1,17 @@
 import { Box, Divider, Drawer, List, ListItemButton, ListItemText, Typography } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import { ROUTES } from "../../constants";
+import type { NavigationLink } from "../navigation/buildNavigationLinks";
 
 const drawerWidth = 280;
 const headerHeight = 64;
 
-type NavLink = {
-  label: string;
-  to: string;
-};
-
 interface AppSideNavProps {
-  sections: NavLink[];
-  adminLinks: NavLink[];
+  sections: NavigationLink[];
+  adminLinks: NavigationLink[];
   pathname: string;
+  selectedAdminSectionId?: string | null;
+  selectedAdminUserGroupId?: string | null;
   /** Controlled open state for the temporary (mobile) drawer. */
   mobileOpen: boolean;
   onMobileClose: () => void;
@@ -30,11 +28,15 @@ function NavList({
   title,
   links,
   pathname,
+  selectedAdminSectionId,
+  selectedAdminUserGroupId,
   onItemNavigate,
 }: {
   title: string;
-  links: NavLink[];
+  links: NavigationLink[];
   pathname: string;
+  selectedAdminSectionId?: string | null;
+  selectedAdminUserGroupId?: string | null;
   onItemNavigate?: () => void;
 }) {
   if (links.length === 0) {
@@ -47,20 +49,81 @@ function NavList({
         {title}
       </Typography>
       <List disablePadding>
-        {links.map((link) => (
-          <ListItemButton
-            key={`${title}-${link.to}`}
-            component={RouterLink}
-            to={link.to}
-            selected={isActive(pathname, link.to)}
-            onClick={onItemNavigate}
-            sx={{ borderRadius: 1, my: 0.5 }}
-          >
-            <ListItemText primary={link.label} />
-          </ListItemButton>
-        ))}
+        {links.map((link) => {
+          const selectedChild = getSelectedChild({
+            link,
+            pathname,
+            selectedAdminSectionId,
+            selectedAdminUserGroupId,
+          });
+          return (
+            <Box key={`${title}-${link.to}-${link.label}`}>
+              <ListItemButton
+                component={RouterLink}
+                to={link.to}
+                state={link.state}
+                selected={isActive(pathname, link.to) && !selectedChild}
+                onClick={onItemNavigate}
+                sx={{ borderRadius: 1, my: 0.5 }}
+              >
+                <ListItemText primary={link.label} />
+              </ListItemButton>
+              {link.children?.map((child) => (
+                <ListItemButton
+                  key={`${link.to}-${child.to}-${child.label}`}
+                  component={RouterLink}
+                  to={child.to}
+                  state={child.state}
+                  selected={selectedChild === child}
+                  onClick={onItemNavigate}
+                  sx={{ borderRadius: 1, my: 0.5, ml: 2, py: 0.5 }}
+                >
+                  <ListItemText
+                    primary={child.label}
+                    primaryTypographyProps={{ variant: "body2", color: "text.secondary" }}
+                  />
+                </ListItemButton>
+              ))}
+            </Box>
+          );
+        })}
       </List>
     </Box>
+  );
+}
+
+function getSelectedChild({
+  link,
+  pathname,
+  selectedAdminSectionId,
+  selectedAdminUserGroupId,
+}: {
+  link: NavigationLink;
+  pathname: string;
+  selectedAdminSectionId?: string | null;
+  selectedAdminUserGroupId?: string | null;
+}): NavigationLink | null {
+  if (!link.children?.length) {
+    return null;
+  }
+
+  return (
+    link.children.find((child) => {
+      if (pathname !== child.to) {
+        return false;
+      }
+      const childState = child.state as
+        | { managedSection?: { id?: string }; expandedGroupId?: string }
+        | null
+        | undefined;
+      if (child.to === ROUTES.MANAGE_SECTIONS) {
+        return childState?.managedSection?.id === selectedAdminSectionId;
+      }
+      if (child.to === ROUTES.USER_GROUPS) {
+        return childState?.expandedGroupId === selectedAdminUserGroupId;
+      }
+      return false;
+    }) ?? null
   );
 }
 
@@ -68,20 +131,37 @@ function SideNavContent({
   sections,
   adminLinks,
   pathname,
+  selectedAdminSectionId,
+  selectedAdminUserGroupId,
   onItemNavigate,
 }: {
-  sections: NavLink[];
-  adminLinks: NavLink[];
+  sections: NavigationLink[];
+  adminLinks: NavigationLink[];
   pathname: string;
+  selectedAdminSectionId?: string | null;
+  selectedAdminUserGroupId?: string | null;
   onItemNavigate?: () => void;
 }) {
   return (
     <Box sx={{ overflow: "auto", py: 1 }}>
-      <NavList title="Sections" links={sections} pathname={pathname} onItemNavigate={onItemNavigate} />
+      <NavList
+        title="Sections"
+        links={sections}
+        pathname={pathname}
+        selectedAdminSectionId={selectedAdminSectionId}
+        onItemNavigate={onItemNavigate}
+      />
       {adminLinks.length > 0 && (
         <>
           <Divider />
-          <NavList title="Admin" links={adminLinks} pathname={pathname} onItemNavigate={onItemNavigate} />
+          <NavList
+            title="Admin"
+            links={adminLinks}
+            pathname={pathname}
+            selectedAdminSectionId={selectedAdminSectionId}
+            selectedAdminUserGroupId={selectedAdminUserGroupId}
+            onItemNavigate={onItemNavigate}
+          />
         </>
       )}
     </Box>
@@ -92,6 +172,8 @@ export default function AppSideNav({
   sections,
   adminLinks,
   pathname,
+  selectedAdminSectionId,
+  selectedAdminUserGroupId,
   mobileOpen,
   onMobileClose,
 }: AppSideNavProps) {
@@ -120,6 +202,8 @@ export default function AppSideNav({
           sections={sections}
           adminLinks={adminLinks}
           pathname={pathname}
+          selectedAdminSectionId={selectedAdminSectionId}
+          selectedAdminUserGroupId={selectedAdminUserGroupId}
           onItemNavigate={closeOnNavigate}
         />
       </Drawer>
@@ -139,7 +223,13 @@ export default function AppSideNav({
           display: { xs: "none", md: "block" },
         }}
       >
-        <SideNavContent sections={sections} adminLinks={adminLinks} pathname={pathname} />
+        <SideNavContent
+          sections={sections}
+          adminLinks={adminLinks}
+          pathname={pathname}
+          selectedAdminSectionId={selectedAdminSectionId}
+          selectedAdminUserGroupId={selectedAdminUserGroupId}
+        />
       </Drawer>
     </>
   );

--- a/src/shared/components/__tests__/AppSideNav.test.tsx
+++ b/src/shared/components/__tests__/AppSideNav.test.tsx
@@ -9,8 +9,22 @@ describe("AppSideNav", () => {
       <MemoryRouter>
         <AppSideNav
           pathname="/admin/users"
-          sections={[{ label: "Sections", to: "/sections" }]}
-          adminLinks={[{ label: "Manage Users", to: "/admin/users" }]}
+          sections={[
+            {
+              label: "Events",
+              to: "/sections/events",
+              children: [{ label: "Administer", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          adminLinks={[
+            {
+              label: "Manage Sections",
+              to: "/admin/sections",
+              state: null,
+              children: [{ label: "Events", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+            { label: "Manage Users", to: "/admin/users" },
+          ]}
           mobileOpen={false}
           onMobileClose={vi.fn()}
         />
@@ -18,6 +32,147 @@ describe("AppSideNav", () => {
     );
 
     expect(screen.getAllByText("Sections").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: "Events" })[0]).toHaveAttribute("href", "/sections/events");
+    expect(screen.getByRole("link", { name: "Administer" })).toHaveAttribute("href", "/admin/sections");
+    expect(screen.getByRole("link", { name: "Manage Sections" })).toHaveAttribute("href", "/admin/sections");
+    expect(screen.getAllByRole("link", { name: "Events" })[1]).toHaveAttribute("href", "/admin/sections");
     expect(screen.getByRole("link", { name: "Manage Users" })).toHaveAttribute("href", "/admin/users");
+  });
+
+  it("does not mark admin section children selected when on the normal section route", () => {
+    render(
+      <MemoryRouter>
+        <AppSideNav
+          pathname="/sections/events"
+          sections={[
+            {
+              label: "Events",
+              to: "/sections/events",
+              children: [{ label: "Administer", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          adminLinks={[
+            {
+              label: "Manage Sections",
+              to: "/admin/sections",
+              state: null,
+              children: [{ label: "Events", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          mobileOpen={false}
+          onMobileClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Administer" })).not.toHaveClass("Mui-selected");
+    const adminEventsLink = screen.getAllByRole("link", { name: "Events" })[1];
+    expect(adminEventsLink).not.toHaveClass("Mui-selected");
+    expect(screen.getAllByRole("link", { name: "Events" })[0]).toHaveClass("Mui-selected");
+  });
+
+  it("selects only the matching nested section link for the active admin section", () => {
+    render(
+      <MemoryRouter>
+        <AppSideNav
+          pathname="/admin/sections"
+          selectedAdminSectionId="events"
+          sections={[
+            {
+              label: "Dining",
+              to: "/sections/dining",
+              children: [{ label: "Administer", to: "/admin/sections", state: { managedSection: { id: "dining" } } }],
+            },
+            {
+              label: "Events",
+              to: "/sections/events",
+              children: [{ label: "Administer", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          adminLinks={[
+            {
+              label: "Manage Sections",
+              to: "/admin/sections",
+              state: null,
+              children: [
+                { label: "Dining", to: "/admin/sections", state: { managedSection: { id: "dining" } } },
+                { label: "Events", to: "/admin/sections", state: { managedSection: { id: "events" } } },
+              ],
+            },
+          ]}
+          mobileOpen={false}
+          onMobileClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    const diningLinks = screen.getAllByRole("link", { name: "Dining" });
+    const eventsLinks = screen.getAllByRole("link", { name: "Events" });
+    const administerLinks = screen.getAllByRole("link", { name: "Administer" });
+    expect(administerLinks[0]).not.toHaveClass("Mui-selected");
+    expect(administerLinks[1]).toHaveClass("Mui-selected");
+    expect(diningLinks[1]).not.toHaveClass("Mui-selected");
+    expect(eventsLinks[1]).toHaveClass("Mui-selected");
+    expect(screen.getByRole("link", { name: "Manage Sections" })).not.toHaveClass("Mui-selected");
+  });
+
+  it("selects the global Manage Sections link outside a section administer context", () => {
+    render(
+      <MemoryRouter>
+        <AppSideNav
+          pathname="/admin/sections"
+          sections={[
+            {
+              label: "Events",
+              to: "/sections/events",
+              children: [{ label: "Administer", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          adminLinks={[
+            {
+              label: "Manage Sections",
+              to: "/admin/sections",
+              state: null,
+              children: [{ label: "Events", to: "/admin/sections", state: { managedSection: { id: "events" } } }],
+            },
+          ]}
+          mobileOpen={false}
+          onMobileClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Administer" })).not.toHaveClass("Mui-selected");
+    expect(screen.getAllByRole("link", { name: "Events" })[1]).not.toHaveClass("Mui-selected");
+    expect(screen.getByRole("link", { name: "Manage Sections" })).toHaveClass("Mui-selected");
+  });
+
+  it("selects only the matching nested user group link", () => {
+    render(
+      <MemoryRouter>
+        <AppSideNav
+          pathname="/admin/user-groups"
+          selectedAdminUserGroupId="group-2"
+          sections={[]}
+          adminLinks={[
+            {
+              label: "User Groups",
+              to: "/admin/user-groups",
+              state: null,
+              children: [
+                { label: "Members", to: "/admin/user-groups", state: { expandedGroupId: "group-1" } },
+                { label: "Volunteers", to: "/admin/user-groups", state: { expandedGroupId: "group-2" } },
+              ],
+            },
+          ]}
+          mobileOpen={false}
+          onMobileClose={vi.fn()}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("link", { name: "Members" })).not.toHaveClass("Mui-selected");
+    expect(screen.getByRole("link", { name: "Volunteers" })).toHaveClass("Mui-selected");
+    expect(screen.getByRole("link", { name: "User Groups" })).not.toHaveClass("Mui-selected");
   });
 });

--- a/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
+++ b/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from "vitest";
+import type { GetSectionsForUserData } from "@dataconnect/generated";
+import { ROUTES } from "../../../constants";
+import { buildNavigationLinks } from "../buildNavigationLinks";
+
+function sectionsData(overrides: Partial<GetSectionsForUserData> = {}): GetSectionsForUserData {
+  return {
+    user: {
+      id: "user-1",
+      membershipStatus: "REGULAR",
+      userGroups: [],
+    },
+    allUserGroups: [],
+    ...overrides,
+  } as GetSectionsForUserData;
+}
+
+function purposeLink(purpose: "ACCESS" | "MODERATOR", id: string, name: string) {
+  return {
+    purpose,
+    section: {
+      id,
+      name,
+      type: "EVENTS",
+      description: null,
+    },
+  };
+}
+
+describe("buildNavigationLinks", () => {
+  it("returns no links when user is not enabled", () => {
+    expect(
+      buildNavigationLinks({
+        isEnabled: false,
+        isAdmin: true,
+        sectionsData: sectionsData(),
+      })
+    ).toEqual({ sections: [], admin: [] });
+  });
+
+  it("builds section links from ACCESS purpose links", () => {
+    const links = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: false,
+      sectionsData: sectionsData({
+        user: {
+          id: "user-1",
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                id: "group-1",
+                name: "Access group",
+                membershipStatuses: null,
+                purposeLinks: [purposeLink("ACCESS", "section-1", "Signals")],
+              },
+            },
+          ],
+        },
+      } as Partial<GetSectionsForUserData>),
+    });
+
+    expect(links.sections).toEqual([{ label: "Signals", to: "/sections/section-1" }]);
+    expect(links.admin).toEqual([]);
+  });
+
+  it("nests moderator section links under Manage Sections", () => {
+    const links = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: false,
+      sectionsData: sectionsData({
+        user: {
+          id: "user-1",
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                id: "group-1",
+                name: "Moderator group",
+                membershipStatuses: null,
+                purposeLinks: [purposeLink("MODERATOR", "section-1", "Signals")],
+              },
+            },
+          ],
+        },
+      } as Partial<GetSectionsForUserData>),
+    });
+
+    expect(links.sections).toEqual([
+      {
+        label: "Signals",
+        to: "/sections/section-1",
+        children: [
+          {
+            label: "Administer",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-1", name: "Signals" } },
+          },
+        ],
+      },
+    ]);
+    expect(links.admin).toEqual([
+      {
+        label: "Manage Sections",
+        to: ROUTES.MANAGE_SECTIONS,
+        state: null,
+        children: [
+          {
+            label: "Signals",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-1", name: "Signals" } },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("nests status-based moderator section links under Manage Sections", () => {
+    const links = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: false,
+      sectionsData: sectionsData({
+        allUserGroups: [
+          {
+            id: "status-group-1",
+            name: "Regular moderators",
+            membershipStatuses: ["REGULAR"],
+            purposeLinks: [purposeLink("MODERATOR", "section-2", "Events")],
+          },
+        ],
+      } as Partial<GetSectionsForUserData>),
+    });
+
+    expect(links.sections).toEqual([
+      {
+        label: "Events",
+        to: "/sections/section-2",
+        children: [
+          {
+            label: "Administer",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-2", name: "Events" } },
+          },
+        ],
+      },
+    ]);
+    expect(links.admin).toEqual([
+      {
+        label: "Manage Sections",
+        to: ROUTES.MANAGE_SECTIONS,
+        state: null,
+        children: [
+          {
+            label: "Events",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-2", name: "Events" } },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("shows global admin links with section and user group children only for admins", () => {
+    const nonAdmin = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: false,
+      sectionsData: sectionsData({
+        user: {
+          id: "user-1",
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                id: "group-1",
+                name: "Access group",
+                membershipStatuses: null,
+                purposeLinks: [purposeLink("ACCESS", "section-1", "Signals")],
+              },
+            },
+          ],
+        },
+        allUserGroups: [
+          {
+            id: "group-1",
+            name: "Access group",
+            membershipStatuses: ["REGULAR"],
+            purposeLinks: [purposeLink("ACCESS", "section-1", "Signals")],
+          },
+        ],
+      } as Partial<GetSectionsForUserData>),
+    });
+    const admin = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: true,
+      sectionsData: sectionsData({
+        user: {
+          id: "user-1",
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                id: "group-1",
+                name: "Access group",
+                membershipStatuses: null,
+                purposeLinks: [purposeLink("ACCESS", "section-1", "Signals")],
+              },
+            },
+          ],
+        },
+        allUserGroups: [
+          {
+            id: "group-1",
+            name: "Access group",
+            membershipStatuses: ["REGULAR"],
+            purposeLinks: [purposeLink("ACCESS", "section-1", "Signals")],
+          },
+        ],
+      } as Partial<GetSectionsForUserData>),
+    });
+
+    expect(nonAdmin.admin).toEqual([]);
+    expect(nonAdmin.sections).toEqual([{ label: "Signals", to: "/sections/section-1" }]);
+    expect(admin.sections).toEqual([
+      {
+        label: "Signals",
+        to: "/sections/section-1",
+        children: [
+          {
+            label: "Administer",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-1", name: "Signals" } },
+          },
+        ],
+      },
+    ]);
+    expect(admin.admin).toEqual(
+      expect.arrayContaining([
+        { label: "Manage Users", to: ROUTES.MANAGE_USERS },
+        {
+          label: "Manage Sections",
+          to: ROUTES.MANAGE_SECTIONS,
+          state: null,
+          children: [
+            {
+              label: "Signals",
+              to: ROUTES.MANAGE_SECTIONS,
+              state: { managedSection: { id: "section-1", name: "Signals" } },
+            },
+          ],
+        },
+        {
+          label: "User Groups",
+          to: ROUTES.USER_GROUPS,
+          state: null,
+          children: [
+            {
+              label: "Access group",
+              to: ROUTES.USER_GROUPS,
+              state: { expandedGroupId: "group-1" },
+            },
+          ],
+        },
+      ])
+    );
+    expect(admin.admin.at(-1)).toEqual({ label: "Audit Logs", to: ROUTES.AUDIT_LOGS });
+  });
+
+  it("deduplicates and sorts section links and admin section children", () => {
+    const links = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: true,
+      sectionsData: sectionsData({
+        user: {
+          id: "user-1",
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                id: "group-1",
+                name: "Moderator group",
+                membershipStatuses: null,
+                purposeLinks: [
+                  purposeLink("MODERATOR", "section-2", "Zulu"),
+                  purposeLink("MODERATOR", "section-1", "Alpha"),
+                  purposeLink("ACCESS", "section-1", "Alpha"),
+                ],
+              },
+            },
+          ],
+        },
+      } as Partial<GetSectionsForUserData>),
+    });
+
+    expect(links.sections).toEqual([
+      {
+        label: "Alpha",
+        to: "/sections/section-1",
+        children: [
+          {
+            label: "Administer",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-1", name: "Alpha" } },
+          },
+        ],
+      },
+      {
+        label: "Zulu",
+        to: "/sections/section-2",
+        children: [
+          {
+            label: "Administer",
+            to: ROUTES.MANAGE_SECTIONS,
+            state: { managedSection: { id: "section-2", name: "Zulu" } },
+          },
+        ],
+      },
+    ]);
+    expect(links.admin).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label: "Manage Sections",
+          children: [
+            {
+              label: "Alpha",
+              to: ROUTES.MANAGE_SECTIONS,
+              state: { managedSection: { id: "section-1", name: "Alpha" } },
+            },
+            {
+              label: "Zulu",
+              to: ROUTES.MANAGE_SECTIONS,
+              state: { managedSection: { id: "section-2", name: "Zulu" } },
+            },
+          ],
+        }),
+      ])
+    );
+  });
+
+  it("moves Audit Logs to the bottom of admin links", () => {
+    const links = buildNavigationLinks({
+      isEnabled: true,
+      isAdmin: true,
+      sectionsData: sectionsData(),
+    });
+
+    expect(links.admin.at(-1)).toEqual({ label: "Audit Logs", to: ROUTES.AUDIT_LOGS });
+  });
+});

--- a/src/shared/navigation/buildNavigationLinks.ts
+++ b/src/shared/navigation/buildNavigationLinks.ts
@@ -1,0 +1,206 @@
+import type { GetSectionsForUserData } from "@dataconnect/generated";
+import { ROUTES } from "../../constants";
+
+export interface NavigationLink {
+  label: string;
+  to: string;
+  state?: unknown;
+  children?: NavigationLink[];
+}
+
+export interface NavigationLinks {
+  sections: NavigationLink[];
+  admin: NavigationLink[];
+}
+
+interface BuildNavigationLinksArgs {
+  isEnabled: boolean;
+  isAdmin: boolean;
+  sectionsData?: GetSectionsForUserData;
+}
+
+type SectionLinkSource = {
+  purpose?: string | null;
+  section?: {
+    id?: string | null;
+    name?: string | null;
+  } | null;
+};
+
+function grantsSectionAccess(purpose?: string | null): boolean {
+  return purpose === "ACCESS" || purpose === "MODERATOR";
+}
+
+function addSectionLink(map: Map<string, NavigationLink>, link: SectionLinkSource) {
+  const section = link.section;
+  if (!section?.id || map.has(section.id)) {
+    return;
+  }
+  const label = section.name || "Untitled section";
+  map.set(section.id, { label, to: `/sections/${section.id}` });
+}
+
+function markSectionAdministerable(map: Map<string, boolean>, link: SectionLinkSource) {
+  const section = link.section;
+  if (link.purpose !== "MODERATOR" || !section?.id) {
+    return;
+  }
+  map.set(section.id, true);
+}
+
+function sortLinks<T extends NavigationLink>(links: Iterable<T>): T[] {
+  return Array.from(links).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function manageSectionLink({
+  label,
+  sectionId,
+  sectionName,
+}: {
+  label: string;
+  sectionId: string;
+  sectionName: string;
+}): NavigationLink {
+  return {
+    label,
+    to: ROUTES.MANAGE_SECTIONS,
+    state: {
+      managedSection: {
+        id: sectionId,
+        name: sectionName,
+      },
+    },
+  };
+}
+
+function buildAdminLinks({
+  isAdmin,
+  sectionMap,
+  administerableSectionIds,
+  sectionsData,
+}: {
+  isAdmin: boolean;
+  sectionMap: Map<string, NavigationLink>;
+  administerableSectionIds: Map<string, boolean>;
+  sectionsData?: GetSectionsForUserData;
+}): NavigationLink[] {
+  const sectionAdminChildren = sortLinks(
+    Array.from(administerableSectionIds.keys()).flatMap((sectionId) => {
+      const section = sectionMap.get(sectionId);
+      if (!section) {
+        return [];
+      }
+      return [
+        manageSectionLink({
+          label: section.label,
+          sectionId,
+          sectionName: section.label,
+        }),
+      ];
+    })
+  );
+
+  const userGroupChildren = isAdmin
+    ? sortLinks(
+        (sectionsData?.allUserGroups ?? []).map((group) => ({
+          label: group.name || "Untitled user group",
+          to: ROUTES.USER_GROUPS,
+          state: {
+            expandedGroupId: group.id,
+          },
+        }))
+      )
+    : [];
+
+  const links: NavigationLink[] = [];
+
+  if (isAdmin) {
+    links.push({ label: "Manage Users", to: ROUTES.MANAGE_USERS });
+    links.push({ label: "Approvals", to: ROUTES.APPROVE_USERS });
+  }
+
+  if (isAdmin || sectionAdminChildren.length > 0) {
+    links.push({
+      label: "Manage Sections",
+      to: ROUTES.MANAGE_SECTIONS,
+      state: null,
+      children: sectionAdminChildren,
+    });
+  }
+
+  if (isAdmin) {
+    links.push({
+      label: "User Groups",
+      to: ROUTES.USER_GROUPS,
+      state: null,
+      children: userGroupChildren,
+    });
+    links.push({ label: "Audit Logs", to: ROUTES.AUDIT_LOGS });
+  }
+
+  return links;
+}
+
+export function buildNavigationLinks({
+  isEnabled,
+  isAdmin,
+  sectionsData,
+}: BuildNavigationLinksArgs): NavigationLinks {
+  if (!isEnabled) {
+    return { sections: [], admin: [] };
+  }
+
+  const sectionMap = new Map<string, NavigationLink>();
+  const administerableSectionIds = new Map<string, boolean>();
+  const explicitGroups = sectionsData?.user?.userGroups ?? [];
+
+  for (const groupRelation of explicitGroups) {
+    for (const purposeLink of groupRelation?.userGroup?.purposeLinks ?? []) {
+      if (grantsSectionAccess(purposeLink.purpose)) {
+        addSectionLink(sectionMap, purposeLink);
+      }
+      markSectionAdministerable(administerableSectionIds, purposeLink);
+    }
+  }
+
+  const userStatus = sectionsData?.user?.membershipStatus;
+  if (userStatus) {
+    for (const userGroup of sectionsData?.allUserGroups ?? []) {
+      if (!userGroup?.membershipStatuses?.includes(userStatus)) {
+        continue;
+      }
+      for (const purposeLink of userGroup.purposeLinks ?? []) {
+        if (grantsSectionAccess(purposeLink.purpose)) {
+          addSectionLink(sectionMap, purposeLink);
+        }
+        markSectionAdministerable(administerableSectionIds, purposeLink);
+      }
+    }
+  }
+
+  if (isAdmin) {
+    for (const sectionId of sectionMap.keys()) {
+      administerableSectionIds.set(sectionId, true);
+    }
+  }
+
+  return {
+    sections: sortLinks(sectionMap.values()).map((section) => {
+      const sectionId = section.to.replace("/sections/", "");
+      if (!administerableSectionIds.has(sectionId)) {
+        return section;
+      }
+      return {
+        ...section,
+        children: [
+          manageSectionLink({
+            label: "Administer",
+            sectionId,
+            sectionName: section.label,
+          }),
+        ],
+      };
+    }),
+    admin: buildAdminLinks({ isAdmin, sectionMap, administerableSectionIds, sectionsData }),
+  };
+}


### PR DESCRIPTION
## Summary
- Centralizes side-nav link construction for section access, section administration, and admin links.
- Adds contextual section admin links for moderators/admins while grouping admin section and user group entries under their manage pages.
- Keeps admin navigation selection in sync with route state and moves Audit Logs to the bottom.

## Test plan
- npm run test:run -- src/shared/navigation/__tests__/buildNavigationLinks.test.ts src/shared/components/__tests__/AppSideNav.test.tsx
- npm run build

Made with [Cursor](https://cursor.com)