### PR TITLE
#174 — My Payments UI: invoice download actions and UX states

### DIFF
--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -1,8 +1,23 @@
-import { Alert, Box, Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from "@mui/material";
+import { useState } from "react";
 import { useGetMyBookingPaymentAdjustments, useGetMyTicketOrders } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import PageHeader from "../../../shared/components/PageHeader";
 import "../../../shared/components/PageContainer.css";
+import { getMyTicketOrderInvoice } from "../../../shared/utils/firebaseFunctions";
 
 interface MyPaymentsProps {
   onBack: () => void;
@@ -18,6 +33,8 @@ function statusChipColor(status: string): "success" | "error" | "warning" | "def
 export default function MyPayments({ onBack }: MyPaymentsProps) {
   const { data, isLoading, isError, error, refetch } = useGetMyTicketOrders(dataConnect);
   const { data: adjustmentsData } = useGetMyBookingPaymentAdjustments(dataConnect, { enabled: !isLoading });
+  const [downloadingByOrderId, setDownloadingByOrderId] = useState<Record<string, boolean>>({});
+  const [invoiceError, setInvoiceError] = useState<string | null>(null);
   const orders = data?.user?.ticketOrders ?? [];
   const bookingAdjustments = (adjustmentsData?.user?.bookings ?? []).flatMap((booking) =>
     (booking.adjustments ?? []).map((adjustment) => ({
@@ -28,9 +45,36 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
     }))
   );
 
+  const handleDownloadInvoice = async (orderId: string): Promise<void> => {
+    setInvoiceError(null);
+    setDownloadingByOrderId((prev) => ({ ...prev, [orderId]: true }));
+    try {
+      const invoice = await getMyTicketOrderInvoice({ orderId });
+      const binary = atob(invoice.contentBase64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      const blob = new Blob([bytes], { type: invoice.mimeType });
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = invoice.fileName;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(objectUrl);
+    } catch (downloadError) {
+      setInvoiceError(downloadError instanceof Error ? downloadError.message : "Failed to download invoice.");
+    } finally {
+      setDownloadingByOrderId((prev) => ({ ...prev, [orderId]: false }));
+    }
+  };
+
   return (
     <Box className="page-container">
       <PageHeader title="My Payments" onBack={onBack} />
+      {invoiceError ? <Alert severity="error">{invoiceError}</Alert> : null}
       {isLoading ? (
         <CircularProgress size={24} />
       ) : isError ? (
@@ -51,6 +95,7 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
                   <TableCell align="right">Qty</TableCell>
                   <TableCell align="right">Amount</TableCell>
                   <TableCell>Lifecycle detail</TableCell>
+                  <TableCell>Invoice</TableCell>
                   <TableCell>Updated</TableCell>
                 </TableRow>
               </TableHead>
@@ -74,6 +119,16 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
                           : order.disputeStatus
                             ? `Dispute: ${order.disputeStatus}${order.disputeReason ? ` (${order.disputeReason})` : ""}`
                             : "Payment settled"}
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        onClick={() => void handleDownloadInvoice(order.id)}
+                        disabled={Boolean(downloadingByOrderId[order.id])}
+                      >
+                        {downloadingByOrderId[order.id] ? "Downloading..." : "Download invoice"}
+                      </Button>
                     </TableCell>
                     <TableCell>{new Date(order.updatedAt).toLocaleString()}</TableCell>
                   </TableRow>

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -1,12 +1,18 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "../../../../test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "../../../../test-utils";
 import MyPayments from "../MyPayments";
 import * as reactGenerated from "@dataconnect/generated/react";
 import { dataConnectQueryResult } from "../../../../test-utils/dataConnectMocks";
+import userEvent from "@testing-library/user-event";
+import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 
 vi.mock("@dataconnect/generated/react", () => ({
   useGetMyTicketOrders: vi.fn(),
   useGetMyBookingPaymentAdjustments: vi.fn(),
+}));
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  getMyTicketOrderInvoice: vi.fn(),
 }));
 
 vi.mock("../../../../config/firebase", () => ({
@@ -14,6 +20,20 @@ vi.mock("../../../../config/firebase", () => ({
 }));
 
 describe("MyPayments", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.mocked(firebaseFunctions.getMyTicketOrderInvoice).mockResolvedValue({
+      invoiceReference: "SODC-20260504-ORDER1",
+      fileName: "invoice.pdf",
+      mimeType: "application/pdf",
+      contentBase64: btoa("invoice"),
+      generatedAt: "2026-05-04T10:00:00Z",
+    });
+  });
+
   it("renders booking adjustment statuses alongside payment history", () => {
     vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
       dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
@@ -76,5 +96,57 @@ describe("MyPayments", () => {
     expect(screen.getByText("PENDING AUTO REFUND")).toBeInTheDocument();
     expect(screen.getByText("Rev 2")).toBeInTheDocument();
     expect(screen.getByText("-5.00 GBP")).toBeInTheDocument();
+  });
+
+  it("downloads invoice for a payment row", async () => {
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
+        data: {
+          user: {
+            id: "u-1",
+            ticketOrders: [
+              {
+                id: "order-1",
+                status: "PAID",
+                quantity: 1,
+                totalAmountMinor: 2500,
+                currency: "gbp",
+                updatedAt: "2026-04-01T12:00:00Z",
+                refundedAmountMinor: null,
+                disputeStatus: null,
+                disputeReason: null,
+                event: { id: "event-1", title: "Spring Ball" },
+                ticketType: { id: "ticket-1", title: "Member ticket" },
+              },
+            ],
+          },
+        },
+        isLoading: false,
+        isError: false,
+      })
+    );
+    vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyBookingPaymentAdjustments>({
+        data: { user: { id: "u-1", bookings: [] } },
+        isLoading: false,
+        isError: false,
+      })
+    );
+
+    const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test");
+    const revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => undefined);
+    const user = userEvent.setup();
+    render(<MyPayments onBack={() => undefined} />);
+    await user.click(screen.getByRole("button", { name: "Download invoice" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.getMyTicketOrderInvoice).toHaveBeenCalledWith({ orderId: "order-1" });
+    });
+    expect(createObjectUrlSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectUrlSpy).toHaveBeenCalledTimes(1);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -266,6 +266,18 @@ export interface CreateTicketCheckoutSessionResponse {
   orderId: string;
 }
 
+export interface GetMyTicketOrderInvoiceRequest {
+  orderId: string;
+}
+
+export interface GetMyTicketOrderInvoiceResponse {
+  invoiceReference: string;
+  fileName: string;
+  mimeType: string;
+  contentBase64: string;
+  generatedAt: string;
+}
+
 /**
  * Submits a booking for an event (validated server-side). Reuse the same idempotency key on retries.
  */
@@ -306,6 +318,19 @@ export async function createTicketCheckoutSession(
     quantity: payload.quantity ?? 1,
   };
   const result = await callable(normalized);
+  return result.data;
+}
+
+export async function getMyTicketOrderInvoice(
+  payload: GetMyTicketOrderInvoiceRequest
+): Promise<GetMyTicketOrderInvoiceResponse> {
+  const callable = httpsCallable<GetMyTicketOrderInvoiceRequest, GetMyTicketOrderInvoiceResponse>(
+    functions,
+    "getMyTicketOrderInvoice"
+  );
+  const result = await callable({
+    orderId: toCanonicalUuid(payload.orderId),
+  });
   return result.data;
 }
 


### PR DESCRIPTION
## Summary
- Add per-order `Download invoice` action in `MyPayments`
- Wire UI to `getMyTicketOrderInvoice` callable wrapper
- Add row-level loading state and user-visible download error handling
- Add frontend test coverage for invoice download trigger path

## Linked issue
- Closes #174

## Test plan
- [x] `npm run test:run -- src/features/sections/components/__tests__/MyPayments.test.tsx`
- [x] `npm run build`

## Notes
- Stacked on `issue-168-pdf-invoices`.

Made with [Cursor](https://cursor.com)