### PR TITLE
Fix post-checkout confirmation and Stripe webhook verification (#181)

### DIFF
--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -43,7 +43,7 @@ describe("function entry guard contracts", () => {
   it("keeps Stripe webhook signature verification in place", () => {
     const payments = readSource("payments.ts");
     expect(payments).toContain("stripe-signature");
-    expect(payments).toContain("constructEvent(req.rawBody, signature, webhookSecret)");
+    expect(payments).toContain("constructEvent(req.rawBody, signature,");
     expect(payments).toContain("getPaymentWebhookEventByStripeEventId");
     expect(payments).toContain("createPaymentWebhookEvent");
     expect(payments).toContain("emitPaymentLifecycleNotification");

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -228,8 +228,8 @@ export const createTicketCheckoutSession = onCall({ region: FUNCTIONS_REGION, se
   const session = await stripeClient.checkout.sessions.create({
     mode: "payment",
     customer: customerId ?? undefined,
-    success_url: `${APP_BASE_URL}/?checkout=success&orderId=${orderId}`,
-    cancel_url: `${APP_BASE_URL}/?checkout=cancel&orderId=${orderId}`,
+    success_url: `${APP_BASE_URL}/my-payments?checkout=success&orderId=${orderId}`,
+    cancel_url: `${APP_BASE_URL}/my-payments?checkout=cancel&orderId=${orderId}`,
     line_items: [
       {
         quantity,
@@ -386,11 +386,11 @@ export const getMyTicketOrderStripeArtifactsBatch = onCall(
   }
 );
 
-function resolveWebhookSecret(domain: "payments"): string | undefined {
-  if (domain === "payments") {
-    return stripeWebhookPaymentsSecret.value() || stripeWebhookSecret.value();
-  }
-  return stripeWebhookSecret.value();
+function webhookSecretCandidates(endpointName: "stripeWebhookPayments" | "stripeWebhook"): string[] {
+  const payments = stripeWebhookPaymentsSecret.value();
+  const legacy = stripeWebhookSecret.value();
+  const candidates = endpointName === "stripeWebhookPayments" ? [payments, legacy] : [legacy, payments];
+  return candidates.filter((value): value is string => Boolean(value));
 }
 
 async function handleStripeWebhookRequest(args: {
@@ -402,8 +402,8 @@ async function handleStripeWebhookRequest(args: {
   const { req, res, domain, endpointName } = args;
   try {
     const stripeClient = requireStripe(stripeSecret.value());
-    const webhookSecret = resolveWebhookSecret(domain);
-    if (!webhookSecret) {
+    const candidates = webhookSecretCandidates(endpointName);
+    if (candidates.length === 0) {
       logger.error(`${endpointName} missing webhook secret`, {
         domain,
         expectedSecret: "STRIPE_WEBHOOK_SECRET_PAYMENTS or STRIPE_WEBHOOK_SECRET",
@@ -417,7 +417,27 @@ async function handleStripeWebhookRequest(args: {
       return;
     }
 
-    const event = stripeClient.webhooks.constructEvent(req.rawBody, signature, webhookSecret);
+    let event: ReturnType<InstanceType<typeof Stripe>["webhooks"]["constructEvent"]> | null = null;
+    let matchedSecretIndex = -1;
+    let constructEventError: unknown = null;
+    for (let i = 0; i < candidates.length; i += 1) {
+      try {
+        event = stripeClient.webhooks.constructEvent(req.rawBody, signature, candidates[i]);
+        matchedSecretIndex = i;
+        break;
+      } catch (err) {
+        constructEventError = err;
+      }
+    }
+    if (!event) {
+      throw constructEventError ?? new Error("Unable to verify webhook signature");
+    }
+    if (matchedSecretIndex > 0) {
+      logger.warn(`${endpointName} verified with fallback webhook secret`, {
+        domain,
+        fallbackIndex: matchedSecretIndex,
+      });
+    }
     const supportedEventType = isSupportedStripeEventType(event.type);
     const routedDomain = classifyStripeWebhookDomain(event.type);
     if (routedDomain !== domain) {

--- a/src/features/sections/components/CheckoutStatusNotice.tsx
+++ b/src/features/sections/components/CheckoutStatusNotice.tsx
@@ -15,6 +15,11 @@ interface CheckoutStatusNoticeProps {
 const POLL_MS = 2500;
 const MAX_POLLS = 8;
 
+function formatMoney(amountMinor: number | null | undefined, currency: string | null | undefined): string | null {
+  if (typeof amountMinor !== "number" || !currency) return null;
+  return `${(amountMinor / 100).toFixed(2)} ${currency.toUpperCase()}`;
+}
+
 export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss }: CheckoutStatusNoticeProps) {
   const [pollCount, setPollCount] = useState(0);
 
@@ -107,10 +112,17 @@ export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss
   }
 
   if (status === "PAID") {
+    const amountSummary = formatMoney(order.totalAmountMinor, order.currency);
     return (
       <Alert severity="success" onClose={onDismiss} sx={{ mb: 2 }}>
         <AlertTitle>Payment confirmed</AlertTitle>
-        Your {order.ticketType?.title ?? "ticket"} purchase is complete.
+        <Typography variant="body2" sx={{ mb: 0.75 }}>
+          Your {order.ticketType?.title ?? "ticket"} purchase is complete.
+        </Typography>
+        <Typography variant="body2">Event: {order.event?.title ?? "Unknown event"}</Typography>
+        <Typography variant="body2">Quantity: {order.quantity ?? 0}</Typography>
+        <Typography variant="body2">Amount: {amountSummary ?? "Unknown amount"}</Typography>
+        <Typography variant="body2">Reference: {order.id}</Typography>
       </Alert>
     );
   }

--- a/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
+++ b/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
@@ -46,7 +46,17 @@ describe("CheckoutStatusNotice", () => {
     vi.mocked(dcReact.useGetMyTicketOrderById).mockReturnValue({
       data: {
         user: {
-          ticketOrders: [{ id: "abc", status: "PAID", ticketType: { title: "Member Ticket" } }],
+          ticketOrders: [
+            {
+              id: "abc",
+              status: "PAID",
+              ticketType: { title: "Member Ticket" },
+              event: { title: "Spring Gala" },
+              quantity: 2,
+              totalAmountMinor: 2500,
+              currency: "gbp",
+            },
+          ],
         },
       },
       isLoading: false,
@@ -63,6 +73,10 @@ describe("CheckoutStatusNotice", () => {
     );
     expect(screen.getByText(/payment confirmed/i)).toBeInTheDocument();
     expect(screen.getByText(/member ticket purchase is complete/i)).toBeInTheDocument();
+    expect(screen.getByText(/event: spring gala/i)).toBeInTheDocument();
+    expect(screen.getByText(/quantity: 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/amount: 25.00 GBP/i)).toBeInTheDocument();
+    expect(screen.getByText(/reference: abc/i)).toBeInTheDocument();
   });
 
   it("polls while order is pending", () => {


### PR DESCRIPTION
## Summary
Addresses [issue #181](https://github.com/rafsodc/sodc-web/issues/181): improve the post-checkout experience and reduce Stripe webhook `400` failures from signature/secret mismatch.

## Changes
- Redirect Stripe Checkout success/cancel URLs to **My Payments** so confirmation aligns with payment context.
- **Checkout status notice**: when the order is `PAID`, show a short summary (event, quantity, amount, reference).
- **Webhooks**: verify signatures using the endpoint-specific secret first (`stripeWebhookPayments` → `STRIPE_WEBHOOK_SECRET_PAYMENTS`, legacy `stripeWebhook` → `STRIPE_WEBHOOK_SECRET`), then fall back to the other secret during migration.

## Testing
- `npm run lint`
- `npm run test:run -- src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx`
- `npm --prefix functions run build`

Closes #181

Made with [Cursor](https://cursor.com)