### PR TITLE
Implement member booking edit flow with revision-aware submit

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -357,6 +357,7 @@ query GetMyBookingsForEvent($eventId: UUID!) @auth(expr: "auth.token.enabled == 
     bookings: bookings_on_booker(where: { eventId: { eq: $eventId } }) {
       id
       status
+      revisionNumber
       clientSubmissionKey
       bookerDietaryNote
       sitNextToUserIds

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -589,6 +589,7 @@ export interface GetMyBookingsForEventData {
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
+      revisionNumber: number;
       clientSubmissionKey?: string | null;
       bookerDietaryNote?: string | null;
       sitNextToUserIds?: string[] | null;

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -3288,6 +3288,7 @@ export interface GetMyBookingsForEventData {
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
+      revisionNumber: number;
       clientSubmissionKey?: string | null;
       bookerDietaryNote?: string | null;
       sitNextToUserIds?: string[] | null;

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -602,6 +602,7 @@ export interface GetMyBookingsForEventData {
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
+      revisionNumber: number;
       clientSubmissionKey?: string | null;
       bookerDietaryNote?: string | null;
       sitNextToUserIds?: string[] | null;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2658,6 +2658,7 @@ export interface GetMyBookingsForEventData {
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
+      revisionNumber: number;
       clientSubmissionKey?: string | null;
       bookerDietaryNote?: string | null;
       sitNextToUserIds?: string[] | null;

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -65,8 +65,10 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
   const [seatingOptions, setSeatingOptions] = useState<Array<{ id: string; label: string }>>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [editingExistingBooking, setEditingExistingBooking] = useState(false);
 
   const idempotencyKeyRef = useRef<string | null>(null);
+  const hydratedBookingIdRef = useRef<string | null>(null);
 
   const { data: currentUserData, isLoading: loadingProfile } = useGetCurrentUser(dataConnect, {});
   const { data: accessData } = useGetUserAccessGroups(dataConnect, {});
@@ -116,7 +118,12 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
 
   const existingTerminalBooking = useMemo(() => {
     const list = myBookingsData?.user?.bookings ?? [];
-    return list.find((b) => b.status === BookingStatus.SUBMITTED || b.status === BookingStatus.CONFIRMED);
+    return list
+      .filter((b) => b.status === BookingStatus.SUBMITTED || b.status === BookingStatus.CONFIRMED)
+      .reduce<typeof list[number] | null>((latest, booking) => {
+        if (!latest) return booking;
+        return booking.revisionNumber > latest.revisionNumber ? booking : latest;
+      }, null);
   }, [myBookingsData]);
 
   /** Server draft for this event — reuse its idempotency key after refresh (new random UUID would conflict). */
@@ -136,6 +143,32 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       // leave ref unchanged if stored value is malformed
     }
   }, [existingDraft?.id, existingDraft?.clientSubmissionKey]);
+
+  useEffect(() => {
+    const booking = existingTerminalBooking;
+    if (!booking) {
+      hydratedBookingIdRef.current = null;
+      setEditingExistingBooking(false);
+      return;
+    }
+    if (hydratedBookingIdRef.current === booking.id) {
+      return;
+    }
+    hydratedBookingIdRef.current = booking.id;
+    setEditingExistingBooking(true);
+    const memberLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.MEMBER);
+    const guestLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.GUEST);
+    setMemberTicketTypeId(memberLine?.ticketType?.id ?? null);
+    setIncludeGuest(Boolean(guestLine?.ticketType?.id));
+    setGuestTicketTypeId(guestLine?.ticketType?.id ?? null);
+    setGuestDisplayName(guestLine?.guestDisplayName ?? "");
+    setBookerDietaryNote(booking.bookerDietaryNote ?? "");
+    setSitNextToUserIds(booking.sitNextToUserIds ?? []);
+    setAccommodationRequested(booking.accommodationRequested === true);
+    setAccommodationNote(booking.accommodationNote ?? "");
+    setActiveStep(0);
+    setSubmitError(null);
+  }, [existingTerminalBooking]);
 
   const selectedMember = memberTicketTypes.find((t) => t.id === memberTicketTypeId);
   const selectedGuest = guestTicketTypes.find((t) => t.id === guestTicketTypeId);
@@ -259,6 +292,8 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       await submitEventBooking({
         idempotencyKey,
         eventId: event.id,
+        baseBookingId: existingTerminalBooking?.id,
+        baseRevisionNumber: existingTerminalBooking?.revisionNumber,
         lines,
         bookerDietaryNote,
         sitNextToUserIds,
@@ -331,28 +366,6 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     );
   }
 
-  if (existingTerminalBooking) {
-    return (
-      <Box sx={{ mt: 2 }}>
-        <Alert severity="success">
-          You already have a booking for this event ({existingTerminalBooking.status.toLowerCase()}).
-        </Alert>
-        <AdditionalGuestRequestSection
-          bookingId={existingTerminalBooking.id}
-          eventTitle={event.title}
-          maxGuestsWithoutModeratorApproval={event.maxGuestsWithoutModeratorApproval}
-          guestTicketTypes={guestTicketTypes.map((tt) => ({
-            id: tt.id,
-            title: tt.title,
-            price: tt.price ?? null,
-          }))}
-          requests={existingTerminalBooking.guestTicketRequests ?? []}
-          onRequestCreated={() => void refetchMyBookings()}
-        />
-      </Box>
-    );
-  }
-
   if (!memberTicketTypes.length) {
     return (
       <Alert severity="warning" sx={{ mt: 2 }}>
@@ -364,8 +377,14 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
   return (
     <Box sx={{ mt: 3 }}>
       <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
-        Book this event
+        {editingExistingBooking ? "Edit your booking" : "Book this event"}
       </Typography>
+      {editingExistingBooking && existingTerminalBooking ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Editing revision {existingTerminalBooking.revisionNumber} ({existingTerminalBooking.status.toLowerCase()}).
+          Saving will create a new booking revision.
+        </Alert>
+      ) : null}
 
       <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
         {STEPS.map((label) => (
@@ -583,7 +602,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
               disabled={submitting}
               sx={{ backgroundColor: colors.callToAction }}
             >
-              {submitting ? "Submitting…" : "Confirm booking"}
+              {submitting ? "Submitting…" : editingExistingBooking ? "Save booking changes" : "Confirm booking"}
             </Button>
           )}
         </Box>
@@ -594,6 +613,22 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
           Start over
         </Button>
       )}
+      {existingTerminalBooking ? (
+        <Box sx={{ mt: 2 }}>
+          <AdditionalGuestRequestSection
+            bookingId={existingTerminalBooking.id}
+            eventTitle={event.title}
+            maxGuestsWithoutModeratorApproval={event.maxGuestsWithoutModeratorApproval}
+            guestTicketTypes={guestTicketTypes.map((tt) => ({
+              id: tt.id,
+              title: tt.title,
+              price: tt.price ?? null,
+            }))}
+            requests={existingTerminalBooking.guestTicketRequests ?? []}
+            onRequestCreated={() => void refetchMyBookings()}
+          />
+        </Box>
+      ) : null}
     </Box>
   );
 }

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import EventBookingWizard from "../EventBookingWizard";
+import { BookingStatus, TicketAudience } from "@dataconnect/generated";
+import * as reactGenerated from "@dataconnect/generated/react";
+import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("@dataconnect/generated/react", () => ({
+  useGetCurrentUser: vi.fn(),
+  useGetMyBookingsForEvent: vi.fn(),
+  useGetUserAccessGroups: vi.fn(),
+}));
+
+vi.mock("../../../../config/firebase", () => ({
+  dataConnect: {},
+}));
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  getSectionMembersMerged: vi.fn().mockResolvedValue({ members: [] }),
+  submitEventBooking: vi.fn().mockResolvedValue({
+    bookingId: "booking-new",
+    status: "SUBMITTED",
+  }),
+}));
+
+describe("EventBookingWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(reactGenerated.useGetCurrentUser).mockReturnValue({
+      data: { user: { id: "user-1", membershipStatus: "REGULAR" } },
+      isLoading: false,
+    } as never);
+    vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue({
+      data: { user: { userGroups: [{ userGroup: { id: "group-1" } }] } },
+    } as never);
+    vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
+      data: {
+        user: {
+          bookings: [
+            {
+              id: "booking-1",
+              status: BookingStatus.SUBMITTED,
+              revisionNumber: 2,
+              clientSubmissionKey: null,
+              bookerDietaryNote: "No nuts",
+              sitNextToUserIds: [],
+              accommodationRequested: false,
+              accommodationNote: null,
+              lines: [
+                {
+                  id: "line-1",
+                  sortOrder: 0,
+                  guestDisplayName: null,
+                  dietaryNote: null,
+                  ticketType: {
+                    id: "ticket-member",
+                    title: "Member standard",
+                    audience: TicketAudience.MEMBER,
+                    price: 50,
+                  },
+                },
+              ],
+              guestTicketRequests: [],
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      refetch: vi.fn().mockResolvedValue({ data: { user: { bookings: [] } } }),
+    } as never);
+  });
+
+  it("submits booking edits with base revision metadata", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventBookingWizard
+        section={{
+          id: "section-1",
+          name: "Events",
+          type: "EVENTS",
+          description: null,
+          purposeLinks: [
+            { purposes: ["ACCESS", "BOOKER"], userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] } },
+          ],
+        } as never}
+        event={{
+          id: "event-1",
+          title: "Annual Dinner",
+          bookingStartDateTime: "2025-01-01T00:00:00Z",
+          bookingEndDateTime: "2030-01-01T00:00:00Z",
+          maxGuestsWithoutModeratorApproval: 1,
+          ticketTypes: [
+            {
+              id: "ticket-member",
+              title: "Member standard",
+              audience: TicketAudience.MEMBER,
+              price: 50,
+              userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+            },
+            {
+              id: "ticket-guest",
+              title: "Guest standard",
+              audience: TicketAudience.GUEST,
+              price: 25,
+              userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+            },
+          ],
+        } as never}
+      />
+    );
+
+    expect(screen.getByText("Edit your booking")).toBeInTheDocument();
+    expect(screen.getByText(/editing revision 2/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Save booking changes" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.submitEventBooking).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventId: "event-1",
+          baseBookingId: "booking-1",
+          baseRevisionNumber: 2,
+        })
+      );
+    });
+  });
+});

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -241,6 +241,8 @@ export interface SubmitEventBookingLine {
 export interface SubmitEventBookingRequest {
   idempotencyKey: string;
   eventId: string;
+  baseBookingId?: string;
+  baseRevisionNumber?: number;
   lines: SubmitEventBookingLine[];
   bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[];
@@ -277,6 +279,8 @@ export async function submitEventBooking(
   const normalized: SubmitEventBookingRequest = {
     idempotencyKey: toCanonicalUuid(payload.idempotencyKey),
     eventId: toCanonicalUuid(payload.eventId),
+    baseBookingId: payload.baseBookingId ? toCanonicalUuid(payload.baseBookingId) : undefined,
+    baseRevisionNumber: payload.baseRevisionNumber,
     lines: payload.lines.map((line) => ({
       ...line,
       ticketTypeId: toCanonicalUuid(line.ticketTypeId),


### PR DESCRIPTION
## Summary
- update booking wizard to support editing existing submitted/confirmed bookings by hydrating from latest revision
- pass `baseBookingId`/`baseRevisionNumber` through the callable wrapper for optimistic mutable-booking submits
- extend booking query payload with revision metadata and add regression test for revision-aware submit payload

## Test plan
- [x] npm run test -- src/features/sections/components/__tests__/EventBookingWizard.test.tsx
- [x] npm run test -- src/features/sections/components/__tests__/SectionDetail.test.tsx
- [x] npm run build

Made with [Cursor](https://cursor.com)