### PR TITLE
Run full frontend tests in PR CI

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build-checks:
-    name: TypeScript and build checks
+    name: Frontend and functions build checks
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
         working-directory: functions
 
   frontend-tests:
-    name: Frontend targeted tests
+    name: Frontend full test suite
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
 
       - name: Run frontend test suite
-        run: npm run test -- SectionEventsManager --run
+        run: npm run test:run
 
   functions-security-tests:
     name: Functions security tests


### PR DESCRIPTION
Closes #93

## Summary
- Changes PR CI from a targeted `SectionEventsManager` test run to the full frontend `npm run test:run` suite.
- Renames CI jobs so the frontend/full-suite and build responsibilities are clearer.
- Leaves lint out of this PR because the current lint baseline is red; #100 tracks making lint pass and adding it as a CI gate.

## Test plan
- npm run test:run
- npm run build

Made with [Cursor](https://cursor.com)