### PR TITLE
Add GOV.UK Notify mailer foundation

### DIFF
--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -27,12 +27,19 @@ Defined via `.env*` files and read from `import.meta.env`:
 |---|---|---|---|
 | `STRIPE_SECRET` | Firebase secret | `createTicketCheckoutSession`, `stripeWebhook` | yes for payments |
 | `STRIPE_WEBHOOK_SECRET` | Firebase secret | `stripeWebhook` | yes for webhook processing |
+| `GOV_NOTIFY_API_KEY` | Firebase secret | Transactional mailer / payment webhook notification path | yes for app-owned transactional email |
 | `APP_BASE_URL` | env var | Checkout success/cancel URLs | yes for non-local |
 | `ENV_NAME` | env var | dev reset guardrail | required for reset tooling |
 | `PERMITTED_PROJECT_IDS` | env var | dev reset guardrail | required for reset tooling |
+| `GOV_NOTIFY_EMAIL_REPLY_TO_ID` | env var | Optional GOV.UK Notify reply-to selection | optional |
+| `GOV_NOTIFY_TEMPLATE_<TEMPLATE_NAME>` | env var | GOV.UK Notify template IDs for app-owned transactional email templates | required for each enabled app email template |
 
 ## Operational notes
 
 - Do not commit secret values to repo.
 - Rotate Stripe secrets if compromised and update Firebase secrets before redeploy.
+- Rotate `GOV_NOTIFY_API_KEY` if compromised and update Firebase secrets before redeploy.
 - Keep environment docs and deployment settings aligned when adding new variables.
+- Configure GOV.UK Notify API keys and template IDs independently per Firebase environment.
+- Template env var names are derived from typed template names in `functions/src/mailer.ts`; for example, `paymentConfirmation` maps to `GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION`.
+- Stripe may send customer receipts/invoices for payment activity when enabled in Stripe. Use GOV.UK Notify for app-owned transactional messages that need application context, links, membership/booking workflow details, or internal operational recipients.

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -9,6 +9,7 @@
         "@dataconnect/admin-generated": "file:src/dataconnect-admin-generated",
         "firebase-admin": "^13.6.0",
         "firebase-functions": "^7.0.0",
+        "notifications-node-client": "^8.3.2",
         "stripe": "^22.0.2"
       },
       "devDependencies": {
@@ -3883,8 +3884,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -3900,6 +3900,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -4439,7 +4466,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4672,7 +4698,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4953,7 +4978,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5880,6 +5904,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6462,7 +6506,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8522,6 +8565,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/notifications-node-client": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.3.2.tgz",
+      "integrity": "sha512-/rLsEz8wyY2195q7KYgPgGbl4Duh7/98nB0HzLvZ+vVKUsuoUx+JdM3QRhZrLoEKlyGTt9tTc4JyZjVQF1euuw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.2",
+        "jsonwebtoken": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=14.17.3",
+        "npm": ">=6.14.13"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -9164,6 +9221,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -21,6 +21,7 @@
     "@dataconnect/admin-generated": "file:src/dataconnect-admin-generated",
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.0.0",
+    "notifications-node-client": "^8.3.2",
     "stripe": "^22.0.2"
   },
   "devDependencies": {

--- a/functions/src/__tests__/mailer.test.ts
+++ b/functions/src/__tests__/mailer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("firebase-functions/params", () => ({
+  defineSecret: vi.fn((name: string) => ({
+    name,
+    value: vi.fn(() => undefined),
+  })),
+}));
+
+import {
+  createGovNotifyMailer,
+  govNotifyTemplateEnvVarName,
+  readGovNotifyTemplateIds,
+  type NotifyEmailClient,
+} from "../mailer";
+
+type TestTemplates = {
+  paymentConfirmation: {
+    event_title: string;
+    amount_paid: string;
+  };
+  paymentFailure: {
+    recovery_link: string;
+  };
+};
+
+function fakeLogger() {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+describe("mailer", () => {
+  it("derives GOV.UK Notify template environment variable names", () => {
+    expect(govNotifyTemplateEnvVarName("paymentConfirmation")).toBe("GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION");
+    expect(govNotifyTemplateEnvVarName("booking-revision")).toBe("GOV_NOTIFY_TEMPLATE_BOOKING_REVISION");
+  });
+
+  it("reads configured template ids from environment", () => {
+    expect(
+      readGovNotifyTemplateIds(["paymentConfirmation", "paymentFailure"] as const, {
+        GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION: "template-paid",
+      })
+    ).toEqual({
+      paymentConfirmation: "template-paid",
+    });
+  });
+
+  it("sends typed template payloads through GOV.UK Notify", async () => {
+    const sendEmail = vi.fn<NotifyEmailClient["sendEmail"]>(async () => ({
+      data: {
+        id: "notify-message-id",
+        reference: "order-123",
+      },
+    }));
+    const logger = fakeLogger();
+    const mailer = createGovNotifyMailer<TestTemplates>({
+      apiKey: "notify-api-key",
+      templateIds: {
+        paymentConfirmation: "template-paid",
+      },
+      emailReplyToId: "reply-to-id",
+      clientFactory: () => ({ sendEmail }),
+      logger,
+    });
+
+    await expect(
+      mailer.sendEmail({
+        templateName: "paymentConfirmation",
+        to: "buyer@example.com",
+        personalisation: {
+          event_title: "Annual Dinner",
+          amount_paid: "GBP 10.00",
+        },
+        reference: "order-123",
+      })
+    ).resolves.toEqual({
+      provider: "govuk_notify",
+      providerNotificationId: "notify-message-id",
+      reference: "order-123",
+    });
+
+    expect(sendEmail).toHaveBeenCalledWith("template-paid", "buyer@example.com", {
+      personalisation: {
+        event_title: "Annual Dinner",
+        amount_paid: "GBP 10.00",
+      },
+      reference: "order-123",
+      emailReplyToId: "reply-to-id",
+    });
+    expect(JSON.stringify(logger.info.mock.calls)).not.toContain("buyer@example.com");
+  });
+
+  it("logs provider failures without recipient PII", async () => {
+    const providerError = new Error("Notify rejected buyer@example.com") as Error & {
+      response?: unknown;
+    };
+    providerError.response = {
+      status: 400,
+      statusText: "Bad Request",
+      data: {
+        errors: [
+          {
+            error: "BadRequestError",
+            message: "email_address buyer@example.com is invalid",
+          },
+        ],
+      },
+    };
+    const sendEmail = vi.fn<NotifyEmailClient["sendEmail"]>(async () => {
+      throw providerError;
+    });
+    const logger = fakeLogger();
+    const mailer = createGovNotifyMailer<TestTemplates>({
+      apiKey: "notify-api-key",
+      templateIds: {
+        paymentFailure: "template-failed",
+      },
+      clientFactory: () => ({ sendEmail }),
+      logger,
+    });
+
+    await expect(
+      mailer.sendEmail({
+        templateName: "paymentFailure",
+        to: "buyer@example.com",
+        personalisation: {
+          recovery_link: "https://example.test/payments",
+        },
+        reference: "order-456",
+      })
+    ).rejects.toThrow("Notify rejected buyer@example.com");
+
+    const loggedMetadata = JSON.stringify(logger.error.mock.calls[0][1]);
+    expect(loggedMetadata).not.toContain("buyer@example.com");
+    expect(loggedMetadata).toContain("[redacted-email]");
+    expect(loggedMetadata).toContain("BadRequestError");
+  });
+});

--- a/functions/src/__tests__/paymentNotifications.test.ts
+++ b/functions/src/__tests__/paymentNotifications.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as logger from "firebase-functions/logger";
 import type { TicketOrderStatus } from "@dataconnect/admin-generated";
 import { emitPaymentLifecycleNotification } from "../paymentNotifications";
 
 describe("paymentNotifications", () => {
+  beforeEach(() => {
+    vi.mocked(logger.error).mockClear();
+  });
+
   it("dispatches notification payloads", async () => {
     const dispatcher = vi.fn(async () => undefined);
     await emitPaymentLifecycleNotification(
@@ -28,7 +33,7 @@ describe("paymentNotifications", () => {
 
   it("swallows dispatcher failures to keep payment path non-blocking", async () => {
     const dispatcher = vi.fn(async () => {
-      throw new Error("dispatch failed");
+      throw new Error("dispatch failed for buyer@example.com");
     });
 
     await expect(
@@ -43,5 +48,9 @@ describe("paymentNotifications", () => {
         dispatcher
       )
     ).resolves.toBeUndefined();
+
+    const loggedMetadata = JSON.stringify(vi.mocked(logger.error).mock.calls[0][1]);
+    expect(loggedMetadata).not.toContain("buyer@example.com");
+    expect(loggedMetadata).toContain("[redacted-email]");
   });
 });

--- a/functions/src/mailer.ts
+++ b/functions/src/mailer.ts
@@ -1,0 +1,182 @@
+import {defineSecret} from "firebase-functions/params";
+import * as logger from "firebase-functions/logger";
+import {NotifyClient} from "notifications-node-client";
+import {sanitizeMailerError} from "./mailerErrors";
+
+export const govNotifyApiKey = defineSecret("GOV_NOTIFY_API_KEY");
+
+export const GOV_NOTIFY_EMAIL_REPLY_TO_ID_ENV = "GOV_NOTIFY_EMAIL_REPLY_TO_ID";
+export const GOV_NOTIFY_TEMPLATE_ENV_PREFIX = "GOV_NOTIFY_TEMPLATE_";
+export const GOV_NOTIFY_PROVIDER = "govuk_notify";
+
+export type TemplatePersonalisationValue = string | number | boolean | null | undefined;
+export type TemplatePersonalisation = Record<string, TemplatePersonalisationValue>;
+export type TransactionalEmailPayloads<TPayloads> = {
+  [K in keyof TPayloads]: TemplatePersonalisation;
+};
+
+export interface TransactionalEmailRequest<
+  TTemplateName extends string,
+  TPayload extends TemplatePersonalisation
+> {
+  templateName: TTemplateName;
+  to: string;
+  personalisation: TPayload;
+  reference?: string;
+}
+
+export interface TransactionalEmailResult {
+  provider: typeof GOV_NOTIFY_PROVIDER;
+  providerNotificationId?: string;
+  reference?: string;
+}
+
+export interface TransactionalMailer<
+  TPayloads extends TransactionalEmailPayloads<TPayloads>
+> {
+  sendEmail<TTemplateName extends Extract<keyof TPayloads, string>>(
+    request: TransactionalEmailRequest<TTemplateName, TPayloads[TTemplateName]>
+  ): Promise<TransactionalEmailResult>;
+}
+
+export interface NotifyEmailClient {
+  sendEmail(
+    templateId: string,
+    emailAddress: string,
+    options?: {
+      personalisation?: TemplatePersonalisation;
+      reference?: string;
+      emailReplyToId?: string;
+    }
+  ): Promise<{
+    data?: {
+      id?: string;
+      reference?: string;
+    };
+  }>;
+}
+
+export interface MailerLogger {
+  info(message: string, metadata?: Record<string, unknown>): void;
+  error(message: string, metadata?: Record<string, unknown>): void;
+}
+
+export interface GovNotifyMailerOptions<
+  TPayloads extends TransactionalEmailPayloads<TPayloads>
+> {
+  apiKey?: string;
+  templateIds: Partial<Record<Extract<keyof TPayloads, string>, string | undefined>>;
+  emailReplyToId?: string;
+  clientFactory?: (apiKey: string) => NotifyEmailClient;
+  logger?: MailerLogger;
+}
+
+export class MailerConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MailerConfigurationError";
+  }
+}
+
+function requiredConfig(value: string | undefined, name: string): string {
+  if (!value || value.trim().length === 0) {
+    throw new MailerConfigurationError(`${name} is not configured`);
+  }
+  return value;
+}
+
+function createNotifyClient(apiKey: string): NotifyEmailClient {
+  return new NotifyClient(apiKey);
+}
+
+function maybeNonEmpty(value: string | undefined): string | undefined {
+  return value && value.trim().length > 0 ? value : undefined;
+}
+
+export function govNotifyTemplateEnvVarName(templateName: string): string {
+  const envSuffix = templateName
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+  return `${GOV_NOTIFY_TEMPLATE_ENV_PREFIX}${envSuffix}`;
+}
+
+export function readGovNotifyTemplateIds<TTemplateName extends string>(
+  templateNames: readonly TTemplateName[],
+  env: NodeJS.ProcessEnv = process.env
+): Partial<Record<TTemplateName, string>> {
+  return Object.fromEntries(
+    templateNames.flatMap((templateName) => {
+      const value = maybeNonEmpty(env[govNotifyTemplateEnvVarName(templateName)]);
+      return value ? [[templateName, value]] : [];
+    })
+  ) as Partial<Record<TTemplateName, string>>;
+}
+
+export function getGovNotifyEmailReplyToId(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return maybeNonEmpty(env[GOV_NOTIFY_EMAIL_REPLY_TO_ID_ENV]);
+}
+
+export function createGovNotifyMailer<
+  TPayloads extends TransactionalEmailPayloads<TPayloads>
+>(options: GovNotifyMailerOptions<TPayloads>): TransactionalMailer<TPayloads> {
+  const activeLogger = options.logger ?? logger;
+  const clientFactory = options.clientFactory ?? createNotifyClient;
+
+  return {
+    async sendEmail<TTemplateName extends Extract<keyof TPayloads, string>>(
+      request: TransactionalEmailRequest<TTemplateName, TPayloads[TTemplateName]>
+    ): Promise<TransactionalEmailResult> {
+      try {
+        const apiKey = requiredConfig(options.apiKey, "GOV_NOTIFY_API_KEY");
+        const templateId = requiredConfig(
+          options.templateIds[request.templateName],
+          govNotifyTemplateEnvVarName(request.templateName)
+        );
+        const client = clientFactory(apiKey);
+        const response = await client.sendEmail(templateId, request.to, {
+          personalisation: request.personalisation,
+          reference: request.reference,
+          emailReplyToId: options.emailReplyToId,
+        });
+        const providerNotificationId = maybeNonEmpty(response.data?.id);
+        const reference = maybeNonEmpty(response.data?.reference) ?? request.reference;
+        activeLogger.info("transactional email sent", {
+          provider: GOV_NOTIFY_PROVIDER,
+          templateName: request.templateName,
+          reference,
+          providerNotificationId,
+        });
+        return {
+          provider: GOV_NOTIFY_PROVIDER,
+          providerNotificationId,
+          reference,
+        };
+      } catch (error) {
+        activeLogger.error("transactional email failed", {
+          provider: GOV_NOTIFY_PROVIDER,
+          templateName: request.templateName,
+          reference: request.reference,
+          error: sanitizeMailerError(error),
+        });
+        throw error;
+      }
+    },
+  };
+}
+
+export function createConfiguredGovNotifyMailer<
+  TPayloads extends TransactionalEmailPayloads<TPayloads>
+>(
+  templateNames: readonly Extract<keyof TPayloads, string>[],
+  env: NodeJS.ProcessEnv = process.env
+): TransactionalMailer<TPayloads> {
+  return createGovNotifyMailer<TPayloads>({
+    apiKey: govNotifyApiKey.value(),
+    templateIds: readGovNotifyTemplateIds(templateNames, env),
+    emailReplyToId: getGovNotifyEmailReplyToId(env),
+  });
+}
+
+export {sanitizeMailerError};

--- a/functions/src/mailerErrors.ts
+++ b/functions/src/mailerErrors.ts
@@ -39,17 +39,20 @@ function sanitizeProviderErrors(value: unknown): SanitizedMailerError["providerE
     return undefined;
   }
 
-  return value
-    .map((entry) => {
-      if (!isRecord(entry)) {
-        return undefined;
-      }
-      return {
-        error: sanitizedString(entry.error),
-        message: sanitizedString(entry.message),
-      };
-    })
-    .filter((entry): entry is { error?: string; message?: string } => Boolean(entry?.error || entry?.message));
+  const providerErrors: Array<{ error?: string; message?: string }> = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) {
+      continue;
+    }
+    const sanitizedEntry = {
+      error: sanitizedString(entry.error),
+      message: sanitizedString(entry.message),
+    };
+    if (sanitizedEntry.error || sanitizedEntry.message) {
+      providerErrors.push(sanitizedEntry);
+    }
+  }
+  return providerErrors.length > 0 ? providerErrors : undefined;
 }
 
 export function sanitizeMailerError(error: unknown): SanitizedMailerError {

--- a/functions/src/mailerErrors.ts
+++ b/functions/src/mailerErrors.ts
@@ -1,0 +1,71 @@
+export interface SanitizedMailerError {
+  name?: string;
+  message?: string;
+  code?: string | number;
+  status?: number;
+  statusText?: string;
+  providerErrors?: Array<{
+    error?: string;
+    message?: string;
+  }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function sanitizedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const withoutEmailAddresses = value.replace(
+    /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+    "[redacted-email]"
+  );
+  return withoutEmailAddresses.length > 240 ? `${withoutEmailAddresses.slice(0, 237)}...` : withoutEmailAddresses;
+}
+
+function sanitizedStatus(value: unknown): number | undefined {
+  return typeof value === "number" ? value : undefined;
+}
+
+function sanitizedCode(value: unknown): string | number | undefined {
+  return typeof value === "string" || typeof value === "number" ? value : undefined;
+}
+
+function sanitizeProviderErrors(value: unknown): SanitizedMailerError["providerErrors"] {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  return value
+    .map((entry) => {
+      if (!isRecord(entry)) {
+        return undefined;
+      }
+      return {
+        error: sanitizedString(entry.error),
+        message: sanitizedString(entry.message),
+      };
+    })
+    .filter((entry): entry is { error?: string; message?: string } => Boolean(entry?.error || entry?.message));
+}
+
+export function sanitizeMailerError(error: unknown): SanitizedMailerError {
+  if (!isRecord(error)) {
+    return {message: sanitizedString(String(error))};
+  }
+
+  const response = isRecord(error.response) ? error.response : undefined;
+  const responseData = response && isRecord(response.data) ? response.data : undefined;
+
+  return {
+    name: sanitizedString(error.name),
+    message: sanitizedString(error.message),
+    code: sanitizedCode(error.code),
+    status: sanitizedStatus(response?.status) ?? sanitizedStatus(error.status) ?? sanitizedStatus(error.statusCode),
+    statusText: sanitizedString(response?.statusText),
+    providerErrors: sanitizeProviderErrors(responseData?.errors),
+  };
+}

--- a/functions/src/paymentNotifications.ts
+++ b/functions/src/paymentNotifications.ts
@@ -1,6 +1,7 @@
 import * as logger from "firebase-functions/logger";
 import { TicketOrderStatus } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
+import { sanitizeMailerError } from "./mailerErrors";
 
 export type PaymentLifecycleNotificationType =
   | "PAYMENT_PAID"
@@ -35,7 +36,7 @@ export async function emitPaymentLifecycleNotification(
       notificationType: notification.type,
       orderId: notification.orderId,
       stripeEventId: notification.stripeEventId,
-      error,
+      error: sanitizeMailerError(error),
     });
   }
 }

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -38,6 +38,7 @@ import { runTicketOrderTransition } from "./paymentTransitionEngine";
 import { evaluateReconciliationSignals } from "./paymentReconciliation";
 import { emitPaymentLifecycleNotification } from "./paymentNotifications";
 import { classifyStripeWebhookDomain } from "./stripeWebhookRouting";
+import { govNotifyApiKey } from "./mailer";
 
 const stripeSecret = defineSecret("STRIPE_SECRET");
 const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
@@ -707,14 +708,14 @@ async function handleStripeWebhookRequest(args: {
 }
 
 export const stripeWebhookPayments = onRequest(
-  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret] },
+  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret, govNotifyApiKey] },
   async (req, res) => {
     await handleStripeWebhookRequest({ domain: "payments", endpointName: "stripeWebhookPayments", req, res });
   }
 );
 
 export const stripeWebhook = onRequest(
-  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret] },
+  { region: FUNCTIONS_REGION, secrets: [stripeSecret, stripeWebhookSecret, stripeWebhookPaymentsSecret, govNotifyApiKey] },
   async (req, res) => {
     logger.warn("stripeWebhook legacy endpoint invoked", {
       migrationTarget: "stripeWebhookPayments",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements issue #184 - Add transactional email provider and mailer abstraction

## Changes

- Add GOV.UK Notify as the transactional email provider dependency for Firebase Functions.
- Add a shared typed mailer abstraction with template env resolution, optional reply-to config, safe provider error logging, and GOV.UK Notify adapter support.
- Sanitize payment notification failure logs and keep dispatcher failures non-blocking.
- Bind `GOV_NOTIFY_API_KEY` to Stripe webhook functions for future payment notification dispatch.
- Update environment/secrets documentation for GOV.UK Notify config and Stripe-vs-app email policy.

## Related Issue

Closes #184

## Testing

- [ ] Security tests pass
- [x] Functionality tests pass (`npm run build`, `npm test` in `functions/`)
- [ ] Manual testing completed

Note: `npm run lint` in `functions/` currently fails before linting these changes because ESLint loads the root flat config and `@eslint/js` is not installed in this workspace. Running with `ESLINT_USE_FLAT_CONFIG=false` reaches the existing legacy lint baseline, which has many pre-existing style errors across current functions files.

## Checklist

- [ ] Code follows project style guidelines
- [x] Tests added/updated
- [x] Documentation updated (if needed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-648b6c38-36b7-4652-a472-fb63b8112242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-648b6c38-36b7-4652-a472-fb63b8112242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

