### PR TITLE
docs(ops): Vite .env templates for dev and staging (#193)

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,0 +1,30 @@
+# -----------------------------------------------------------------------------
+# Local development → Firebase project for alias `dev` (see `.firebaserc`).
+#
+# Setup:
+#   cp .env.development.example .env.development.local
+#
+# Fill values from Firebase Console → Project settings → Your apps → Web app.
+# `.env.development.local` is gitignored (`*.local`); never commit it.
+#
+# Docs: docs/operations/environments-dev-beta-prod.md
+# -----------------------------------------------------------------------------
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+# Optional if Analytics is configured for this web app
+VITE_FIREBASE_MEASUREMENT_ID=
+
+VITE_ENVIRONMENT=development
+
+# Stripe.js / Checkout (publishable key only — safe in the browser bundle)
+VITE_STRIPE_PUBLISHABLE_KEY=
+
+# Optional: only for ad-hoc scripts run from repo root that expect these names.
+# Deployed Cloud Functions use Firebase secrets (see docs/operations/environment-and-secrets.md).
+# STRIPE_SECRET=
+# STRIPE_WEBHOOK_SECRET=

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,26 @@
+# -----------------------------------------------------------------------------
+# Beta / staging frontend builds → Firebase project for alias `beta` (see `.firebaserc`).
+#
+# Setup:
+#   cp .env.staging.example .env.staging.local
+#
+# Fill values from the **beta** project's Firebase Console → Web app config.
+# `.env.staging.local` is gitignored (`*.local`); never commit it.
+#
+# Build for Hosting (beta):
+#   npm run build -- --mode staging
+#
+# Docs: docs/operations/environments-dev-beta-prod.md
+# -----------------------------------------------------------------------------
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_MEASUREMENT_ID=
+
+VITE_ENVIRONMENT=staging
+
+VITE_STRIPE_PUBLISHABLE_KEY=

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -6,6 +6,15 @@ For **how we use Dev, Beta, and Prod Firebase projects** (no emulators), promoti
 
 Each environment should have its **own** values for the variables below (typically three Firebase web apps and three sets of secrets).
 
+### Template files (committed)
+
+| Template | Copy to (gitignored) | When loaded |
+|----------|----------------------|-------------|
+| `.env.development.example` | `.env.development.local` | `npm run dev` (default mode `development`) |
+| `.env.staging.example` | `.env.staging.local` | `npm run build -- --mode staging` |
+
+Do not put real keys in the `.example` files; copy them and fill in `.env.*.local` locally or inject vars in CI.
+
 ## Frontend (Vite) variables
 
 Defined via `.env*` files and read from `import.meta.env`:

--- a/docs/operations/environments-dev-beta-prod.md
+++ b/docs/operations/environments-dev-beta-prod.md
@@ -46,9 +46,13 @@ The repo expects a **beta** Firebase project whose ID matches the `beta` entry i
 ## Local development (laptop → cloud Dev)
 
 1. **Clone** the repo and install dependencies (`npm install`, `cd functions && npm install`).
-2. **Configure web app env** — Copy or merge from your team’s secure storage (do not commit secrets):
-   - Use a **Dev-only** Firebase web app config in `.env` or `.env.local` (see variable list in [environment-and-secrets.md](./environment-and-secrets.md)).
-   - Ensure every `VITE_FIREBASE_*` value matches the **dev** Firebase project that backends should use.
+2. **Configure web app env** — Start from the committed template (no secrets in git):
+
+   ```sh
+   cp .env.development.example .env.development.local
+   ```
+
+   Edit `.env.development.local` with the **dev** Firebase web app values from the console (Project settings → Your apps). Variable meanings are listed in [environment-and-secrets.md](./environment-and-secrets.md). Ensure every `VITE_FIREBASE_*` value matches the **dev** project (`firebase use dev`).
 3. **Run the app**:
 
    ```sh
@@ -67,20 +71,25 @@ The repo expects a **beta** Firebase project whose ID matches the `beta` entry i
 
 ## Building and deploying the SPA
 
-Always build with the environment variables for **the project you are about to deploy to**:
+Always build with the environment variables for **the project you are about to deploy to**.
+
+**Beta (staging mode)** — copy the template once, then fill with the **beta** Firebase web app:
 
 ```sh
-# Example: deploy Hosting to beta — ensure VITE_* point at the beta Firebase web app
-npm run build
+cp .env.staging.example .env.staging.local
+# edit .env.staging.local …
+npm run build -- --mode staging
 firebase deploy --only hosting --project beta
 ```
 
+**Production** — use `.env.production.local` (gitignored) with the **prod** web app config, then `npm run build` (default mode is `production`), or set `VITE_*` in CI for the prod project.
+
 Common mistakes:
 
-- Building with **prod** `.env` and deploying to **dev** (wrong Auth project, confusing failures).
-- Deploying **without** rebuilding after changing `.env` (stale API keys in `dist/`).
+- Building with **prod** vars and deploying to **beta** (or vice versa): wrong Auth project and confusing failures.
+- Deploying **without** rebuilding after changing env files (stale API keys in `dist/`).
 
-Recommendation: maintain **separate env files** that are **not committed**, e.g. `.env.dev.local`, `.env.beta.local`, `.env.prod.local`, and copy or symlink the right one before `npm run build`, or use your shell/CI to export variables.
+Recommendation: keep **only** `*.local` files on disk for secrets; use the committed `*.example` files as the checklist of keys, or export `VITE_*` in CI per environment.
 
 ## Promotion flow (recommended)
 


### PR DESCRIPTION
## Summary

Adds committed **`.env.development.example`** and **`.env.staging.example`** templates (placeholders only) so developers can `cp` → `.env.*.local` without guessing keys. Updates ops docs with copy commands and `npm run build -- --mode staging` for beta builds.

Follow-up to #194 / part of #193.

## Test plan

- [x] Templates contain no real secrets.
- [x] Docs cross-links consistent.

Part of #193

Made with [Cursor](https://cursor.com)