### PR TITLE
Remove section list debug logging

### DIFF
--- a/src/features/sections/components/SectionsList.tsx
+++ b/src/features/sections/components/SectionsList.tsx
@@ -58,20 +58,8 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
     refetch: refetchAllSections,
   } = useListSections(dataConnect, { enabled: isAdmin });
 
-  // Log errors and data for debugging
+  // Surface query errors without logging successful query state on every render.
   useEffect(() => {
-    console.log('SectionsList Debug:', {
-      isAdmin,
-      loadingUserSections,
-      loadingAllSections,
-      errorUserSections,
-      errorAllSections,
-      userSectionsData,
-      allSectionsData,
-      userSectionsError,
-      allSectionsError,
-    });
-    
     if (userSectionsError) {
       console.error('GetSectionsForUser error:', userSectionsError);
       setErrorMessage(userSectionsError instanceof Error ? userSectionsError.message : 'Failed to load sections');
@@ -80,7 +68,7 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
       console.error('ListSections error:', allSectionsError);
       setErrorMessage(allSectionsError instanceof Error ? allSectionsError.message : 'Failed to load sections');
     }
-  }, [isAdmin, loadingUserSections, loadingAllSections, errorUserSections, errorAllSections, userSectionsData, allSectionsData, userSectionsError, allSectionsError]);
+  }, [userSectionsError, allSectionsError]);
 
   // Extract sections from query results
   const sections = useMemo(() => {


### PR DESCRIPTION
Closes #94

## Summary
- Removes noisy `SectionsList Debug` state dumps from normal renders and test runs.
- Keeps query error logging and user-facing error handling intact.
- Narrows the error handling effect dependencies to the actual error objects.

## Test plan
- npm run test:run -- src/features/sections/components/__tests__/SectionsList.test.tsx
- npm run test:run
- npm run build

Note: the suite still emits the known React act(...) warnings tracked by #90.

Made with [Cursor](https://cursor.com)