### PR TITLE
#148 — Split Stripe webhook handling into domain endpoints

### DIFF
--- a/docs/architecture/payment-state-machine.md
+++ b/docs/architecture/payment-state-machine.md
@@ -56,6 +56,15 @@ Functions maintain an explicit Stripe event allowlist in code (`SUPPORTED_STRIPE
 - Illegal transition: acknowledge webhook (2xx), no mutation.
 - Valid transition: apply mutation and acknowledge webhook (2xx).
 
+## Endpoint Topology
+
+Stripe webhooks are split by domain starting with a dedicated payments endpoint:
+
+- `stripeWebhookPayments` (preferred): handles payment lifecycle allowlisted events.
+- `stripeWebhook` (legacy compatibility): still accepts payment lifecycle events during cutover.
+
+See `docs/operations/stripe-webhook-endpoints.md` for endpoint URLs, Stripe dashboard setup, secret mapping, local replay/testing, and migration steps.
+
 ## Refund/Dispute Persistence Model
 
 `TicketOrder` now stores lifecycle side-state metadata required for reconciliation and support workflows:

--- a/docs/operations/stripe-webhook-endpoints.md
+++ b/docs/operations/stripe-webhook-endpoints.md
@@ -1,0 +1,86 @@
+# Stripe Webhook Endpoints
+
+This runbook defines how Stripe webhook endpoints are configured for this project, including URL patterns, secret mapping, and migration from the legacy consolidated endpoint.
+
+## Endpoints
+
+- Preferred payments endpoint: `stripeWebhookPayments`
+- Legacy compatibility endpoint: `stripeWebhook`
+
+## URL Patterns
+
+Use your Firebase project id in place of `<project-id>`.
+
+- Production payments endpoint:
+  - `https://europe-west2-<project-id>.cloudfunctions.net/stripeWebhookPayments`
+- Production legacy endpoint:
+  - `https://europe-west2-<project-id>.cloudfunctions.net/stripeWebhook`
+- Local emulator payments endpoint:
+  - `http://127.0.0.1:5001/<project-id>/europe-west2/stripeWebhookPayments`
+- Local emulator legacy endpoint:
+  - `http://127.0.0.1:5001/<project-id>/europe-west2/stripeWebhook`
+
+## Stripe Dashboard Setup
+
+1. In Stripe Dashboard, open `Developers -> Webhooks`.
+2. Click `Add endpoint`.
+3. Set the endpoint URL to the payments endpoint URL.
+4. Select only the payments-domain event allowlist:
+   - `checkout.session.completed`
+   - `checkout.session.expired`
+   - `checkout.session.async_payment_failed`
+   - `charge.refunded`
+   - `charge.dispute.created`
+   - `charge.dispute.updated`
+   - `charge.dispute.closed`
+5. Save, then reveal the signing secret for that endpoint.
+6. Store the secret for Functions:
+   - Primary: `STRIPE_WEBHOOK_SECRET_PAYMENTS`
+   - Fallback during migration: `STRIPE_WEBHOOK_SECRET`
+
+## Secret and Endpoint Mapping
+
+- `STRIPE_WEBHOOK_SECRET_PAYMENTS`: signing secret for `stripeWebhookPayments`.
+- `STRIPE_WEBHOOK_SECRET`: legacy endpoint secret, also used as fallback if the payments-specific secret is not yet configured.
+
+## Cutover Plan
+
+1. Deploy code with both `stripeWebhookPayments` and `stripeWebhook`.
+2. Configure Stripe to deliver payment events to `stripeWebhookPayments`.
+3. Monitor logs and payment state transitions for stable processing.
+4. Keep legacy endpoint available during transition to avoid missed events.
+5. After verification, remove payment event subscriptions from legacy endpoint.
+
+## Local Testing and Replay
+
+Use Stripe CLI to forward events to the payments endpoint:
+
+```bash
+stripe listen --forward-to "http://127.0.0.1:5001/<project-id>/europe-west2/stripeWebhookPayments"
+```
+
+Trigger representative events:
+
+```bash
+stripe trigger checkout.session.completed
+stripe trigger checkout.session.expired
+```
+
+Replay a known event id:
+
+```bash
+stripe events resend <event-id> --webhook-endpoint=<endpoint-id>
+```
+
+## Troubleshooting Checklist
+
+- Signature errors:
+  - verify endpoint URL and signing secret pairing
+  - confirm secret is stored in the correct environment
+- Event ignored:
+  - check event type is in payments allowlist
+  - verify event includes `metadata.orderId`
+- Duplicate delivery:
+  - confirm webhook idempotency ledger recorded prior processing
+- Missing order:
+  - verify `orderId` exists and matches persisted `TicketOrder` id

--- a/functions/src/__tests__/stripeWebhookRouting.test.ts
+++ b/functions/src/__tests__/stripeWebhookRouting.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { classifyStripeWebhookDomain, eventBelongsToPaymentsDomain } from "../stripeWebhookRouting";
+
+describe("stripeWebhookRouting", () => {
+  it("routes payment lifecycle events to the payments domain", () => {
+    expect(eventBelongsToPaymentsDomain("checkout.session.completed")).toBe(true);
+    expect(eventBelongsToPaymentsDomain("charge.refunded")).toBe(true);
+    expect(eventBelongsToPaymentsDomain("charge.dispute.created")).toBe(true);
+  });
+
+  it("marks unsupported events outside domain endpoints", () => {
+    expect(eventBelongsToPaymentsDomain("payment_intent.succeeded")).toBe(false);
+    expect(classifyStripeWebhookDomain("payment_intent.succeeded")).toBe("unsupported");
+  });
+
+  it("classifies supported events to payments domain", () => {
+    expect(classifyStripeWebhookDomain("checkout.session.expired")).toBe("payments");
+  });
+});

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -36,9 +36,11 @@ import {
 import { runTicketOrderTransition } from "./paymentTransitionEngine";
 import { evaluateReconciliationSignals } from "./paymentReconciliation";
 import { emitPaymentLifecycleNotification } from "./paymentNotifications";
+import { classifyStripeWebhookDomain } from "./stripeWebhookRouting";
 
 const stripeSecret = defineSecret("STRIPE_SECRET");
 const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
+const stripeWebhookPaymentsSecret = defineSecret("STRIPE_WEBHOOK_SECRET_PAYMENTS");
 const CHECKOUT_CURRENCY = "gbp";
 const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
@@ -252,12 +254,28 @@ export const createTicketCheckoutSession = onCall({ region: FUNCTIONS_REGION, se
   return { url: session.url, orderId };
 });
 
-export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret] }, async (req, res) => {
+function resolveWebhookSecret(domain: "payments"): string | undefined {
+  if (domain === "payments") {
+    return stripeWebhookPaymentsSecret.value() || stripeWebhookSecret.value();
+  }
+  return stripeWebhookSecret.value();
+}
+
+async function handleStripeWebhookRequest(args: {
+  domain: "payments";
+  endpointName: "stripeWebhookPayments" | "stripeWebhook";
+  req: { headers: Record<string, unknown>; rawBody: Buffer };
+  res: { status: (code: number) => { send: (body: string) => void } };
+}): Promise<void> {
+  const { req, res, domain, endpointName } = args;
   try {
     const stripeClient = requireStripe(stripeSecret.value());
-    const webhookSecret = stripeWebhookSecret.value();
+    const webhookSecret = resolveWebhookSecret(domain);
     if (!webhookSecret) {
-      logger.error("Missing STRIPE_WEBHOOK_SECRET");
+      logger.error(`${endpointName} missing webhook secret`, {
+        domain,
+        expectedSecret: "STRIPE_WEBHOOK_SECRET_PAYMENTS or STRIPE_WEBHOOK_SECRET",
+      });
       res.status(500).send("Webhook secret not configured");
       return;
     }
@@ -269,10 +287,21 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
 
     const event = stripeClient.webhooks.constructEvent(req.rawBody, signature, webhookSecret);
     const supportedEventType = isSupportedStripeEventType(event.type);
+    const routedDomain = classifyStripeWebhookDomain(event.type);
+    if (routedDomain !== domain) {
+      logger.info(`${endpointName} ignored out-of-domain event`, {
+        eventType: event.type,
+        eventId: event.id,
+        domain,
+        routedDomain,
+      });
+      res.status(200).send("Ignored out-of-domain event");
+      return;
+    }
     const stripeObjectId = stripeObjectIdFromEvent(event);
     const existingWebhookEvent = await getPaymentWebhookEventByStripeEventId({ stripeEventId: event.id });
     if ((existingWebhookEvent.data?.paymentWebhookEvents?.length ?? 0) > 0) {
-      logger.info("stripeWebhook duplicate delivery", {
+      logger.info(`${endpointName} duplicate delivery`, {
         eventType: event.type,
         eventId: event.id,
         stripeObjectId,
@@ -283,7 +312,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
 
     const normalized = normalizeStripeEvent(event);
     if (normalized.kind === "ignore") {
-      logger.info("stripeWebhook ignored event", {
+      logger.info(`${endpointName} ignored event`, {
         eventType: event.type,
         eventId: event.id,
         supportedEventType,
@@ -301,7 +330,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
       return;
     }
     if (!normalized.orderId) {
-      logger.info("stripeWebhook missing order metadata", { eventType: event.type, reason: normalized.reason, eventId: event.id });
+      logger.info(`${endpointName} missing order metadata`, { eventType: event.type, reason: normalized.reason, eventId: event.id });
       await appendWebhookLedgerEvent({
         stripeEventId: event.id,
         eventType: event.type,
@@ -318,7 +347,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
     const existing = await getTicketOrderForWebhook({ id: canonicalOrderId });
     const order = existing.data?.ticketOrder;
     if (!order) {
-      logger.info("stripeWebhook order not found", { eventType: event.type, eventId: event.id, orderId: canonicalOrderId });
+      logger.info(`${endpointName} order not found`, { eventType: event.type, eventId: event.id, orderId: canonicalOrderId });
       await appendWebhookLedgerEvent({
         stripeEventId: event.id,
         eventType: event.type,
@@ -351,7 +380,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
         disputeUpdatedAt: eventTimestamp,
         disputeClosedAt: normalized.disputeState === "DISPUTE_CLOSED" ? eventTimestamp : null,
       });
-      logger.info("stripeWebhook dispute side-state (no order status change)", {
+      logger.info(`${endpointName} dispute side-state (no order status change)`, {
         eventType: event.type,
         eventId: event.id,
         orderId: canonicalOrderId,
@@ -391,7 +420,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
 
     const intent = normalized.intent;
     if (!intent) {
-      logger.error("stripeWebhook payment transition without intent", {
+      logger.error(`${endpointName} payment transition without intent`, {
         eventType: event.type,
         eventId: event.id,
         orderId: canonicalOrderId,
@@ -452,7 +481,7 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
       }
     );
     if (transitionResult.action !== "applied") {
-      logger.info("stripeWebhook transition skipped", {
+      logger.info(`${endpointName} transition skipped`, {
         eventType: event.type,
         eventId: event.id,
         orderId: canonicalOrderId,
@@ -520,7 +549,24 @@ export const stripeWebhook = onRequest({ region: FUNCTIONS_REGION, secrets: [str
     });
     res.status(200).send("ok");
   } catch (err) {
-    logger.error("stripeWebhook error", err);
+    logger.error(`${endpointName} error`, err);
     res.status(400).send("Webhook error");
   }
-});
+}
+
+export const stripeWebhookPayments = onRequest(
+  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret] },
+  async (req, res) => {
+    await handleStripeWebhookRequest({ domain: "payments", endpointName: "stripeWebhookPayments", req, res });
+  }
+);
+
+export const stripeWebhook = onRequest(
+  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret] },
+  async (req, res) => {
+    logger.warn("stripeWebhook legacy endpoint invoked", {
+      migrationTarget: "stripeWebhookPayments",
+    });
+    await handleStripeWebhookRequest({ domain: "payments", endpointName: "stripeWebhook", req, res });
+  }
+);

--- a/functions/src/stripeWebhookRouting.ts
+++ b/functions/src/stripeWebhookRouting.ts
@@ -1,0 +1,11 @@
+import { isSupportedStripeEventType } from "./paymentStateMachine";
+
+export type StripeWebhookDomain = "payments";
+
+export function eventBelongsToPaymentsDomain(eventType: string): boolean {
+  return isSupportedStripeEventType(eventType);
+}
+
+export function classifyStripeWebhookDomain(eventType: string): StripeWebhookDomain | "unsupported" {
+  return eventBelongsToPaymentsDomain(eventType) ? "payments" : "unsupported";
+}


### PR DESCRIPTION
## Summary
- Start implementation for #148
- Split Stripe webhook handling into domain-specific endpoints (payments first)
- Add operator documentation for Stripe endpoint setup and URL/secret management

## Linked issue
- Closes #148

## Planned deliverables
- Dedicated payments webhook endpoint + shared verification utilities
- Backward-compatible cutover from consolidated endpoint
- Runbook/docs for Stripe dashboard endpoint URLs, secrets, replay/testing, and troubleshooting

Made with [Cursor](https://cursor.com)