### PR TITLE
Formalize Stripe webhook allowlist and router observability

### DIFF
--- a/docs/architecture/payment-state-machine.md
+++ b/docs/architecture/payment-state-machine.md
@@ -40,6 +40,14 @@ Disputes are intentionally modeled as **side-state metadata** for now (issue #12
 | `charge.dispute.closed` | dispute side-state | `DISPUTE_CLOSED` | no `TicketOrderStatus` change |
 | anything else | ignore | n/a | logged as ignored |
 
+### Supported-event allowlist
+
+Functions maintain an explicit Stripe event allowlist in code (`SUPPORTED_STRIPE_EVENT_TYPES`), used by routing and observability:
+
+- supported events are normalized into transition or dispute side-state handling
+- unsupported events are acknowledged (2xx) and logged as ignored
+- this keeps webhook processing non-destructive for unknown event types
+
 ## Webhook Outcome Contract
 
 - Missing `orderId` metadata: acknowledge webhook (2xx), no mutation.

--- a/functions/src/__tests__/paymentStateMachine.test.ts
+++ b/functions/src/__tests__/paymentStateMachine.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 import { TicketOrderStatus } from "@dataconnect/admin-generated";
 import {
   evaluateTransition,
+  isSupportedStripeEventType,
   mapIntentToTargetStatus,
   normalizeStripeEvent,
+  SUPPORTED_STRIPE_EVENT_TYPES,
 } from "../paymentStateMachine";
 
 function stripeEvent(type: string, metadata: Record<string, string> = {}) {
@@ -19,6 +21,22 @@ function stripeEvent(type: string, metadata: Record<string, string> = {}) {
 }
 
 describe("paymentStateMachine", () => {
+  it("keeps a single explicit allowlist of supported Stripe events", () => {
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("checkout.session.completed")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("checkout.session.expired")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("checkout.session.async_payment_failed")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("charge.refunded")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("charge.dispute.created")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("charge.dispute.updated")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("charge.dispute.closed")).toBe(true);
+    expect(SUPPORTED_STRIPE_EVENT_TYPES.has("payment_intent.succeeded")).toBe(false);
+  });
+
+  it("exposes supported-event check for webhook router observability", () => {
+    expect(isSupportedStripeEventType("checkout.session.completed")).toBe(true);
+    expect(isSupportedStripeEventType("payment_intent.succeeded")).toBe(false);
+  });
+
   it("maps intents to target statuses", () => {
     expect(mapIntentToTargetStatus("MARK_PAID")).toBe(TicketOrderStatus.PAID);
     expect(mapIntentToTargetStatus("MARK_FAILED")).toBe(TicketOrderStatus.FAILED);
@@ -67,5 +85,6 @@ describe("paymentStateMachine", () => {
   it("marks unsupported events as ignore", () => {
     const ignored = normalizeStripeEvent(stripeEvent("payment_intent.succeeded", { orderId: "o-6" }));
     expect(ignored.kind).toBe("ignore");
+    expect(ignored.reason).toBe("unsupported_event_type");
   });
 });

--- a/functions/src/paymentStateMachine.ts
+++ b/functions/src/paymentStateMachine.ts
@@ -23,6 +23,16 @@ export interface TransitionDecision {
   reason: string;
 }
 
+export const SUPPORTED_STRIPE_EVENT_TYPES = new Set<string>([
+  "checkout.session.completed",
+  "checkout.session.expired",
+  "checkout.session.async_payment_failed",
+  "charge.refunded",
+  "charge.dispute.created",
+  "charge.dispute.updated",
+  "charge.dispute.closed",
+]);
+
 const LEGAL_TRANSITIONS: Record<TicketOrderStatus, ReadonlySet<TicketOrderStatus>> = {
   [TicketOrderStatus.PENDING]: new Set([TicketOrderStatus.PAID, TicketOrderStatus.FAILED]),
   [TicketOrderStatus.PAID]: new Set([TicketOrderStatus.REFUNDED]),
@@ -43,8 +53,15 @@ function extractOrderIdFromStripeEvent(event: StripeEventLike): string | null {
   return extractMetadataOrderId(objectWithMetadata);
 }
 
+export function isSupportedStripeEventType(eventType: string): boolean {
+  return SUPPORTED_STRIPE_EVENT_TYPES.has(eventType);
+}
+
 export function normalizeStripeEvent(event: StripeEventLike): StripeEventNormalization {
   const orderId = extractOrderIdFromStripeEvent(event) ?? undefined;
+  if (!isSupportedStripeEventType(event.type)) {
+    return { kind: "ignore", reason: "unsupported_event_type" };
+  }
   switch (event.type) {
     case "checkout.session.completed":
       return {
@@ -75,7 +92,8 @@ export function normalizeStripeEvent(event: StripeEventLike): StripeEventNormali
     case "charge.dispute.closed":
       return { kind: "dispute_side_state", disputeState: "DISPUTE_CLOSED", orderId, reason: "dispute_closed" };
     default:
-      return { kind: "ignore", reason: "unsupported_event_type" };
+      // Defensive fallback if a supported-event list and switch ever drift.
+      return { kind: "ignore", reason: "unmapped_supported_event_type" };
   }
 }
 

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -21,6 +21,7 @@ import { userMatchesUserGroup, userHasBookerPurpose } from "./bookingRules";
 import Stripe from "stripe";
 import {
   evaluateTransition,
+  isSupportedStripeEventType,
   mapIntentToTargetStatus,
   normalizeStripeEvent,
 } from "./paymentStateMachine";
@@ -171,9 +172,15 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
     }
 
     const event = stripeClient.webhooks.constructEvent(req.rawBody, signature, webhookSecret);
+    const supportedEventType = isSupportedStripeEventType(event.type);
     const normalized = normalizeStripeEvent(event);
     if (normalized.kind === "ignore") {
-      logger.info("stripeWebhook ignored event", { eventType: event.type, reason: normalized.reason, eventId: event.id });
+      logger.info("stripeWebhook ignored event", {
+        eventType: event.type,
+        eventId: event.id,
+        supportedEventType,
+        reason: normalized.reason,
+      });
       res.status(200).send("Ignored event");
       return;
     }


### PR DESCRIPTION
## Summary
- add an explicit `SUPPORTED_STRIPE_EVENT_TYPES` contract for payment lifecycle webhook routing
- expose supported-event checks for router observability and include support status in ignored-event logs
- expand payment state machine tests and architecture docs to lock the supported event set and unsupported-event behavior

## Test plan
- [x] `cd functions && npm run test -- paymentStateMachine.test.ts`
- [x] `cd functions && npm run build`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)