### PR TITLE
Reduce Data Connect test mock boilerplate

### DIFF
--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -4,6 +4,10 @@ import SectionEventsManager from "../SectionEventsManager";
 import * as reactGenerated from "@dataconnect/generated/react";
 import userEvent from "@testing-library/user-event";
 import { executeMutation } from "firebase/data-connect";
+import {
+  dataConnectQueryResult,
+  type DataConnectQueryResultOverrides,
+} from "../../../../test-utils/dataConnectMocks";
 
 vi.mock("@dataconnect/generated/react", () => ({
   useGetEventsForSection: vi.fn(),
@@ -26,6 +30,36 @@ vi.mock("../../../../config/firebase", () => ({
   dataConnect: {},
 }));
 
+function mockGetEventsForSection(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetEventsForSection>(overrides)
+  );
+}
+
+function mockGetEventById(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetEventById).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetEventById>(overrides)
+  );
+}
+
+function mockGuestTicketRequests(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useListGuestTicketRequestsForAdmin).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useListGuestTicketRequestsForAdmin>(overrides)
+  );
+}
+
+function mockEventBookings(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useListEventBookingsForAdmin).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useListEventBookingsForAdmin>(overrides)
+  );
+}
+
+function mockTicketOrders(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useListTicketOrdersForAdmin).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useListTicketOrdersForAdmin>(overrides)
+  );
+}
+
 vi.mock("@dataconnect/generated", async () => {
   const actual = await vi.importActual("@dataconnect/generated");
   return {
@@ -41,36 +75,31 @@ describe("SectionEventsManager", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
-      data: { section: { id: sectionId, events: [] } } as any,
+    mockGetEventsForSection({
+      data: { section: { id: sectionId, events: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
+    });
+    mockGetEventById({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListGuestTicketRequestsForAdmin).mockReturnValue({
-      data: { event: { id: "ev-1", bookings: [] } } as any,
+    });
+    mockGuestTicketRequests({
+      data: { event: { id: "ev-1", bookings: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListEventBookingsForAdmin).mockReturnValue({
-      data: { event: { id: "ev-1", bookings: [] } } as any,
+    });
+    mockEventBookings({
+      data: { event: { id: "ev-1", bookings: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListTicketOrdersForAdmin).mockReturnValue({
-      data: { event: { id: "ev-1", ticketOrders: [] } } as any,
+    });
+    mockTicketOrders({
+      data: { event: { id: "ev-1", ticketOrders: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
   });
 
   it("renders events list with section name and Back returns to sections", async () => {
@@ -88,7 +117,7 @@ describe("SectionEventsManager", () => {
   });
 
   it("shows events table when section has events", async () => {
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+    mockGetEventsForSection({
       data: {
         section: {
           id: sectionId,
@@ -105,11 +134,10 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
 
@@ -122,12 +150,11 @@ describe("SectionEventsManager", () => {
   });
 
   it("renders error message when events query fails", async () => {
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+    mockGetEventsForSection({
       data: undefined,
       isLoading: false,
       isError: true,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
 
@@ -138,7 +165,7 @@ describe("SectionEventsManager", () => {
 
   it("renders moderation queue and approves a pending request", async () => {
     const user = userEvent.setup();
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+    mockGetEventsForSection({
       data: {
         section: {
           id: sectionId,
@@ -155,23 +182,21 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
+    });
+    mockGetEventById({
       data: {
         event: {
           id: "ev-1",
           ticketTypes: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListGuestTicketRequestsForAdmin).mockReturnValue({
+    });
+    mockGuestTicketRequests({
       data: {
         event: {
           id: "ev-1",
@@ -196,12 +221,11 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListEventBookingsForAdmin).mockReturnValue({
+    });
+    mockEventBookings({
       data: {
         event: {
           id: "ev-1",
@@ -218,12 +242,11 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useListTicketOrdersForAdmin).mockReturnValue({
+    });
+    mockTicketOrders({
       data: {
         event: {
           id: "ev-1",
@@ -242,11 +265,10 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
     await user.click(screen.getByRole("button", { name: /ticket types/i }));
@@ -262,7 +284,7 @@ describe("SectionEventsManager", () => {
 
   it("shows empty-state alerts for moderation, booking audit, and payment activity", async () => {
     const user = userEvent.setup();
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
+    mockGetEventsForSection({
       data: {
         section: {
           id: sectionId,
@@ -279,17 +301,15 @@ describe("SectionEventsManager", () => {
             },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
-      data: { event: { id: "ev-1", ticketTypes: [] } } as any,
+    });
+    mockGetEventById({
+      data: { event: { id: "ev-1", ticketTypes: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
     await user.click(screen.getByRole("button", { name: /ticket types/i }));

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -5,6 +5,10 @@ import SectionDetail from '../SectionDetail';
 import * as reactGenerated from '@dataconnect/generated/react';
 import { createMockUser } from '../../../../test-utils/mocks/firebase';
 import { getSectionMembersMerged } from '../../../../shared/utils/firebaseFunctions';
+import {
+  dataConnectQueryResult,
+  type DataConnectQueryResultOverrides,
+} from '../../../../test-utils/dataConnectMocks';
 
 // Mock the DataConnect hooks (SectionDetail uses getSectionMembersMerged callable, not useGetSectionMembers)
 vi.mock('@dataconnect/generated/react', () => ({
@@ -51,10 +55,46 @@ vi.mock('@dataconnect/generated', async () => {
   const actual = await vi.importActual('@dataconnect/generated');
   return {
     ...actual,
-    subscribeToUserGroupRef: vi.fn((dc: any, vars: any) => ({ type: 'mutation', dc, vars })),
-    unsubscribeFromUserGroupRef: vi.fn((dc: any, vars: any) => ({ type: 'mutation', dc, vars })),
+    subscribeToUserGroupRef: vi.fn((dc: unknown, vars: unknown) => ({ type: 'mutation', dc, vars })),
+    unsubscribeFromUserGroupRef: vi.fn((dc: unknown, vars: unknown) => ({ type: 'mutation', dc, vars })),
   };
 });
+
+function mockGetSectionById(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetSectionById).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetSectionById>(overrides)
+  );
+}
+
+function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetUserAccessGroups>(overrides)
+  );
+}
+
+function mockGetEventsForSection(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetEventsForSection>(overrides)
+  );
+}
+
+function mockGetEventById(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetEventById).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetEventById>(overrides)
+  );
+}
+
+function mockGetCurrentUser(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetCurrentUser).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetCurrentUser>(overrides)
+  );
+}
+
+function mockGetMyBookingsForEvent(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetMyBookingsForEvent>(overrides)
+  );
+}
 
 describe('SectionDetail', () => {
   const mockOnBack = vi.fn();
@@ -70,46 +110,42 @@ describe('SectionDetail', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getSectionMembersMerged).mockResolvedValue({ members: [] });
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
-      data: { section: { id: sectionId, events: [] } } as any,
+    mockGetEventsForSection({
+      data: { section: { id: sectionId, events: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
+    });
+    mockGetEventById({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
-    vi.mocked(reactGenerated.useGetCurrentUser).mockReturnValue({
-      data: { user: { membershipStatus: 'REGULAR' } } as any,
+    });
+    mockGetCurrentUser({
+      data: { user: { membershipStatus: 'REGULAR' } },
       isLoading: false,
       isError: false,
-    } as any);
-    vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
-      data: { user: { bookings: [] } } as any,
+    });
+    mockGetMyBookingsForEvent({
+      data: { user: { bookings: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
   });
 
   it('should render loading state', () => {
-    vi.mocked(getSectionMembersMerged).mockReturnValue(new Promise(() => undefined) as any);
+    vi.mocked(getSectionMembersMerged).mockReturnValue(new Promise(() => undefined));
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
+    mockGetSectionById({
       data: undefined,
       isLoading: true,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: undefined,
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -118,18 +154,17 @@ describe('SectionDetail', () => {
   });
 
   it('should render error state', async () => {
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
+    mockGetSectionById({
       data: undefined,
       isLoading: false,
       isError: true,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: undefined,
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -160,23 +195,22 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
           userGroups: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -215,23 +249,22 @@ describe('SectionDetail', () => {
       ],
     });
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
           userGroups: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -274,14 +307,13 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
@@ -289,10 +321,10 @@ describe('SectionDetail', () => {
             { userGroup: { id: 'view-group-1' } },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -328,14 +360,13 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
@@ -344,10 +375,10 @@ describe('SectionDetail', () => {
             { userGroup: { id: 'member-group-1' } },
           ],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -373,23 +404,22 @@ describe('SectionDetail', () => {
       ],
     });
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
           userGroups: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
@@ -418,30 +448,28 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+    mockGetUserAccessGroups({
       data: {
         user: {
           id: 'user-1',
           userGroups: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
-      data: { section: { id: sectionId, events: [] } } as any,
+    mockGetEventsForSection({
+      data: { section: { id: sectionId, events: [] } },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -504,32 +532,29 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
-      data: { user: { id: 'user-1', userGroups: [] } } as any,
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
-      data: mockEventsData as any,
+    mockGetEventsForSection({
+      data: mockEventsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
-      data: mockEventDetailData as any,
+    mockGetEventById({
+      data: mockEventDetailData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     renderSectionDetail();
 
@@ -584,32 +609,29 @@ describe('SectionDetail', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionById).mockReturnValue({
-      data: mockSectionData as any,
+    mockGetSectionById({
+      data: mockSectionData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
-      data: { user: { id: 'user-1', userGroups: [] } } as any,
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
       isLoading: false,
       isError: false,
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue({
-      data: mockEventsData as any,
+    mockGetEventsForSection({
+      data: mockEventsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useGetEventById).mockReturnValue({
-      data: mockEventDetailData as any,
+    mockGetEventById({
+      data: mockEventDetailData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     renderSectionDetail();
 

--- a/src/features/sections/components/__tests__/SectionsList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionsList.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../../../test-utils';
 import SectionsList from '../SectionsList';
 import * as reactGenerated from '@dataconnect/generated/react';
+import {
+  dataConnectQueryResult,
+  type DataConnectQueryResultOverrides,
+} from '../../../../test-utils/dataConnectMocks';
 
 // Mock the DataConnect hooks
 vi.mock('@dataconnect/generated/react', () => ({
@@ -25,6 +29,18 @@ vi.mock('../../../users/hooks/useAdminClaim', () => ({
   useAdminClaim: vi.fn(() => false),
 }));
 
+function mockGetSectionsForUser(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetSectionsForUser>(overrides)
+  );
+}
+
+function mockListSections(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useListSections).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useListSections>(overrides)
+  );
+}
+
 describe('SectionsList', () => {
   const mockOnBack = vi.fn();
   const mockOnSelectSection = vi.fn();
@@ -36,19 +52,17 @@ describe('SectionsList', () => {
   });
 
   it('should render loading state', () => {
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
+    mockGetSectionsForUser({
       data: undefined,
       isLoading: true,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -57,19 +71,17 @@ describe('SectionsList', () => {
   });
 
   it('should render error state', () => {
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
+    mockGetSectionsForUser({
       data: undefined,
       isLoading: false,
       isError: true,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -103,19 +115,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -153,19 +163,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -209,19 +217,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -235,7 +241,7 @@ describe('SectionsList', () => {
     const useAdminClaimModule = await import('../../../users/hooks/useAdminClaim');
     vi.mocked(useAdminClaimModule.useAdminClaim).mockReturnValue(true);
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: {
         sections: [
           {
@@ -245,11 +251,10 @@ describe('SectionsList', () => {
             description: 'Admin description',
           },
         ],
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
@@ -293,19 +298,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
@@ -349,19 +352,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
@@ -404,19 +405,17 @@ describe('SectionsList', () => {
       },
     };
 
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
-      data: mockSectionsData as any,
+    mockGetSectionsForUser({
+      data: mockSectionsData,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
@@ -434,24 +433,22 @@ describe('SectionsList', () => {
   });
 
   it('should show empty state when no sections available', async () => {
-    vi.mocked(reactGenerated.useGetSectionsForUser).mockReturnValue({
+    mockGetSectionsForUser({
       data: {
         user: {
           id: 'user-1',
           userGroups: [],
         },
-      } as any,
+      },
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
     
-    vi.mocked(reactGenerated.useListSections).mockReturnValue({
+    mockListSections({
       data: undefined,
       isLoading: false,
       isError: false,
-      refetch: vi.fn(),
-    } as any);
+    });
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 

--- a/src/test-utils/dataConnectMocks.ts
+++ b/src/test-utils/dataConnectMocks.ts
@@ -1,0 +1,20 @@
+import { vi } from "vitest";
+
+export interface DataConnectQueryResultOverrides {
+  data?: unknown;
+  isLoading?: boolean;
+  isError?: boolean;
+  refetch?: ReturnType<typeof vi.fn>;
+}
+
+export function dataConnectQueryResult<THook extends (...args: never[]) => unknown>(
+  overrides: DataConnectQueryResultOverrides = {}
+): ReturnType<THook> {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+    ...overrides,
+  } as ReturnType<THook>;
+}


### PR DESCRIPTION
## Summary
- Add a shared Data Connect query mock helper for tests.
- Replace repeated `as any` Data Connect hook return mocks in the high-churn section/admin tests.
- Keep unavoidable generated return type casting isolated in the shared helper.

## Test plan
- `env -u npm_config_devdir npm run test:run -- SectionDetail SectionsList SectionEventsManager --run`
- `env -u npm_config_devdir npm run build`

Closes #95.

Made with [Cursor](https://cursor.com)