### PR TITLE
Split SectionDetail member and event views

### DIFF
--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -1,18 +1,9 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
 import {
   Box,
-  Typography,
   Alert,
   CircularProgress,
   Button,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Chip,
   Snackbar,
 } from "@mui/material";
 import { useGetSectionById, useGetUserAccessGroups, useGetEventsForSection, useGetEventById } from "@dataconnect/generated/react";
@@ -20,25 +11,27 @@ import { dataConnect } from "../../../config/firebase";
 import { executeMutation } from "firebase/data-connect";
 import { colors } from "../../../config/colors";
 import PageHeader from "../../../shared/components/PageHeader";
-import SearchBar from "../../../shared/components/SearchBar";
-import PaginationDisplay from "../../../shared/components/PaginationDisplay";
 import {
   getMemberGroups,
   canUserSubscribe,
   isUserMember,
   isMembersSection,
 } from "../utils/sectionHelpers";
-import EventBookingWizard from "./EventBookingWizard";
 import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
-import { ROUTES } from "../../../constants";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { useNavigate } from "react-router-dom";
 import { createTicketCheckoutSession, getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
-import type { GetSectionByIdData, UUIDString } from "@dataconnect/generated";
-import { TicketAudience } from "@dataconnect/generated";
+import type { UUIDString } from "@dataconnect/generated";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import "../../../shared/components/PageContainer.css";
+import { getSectionAdminDestination } from "../utils/sectionDetailAdminNavigation";
+import {
+  SectionEventDetailView,
+  SectionEventsListView,
+  SectionInformationView,
+  SectionMembersView,
+} from "./SectionDetailViews";
 
 interface SectionDetailProps {
   sectionId: string;
@@ -338,316 +331,68 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
 
   const section = sectionData.section;
   const isMembers = isMembersSection(section as any);
+  const hasSubscribableMemberGroup = memberGroups.some((group) => group.subscribable === true);
+  const eventRows = eventsData?.section?.events ?? [];
   const sectionAdminAction = {
     visible: Boolean(currentUser && (isAdmin || canModerateSection)),
     onClick: () => {
-      if (isMembers) {
-        navigate(ROUTES.MANAGE_SECTIONS, {
-          state: { editSectionId: section.id },
-        });
-        return;
-      }
-
-      navigate(ROUTES.MANAGE_SECTIONS, {
-        state: {
-          managedSection: {
-            id: section.id,
-            name: section.name,
-          },
-          eventId: selectedEventId ?? undefined,
-        },
-      });
+      const destination = getSectionAdminDestination(section, isMembers, selectedEventId);
+      navigate(destination.to, { state: destination.state });
     },
   };
 
   return (
     <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
       <PageHeader title={section.name} onBack={onBack} adminAction={sectionAdminAction} />
-      
-      <Box sx={{ mt: 3, mb: 3 }}>
-        <Typography variant="h6" sx={{ mb: 1 }}>
-          Section Information
-        </Typography>
-        <Box sx={{ display: "flex", gap: 2, alignItems: "center", mb: 2 }}>
-          <Chip
-            label={section.type}
-            size="small"
-            color={section.type === "MEMBERS" ? "primary" : "secondary"}
-          />
-          {section.description && (
-            <Typography variant="body2" color="text.secondary">
-              {section.description}
-            </Typography>
-          )}
-        </Box>
-        
-        {/* Subscribe/Unsubscribe button */}
-        {isMembers && currentUser && (
-          <Box sx={{ mt: 2 }}>
-            {canSubscribe && (
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={handleSubscribe}
-                disabled={subscribing}
-                sx={{ backgroundColor: colors.callToAction }}
-              >
-                {subscribing ? "Subscribing..." : "Subscribe"}
-              </Button>
-            )}
-            {userIsMember && memberGroups.some((g) => g.subscribable === true) && (
-              <Button
-                variant="outlined"
-                color="error"
-                onClick={handleUnsubscribe}
-                disabled={subscribing}
-                sx={{ ml: 2 }}
-              >
-                {subscribing ? "Unsubscribing..." : "Unsubscribe"}
-              </Button>
-            )}
-          </Box>
-        )}
-      </Box>
+
+      <SectionInformationView
+        section={section}
+        isMembers={isMembers}
+        hasCurrentUser={Boolean(currentUser)}
+        canSubscribe={canSubscribe}
+        userIsMember={userIsMember}
+        hasSubscribableMemberGroup={hasSubscribableMemberGroup}
+        subscribing={subscribing}
+        onSubscribe={handleSubscribe}
+        onUnsubscribe={handleUnsubscribe}
+      />
 
       {isMembers ? (
-        <>
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            Members ({allMembers.length})
-          </Typography>
-          <SearchBar
-            value={searchTerm}
-            onChange={setSearchTerm}
-            onRefresh={() => refetchSection()}
-            loading={loadingSection}
-            label="Search members"
-            placeholder="Search by name or email..."
-          />
-          {filteredMembers.length === 0 ? (
-            <Alert severity="info" sx={{ mt: 2 }}>
-              {searchTerm ? "No members match your search." : "No members in this section."}
-            </Alert>
-          ) : (
-            <>
-              <Typography variant="body2" sx={{ mt: 2, mb: 2, color: colors.titleSecondary }}>
-                Showing {paginatedMembers.length} of {filteredMembers.length} {searchTerm ? "filtered " : ""}members
-                {totalPages > 1 && ` (page ${page} of ${totalPages})`}
-              </Typography>
-              <TableContainer component={Paper} sx={{ mt: 2 }}>
-                <Table>
-                  <TableHead>
-                    <TableRow>
-                      <TableCell>Name</TableCell>
-                      <TableCell>Email</TableCell>
-                      <TableCell>Membership Status</TableCell>
-                    </TableRow>
-                  </TableHead>
-                  <TableBody>
-                    {paginatedMembers.map((member) => (
-                      <TableRow key={member.userId}>
-                        <TableCell>
-                          <Typography variant="body1">
-                            {member.firstName} {member.lastName}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Typography variant="body2" color="text.secondary">
-                            {member.email}
-                          </Typography>
-                        </TableCell>
-                        <TableCell>
-                          <Chip label={member.membershipStatus} size="small" />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </TableContainer>
-              <PaginationDisplay
-                page={page}
-                totalPages={totalPages}
-                onChange={(newPage) => setPage(newPage)}
-              />
-            </>
-          )}
-        </>
+        <SectionMembersView
+          allMembersCount={allMembers.length}
+          filteredMembers={filteredMembers}
+          paginatedMembers={paginatedMembers}
+          searchTerm={searchTerm}
+          page={page}
+          totalPages={totalPages}
+          loading={loadingSection}
+          onSearchTermChange={setSearchTerm}
+          onRefresh={() => refetchSection()}
+          onPageChange={setPage}
+        />
       ) : selectedEventId ? (
-        <Box sx={{ mt: 2 }}>
-          <Button size="small" onClick={() => setSelectedEventId(null)} sx={{ mb: 2 }}>
-            Back to events
-          </Button>
-          {loadingEventDetail ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-              <CircularProgress />
-            </Box>
-          ) : errorEventDetail ? (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              Failed to load event.{" "}
-              <Button size="small" onClick={() => refetchEventDetail()}>
-                Retry
-              </Button>
-            </Alert>
-          ) : !eventDetailData?.event ? (
-            <Alert severity="info">Event not found.</Alert>
-          ) : (
-            <>
-              <Typography variant="h6" sx={{ mb: 2 }}>
-                {eventDetailData.event.title}
-              </Typography>
-              <Box component="dl" sx={{ "& dd": { m: 0 }, "& dt": { fontWeight: 500, mt: 1 } }}>
-                <Typography component="dt" variant="body2">Date / time</Typography>
-                <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                  {new Date(eventDetailData.event.startDateTime).toLocaleString()} –{" "}
-                  {new Date(eventDetailData.event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                </Typography>
-                <Typography component="dt" variant="body2">Location</Typography>
-                <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                  {eventDetailData.event.location || "—"}
-                </Typography>
-                <Typography component="dt" variant="body2">Guest of honour</Typography>
-                <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                  {eventDetailData.event.guestOfHonour || "—"}
-                </Typography>
-                <Typography component="dt" variant="body2">Booking window</Typography>
-                <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                  {new Date(eventDetailData.event.bookingStartDateTime).toLocaleString()} –{" "}
-                  {new Date(eventDetailData.event.bookingEndDateTime).toLocaleString()}
-                </Typography>
-                <Typography component="dt" variant="body2">Max guests without moderator approval</Typography>
-                <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-                  {eventDetailData.event.maxGuestsWithoutModeratorApproval != null
-                    ? String(eventDetailData.event.maxGuestsWithoutModeratorApproval)
-                    : "—"}
-                </Typography>
-              </Box>
-              <Typography variant="subtitle2" sx={{ mb: 1 }}>Ticket types</Typography>
-              {!eventDetailData.event.ticketTypes?.length ? (
-                <Typography variant="body2" color="text.secondary">No ticket types.</Typography>
-              ) : (
-                <TableContainer component={Paper}>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Title</TableCell>
-                        <TableCell>Description</TableCell>
-                        <TableCell>Price</TableCell>
-                        <TableCell>Audience</TableCell>
-                        <TableCell>User group</TableCell>
-                        <TableCell align="right">Purchase</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {eventDetailData.event.ticketTypes.map((tt) => (
-                        <TableRow key={tt.id}>
-                          <TableCell>{tt.title}</TableCell>
-                          <TableCell>{tt.description ?? "—"}</TableCell>
-                          <TableCell>{tt.price}</TableCell>
-                          <TableCell>{tt.audience === TicketAudience.GUEST ? "Guest" : "Member"}</TableCell>
-                          <TableCell>{tt.userGroup?.name ?? "—"}</TableCell>
-                          <TableCell align="right">
-                            {currentUser && tt.audience === TicketAudience.MEMBER ? (
-                              <Button
-                                size="small"
-                                variant="contained"
-                                disabled={startingCheckoutId === tt.id}
-                                onClick={() => void handleStartCheckout(tt.id)}
-                                sx={{ backgroundColor: colors.callToAction }}
-                              >
-                                {startingCheckoutId === tt.id ? "Starting..." : "Pay"}
-                              </Button>
-                            ) : (
-                              "—"
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
-              )}
-              {currentUser && (
-                <EventBookingWizard
-                  section={section as NonNullable<GetSectionByIdData["section"]>}
-                  event={eventDetailData.event}
-                  onBookingComplete={() => {
-                    void refetchEventDetail();
-                  }}
-                />
-              )}
-            </>
-          )}
-        </Box>
+        <SectionEventDetailView
+          section={section}
+          event={eventDetailData?.event ?? null}
+          loading={loadingEventDetail}
+          isError={errorEventDetail}
+          hasCurrentUser={Boolean(currentUser)}
+          startingCheckoutId={startingCheckoutId}
+          onBackToEvents={() => setSelectedEventId(null)}
+          onRetry={() => refetchEventDetail()}
+          onStartCheckout={(ticketTypeId) => void handleStartCheckout(ticketTypeId)}
+          onBookingComplete={() => {
+            void refetchEventDetail();
+          }}
+        />
       ) : (
-        <Box sx={{ mt: 2 }}>
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            Events
-          </Typography>
-          {loadingEvents ? (
-            <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-              <CircularProgress />
-            </Box>
-          ) : errorEvents ? (
-            <Alert severity="error" sx={{ mt: 2 }}>
-              Failed to load events.{" "}
-              <Button size="small" onClick={() => refetchEvents()}>
-                Retry
-              </Button>
-            </Alert>
-          ) : !eventsData?.section?.events?.length ? (
-            <Alert severity="info">No events yet.</Alert>
-          ) : (
-            <TableContainer component={Paper}>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Title</TableCell>
-                    <TableCell>Date / time</TableCell>
-                    <TableCell>Location</TableCell>
-                    <TableCell>Guest of honour</TableCell>
-                    <TableCell />
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {eventsData.section.events.map((ev) => (
-                    <TableRow
-                      key={ev.id}
-                      hover
-                      sx={{ cursor: "pointer" }}
-                      onClick={() => setSelectedEventId(ev.id)}
-                    >
-                      <TableCell>
-                        <Typography variant="body2" fontWeight={500}>
-                          {ev.title}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2" color="text.secondary">
-                          {new Date(ev.startDateTime).toLocaleString()} –{" "}
-                          {new Date(ev.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2" color="text.secondary">
-                          {ev.location || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2" color="text.secondary">
-                          {ev.guestOfHonour || "—"}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Button size="small" onClick={(e) => { e.stopPropagation(); setSelectedEventId(ev.id); }}>
-                          View
-                        </Button>
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-        </Box>
+        <SectionEventsListView
+          events={eventRows}
+          loading={loadingEvents}
+          isError={errorEvents}
+          onRetry={() => refetchEvents()}
+          onSelectEvent={setSelectedEventId}
+        />
       )}
 
       <Snackbar

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -1,0 +1,423 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { TicketAudience, type GetEventByIdData, type GetEventsForSectionData, type GetSectionByIdData } from "@dataconnect/generated";
+import { colors } from "../../../config/colors";
+import PaginationDisplay from "../../../shared/components/PaginationDisplay";
+import SearchBar from "../../../shared/components/SearchBar";
+import type { SectionMember } from "../utils/sectionHelpers";
+import EventBookingWizard from "./EventBookingWizard";
+
+type SectionDetailSection = NonNullable<GetSectionByIdData["section"]>;
+type SectionEventRow = NonNullable<NonNullable<GetEventsForSectionData["section"]>["events"]>[number];
+type SectionEventDetail = NonNullable<GetEventByIdData["event"]>;
+
+interface SectionInformationViewProps {
+  section: SectionDetailSection;
+  isMembers: boolean;
+  hasCurrentUser: boolean;
+  canSubscribe: boolean;
+  userIsMember: boolean;
+  hasSubscribableMemberGroup: boolean;
+  subscribing: boolean;
+  onSubscribe: () => void;
+  onUnsubscribe: () => void;
+}
+
+export function SectionInformationView({
+  section,
+  isMembers,
+  hasCurrentUser,
+  canSubscribe,
+  userIsMember,
+  hasSubscribableMemberGroup,
+  subscribing,
+  onSubscribe,
+  onUnsubscribe,
+}: SectionInformationViewProps) {
+  return (
+    <Box sx={{ mt: 3, mb: 3 }}>
+      <Typography variant="h6" sx={{ mb: 1 }}>
+        Section Information
+      </Typography>
+      <Box sx={{ display: "flex", gap: 2, alignItems: "center", mb: 2 }}>
+        <Chip
+          label={section.type}
+          size="small"
+          color={section.type === "MEMBERS" ? "primary" : "secondary"}
+        />
+        {section.description && (
+          <Typography variant="body2" color="text.secondary">
+            {section.description}
+          </Typography>
+        )}
+      </Box>
+
+      {isMembers && hasCurrentUser && (
+        <Box sx={{ mt: 2 }}>
+          {canSubscribe && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={onSubscribe}
+              disabled={subscribing}
+              sx={{ backgroundColor: colors.callToAction }}
+            >
+              {subscribing ? "Subscribing..." : "Subscribe"}
+            </Button>
+          )}
+          {userIsMember && hasSubscribableMemberGroup && (
+            <Button
+              variant="outlined"
+              color="error"
+              onClick={onUnsubscribe}
+              disabled={subscribing}
+              sx={{ ml: 2 }}
+            >
+              {subscribing ? "Unsubscribing..." : "Unsubscribe"}
+            </Button>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+interface SectionMembersViewProps {
+  allMembersCount: number;
+  filteredMembers: SectionMember[];
+  paginatedMembers: SectionMember[];
+  searchTerm: string;
+  page: number;
+  totalPages: number;
+  loading: boolean;
+  onSearchTermChange: (value: string) => void;
+  onRefresh: () => void;
+  onPageChange: (page: number) => void;
+}
+
+export function SectionMembersView({
+  allMembersCount,
+  filteredMembers,
+  paginatedMembers,
+  searchTerm,
+  page,
+  totalPages,
+  loading,
+  onSearchTermChange,
+  onRefresh,
+  onPageChange,
+}: SectionMembersViewProps) {
+  return (
+    <>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Members ({allMembersCount})
+      </Typography>
+      <SearchBar
+        value={searchTerm}
+        onChange={onSearchTermChange}
+        onRefresh={onRefresh}
+        loading={loading}
+        label="Search members"
+        placeholder="Search by name or email..."
+      />
+      {filteredMembers.length === 0 ? (
+        <Alert severity="info" sx={{ mt: 2 }}>
+          {searchTerm ? "No members match your search." : "No members in this section."}
+        </Alert>
+      ) : (
+        <>
+          <Typography variant="body2" sx={{ mt: 2, mb: 2, color: colors.titleSecondary }}>
+            Showing {paginatedMembers.length} of {filteredMembers.length} {searchTerm ? "filtered " : ""}members
+            {totalPages > 1 && ` (page ${page} of ${totalPages})`}
+          </Typography>
+          <TableContainer component={Paper} sx={{ mt: 2 }}>
+            <Table>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Email</TableCell>
+                  <TableCell>Membership Status</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {paginatedMembers.map((member) => (
+                  <TableRow key={member.userId}>
+                    <TableCell>
+                      <Typography variant="body1">
+                        {member.firstName} {member.lastName}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {member.email}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Chip label={member.membershipStatus} size="small" />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <PaginationDisplay page={page} totalPages={totalPages} onChange={onPageChange} />
+        </>
+      )}
+    </>
+  );
+}
+
+interface SectionEventsListViewProps {
+  events: SectionEventRow[];
+  loading: boolean;
+  isError: boolean;
+  onRetry: () => void;
+  onSelectEvent: (eventId: string) => void;
+}
+
+export function SectionEventsListView({
+  events,
+  loading,
+  isError,
+  onRetry,
+  onSelectEvent,
+}: SectionEventsListViewProps) {
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Events
+      </Typography>
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress />
+        </Box>
+      ) : isError ? (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          Failed to load events.{" "}
+          <Button size="small" onClick={onRetry}>
+            Retry
+          </Button>
+        </Alert>
+      ) : !events.length ? (
+        <Alert severity="info">No events yet.</Alert>
+      ) : (
+        <TableContainer component={Paper}>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Title</TableCell>
+                <TableCell>Date / time</TableCell>
+                <TableCell>Location</TableCell>
+                <TableCell>Guest of honour</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {events.map((event) => (
+                <TableRow
+                  key={event.id}
+                  hover
+                  sx={{ cursor: "pointer" }}
+                  onClick={() => onSelectEvent(event.id)}
+                >
+                  <TableCell>
+                    <Typography variant="body2" fontWeight={500}>
+                      {event.title}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {new Date(event.startDateTime).toLocaleString()} -{" "}
+                      {new Date(event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {event.location || "-"}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Typography variant="body2" color="text.secondary">
+                      {event.guestOfHonour || "-"}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      size="small"
+                      onClick={(clickEvent) => {
+                        clickEvent.stopPropagation();
+                        onSelectEvent(event.id);
+                      }}
+                    >
+                      View
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+}
+
+interface SectionEventDetailViewProps {
+  section: SectionDetailSection;
+  event: SectionEventDetail | null;
+  loading: boolean;
+  isError: boolean;
+  hasCurrentUser: boolean;
+  startingCheckoutId: string | null;
+  onBackToEvents: () => void;
+  onRetry: () => void;
+  onStartCheckout: (ticketTypeId: string) => void;
+  onBookingComplete: () => void;
+}
+
+export function SectionEventDetailView({
+  section,
+  event,
+  loading,
+  isError,
+  hasCurrentUser,
+  startingCheckoutId,
+  onBackToEvents,
+  onRetry,
+  onStartCheckout,
+  onBookingComplete,
+}: SectionEventDetailViewProps) {
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Button size="small" onClick={onBackToEvents} sx={{ mb: 2 }}>
+        Back to events
+      </Button>
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress />
+        </Box>
+      ) : isError ? (
+        <Alert severity="error" sx={{ mt: 2 }}>
+          Failed to load event.{" "}
+          <Button size="small" onClick={onRetry}>
+            Retry
+          </Button>
+        </Alert>
+      ) : !event ? (
+        <Alert severity="info">Event not found.</Alert>
+      ) : (
+        <>
+          <Typography variant="h6" sx={{ mb: 2 }}>
+            {event.title}
+          </Typography>
+          <Box component="dl" sx={{ "& dd": { m: 0 }, "& dt": { fontWeight: 500, mt: 1 } }}>
+            <Typography component="dt" variant="body2">
+              Date / time
+            </Typography>
+            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {new Date(event.startDateTime).toLocaleString()} -{" "}
+              {new Date(event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            </Typography>
+            <Typography component="dt" variant="body2">
+              Location
+            </Typography>
+            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {event.location || "-"}
+            </Typography>
+            <Typography component="dt" variant="body2">
+              Guest of honour
+            </Typography>
+            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {event.guestOfHonour || "-"}
+            </Typography>
+            <Typography component="dt" variant="body2">
+              Booking window
+            </Typography>
+            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {new Date(event.bookingStartDateTime).toLocaleString()} -{" "}
+              {new Date(event.bookingEndDateTime).toLocaleString()}
+            </Typography>
+            <Typography component="dt" variant="body2">
+              Max guests without moderator approval
+            </Typography>
+            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+              {event.maxGuestsWithoutModeratorApproval != null
+                ? String(event.maxGuestsWithoutModeratorApproval)
+                : "-"}
+            </Typography>
+          </Box>
+          <Typography variant="subtitle2" sx={{ mb: 1 }}>
+            Ticket types
+          </Typography>
+          {!event.ticketTypes?.length ? (
+            <Typography variant="body2" color="text.secondary">
+              No ticket types.
+            </Typography>
+          ) : (
+            <TableContainer component={Paper}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Title</TableCell>
+                    <TableCell>Description</TableCell>
+                    <TableCell>Price</TableCell>
+                    <TableCell>Audience</TableCell>
+                    <TableCell>User group</TableCell>
+                    <TableCell align="right">Purchase</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {event.ticketTypes.map((ticketType) => (
+                    <TableRow key={ticketType.id}>
+                      <TableCell>{ticketType.title}</TableCell>
+                      <TableCell>{ticketType.description ?? "-"}</TableCell>
+                      <TableCell>{ticketType.price}</TableCell>
+                      <TableCell>{ticketType.audience === TicketAudience.GUEST ? "Guest" : "Member"}</TableCell>
+                      <TableCell>{ticketType.userGroup?.name ?? "-"}</TableCell>
+                      <TableCell align="right">
+                        {hasCurrentUser && ticketType.audience === TicketAudience.MEMBER ? (
+                          <Button
+                            size="small"
+                            variant="contained"
+                            disabled={startingCheckoutId === ticketType.id}
+                            onClick={() => onStartCheckout(ticketType.id)}
+                            sx={{ backgroundColor: colors.callToAction }}
+                          >
+                            {startingCheckoutId === ticketType.id ? "Starting..." : "Pay"}
+                          </Button>
+                        ) : (
+                          "-"
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+          {hasCurrentUser && (
+            <EventBookingWizard
+              section={section}
+              event={event}
+              onBookingComplete={onBookingComplete}
+            />
+          )}
+        </>
+      )}
+    </Box>
+  );
+}
+

--- a/src/features/sections/utils/__tests__/sectionDetailAdminNavigation.test.ts
+++ b/src/features/sections/utils/__tests__/sectionDetailAdminNavigation.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { ROUTES } from "../../../../constants";
+import { getSectionAdminDestination } from "../sectionDetailAdminNavigation";
+
+describe("getSectionAdminDestination", () => {
+  it("routes member sections to the section edit dialog", () => {
+    expect(
+      getSectionAdminDestination({ id: "section-1", name: "Members" }, true, null)
+    ).toEqual({
+      to: ROUTES.MANAGE_SECTIONS,
+      state: { editSectionId: "section-1" },
+    });
+  });
+
+  it("routes event sections to event administration with selected event context", () => {
+    expect(
+      getSectionAdminDestination({ id: "section-2", name: "Events" }, false, "event-1")
+    ).toEqual({
+      to: ROUTES.MANAGE_SECTIONS,
+      state: {
+        managedSection: {
+          id: "section-2",
+          name: "Events",
+        },
+        eventId: "event-1",
+      },
+    });
+  });
+});

--- a/src/features/sections/utils/sectionDetailAdminNavigation.ts
+++ b/src/features/sections/utils/sectionDetailAdminNavigation.ts
@@ -1,0 +1,30 @@
+import { ROUTES } from "../../../constants";
+
+interface SectionAdminNavigationSection {
+  id: string;
+  name: string;
+}
+
+export function getSectionAdminDestination(
+  section: SectionAdminNavigationSection,
+  isMembers: boolean,
+  selectedEventId: string | null
+) {
+  if (isMembers) {
+    return {
+      to: ROUTES.MANAGE_SECTIONS,
+      state: { editSectionId: section.id },
+    };
+  }
+
+  return {
+    to: ROUTES.MANAGE_SECTIONS,
+    state: {
+      managedSection: {
+        id: section.id,
+        name: section.name,
+      },
+      eventId: selectedEventId ?? undefined,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extract section information, member directory, event list, and event detail rendering into dedicated SectionDetail views.
- Keep SectionDetail focused on data orchestration, selected event state, subscription actions, and checkout handling.
- Move admin route-state derivation into a small helper with focused tests.

Closes #115

## Test plan
- `npm_config_loglevel=error npm run test:run -- SectionDetail sectionDetailAdminNavigation --run`
- `npm_config_loglevel=error node .github/scripts/fail-on-warning-output.mjs -- npm run lint`
- `npm_config_loglevel=error node .github/scripts/fail-on-warning-output.mjs -- npm run build`

Made with [Cursor](https://cursor.com)