### PR TITLE
Clarify ticket category terminology in event flows

### DIFF
--- a/src/features/admin/components/SectionEventsManagerSurfaces.tsx
+++ b/src/features/admin/components/SectionEventsManagerSurfaces.tsx
@@ -35,6 +35,7 @@ import {
 } from "@mui/icons-material";
 import { GuestTicketRequestStatus, TicketAudience } from "@dataconnect/generated";
 import PageHeader from "../../../shared/components/PageHeader";
+import { getTicketCategoryLabel, TICKET_CATEGORY_LABEL } from "../../../shared/utils/ticketAudienceLabels";
 import type {
   EventBookingAdminRow,
   EventRow,
@@ -561,7 +562,7 @@ function TicketTypesTable({
             <TableCell>Title</TableCell>
             <TableCell>Description</TableCell>
             <TableCell>Price</TableCell>
-            <TableCell>Audience</TableCell>
+            <TableCell>{TICKET_CATEGORY_LABEL}</TableCell>
             <TableCell>Access group</TableCell>
             <TableCell align="right">Actions</TableCell>
           </TableRow>
@@ -572,7 +573,7 @@ function TicketTypesTable({
               <TableCell>{ticketType.title}</TableCell>
               <TableCell>{ticketType.description ?? "—"}</TableCell>
               <TableCell>{ticketType.price}</TableCell>
-              <TableCell>{ticketType.audience === TicketAudience.GUEST ? "Guest" : "Member"}</TableCell>
+              <TableCell>{getTicketCategoryLabel(ticketType.audience)}</TableCell>
               <TableCell>
                 {ticketType.userGroup ? (
                   <Chip label={ticketType.userGroup.name} size="small" variant="outlined" color="primary" />
@@ -888,15 +889,15 @@ export function TicketTypeDialogSurface({
           margin="dense"
         />
         <FormControl fullWidth margin="dense" sx={{ mt: 1 }}>
-          <InputLabel id="ticket-audience-label">Audience</InputLabel>
+          <InputLabel id="ticket-audience-label">{TICKET_CATEGORY_LABEL}</InputLabel>
           <Select
             labelId="ticket-audience-label"
-            label="Audience"
+            label={TICKET_CATEGORY_LABEL}
             value={audience}
             onChange={(event) => onAudienceChange(event.target.value as TicketAudience)}
           >
-            <MenuItem value={TicketAudience.MEMBER}>Member</MenuItem>
-            <MenuItem value={TicketAudience.GUEST}>Guest</MenuItem>
+            <MenuItem value={TicketAudience.MEMBER}>{getTicketCategoryLabel(TicketAudience.MEMBER)}</MenuItem>
+            <MenuItem value={TicketAudience.GUEST}>{getTicketCategoryLabel(TicketAudience.GUEST)}</MenuItem>
           </Select>
         </FormControl>
         <Autocomplete

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -385,7 +385,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
         {activeStep === 0 && (
           <FormControl component="fieldset" fullWidth>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              Select your ticket (member-priced).
+              Select your member ticket category.
             </Typography>
             <RadioGroup
               value={memberTicketTypeId ?? ""}
@@ -485,7 +485,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
                   <Box sx={{ mt: 2, pl: 1, borderLeft: 2, borderColor: "divider" }}>
                     <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
                       <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
-                        Guest ticket type
+                        Guest ticket category
                       </Typography>
                       <RadioGroup
                         value={guestTicketTypeId ?? ""}

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -17,6 +17,7 @@ import { TicketAudience, type GetEventByIdData, type GetEventsForSectionData, ty
 import { colors } from "../../../config/colors";
 import PaginationDisplay from "../../../shared/components/PaginationDisplay";
 import SearchBar from "../../../shared/components/SearchBar";
+import { getTicketCategoryLabel, TICKET_CATEGORY_LABEL } from "../../../shared/utils/ticketAudienceLabels";
 import type { SectionMember } from "../utils/sectionHelpers";
 import EventBookingWizard from "./EventBookingWizard";
 
@@ -374,7 +375,7 @@ export function SectionEventDetailView({
                     <TableCell>Title</TableCell>
                     <TableCell>Description</TableCell>
                     <TableCell>Price</TableCell>
-                    <TableCell>Audience</TableCell>
+                    <TableCell>{TICKET_CATEGORY_LABEL}</TableCell>
                     <TableCell>User group</TableCell>
                     <TableCell align="right">Purchase</TableCell>
                   </TableRow>
@@ -385,7 +386,7 @@ export function SectionEventDetailView({
                       <TableCell>{ticketType.title}</TableCell>
                       <TableCell>{ticketType.description ?? "-"}</TableCell>
                       <TableCell>{ticketType.price}</TableCell>
-                      <TableCell>{ticketType.audience === TicketAudience.GUEST ? "Guest" : "Member"}</TableCell>
+                      <TableCell>{getTicketCategoryLabel(ticketType.audience)}</TableCell>
                       <TableCell>{ticketType.userGroup?.name ?? "-"}</TableCell>
                       <TableCell align="right">
                         {hasCurrentUser && ticketType.audience === TicketAudience.MEMBER ? (

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -574,7 +574,7 @@ describe('SectionDetail', () => {
       expect(screen.getByText('Jane Doe')).toBeInTheDocument();
       expect(screen.getByText('Ticket types')).toBeInTheDocument();
       expect(screen.getByText('Standard')).toBeInTheDocument();
-      expect(screen.getByText('Member')).toBeInTheDocument();
+      expect(screen.getByText('Member ticket')).toBeInTheDocument();
       expect(screen.getByText('Standard Access')).toBeInTheDocument();
     });
   });

--- a/src/shared/utils/ticketAudienceLabels.ts
+++ b/src/shared/utils/ticketAudienceLabels.ts
@@ -1,0 +1,7 @@
+import { TicketAudience } from "@dataconnect/generated";
+
+export const TICKET_CATEGORY_LABEL = "Ticket category";
+
+export function getTicketCategoryLabel(audience: TicketAudience): string {
+  return audience === TicketAudience.GUEST ? "Guest ticket" : "Member ticket";
+}


### PR DESCRIPTION
## Summary
- replace user-facing ticket wording from "Audience" to "Ticket category" in event admin and section event detail tables
- display ticket category values consistently as "Member ticket" and "Guest ticket" via a shared `ticketAudienceLabels` utility
- update booking wizard copy and adjust section detail test expectations to match the new terminology

## Test plan
- [x] `npm run test -- SectionDetail.test.tsx SectionEventsManager.test.tsx`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)