### PR TITLE
feat(payments): centralize ticket order transition engine

### DIFF
--- a/functions/src/__tests__/paymentTransitionEngine.test.ts
+++ b/functions/src/__tests__/paymentTransitionEngine.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { TicketOrderStatus } from "@dataconnect/admin-generated";
+import { runTicketOrderTransition, type TicketOrderTransitionMutations } from "../paymentTransitionEngine";
+
+function buildMutations(): TicketOrderTransitionMutations {
+  return {
+    markPaid: vi.fn(async () => undefined),
+    markFailed: vi.fn(async () => undefined),
+    markRefunded: vi.fn(async () => undefined),
+  };
+}
+
+describe("paymentTransitionEngine", () => {
+  it("applies legal paid transition and forwards payment metadata", async () => {
+    const mutations = buildMutations();
+    const result = await runTicketOrderTransition(
+      {
+        orderId: "00000000-0000-0000-0000-000000000001",
+        currentStatus: TicketOrderStatus.PENDING,
+        intent: "MARK_PAID",
+        webhookEventId: "evt_paid",
+        paidContext: {
+          stripeCheckoutSessionId: "cs_test_1",
+          stripePaymentIntentId: "pi_test_1",
+        },
+      },
+      mutations
+    );
+
+    expect(result.action).toBe("applied");
+    expect(result.fromStatus).toBe(TicketOrderStatus.PENDING);
+    expect(result.targetStatus).toBe(TicketOrderStatus.PAID);
+    expect(mutations.markPaid).toHaveBeenCalledWith({
+      id: "00000000-0000-0000-0000-000000000001",
+      stripeCheckoutSessionId: "cs_test_1",
+      stripePaymentIntentId: "pi_test_1",
+      webhookEventId: "evt_paid",
+    });
+  });
+
+  it("returns replay no-op metadata without applying mutation", async () => {
+    const mutations = buildMutations();
+    const result = await runTicketOrderTransition(
+      {
+        orderId: "00000000-0000-0000-0000-000000000002",
+        currentStatus: TicketOrderStatus.PAID,
+        intent: "MARK_PAID",
+        webhookEventId: "evt_replay",
+      },
+      mutations
+    );
+
+    expect(result.action).toBe("noop_replay");
+    expect(result.reason).toBe("already_in_target_state");
+    expect(mutations.markPaid).not.toHaveBeenCalled();
+    expect(mutations.markFailed).not.toHaveBeenCalled();
+    expect(mutations.markRefunded).not.toHaveBeenCalled();
+  });
+
+  it("returns illegal no-op metadata without applying mutation", async () => {
+    const mutations = buildMutations();
+    const result = await runTicketOrderTransition(
+      {
+        orderId: "00000000-0000-0000-0000-000000000003",
+        currentStatus: TicketOrderStatus.REFUNDED,
+        intent: "MARK_FAILED",
+        webhookEventId: "evt_illegal",
+      },
+      mutations
+    );
+
+    expect(result.action).toBe("noop_illegal");
+    expect(result.reason).toBe("illegal_transition");
+    expect(result.fromStatus).toBe(TicketOrderStatus.REFUNDED);
+    expect(result.targetStatus).toBe(TicketOrderStatus.FAILED);
+    expect(mutations.markPaid).not.toHaveBeenCalled();
+    expect(mutations.markFailed).not.toHaveBeenCalled();
+    expect(mutations.markRefunded).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/paymentTransitionEngine.ts
+++ b/functions/src/paymentTransitionEngine.ts
@@ -1,0 +1,86 @@
+import { TicketOrderStatus } from "@dataconnect/admin-generated";
+import type { UUIDString } from "@dataconnect/admin-generated";
+import { evaluateTransition, mapIntentToTargetStatus, type PaymentTransitionIntent } from "./paymentStateMachine";
+
+export interface TicketOrderTransitionRequest {
+  orderId: UUIDString;
+  currentStatus: TicketOrderStatus;
+  intent: PaymentTransitionIntent;
+  webhookEventId: string;
+  paidContext?: {
+    stripeCheckoutSessionId?: string | null;
+    stripePaymentIntentId?: string | null;
+  };
+}
+
+export interface TicketOrderTransitionResult {
+  action: "applied" | "noop_replay" | "noop_illegal";
+  reason: string;
+  orderId: UUIDString;
+  fromStatus: TicketOrderStatus;
+  targetStatus: TicketOrderStatus;
+  intent: PaymentTransitionIntent;
+}
+
+export interface TicketOrderTransitionMutations {
+  markPaid(args: {
+    id: UUIDString;
+    stripeCheckoutSessionId?: string | null;
+    stripePaymentIntentId?: string | null;
+    webhookEventId: string;
+  }): Promise<unknown>;
+  markFailed(args: {
+    id: UUIDString;
+    webhookEventId: string;
+  }): Promise<unknown>;
+  markRefunded(args: {
+    id: UUIDString;
+    webhookEventId: string;
+  }): Promise<unknown>;
+}
+
+export async function runTicketOrderTransition(
+  request: TicketOrderTransitionRequest,
+  mutations: TicketOrderTransitionMutations
+): Promise<TicketOrderTransitionResult> {
+  const targetStatus = mapIntentToTargetStatus(request.intent);
+  const decision = evaluateTransition(request.currentStatus, request.intent);
+
+  if (decision.action === "apply") {
+    if (request.intent === "MARK_PAID") {
+      await mutations.markPaid({
+        id: request.orderId,
+        stripeCheckoutSessionId: request.paidContext?.stripeCheckoutSessionId ?? null,
+        stripePaymentIntentId: request.paidContext?.stripePaymentIntentId ?? null,
+        webhookEventId: request.webhookEventId,
+      });
+    } else if (request.intent === "MARK_FAILED") {
+      await mutations.markFailed({
+        id: request.orderId,
+        webhookEventId: request.webhookEventId,
+      });
+    } else {
+      await mutations.markRefunded({
+        id: request.orderId,
+        webhookEventId: request.webhookEventId,
+      });
+    }
+    return {
+      action: "applied",
+      reason: decision.reason,
+      orderId: request.orderId,
+      fromStatus: request.currentStatus,
+      targetStatus,
+      intent: request.intent,
+    };
+  }
+
+  return {
+    action: decision.action,
+    reason: decision.reason,
+    orderId: request.orderId,
+    fromStatus: request.currentStatus,
+    targetStatus,
+    intent: request.intent,
+  };
+}

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -23,11 +23,10 @@ import { FUNCTIONS_REGION } from "./constants";
 import { userMatchesUserGroup, userHasBookerPurpose } from "./bookingRules";
 import Stripe from "stripe";
 import {
-  evaluateTransition,
   isSupportedStripeEventType,
-  mapIntentToTargetStatus,
   normalizeStripeEvent,
 } from "./paymentStateMachine";
+import { runTicketOrderTransition } from "./paymentTransitionEngine";
 
 const stripeSecret = defineSecret("STRIPE_SECRET");
 const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
@@ -303,59 +302,61 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
       res.status(200).send("Missing transition intent");
       return;
     }
-    const targetStatus = mapIntentToTargetStatus(intent);
-    const decision = evaluateTransition(order.status, intent);
-    if (decision.action !== "apply") {
+    const transitionResult = await runTicketOrderTransition(
+      {
+        orderId: canonicalOrderId,
+        currentStatus: order.status,
+        intent,
+        webhookEventId: event.id,
+        paidContext:
+          intent === "MARK_PAID"
+            ? (() => {
+                const session = event.data.object as {
+                  id?: string;
+                  payment_intent?: string | { id?: string };
+                };
+                return {
+                  stripeCheckoutSessionId: session.id ?? null,
+                  stripePaymentIntentId:
+                    typeof session.payment_intent === "string" ? session.payment_intent : session.payment_intent?.id ?? null,
+                };
+              })()
+            : undefined,
+      },
+      {
+        markPaid: markTicketOrderPaidFromWebhook,
+        markFailed: markTicketOrderFailedFromWebhook,
+        markRefunded: markTicketOrderRefundedFromWebhook,
+      }
+    );
+    if (transitionResult.action !== "applied") {
       logger.info("stripeWebhook transition skipped", {
         eventType: event.type,
         eventId: event.id,
         orderId: canonicalOrderId,
-        fromStatus: order.status,
-        targetStatus,
-        decision: decision.action,
-        reason: decision.reason,
+        fromStatus: transitionResult.fromStatus,
+        targetStatus: transitionResult.targetStatus,
+        decision: transitionResult.action,
+        reason: transitionResult.reason,
+        intent: transitionResult.intent,
       });
       await appendWebhookLedgerEvent({
         stripeEventId: event.id,
         eventType: event.type,
         outcome: PaymentWebhookEventOutcome.IGNORED,
-        reason: `transition_skipped:${decision.reason}`,
+        reason: `transition_${transitionResult.action}:${transitionResult.reason}:${transitionResult.fromStatus}->${transitionResult.targetStatus}:${transitionResult.intent}`,
         ticketOrderId: canonicalOrderId,
         stripeObjectId,
         livemode: event.livemode,
       });
-      res.status(200).send(decision.action === "noop_replay" ? "Already processed" : "Illegal transition skipped");
+      res.status(200).send(transitionResult.action === "noop_replay" ? "Already processed" : "Illegal transition skipped");
       return;
-    }
-
-    if (intent === "MARK_PAID") {
-      const session = event.data.object as {
-        id?: string;
-        payment_intent?: string | { id?: string };
-      };
-      await markTicketOrderPaidFromWebhook({
-        id: canonicalOrderId,
-        stripeCheckoutSessionId: session.id ?? null,
-        stripePaymentIntentId:
-          typeof session.payment_intent === "string" ? session.payment_intent : session.payment_intent?.id ?? null,
-        webhookEventId: event.id,
-      });
-    } else if (intent === "MARK_FAILED") {
-      await markTicketOrderFailedFromWebhook({
-        id: canonicalOrderId,
-        webhookEventId: event.id,
-      });
-    } else if (intent === "MARK_REFUNDED") {
-      await markTicketOrderRefundedFromWebhook({
-        id: canonicalOrderId,
-        webhookEventId: event.id,
-      });
     }
     await appendWebhookLedgerEvent({
       stripeEventId: event.id,
       eventType: event.type,
       outcome: PaymentWebhookEventOutcome.PROCESSED,
-      reason: `transition_applied:${intent}`,
+      reason: `transition_applied:${transitionResult.reason}:${transitionResult.fromStatus}->${transitionResult.targetStatus}:${transitionResult.intent}`,
       ticketOrderId: canonicalOrderId,
       stripeObjectId,
       livemode: event.livemode,


### PR DESCRIPTION
## Summary
- add a dedicated `paymentTransitionEngine` service to own guarded ticket-order status mutations
- refactor `stripeWebhook` to delegate transition execution to the engine and keep webhook routing focused on normalization/idempotency
- persist richer transition audit metadata into webhook ledger reasons and add engine unit tests for apply/replay/illegal paths

## Test plan
- [x] `npm --prefix functions test -- --run`
- [x] `npm --prefix functions run build`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)