### PR TITLE
Clean up React act warnings in tests

### DIFF
--- a/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
+++ b/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "../../../../test-utils";
+import { act, render, screen } from "../../../../test-utils";
 import CheckoutStatusNotice from "../CheckoutStatusNotice";
 import * as dcReact from "@dataconnect/generated/react";
 
@@ -88,7 +88,9 @@ describe("CheckoutStatusNotice", () => {
     );
 
     expect(screen.getByText(/payment processing/i)).toBeInTheDocument();
-    vi.advanceTimersByTime(2500);
+    act(() => {
+      vi.advanceTimersByTime(2500);
+    });
     expect(refetch).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -21,6 +21,10 @@ vi.mock('../../../../shared/utils/firebaseFunctions', () => ({
   submitEventBooking: vi.fn(),
 }));
 
+vi.mock('../../../users/hooks/useAdminClaim', () => ({
+  useAdminClaim: vi.fn(() => false),
+}));
+
 vi.mock('firebase/data-connect', () => ({
   executeMutation: vi.fn().mockResolvedValue({}),
 }));
@@ -65,6 +69,7 @@ describe('SectionDetail', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getSectionMembersMerged).mockResolvedValue({ members: [] });
     vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
       data: { section: { id: sectionId, events: [] } } as any,
       isLoading: false,
@@ -91,6 +96,8 @@ describe('SectionDetail', () => {
   });
 
   it('should render loading state', () => {
+    vi.mocked(getSectionMembersMerged).mockReturnValue(new Promise(() => undefined) as any);
+
     vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
       data: undefined,
       isLoading: true,

--- a/src/features/users/hooks/__tests__/useUserSearch.test.ts
+++ b/src/features/users/hooks/__tests__/useUserSearch.test.ts
@@ -26,10 +26,29 @@ describe('useUserSearch', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('should initialize with provided search term', () => {
+  it('should initialize with provided search term', async () => {
+    vi.mocked(searchUsers.searchUsers).mockResolvedValue({
+      success: true,
+      data: {
+        users: [],
+        total: 0,
+        page: 1,
+        pageSize: 25,
+        totalPages: 1,
+      },
+    });
+
     const { result } = renderHook(() => useUserSearch('test'));
     
     expect(result.current.searchTerm).toBe('test');
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(searchUsers.searchUsers).toHaveBeenCalledWith('test', 1, 25);
+    expect(result.current.loading).toBe(false);
   });
 
   it.skip('should not search when search term is empty', async () => {


### PR DESCRIPTION
Closes #90

## Summary
- Awaits the initial `useUserSearch` async updates for provided search terms.
- Wraps checkout polling timer advancement in `act`.
- Stabilizes `SectionDetail` tests by mocking admin claims and controlling background member loading in the loading-state case.

## Test plan
- npm run test:run -- src/features/users/hooks/__tests__/useUserSearch.test.ts src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx src/features/sections/components/__tests__/SectionDetail.test.tsx
- npm run test:run
- npm run build

Note: `npm` still prints `Unknown env config "devdir"`; that is separate from the React `act(...)` warnings and is part of the warning-policy work in #91.

Made with [Cursor](https://cursor.com)