### PR TITLE
Enhance event admin surface

### DIFF
--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -372,14 +372,29 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
 
   if (ticketTypesEventId) {
     const event = events.find((e) => e.id === ticketTypesEventId);
+    const eventForAdmin: EventRow | null = eventDetailData?.event
+      ? {
+          id: eventDetailData.event.id,
+          title: eventDetailData.event.title,
+          location: eventDetailData.event.location,
+          guestOfHonour: eventDetailData.event.guestOfHonour,
+          startDateTime: eventDetailData.event.startDateTime,
+          endDateTime: eventDetailData.event.endDateTime,
+          bookingStartDateTime: eventDetailData.event.bookingStartDateTime,
+          bookingEndDateTime: eventDetailData.event.bookingEndDateTime,
+          maxGuestsWithoutModeratorApproval: eventDetailData.event.maxGuestsWithoutModeratorApproval,
+        }
+      : event ?? null;
     const ticketTypes = eventDetailData?.event?.ticketTypes ?? [];
     return (
       <Box className="page-container" sx={{ backgroundColor: "#fafafa", minHeight: "100vh" }}>
         <TicketAdminSurface
-          eventTitle={event?.title ?? "Event"}
+          event={eventForAdmin}
+          eventTitle={eventForAdmin?.title ?? "Event"}
           error={error}
           onDismissError={() => setError(null)}
           onBack={() => setTicketTypesEventId(null)}
+          onEditEvent={openEventDialog}
           onAddTicketType={() => openTicketTypeDialog()}
           loadingEventDetail={loadingEventDetail}
           ticketTypes={ticketTypes}
@@ -423,6 +438,30 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           onAudienceChange={setTtAudience}
           onAccessGroupChange={setTtAccessGroup}
         />
+
+        <EventDialogSurface
+          open={eventDialogOpen}
+          editingEvent={editingEvent}
+          title={title}
+          location={location}
+          guestOfHonour={guestOfHonour}
+          startDateTime={startDateTime}
+          endDateTime={endDateTime}
+          bookingStartDateTime={bookingStartDateTime}
+          bookingEndDateTime={bookingEndDateTime}
+          maxGuestsStr={maxGuestsStr}
+          submitting={submitting}
+          onClose={() => setEventDialogOpen(false)}
+          onSubmit={handleEventSubmit}
+          onTitleChange={setTitle}
+          onLocationChange={setLocation}
+          onGuestOfHonourChange={setGuestOfHonour}
+          onStartDateTimeChange={setStartDateTime}
+          onEndDateTimeChange={setEndDateTime}
+          onBookingStartDateTimeChange={setBookingStartDateTime}
+          onBookingEndDateTimeChange={setBookingEndDateTime}
+          onMaxGuestsChange={setMaxGuestsStr}
+        />
       </Box>
     );
   }
@@ -439,8 +478,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
         errorEvents={errorEvents}
         events={events}
         deletingEventId={deletingEventId}
-        onManageTicketTypes={setTicketTypesEventId}
-        onEditEvent={openEventDialog}
+        onManageEventAdmin={setTicketTypesEventId}
         onDeleteEvent={(event) => void handleDeleteEvent(event)}
       />
 

--- a/src/features/admin/components/SectionEventsManagerSurfaces.tsx
+++ b/src/features/admin/components/SectionEventsManagerSurfaces.tsx
@@ -1,4 +1,7 @@
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Alert,
   Autocomplete,
   Box,
@@ -23,7 +26,13 @@ import {
   TableRow,
   TextField,
 } from "@mui/material";
-import { Add as AddIcon, ConfirmationNumber as TicketIcon, Delete as DeleteIcon, Edit as EditIcon } from "@mui/icons-material";
+import type { ReactNode } from "react";
+import {
+  Add as AddIcon,
+  Delete as DeleteIcon,
+  Edit as EditIcon,
+  ExpandMore as ExpandMoreIcon,
+} from "@mui/icons-material";
 import { GuestTicketRequestStatus, TicketAudience } from "@dataconnect/generated";
 import PageHeader from "../../../shared/components/PageHeader";
 import type {
@@ -45,8 +54,7 @@ interface EventListSurfaceProps {
   errorEvents: boolean;
   events: EventRow[];
   deletingEventId: string | null;
-  onManageTicketTypes: (eventId: string) => void;
-  onEditEvent: (event: EventRow) => void;
+  onManageEventAdmin: (eventId: string) => void;
   onDeleteEvent: (event: EventRow) => void;
 }
 
@@ -60,8 +68,7 @@ export function EventListSurface({
   errorEvents,
   events,
   deletingEventId,
-  onManageTicketTypes,
-  onEditEvent,
+  onManageEventAdmin,
   onDeleteEvent,
 }: EventListSurfaceProps) {
   return (
@@ -82,8 +89,7 @@ export function EventListSurface({
       ) : events.length === 0 ? (
         <Alert severity="info">No events yet. Add one to get started.</Alert>
       ) : (
-        <TableContainer component={Paper}>
-          <Table size="small">
+        <AdminTable>
             <TableHead>
               <TableRow>
                 <TableCell>Title</TableCell>
@@ -104,12 +110,14 @@ export function EventListSurface({
                   <TableCell>{event.location ?? "—"}</TableCell>
                   <TableCell>{event.guestOfHonour ?? "—"}</TableCell>
                   <TableCell align="right">
-                    <Button size="small" startIcon={<TicketIcon />} onClick={() => onManageTicketTypes(event.id)}>
-                      Ticket types
+                    <Button
+                      size="small"
+                      variant="outlined"
+                      onClick={() => onManageEventAdmin(event.id)}
+                      sx={{ mr: 1 }}
+                    >
+                      Event admin
                     </Button>
-                    <IconButton size="small" onClick={() => onEditEvent(event)}>
-                      <EditIcon />
-                    </IconButton>
                     <IconButton
                       size="small"
                       color="error"
@@ -122,8 +130,7 @@ export function EventListSurface({
                 </TableRow>
               ))}
             </TableBody>
-          </Table>
-        </TableContainer>
+        </AdminTable>
       )}
     </>
   );
@@ -247,10 +254,12 @@ export function EventDialogSurface({
 }
 
 interface TicketAdminSurfaceProps {
+  event: EventRow | null;
   eventTitle: string;
   error: string | null;
   onDismissError: () => void;
   onBack: () => void;
+  onEditEvent: (event: EventRow) => void;
   onAddTicketType: () => void;
   loadingEventDetail: boolean;
   ticketTypes: TicketTypeRow[];
@@ -275,10 +284,12 @@ interface TicketAdminSurfaceProps {
 }
 
 export function TicketAdminSurface({
+  event,
   eventTitle,
   error,
   onDismissError,
   onBack,
+  onEditEvent,
   onAddTicketType,
   loadingEventDetail,
   ticketTypes,
@@ -300,35 +311,229 @@ export function TicketAdminSurface({
 }: TicketAdminSurfaceProps) {
   return (
     <>
-      <PageHeader title={`Ticket types: ${eventTitle}`} onBack={onBack} />
+      <PageHeader title={`Event admin: ${eventTitle}`} onBack={onBack} />
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={onDismissError}>
           {error}
         </Alert>
       )}
-      <Button startIcon={<AddIcon />} variant="contained" onClick={onAddTicketType} sx={{ mb: 2 }}>
-        Add ticket type
-      </Button>
-      <TicketTypesTable
-        loading={loadingEventDetail}
-        ticketTypes={ticketTypes}
-        deletingTicketTypeId={deletingTicketTypeId}
-        onEdit={onEditTicketType}
-        onDelete={onDeleteTicketType}
-      />
-      <GuestTicketRequestsSection
-        filter={requestStatusFilter}
-        onFilterChange={onRequestStatusFilterChange}
-        loading={loadingGuestRequests}
-        requests={guestRequests}
-        moderatorNoteDraft={moderatorNoteDraft}
-        onModeratorNoteChange={onModeratorNoteChange}
-        reviewingRequestId={reviewingRequestId}
-        onReview={onReviewRequest}
-      />
-      <BookingAuditSection loading={loadingEventBookings} bookings={eventBookings} />
-      <PaymentActivitySection loading={loadingTicketOrders} ticketOrders={ticketOrders} />
+      <AdminAccordion title="Event details">
+        <EventDetailsSection event={event} loading={loadingEventDetail} onEditEvent={onEditEvent} />
+      </AdminAccordion>
+      <AdminAccordion title="Ticket types">
+        <Button startIcon={<AddIcon />} variant="contained" onClick={onAddTicketType} sx={{ mb: 2 }}>
+          Add ticket type
+        </Button>
+        <TicketTypesTable
+          loading={loadingEventDetail}
+          ticketTypes={ticketTypes}
+          deletingTicketTypeId={deletingTicketTypeId}
+          onEdit={onEditTicketType}
+          onDelete={onDeleteTicketType}
+        />
+      </AdminAccordion>
+      <AdminAccordion title="Guest ticket requests">
+        <GuestTicketRequestsSection
+          filter={requestStatusFilter}
+          onFilterChange={onRequestStatusFilterChange}
+          loading={loadingGuestRequests}
+          requests={guestRequests}
+          moderatorNoteDraft={moderatorNoteDraft}
+          onModeratorNoteChange={onModeratorNoteChange}
+          reviewingRequestId={reviewingRequestId}
+          onReview={onReviewRequest}
+        />
+      </AdminAccordion>
+      <AdminAccordion title="Booking audit activity">
+        <BookingAuditSection loading={loadingEventBookings} bookings={eventBookings} />
+      </AdminAccordion>
+      <AdminAccordion title="Payment status activity">
+        <PaymentActivitySection loading={loadingTicketOrders} ticketOrders={ticketOrders} />
+      </AdminAccordion>
     </>
+  );
+}
+
+function AdminAccordion({
+  title,
+  defaultExpanded = false,
+  children,
+}: {
+  title: string;
+  defaultExpanded?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <Accordion
+      defaultExpanded={defaultExpanded}
+      disableGutters
+      sx={{
+        mb: 2,
+        border: "1px solid",
+        borderColor: "divider",
+        borderRadius: "12px !important",
+        boxShadow: "0 10px 28px rgba(15, 23, 42, 0.06)",
+        overflow: "hidden",
+        "&:before": {
+          display: "none",
+        },
+        "&:focus, &:focus-visible, &:focus-within": {
+          outline: "none",
+          boxShadow: "0 10px 28px rgba(15, 23, 42, 0.06)",
+        },
+      }}
+    >
+      <AccordionSummary
+        disableRipple
+        expandIcon={<ExpandMoreIcon />}
+        sx={{
+          bgcolor: "background.paper",
+          minHeight: 58,
+          px: 2.5,
+          transition: "background-color 150ms ease",
+          outline: "none",
+          boxShadow: "none",
+          "&:hover": {
+            bgcolor: "grey.50",
+          },
+          "&:focus, &:focus-visible, &:active": {
+            outline: "none",
+            boxShadow: "none",
+          },
+          "&.Mui-focusVisible": {
+            bgcolor: "background.paper",
+            outline: "none",
+            boxShadow: "none",
+          },
+          "& .MuiTouchRipple-root": {
+            display: "none",
+          },
+          "&.Mui-expanded": {
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            minHeight: 58,
+          },
+          "& .MuiAccordionSummary-content": {
+            alignItems: "center",
+            my: 1.5,
+          },
+          "& .MuiAccordionSummary-expandIconWrapper": {
+            color: "text.secondary",
+          },
+        }}
+      >
+        <Box sx={{ fontWeight: 700, color: "text.primary", letterSpacing: "0.01em" }}>{title}</Box>
+      </AccordionSummary>
+      <AccordionDetails sx={{ bgcolor: "grey.50", p: 2.5 }}>{children}</AccordionDetails>
+    </Accordion>
+  );
+}
+
+function AdminTable({ children, minWidth = 650 }: { children: ReactNode; minWidth?: number }) {
+  return (
+    <TableContainer
+      component={Paper}
+      variant="outlined"
+      sx={{
+        borderColor: "divider",
+        borderRadius: 2,
+        boxShadow: "0 8px 24px rgba(15, 23, 42, 0.06)",
+        overflow: "hidden",
+      }}
+    >
+      <Table
+        size="small"
+        sx={{
+          minWidth,
+          "& .MuiTableCell-head": {
+            bgcolor: "grey.50",
+            color: "text.secondary",
+            fontSize: "0.75rem",
+            fontWeight: 700,
+            letterSpacing: "0.04em",
+            textTransform: "uppercase",
+          },
+          "& .MuiTableCell-body": {
+            borderBottomColor: "divider",
+            py: 1.25,
+          },
+          "& .MuiTableBody-root .MuiTableRow-root:hover": {
+            bgcolor: "action.hover",
+          },
+          "& .MuiTableRow-root:last-of-type .MuiTableCell-body": {
+            borderBottom: 0,
+          },
+        }}
+      >
+        {children}
+      </Table>
+    </TableContainer>
+  );
+}
+
+function EventDetailsSection({
+  event,
+  loading,
+  onEditEvent,
+}: {
+  event: EventRow | null;
+  loading: boolean;
+  onEditEvent: (event: EventRow) => void;
+}) {
+  if (loading && !event) {
+    return <CircularProgress size={22} />;
+  }
+
+  if (!event) {
+    return <Alert severity="info">Event details are not available.</Alert>;
+  }
+
+  return (
+    <Box>
+      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+        <Button size="small" startIcon={<EditIcon />} variant="outlined" onClick={() => onEditEvent(event)}>
+          Edit event details
+        </Button>
+      </Box>
+      <AdminTable minWidth={360}>
+          <TableBody>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600, width: 220 }}>Title</TableCell>
+              <TableCell>{event.title}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Date / time</TableCell>
+              <TableCell>
+                {new Date(event.startDateTime).toLocaleString()} –{" "}
+                {new Date(event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Location</TableCell>
+              <TableCell>{event.location ?? "—"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Guest of honour</TableCell>
+              <TableCell>{event.guestOfHonour ?? "—"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Booking window</TableCell>
+              <TableCell>
+                {new Date(event.bookingStartDateTime).toLocaleString()} –{" "}
+                {new Date(event.bookingEndDateTime).toLocaleString()}
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Max guests without moderator approval</TableCell>
+              <TableCell>
+                {event.maxGuestsWithoutModeratorApproval != null
+                  ? String(event.maxGuestsWithoutModeratorApproval)
+                  : "—"}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+      </AdminTable>
+    </Box>
   );
 }
 
@@ -350,8 +555,7 @@ function TicketTypesTable({
   }
 
   return (
-    <TableContainer component={Paper}>
-      <Table size="small">
+    <AdminTable>
         <TableHead>
           <TableRow>
             <TableCell>Title</TableCell>
@@ -369,7 +573,13 @@ function TicketTypesTable({
               <TableCell>{ticketType.description ?? "—"}</TableCell>
               <TableCell>{ticketType.price}</TableCell>
               <TableCell>{ticketType.audience === TicketAudience.GUEST ? "Guest" : "Member"}</TableCell>
-              <TableCell>{ticketType.userGroup?.name ?? "—"}</TableCell>
+              <TableCell>
+                {ticketType.userGroup ? (
+                  <Chip label={ticketType.userGroup.name} size="small" variant="outlined" color="primary" />
+                ) : (
+                  "—"
+                )}
+              </TableCell>
               <TableCell align="right">
                 <IconButton size="small" onClick={() => onEdit(ticketType)}>
                   <EditIcon />
@@ -386,8 +596,7 @@ function TicketTypesTable({
             </TableRow>
           ))}
         </TableBody>
-      </Table>
-    </TableContainer>
+    </AdminTable>
   );
 }
 
@@ -437,8 +646,7 @@ function GuestTicketRequestsSection({
       ) : requests.length === 0 ? (
         <Alert severity="info">No guest ticket requests for this filter.</Alert>
       ) : (
-        <TableContainer component={Paper}>
-          <Table size="small">
+        <AdminTable>
             <TableHead>
               <TableRow>
                 <TableCell>Status</TableCell>
@@ -510,8 +718,7 @@ function GuestTicketRequestsSection({
                 </TableRow>
               ))}
             </TableBody>
-          </Table>
-        </TableContainer>
+        </AdminTable>
       )}
     </Box>
   );
@@ -519,15 +726,13 @@ function GuestTicketRequestsSection({
 
 function BookingAuditSection({ loading, bookings }: { loading: boolean; bookings: EventBookingAdminRow[] }) {
   return (
-    <Box sx={{ mt: 3 }}>
-      <Box sx={{ fontWeight: 600, mb: 1 }}>Booking audit activity</Box>
+    <Box>
       {loading ? (
         <CircularProgress size={22} />
       ) : bookings.length === 0 ? (
         <Alert severity="info">No bookings found for this event.</Alert>
       ) : (
-        <TableContainer component={Paper}>
-          <Table size="small">
+        <AdminTable>
             <TableHead>
               <TableRow>
                 <TableCell>Booking</TableCell>
@@ -556,8 +761,7 @@ function BookingAuditSection({ loading, bookings }: { loading: boolean; bookings
                 </TableRow>
               ))}
             </TableBody>
-          </Table>
-        </TableContainer>
+        </AdminTable>
       )}
     </Box>
   );
@@ -565,15 +769,13 @@ function BookingAuditSection({ loading, bookings }: { loading: boolean; bookings
 
 function PaymentActivitySection({ loading, ticketOrders }: { loading: boolean; ticketOrders: TicketOrderAdminRow[] }) {
   return (
-    <Box sx={{ mt: 3 }}>
-      <Box sx={{ fontWeight: 600, mb: 1 }}>Payment status activity</Box>
+    <Box>
       {loading ? (
         <CircularProgress size={22} />
       ) : ticketOrders.length === 0 ? (
         <Alert severity="info">No payment orders found for this event.</Alert>
       ) : (
-        <TableContainer component={Paper}>
-          <Table size="small">
+        <AdminTable>
             <TableHead>
               <TableRow>
                 <TableCell>Status</TableCell>
@@ -606,8 +808,7 @@ function PaymentActivitySection({ loading, ticketOrders }: { loading: boolean; t
                 </TableRow>
               ))}
             </TableBody>
-          </Table>
-        </TableContainer>
+        </AdminTable>
       )}
     </Box>
   );

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -146,7 +146,7 @@ describe("SectionEventsManager", () => {
     });
     expect(screen.getByText("Main Hall")).toBeInTheDocument();
     expect(screen.getByText("Jane Doe")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /ticket types/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /event admin/i })).toBeInTheDocument();
   });
 
   it("renders error message when events query fails", async () => {
@@ -190,6 +190,14 @@ describe("SectionEventsManager", () => {
       data: {
         event: {
           id: "ev-1",
+          title: "Annual Dinner",
+          startDateTime: "2025-03-01T18:00:00Z",
+          endDateTime: "2025-03-01T22:00:00Z",
+          bookingStartDateTime: "2025-02-01T00:00:00Z",
+          bookingEndDateTime: "2025-02-28T23:59:59Z",
+          location: "Main Hall",
+          guestOfHonour: "Jane Doe",
+          maxGuestsWithoutModeratorApproval: 1,
           ticketTypes: [],
         },
       },
@@ -271,15 +279,93 @@ describe("SectionEventsManager", () => {
     });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
-    await user.click(screen.getByRole("button", { name: /ticket types/i }));
+    await user.click(screen.getByRole("button", { name: /event admin/i }));
 
+    expect(screen.getByText(/event admin: annual dinner/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^event details$/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /^ticket types$/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByRole("button", { name: /^guest ticket requests$/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(screen.getByRole("button", { name: /^booking audit activity$/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+    expect(screen.getByRole("button", { name: /^payment status activity$/i })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+
+    await user.click(screen.getByRole("button", { name: /^event details$/i }));
+    expect(screen.getByRole("button", { name: /edit event details/i })).toBeInTheDocument();
+    expect(screen.getByText(/max guests without moderator approval/i)).toBeInTheDocument();
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: /^guest ticket requests$/i }));
     expect(screen.getByText(/additional guest ticket requests/i)).toBeInTheDocument();
+    expect(screen.getByText("Jamie Guest")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^booking audit activity$/i }));
     expect(screen.getByText(/booking audit activity/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^payment status activity$/i }));
     expect(screen.getByText(/payment status activity/i)).toBeInTheDocument();
     expect(screen.getByText(/evt_123/i)).toBeInTheDocument();
-    expect(screen.getByText("Jamie Guest")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /approve/i }));
     await waitFor(() => expect(executeMutation).toHaveBeenCalled());
+  });
+
+  it("opens event edit dialog from the event admin details section", async () => {
+    const user = userEvent.setup();
+    mockGetEventsForSection({
+      data: {
+        section: {
+          id: sectionId,
+          events: [
+            {
+              id: "ev-1",
+              title: "Annual Dinner",
+              startDateTime: "2025-03-01T18:00:00Z",
+              endDateTime: "2025-03-01T22:00:00Z",
+              bookingStartDateTime: "2025-02-01T00:00:00Z",
+              bookingEndDateTime: "2025-02-28T23:59:59Z",
+              location: "Main Hall",
+              guestOfHonour: "Jane Doe",
+              maxGuestsWithoutModeratorApproval: 2,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetEventById({
+      data: {
+        event: {
+          id: "ev-1",
+          title: "Annual Dinner",
+          startDateTime: "2025-03-01T18:00:00Z",
+          endDateTime: "2025-03-01T22:00:00Z",
+          bookingStartDateTime: "2025-02-01T00:00:00Z",
+          bookingEndDateTime: "2025-02-28T23:59:59Z",
+          location: "Main Hall",
+          guestOfHonour: "Jane Doe",
+          maxGuestsWithoutModeratorApproval: 2,
+          ticketTypes: [],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+    await user.click(screen.getByRole("button", { name: /event admin/i }));
+    await user.click(screen.getByRole("button", { name: /^event details$/i }));
+    await user.click(screen.getByRole("button", { name: /edit event details/i }));
+
+    expect(screen.getByRole("dialog", { name: /edit event/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toHaveValue("Annual Dinner");
+    expect(screen.getByLabelText(/location/i)).toHaveValue("Main Hall");
+    expect(screen.getByLabelText(/max guests without moderator approval/i)).toHaveValue(2);
   });
 
   it("shows empty-state alerts for moderation, booking audit, and payment activity", async () => {
@@ -306,13 +392,29 @@ describe("SectionEventsManager", () => {
       isError: false,
     });
     mockGetEventById({
-      data: { event: { id: "ev-1", ticketTypes: [] } },
+      data: {
+        event: {
+          id: "ev-1",
+          title: "Annual Dinner",
+          startDateTime: "2025-03-01T18:00:00Z",
+          endDateTime: "2025-03-01T22:00:00Z",
+          bookingStartDateTime: "2025-02-01T00:00:00Z",
+          bookingEndDateTime: "2025-02-28T23:59:59Z",
+          location: "Main Hall",
+          guestOfHonour: "Jane Doe",
+          maxGuestsWithoutModeratorApproval: null,
+          ticketTypes: [],
+        },
+      },
       isLoading: false,
       isError: false,
     });
 
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
-    await user.click(screen.getByRole("button", { name: /ticket types/i }));
+    await user.click(screen.getByRole("button", { name: /event admin/i }));
+    await user.click(screen.getByRole("button", { name: /^guest ticket requests$/i }));
+    await user.click(screen.getByRole("button", { name: /^booking audit activity$/i }));
+    await user.click(screen.getByRole("button", { name: /^payment status activity$/i }));
 
     expect(screen.getByText(/no guest ticket requests for this filter/i)).toBeInTheDocument();
     expect(screen.getByText(/no bookings found for this event/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Reframe the event-specific admin page as an event admin surface with editable event details.
- Group ticket types, guest ticket requests, booking audit activity, and payment status activity in collapsed styled accordions.
- Simplify event list actions and align admin tables with the rest of the admin UI.

Closes #86.

## Test plan
- npm test -- SectionEventsManager.test.tsx
- npm run lint
- npm run build


Made with [Cursor](https://cursor.com)