### PR TITLE
Fix section access checks for multi-purpose links

### DIFF
--- a/functions/src/__tests__/bookingRules.test.ts
+++ b/functions/src/__tests__/bookingRules.test.ts
@@ -53,6 +53,20 @@ describe("bookingRules", () => {
     ).toBe(true);
   });
 
+  it("accepts ACCESS from purposes array when legacy purpose differs", () => {
+    const r = evaluateBookingGatekeeping({
+      purposeLinks: [
+        { purpose: "MEMBER", purposes: ["MEMBER", "ACCESS"], userGroup: group("g1", ["REGULAR"]) },
+        { purpose: "BOOKER", userGroup: group("g1", ["REGULAR"]) },
+      ],
+      membershipStatus: "REGULAR",
+      explicitGroupIds: explicit,
+      bookingStartDateTime: new Date(Date.now() - 60_000).toISOString(),
+      bookingEndDateTime: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(r.ok).toBe(true);
+  });
+
   it("denies when no BOOKER purpose rows exist", () => {
     const r = evaluateBookingGatekeeping({
       purposeLinks: [{ purpose: "ACCESS", userGroup: group("g1", ["REGULAR"]) }],

--- a/functions/src/bookingRules.ts
+++ b/functions/src/bookingRules.ts
@@ -32,8 +32,7 @@ export function purposeGrantsSectionAccess(purpose: string): boolean {
 }
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  if (link.purpose) return link.purpose === target;
-  return link.purposes?.includes(target) ?? false;
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
 }
 
 /** Explicit group membership or membership-status–based group (same idea as getSectionMembersMerged). */

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -19,8 +19,7 @@ export interface SectionMemberResponse {
 }
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  if (link.purpose) return link.purpose === target;
-  return link.purposes?.includes(target) ?? false;
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
 }
 
 /**

--- a/src/features/sections/utils/__tests__/bookingEligibility.test.ts
+++ b/src/features/sections/utils/__tests__/bookingEligibility.test.ts
@@ -62,6 +62,20 @@ describe("bookingEligibility", () => {
       expect(r.ok).toBe(true);
     });
 
+    it("uses purposes array for access checks when legacy purpose differs", () => {
+      const r = evaluateBookingGatePreview({
+        purposeLinks: [
+          { purpose: "MEMBER", purposes: ["MEMBER", "ACCESS"], userGroup: { id: "ag", membershipStatuses: ["REGULAR"] } },
+          { purpose: "BOOKER", userGroup: { id: "bg", membershipStatuses: ["REGULAR"] } },
+        ],
+        membershipStatus: MembershipStatus.REGULAR,
+        explicitGroupIds: new Set(),
+        ...window,
+        nowMs: Date.parse("2025-06-01T12:00:00.000Z"),
+      });
+      expect(r.ok).toBe(true);
+    });
+
     it("fails outside booking window", () => {
       const r = evaluateBookingGatePreview({
         purposeLinks: baseLinks,

--- a/src/features/sections/utils/__tests__/sectionHelpers.test.ts
+++ b/src/features/sections/utils/__tests__/sectionHelpers.test.ts
@@ -234,6 +234,14 @@ describe('sectionHelpers', () => {
   });
 
   describe('canUserAccessSection', () => {
+    it('should use purposes array even when legacy purpose field is present with a different value', () => {
+      const userUserGroupIds = ['group-1'];
+      const links = [
+        { purpose: 'MEMBER', purposes: ['MEMBER', 'ACCESS'], userGroup: { id: 'group-1' } },
+      ];
+      expect(canUserAccessSection(userUserGroupIds, links)).toBe(true);
+    });
+
     it('should return true when user matches ACCESS purpose', () => {
       const userUserGroupIds = ['group-1', 'group-2'];
       const links = [

--- a/src/features/sections/utils/bookingEligibility.ts
+++ b/src/features/sections/utils/bookingEligibility.ts
@@ -17,8 +17,7 @@ export function purposeGrantsSectionAccess(purpose: string): boolean {
 }
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  if (link.purpose) return link.purpose === target;
-  return link.purposes?.includes(target) ?? false;
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
 }
 
 export function userHasSectionAccess(

--- a/src/features/sections/utils/sectionHelpers.ts
+++ b/src/features/sections/utils/sectionHelpers.ts
@@ -43,8 +43,7 @@ type PurposeLinkWithUsers = {
 };
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  if (link.purpose) return link.purpose === target;
-  return link.purposes?.includes(target) ?? false;
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
 }
 
 type SectionDataWithPurposeLinks = {


### PR DESCRIPTION
## Summary
- fix section permission helpers to evaluate both legacy `purpose` and new `purposes` fields
- prevent false permission-denied outcomes when mixed payloads are present after #143/#145 migration
- add frontend and functions regression tests for mixed-field access evaluation

## Test plan
- [x] npm run test -- src/features/sections/utils/__tests__/sectionHelpers.test.ts src/features/sections/utils/__tests__/bookingEligibility.test.ts
- [x] cd functions && npm run test -- src/__tests__/bookingRules.test.ts

Made with [Cursor](https://cursor.com)