### PR TITLE
Internal payment reconciliation and dispute ops alerts (#187)

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -724,6 +724,7 @@ query GetPaymentReconciliationExceptionByOrderAndType(
     limit: 1
   ) {
     id
+    status
   }
 }
 

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -28,11 +28,14 @@ Defined via `.env*` files and read from `import.meta.env`:
 | `STRIPE_SECRET` | Firebase secret | `createTicketCheckoutSession`, `stripeWebhook` | yes for payments |
 | `STRIPE_WEBHOOK_SECRET` | Firebase secret | `stripeWebhook` | yes for webhook processing |
 | `GOV_NOTIFY_API_KEY` | Firebase secret | Transactional mailer / payment webhook notification path | yes for app-owned transactional email |
-| `APP_BASE_URL` | env var | Checkout success/cancel URLs | yes for non-local |
+| `APP_BASE_URL` | env var | Checkout success/cancel URLs and internal ops email links | yes for non-local |
 | `ENV_NAME` | env var | dev reset guardrail | required for reset tooling |
 | `PERMITTED_PROJECT_IDS` | env var | dev reset guardrail | required for reset tooling |
 | `GOV_NOTIFY_EMAIL_REPLY_TO_ID` | env var | Optional GOV.UK Notify reply-to selection | optional |
 | `GOV_NOTIFY_TEMPLATE_<TEMPLATE_NAME>` | env var | GOV.UK Notify template IDs for app-owned transactional email templates | required for each enabled app email template |
+| `PAYMENT_OPS_ALERT_EMAILS` | env var | Comma-separated internal recipient emails for payment reconciliation / dispute ops alerts (Stripe webhook path); unset disables sends | optional |
+| `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT` | env var | Notify template UUID for internal reconciliation-exception alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
+| `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT` | env var | Notify template UUID for internal dispute side-state alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
 
 ## Operational notes
 
@@ -43,4 +46,5 @@ Defined via `.env*` files and read from `import.meta.env`:
 - Configure GOV.UK Notify API keys and template IDs independently per Firebase environment.
 - Template env var names are derived from typed template names in `functions/src/mailer.ts`; for example, `paymentConfirmation` maps to `GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION`.
 - Ticket order lifecycle emails (issue #186): template keys `ticketOrderPaid`, `ticketOrderFailed`, `ticketOrderRefunded` — full placeholder spec and env var mapping in [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md).
+- Internal payment ops / finance alerts (reconciliation exceptions and dispute side-state): see [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md).
 - Stripe may send customer receipts/invoices for payment activity when enabled in Stripe. Use GOV.UK Notify for app-owned transactional messages that need application context, links, membership/booking workflow details, or internal operational recipients.

--- a/docs/operations/govuk-notify-payment-ops-internal-templates.md
+++ b/docs/operations/govuk-notify-payment-ops-internal-templates.md
@@ -1,0 +1,58 @@
+# GOV.UK Notify: internal payment ops templates
+
+These templates send **internal** email to finance/ops when payment reconciliation exceptions open or when Stripe dispute side-state webhooks are processed. Implementation: [`functions/src/paymentOpsInternalAlerts.ts`](../../functions/src/paymentOpsInternalAlerts.ts), wired from [`functions/src/payments.ts`](../../functions/src/payments.ts).
+
+Recipients are **`PAYMENT_OPS_ALERT_EMAILS`** (comma-separated). If unset or empty, no internal emails are sent.
+
+**Source of truth:** Personalisation **keys** in this document must match the object sent to Notify.
+
+## Configuration
+
+| Logical key (code) | Firebase / runtime env var for template UUID |
+|---------------------|-----------------------------------------------|
+| `paymentReconciliationExceptionAlert` | `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT` |
+| `paymentDisputeOpsAlert` | `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT` |
+
+Env var names follow [`govNotifyTemplateEnvVarName`](../../functions/src/mailer.ts).
+
+Also required for sends: `GOV_NOTIFY_API_KEY` (secret), optional `GOV_NOTIFY_EMAIL_REPLY_TO_ID`, and **`APP_BASE_URL`** for the reconciliation dashboard link (see [environment-and-secrets.md](./environment-and-secrets.md)).
+
+## Notify `reference` field
+
+Functions set short references for Notify logs, e.g. `reconciliation-ops:<orderId>:<exceptionType>:<stripeEventId>` and `dispute-ops:<orderId>:<stripeEventId>`.
+
+## Template 1: reconciliation exception — `paymentReconciliationExceptionAlert`
+
+**Trigger:** A reconciliation exception row becomes **OPEN** (new row or reopened from **RESOLVED**). For **`ACTIVE_DISPUTE`**, the reconciliation-path alert is skipped when the snapshot upsert runs on the **dispute webhook** path (the dispute-specific template covers that case).
+
+| Key | Semantics |
+|-----|-----------|
+| `orderId` | Ticket order UUID |
+| `eventTitle` | Event title from order |
+| `customerDisplay` | Booker display, e.g. `Name <email>` |
+| `exceptionType` | Enum string, e.g. `ACTIVE_DISPUTE`, `UNDERPAID`, … |
+| `exceptionNote` | Stored exception note |
+| `reconciliationDashboardUrl` | `APP_BASE_URL` (normalised) + `/admin/payments/reconciliation` |
+| `stripeEventId` | Stripe webhook event id |
+
+## Template 2: dispute side-state — `paymentDisputeOpsAlert`
+
+**Trigger:** `dispute_side_state` branch in the payments Stripe webhook (after dispute persistence and ledger).
+
+| Key | Semantics |
+|-----|-----------|
+| `orderId` | Ticket order UUID |
+| `eventTitle` | Event title |
+| `customerDisplay` | Booker display |
+| `disputeStripeStatus` | Stripe dispute `status` |
+| `disputeReason` | Stripe dispute `reason` |
+| `disputeLocalState` | Normalised dispute state label from webhook routing |
+| `stripeDisputeId` | Stripe dispute id |
+| `stripeEventType` | Stripe event `type` string |
+| `reconciliationDashboardUrl` | Same as template 1 |
+| `stripeEventId` | Stripe webhook event id |
+
+## Related docs
+
+- [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md) — customer-facing ticket order lifecycle email
+- [payment-state-machine.md](../architecture/payment-state-machine.md)

--- a/docs/operations/govuk-notify-ticket-order-templates.md
+++ b/docs/operations/govuk-notify-ticket-order-templates.md
@@ -73,7 +73,7 @@ Includes **all** keys from the paid/failed set, plus:
 
 ## What does *not* use these templates
 
-**Dispute** side-state events (`charge.dispute.*`) update dispute metadata only; they do **not** send customer lifecycle email through this path. Internal / ops alerting is handled separately (see epic #183 / follow-up issues).
+**Dispute** side-state events (`charge.dispute.*`) update dispute metadata only; they do **not** send customer lifecycle email through this path. Internal ops alerting for disputes and reconciliation exceptions uses [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md).
 
 ## Related docs
 

--- a/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
+++ b/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  PAYMENT_OPS_ALERT_EMAILS_ENV,
+  parsePaymentOpsAlertEmails,
+} from "../paymentOpsInternalAlerts";
+import { govNotifyTemplateEnvVarName } from "../mailer";
+
+describe("parsePaymentOpsAlertEmails", () => {
+  it("returns empty list when unset or blank", () => {
+    expect(parsePaymentOpsAlertEmails({})).toEqual([]);
+    expect(parsePaymentOpsAlertEmails({ [PAYMENT_OPS_ALERT_EMAILS_ENV]: "  " })).toEqual([]);
+  });
+
+  it("parses comma-separated addresses, lowercases, trims, and dedupes", () => {
+    expect(
+      parsePaymentOpsAlertEmails({
+        [PAYMENT_OPS_ALERT_EMAILS_ENV]: " OPS@EXAMPLE.COM , finance@example.com , ops@example.com ",
+      })
+    ).toEqual(["ops@example.com", "finance@example.com"]);
+  });
+});
+
+describe("payment ops internal template env vars", () => {
+  it("matches mailer naming for GOV.UK Notify template keys", () => {
+    expect(govNotifyTemplateEnvVarName("paymentReconciliationExceptionAlert")).toBe(
+      "GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT"
+    );
+    expect(govNotifyTemplateEnvVarName("paymentDisputeOpsAlert")).toBe(
+      "GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT"
+    );
+  });
+});

--- a/functions/src/dataconnect-admin-generated/esm/index.esm.js
+++ b/functions/src/dataconnect-admin-generated/esm/index.esm.js
@@ -92,60 +92,6 @@ export const connectorConfig = {
   location: 'europe-west2'
 };
 
-export function createBookingDraft(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('CreateBookingDraft', inputVars, inputOpts);
-}
-
-export function addBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AddBookingLine', inputVars, inputOpts);
-}
-
-export function updateBookingStatus(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('UpdateBookingStatus', inputVars, inputOpts);
-}
-
-export function createGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('CreateGuestTicketRequest', inputVars, inputOpts);
-}
-
-export function adminDeleteGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteGuestTicketRequest', inputVars, inputOpts);
-}
-
-export function adminReviewGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminReviewGuestTicketRequest', inputVars, inputOpts);
-}
-
-export function adminDeleteBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteBookingLine', inputVars, inputOpts);
-}
-
-export function adminDeleteBooking(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteBooking', inputVars, inputOpts);
-}
-
-export function resolvePaymentReconciliationException(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('ResolvePaymentReconciliationException', inputVars, inputOpts);
-}
-
 export function getCurrentUser(dcOrOptions, options) {
   const { dc: dcInstance, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrOptions, options, undefined);
   dcInstance.useGen(true);
@@ -672,5 +618,59 @@ export function deleteBookingLineFromCallable(dcOrVarsOrOptions, varsOrOptions, 
   const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
   dcInstance.useGen(true);
   return dcInstance.executeMutation('DeleteBookingLineFromCallable', inputVars, inputOpts);
+}
+
+export function createBookingDraft(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('CreateBookingDraft', inputVars, inputOpts);
+}
+
+export function addBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AddBookingLine', inputVars, inputOpts);
+}
+
+export function updateBookingStatus(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('UpdateBookingStatus', inputVars, inputOpts);
+}
+
+export function createGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('CreateGuestTicketRequest', inputVars, inputOpts);
+}
+
+export function adminDeleteGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteGuestTicketRequest', inputVars, inputOpts);
+}
+
+export function adminReviewGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminReviewGuestTicketRequest', inputVars, inputOpts);
+}
+
+export function adminDeleteBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteBookingLine', inputVars, inputOpts);
+}
+
+export function adminDeleteBooking(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteBooking', inputVars, inputOpts);
+}
+
+export function resolvePaymentReconciliationException(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('ResolvePaymentReconciliationException', inputVars, inputOpts);
 }
 

--- a/functions/src/dataconnect-admin-generated/index.cjs.js
+++ b/functions/src/dataconnect-admin-generated/index.cjs.js
@@ -106,69 +106,6 @@ const connectorConfig = {
 };
 exports.connectorConfig = connectorConfig;
 
-function createBookingDraft(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('CreateBookingDraft', inputVars, inputOpts);
-}
-exports.createBookingDraft = createBookingDraft;
-
-function addBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AddBookingLine', inputVars, inputOpts);
-}
-exports.addBookingLine = addBookingLine;
-
-function updateBookingStatus(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('UpdateBookingStatus', inputVars, inputOpts);
-}
-exports.updateBookingStatus = updateBookingStatus;
-
-function createGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('CreateGuestTicketRequest', inputVars, inputOpts);
-}
-exports.createGuestTicketRequest = createGuestTicketRequest;
-
-function adminDeleteGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteGuestTicketRequest', inputVars, inputOpts);
-}
-exports.adminDeleteGuestTicketRequest = adminDeleteGuestTicketRequest;
-
-function adminReviewGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminReviewGuestTicketRequest', inputVars, inputOpts);
-}
-exports.adminReviewGuestTicketRequest = adminReviewGuestTicketRequest;
-
-function adminDeleteBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteBookingLine', inputVars, inputOpts);
-}
-exports.adminDeleteBookingLine = adminDeleteBookingLine;
-
-function adminDeleteBooking(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('AdminDeleteBooking', inputVars, inputOpts);
-}
-exports.adminDeleteBooking = adminDeleteBooking;
-
-function resolvePaymentReconciliationException(dcOrVarsOrOptions, varsOrOptions, options) {
-  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
-  dcInstance.useGen(true);
-  return dcInstance.executeMutation('ResolvePaymentReconciliationException', inputVars, inputOpts);
-}
-exports.resolvePaymentReconciliationException = resolvePaymentReconciliationException;
-
 function getCurrentUser(dcOrOptions, options) {
   const { dc: dcInstance, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrOptions, options, undefined);
   dcInstance.useGen(true);
@@ -784,4 +721,67 @@ function deleteBookingLineFromCallable(dcOrVarsOrOptions, varsOrOptions, options
   return dcInstance.executeMutation('DeleteBookingLineFromCallable', inputVars, inputOpts);
 }
 exports.deleteBookingLineFromCallable = deleteBookingLineFromCallable;
+
+function createBookingDraft(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('CreateBookingDraft', inputVars, inputOpts);
+}
+exports.createBookingDraft = createBookingDraft;
+
+function addBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AddBookingLine', inputVars, inputOpts);
+}
+exports.addBookingLine = addBookingLine;
+
+function updateBookingStatus(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('UpdateBookingStatus', inputVars, inputOpts);
+}
+exports.updateBookingStatus = updateBookingStatus;
+
+function createGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('CreateGuestTicketRequest', inputVars, inputOpts);
+}
+exports.createGuestTicketRequest = createGuestTicketRequest;
+
+function adminDeleteGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteGuestTicketRequest', inputVars, inputOpts);
+}
+exports.adminDeleteGuestTicketRequest = adminDeleteGuestTicketRequest;
+
+function adminReviewGuestTicketRequest(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminReviewGuestTicketRequest', inputVars, inputOpts);
+}
+exports.adminReviewGuestTicketRequest = adminReviewGuestTicketRequest;
+
+function adminDeleteBookingLine(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteBookingLine', inputVars, inputOpts);
+}
+exports.adminDeleteBookingLine = adminDeleteBookingLine;
+
+function adminDeleteBooking(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('AdminDeleteBooking', inputVars, inputOpts);
+}
+exports.adminDeleteBooking = adminDeleteBooking;
+
+function resolvePaymentReconciliationException(dcOrVarsOrOptions, varsOrOptions, options) {
+  const { dc: dcInstance, vars: inputVars, options: inputOpts} = validateAdminArgs(connectorConfig, dcOrVarsOrOptions, varsOrOptions, options, true, true);
+  dcInstance.useGen(true);
+  return dcInstance.executeMutation('ResolvePaymentReconciliationException', inputVars, inputOpts);
+}
+exports.resolvePaymentReconciliationException = resolvePaymentReconciliationException;
 

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -770,6 +770,7 @@ export interface GetNotificationDeliveryByChannelAndKeyVariables {
 export interface GetPaymentReconciliationExceptionByOrderAndTypeData {
   paymentReconciliationExceptions: ({
     id: UUIDString;
+    status: PaymentReconciliationExceptionStatus;
   } & PaymentReconciliationException_Key)[];
 }
 
@@ -1803,51 +1804,6 @@ export interface User_Key {
   __typename?: 'User_Key';
 }
 
-/** Generated Node Admin SDK operation action function for the 'CreateBookingDraft' Mutation. Allow users to execute without passing in DataConnect. */
-export function createBookingDraft(dc: DataConnect, vars: CreateBookingDraftVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateBookingDraftData>>;
-/** Generated Node Admin SDK operation action function for the 'CreateBookingDraft' Mutation. Allow users to pass in custom DataConnect instances. */
-export function createBookingDraft(vars: CreateBookingDraftVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateBookingDraftData>>;
-
-/** Generated Node Admin SDK operation action function for the 'AddBookingLine' Mutation. Allow users to execute without passing in DataConnect. */
-export function addBookingLine(dc: DataConnect, vars: AddBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AddBookingLineData>>;
-/** Generated Node Admin SDK operation action function for the 'AddBookingLine' Mutation. Allow users to pass in custom DataConnect instances. */
-export function addBookingLine(vars: AddBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AddBookingLineData>>;
-
-/** Generated Node Admin SDK operation action function for the 'UpdateBookingStatus' Mutation. Allow users to execute without passing in DataConnect. */
-export function updateBookingStatus(dc: DataConnect, vars: UpdateBookingStatusVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<UpdateBookingStatusData>>;
-/** Generated Node Admin SDK operation action function for the 'UpdateBookingStatus' Mutation. Allow users to pass in custom DataConnect instances. */
-export function updateBookingStatus(vars: UpdateBookingStatusVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<UpdateBookingStatusData>>;
-
-/** Generated Node Admin SDK operation action function for the 'CreateGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
-export function createGuestTicketRequest(dc: DataConnect, vars: CreateGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateGuestTicketRequestData>>;
-/** Generated Node Admin SDK operation action function for the 'CreateGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
-export function createGuestTicketRequest(vars: CreateGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateGuestTicketRequestData>>;
-
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
-export function adminDeleteGuestTicketRequest(dc: DataConnect, vars: AdminDeleteGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteGuestTicketRequestData>>;
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
-export function adminDeleteGuestTicketRequest(vars: AdminDeleteGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteGuestTicketRequestData>>;
-
-/** Generated Node Admin SDK operation action function for the 'AdminReviewGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
-export function adminReviewGuestTicketRequest(dc: DataConnect, vars: AdminReviewGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminReviewGuestTicketRequestData>>;
-/** Generated Node Admin SDK operation action function for the 'AdminReviewGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
-export function adminReviewGuestTicketRequest(vars: AdminReviewGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminReviewGuestTicketRequestData>>;
-
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteBookingLine' Mutation. Allow users to execute without passing in DataConnect. */
-export function adminDeleteBookingLine(dc: DataConnect, vars: AdminDeleteBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingLineData>>;
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteBookingLine' Mutation. Allow users to pass in custom DataConnect instances. */
-export function adminDeleteBookingLine(vars: AdminDeleteBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingLineData>>;
-
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteBooking' Mutation. Allow users to execute without passing in DataConnect. */
-export function adminDeleteBooking(dc: DataConnect, vars: AdminDeleteBookingVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingData>>;
-/** Generated Node Admin SDK operation action function for the 'AdminDeleteBooking' Mutation. Allow users to pass in custom DataConnect instances. */
-export function adminDeleteBooking(vars: AdminDeleteBookingVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingData>>;
-
-/** Generated Node Admin SDK operation action function for the 'ResolvePaymentReconciliationException' Mutation. Allow users to execute without passing in DataConnect. */
-export function resolvePaymentReconciliationException(dc: DataConnect, vars: ResolvePaymentReconciliationExceptionVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<ResolvePaymentReconciliationExceptionData>>;
-/** Generated Node Admin SDK operation action function for the 'ResolvePaymentReconciliationException' Mutation. Allow users to pass in custom DataConnect instances. */
-export function resolvePaymentReconciliationException(vars: ResolvePaymentReconciliationExceptionVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<ResolvePaymentReconciliationExceptionData>>;
-
 /** Generated Node Admin SDK operation action function for the 'GetCurrentUser' Query. Allow users to execute without passing in DataConnect. */
 export function getCurrentUser(dc: DataConnect, options?: OperationOptions): Promise<ExecuteOperationResponse<GetCurrentUserData>>;
 /** Generated Node Admin SDK operation action function for the 'GetCurrentUser' Query. Allow users to pass in custom DataConnect instances. */
@@ -2287,4 +2243,49 @@ export function updateBookingPreferencesFromCallable(vars: UpdateBookingPreferen
 export function deleteBookingLineFromCallable(dc: DataConnect, vars: DeleteBookingLineFromCallableVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<DeleteBookingLineFromCallableData>>;
 /** Generated Node Admin SDK operation action function for the 'DeleteBookingLineFromCallable' Mutation. Allow users to pass in custom DataConnect instances. */
 export function deleteBookingLineFromCallable(vars: DeleteBookingLineFromCallableVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<DeleteBookingLineFromCallableData>>;
+
+/** Generated Node Admin SDK operation action function for the 'CreateBookingDraft' Mutation. Allow users to execute without passing in DataConnect. */
+export function createBookingDraft(dc: DataConnect, vars: CreateBookingDraftVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateBookingDraftData>>;
+/** Generated Node Admin SDK operation action function for the 'CreateBookingDraft' Mutation. Allow users to pass in custom DataConnect instances. */
+export function createBookingDraft(vars: CreateBookingDraftVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateBookingDraftData>>;
+
+/** Generated Node Admin SDK operation action function for the 'AddBookingLine' Mutation. Allow users to execute without passing in DataConnect. */
+export function addBookingLine(dc: DataConnect, vars: AddBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AddBookingLineData>>;
+/** Generated Node Admin SDK operation action function for the 'AddBookingLine' Mutation. Allow users to pass in custom DataConnect instances. */
+export function addBookingLine(vars: AddBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AddBookingLineData>>;
+
+/** Generated Node Admin SDK operation action function for the 'UpdateBookingStatus' Mutation. Allow users to execute without passing in DataConnect. */
+export function updateBookingStatus(dc: DataConnect, vars: UpdateBookingStatusVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<UpdateBookingStatusData>>;
+/** Generated Node Admin SDK operation action function for the 'UpdateBookingStatus' Mutation. Allow users to pass in custom DataConnect instances. */
+export function updateBookingStatus(vars: UpdateBookingStatusVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<UpdateBookingStatusData>>;
+
+/** Generated Node Admin SDK operation action function for the 'CreateGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
+export function createGuestTicketRequest(dc: DataConnect, vars: CreateGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateGuestTicketRequestData>>;
+/** Generated Node Admin SDK operation action function for the 'CreateGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
+export function createGuestTicketRequest(vars: CreateGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<CreateGuestTicketRequestData>>;
+
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
+export function adminDeleteGuestTicketRequest(dc: DataConnect, vars: AdminDeleteGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteGuestTicketRequestData>>;
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
+export function adminDeleteGuestTicketRequest(vars: AdminDeleteGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteGuestTicketRequestData>>;
+
+/** Generated Node Admin SDK operation action function for the 'AdminReviewGuestTicketRequest' Mutation. Allow users to execute without passing in DataConnect. */
+export function adminReviewGuestTicketRequest(dc: DataConnect, vars: AdminReviewGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminReviewGuestTicketRequestData>>;
+/** Generated Node Admin SDK operation action function for the 'AdminReviewGuestTicketRequest' Mutation. Allow users to pass in custom DataConnect instances. */
+export function adminReviewGuestTicketRequest(vars: AdminReviewGuestTicketRequestVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminReviewGuestTicketRequestData>>;
+
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteBookingLine' Mutation. Allow users to execute without passing in DataConnect. */
+export function adminDeleteBookingLine(dc: DataConnect, vars: AdminDeleteBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingLineData>>;
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteBookingLine' Mutation. Allow users to pass in custom DataConnect instances. */
+export function adminDeleteBookingLine(vars: AdminDeleteBookingLineVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingLineData>>;
+
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteBooking' Mutation. Allow users to execute without passing in DataConnect. */
+export function adminDeleteBooking(dc: DataConnect, vars: AdminDeleteBookingVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingData>>;
+/** Generated Node Admin SDK operation action function for the 'AdminDeleteBooking' Mutation. Allow users to pass in custom DataConnect instances. */
+export function adminDeleteBooking(vars: AdminDeleteBookingVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<AdminDeleteBookingData>>;
+
+/** Generated Node Admin SDK operation action function for the 'ResolvePaymentReconciliationException' Mutation. Allow users to execute without passing in DataConnect. */
+export function resolvePaymentReconciliationException(dc: DataConnect, vars: ResolvePaymentReconciliationExceptionVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<ResolvePaymentReconciliationExceptionData>>;
+/** Generated Node Admin SDK operation action function for the 'ResolvePaymentReconciliationException' Mutation. Allow users to pass in custom DataConnect instances. */
+export function resolvePaymentReconciliationException(vars: ResolvePaymentReconciliationExceptionVariables, options?: OperationOptions): Promise<ExecuteOperationResponse<ResolvePaymentReconciliationExceptionData>>;
 

--- a/functions/src/paymentOpsInternalAlerts.ts
+++ b/functions/src/paymentOpsInternalAlerts.ts
@@ -1,0 +1,223 @@
+import * as logger from "firebase-functions/logger";
+import {
+  getTicketOrderForWebhook,
+  NotificationChannel,
+  PaymentReconciliationExceptionType,
+} from "@dataconnect/admin-generated";
+import type { UUIDString } from "@dataconnect/admin-generated";
+import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import { sanitizeMailerError } from "./mailerErrors";
+import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
+import { sendNotificationOnce } from "./notificationDelivery";
+
+export const PAYMENT_OPS_ALERT_EMAILS_ENV = "PAYMENT_OPS_ALERT_EMAILS";
+
+export const PAYMENT_OPS_ALERT_TEMPLATE_KEYS = [
+  "paymentReconciliationExceptionAlert",
+  "paymentDisputeOpsAlert",
+] as const;
+
+export type PaymentOpsInternalTemplates = {
+  paymentReconciliationExceptionAlert: {
+    orderId: string;
+    eventTitle: string;
+    customerDisplay: string;
+    exceptionType: string;
+    exceptionNote: string;
+    reconciliationDashboardUrl: string;
+    stripeEventId: string;
+  };
+  paymentDisputeOpsAlert: {
+    orderId: string;
+    eventTitle: string;
+    customerDisplay: string;
+    disputeStripeStatus: string;
+    disputeReason: string;
+    disputeLocalState: string;
+    stripeDisputeId: string;
+    stripeEventType: string;
+    reconciliationDashboardUrl: string;
+    stripeEventId: string;
+  };
+};
+
+export function parsePaymentOpsAlertEmails(env: NodeJS.ProcessEnv = process.env): string[] {
+  const raw = env[PAYMENT_OPS_ALERT_EMAILS_ENV]?.trim();
+  if (!raw) {
+    return [];
+  }
+  return Array.from(new Set(raw.split(",").map((e) => e.trim().toLowerCase()).filter((e) => e.length > 0)));
+}
+
+export function createPaymentOpsInternalMailer(): ReturnType<
+  typeof createConfiguredGovNotifyMailer<PaymentOpsInternalTemplates>
+> {
+  return createConfiguredGovNotifyMailer([...PAYMENT_OPS_ALERT_TEMPLATE_KEYS]);
+}
+
+async function loadOrderOpsContext(orderId: UUIDString): Promise<{
+  eventTitle: string;
+  customerDisplay: string;
+} | null> {
+  const row = await getTicketOrderForWebhook({ id: orderId });
+  const o = row.data?.ticketOrder;
+  if (!o) {
+    return null;
+  }
+  const u = o.user;
+  const name = `${u.firstName} ${u.lastName}`.trim();
+  const customerDisplay = name.length > 0 ? `${name} <${u.email}>` : u.email;
+  return { eventTitle: o.event.title ?? "—", customerDisplay };
+}
+
+/**
+ * Non-blocking internal alerts for finance/ops. Safe to call from Stripe webhooks.
+ */
+export async function notifyPaymentOpsReconciliationExceptionOpened(args: {
+  orderId: UUIDString;
+  exceptionType: PaymentReconciliationExceptionType;
+  exceptionNote: string;
+  stripeEventId: string;
+  appBaseUrl: string;
+  getMailer?: () => ReturnType<typeof createPaymentOpsInternalMailer>;
+}): Promise<void> {
+  const recipients = parsePaymentOpsAlertEmails();
+  if (recipients.length === 0) {
+    return;
+  }
+  try {
+    const ctx = await loadOrderOpsContext(args.orderId);
+    if (!ctx) {
+      logger.warn("payment ops reconciliation alert skipped (order not found)", {
+        orderId: args.orderId,
+        exceptionType: args.exceptionType,
+      });
+      return;
+    }
+    const mailer = (args.getMailer ?? createPaymentOpsInternalMailer)();
+    const base = normaliseAppBaseUrl(args.appBaseUrl);
+    const reconciliationDashboardUrl = `${base}/admin/payments/reconciliation`;
+    const reference = `reconciliation-ops:${args.orderId}:${args.exceptionType}:${args.stripeEventId}`;
+
+    const personalisation: PaymentOpsInternalTemplates["paymentReconciliationExceptionAlert"] = {
+      orderId: args.orderId,
+      eventTitle: ctx.eventTitle,
+      customerDisplay: ctx.customerDisplay,
+      exceptionType: args.exceptionType,
+      exceptionNote: args.exceptionNote,
+      reconciliationDashboardUrl,
+      stripeEventId: args.stripeEventId,
+    };
+
+    for (const to of recipients) {
+      const deliveryKey = `reconciliation-ops:${args.orderId}:${args.exceptionType}:${args.stripeEventId}:${to}`;
+      try {
+        await sendNotificationOnce({
+          channel: NotificationChannel.EMAIL,
+          notificationType: "RECONCILIATION_EXCEPTION_OPEN",
+          deliveryKey,
+          ticketOrderId: args.orderId,
+          userId: null,
+          provider: GOV_NOTIFY_PROVIDER,
+          send: async () => {
+            const r = await mailer.sendEmail({
+              templateName: "paymentReconciliationExceptionAlert",
+              to,
+              personalisation,
+              reference,
+            });
+            return { providerMessageId: r.providerNotificationId ?? null };
+          },
+        });
+      } catch (error) {
+        logger.error("payment ops reconciliation alert delivery failed", {
+          orderId: args.orderId,
+          exceptionType: args.exceptionType,
+          error: sanitizeMailerError(error),
+        });
+      }
+    }
+  } catch (error) {
+    logger.error("payment ops reconciliation alert failed", {
+      orderId: args.orderId,
+      exceptionType: args.exceptionType,
+      error: sanitizeMailerError(error),
+    });
+  }
+}
+
+export async function notifyPaymentOpsDisputeSideState(args: {
+  orderId: UUIDString;
+  stripeEventId: string;
+  stripeEventType: string;
+  disputeStripeStatus: string;
+  disputeReason: string;
+  disputeLocalState: string;
+  stripeDisputeId: string;
+  appBaseUrl: string;
+  getMailer?: () => ReturnType<typeof createPaymentOpsInternalMailer>;
+}): Promise<void> {
+  const recipients = parsePaymentOpsAlertEmails();
+  if (recipients.length === 0) {
+    return;
+  }
+  try {
+    const ctx = await loadOrderOpsContext(args.orderId);
+    if (!ctx) {
+      logger.warn("payment ops dispute alert skipped (order not found)", { orderId: args.orderId });
+      return;
+    }
+    const mailer = (args.getMailer ?? createPaymentOpsInternalMailer)();
+    const base = normaliseAppBaseUrl(args.appBaseUrl);
+    const reconciliationDashboardUrl = `${base}/admin/payments/reconciliation`;
+    const reference = `dispute-ops:${args.orderId}:${args.stripeEventId}`;
+
+    const personalisation: PaymentOpsInternalTemplates["paymentDisputeOpsAlert"] = {
+      orderId: args.orderId,
+      eventTitle: ctx.eventTitle,
+      customerDisplay: ctx.customerDisplay,
+      disputeStripeStatus: args.disputeStripeStatus,
+      disputeReason: args.disputeReason,
+      disputeLocalState: args.disputeLocalState,
+      stripeDisputeId: args.stripeDisputeId,
+      stripeEventType: args.stripeEventType,
+      reconciliationDashboardUrl,
+      stripeEventId: args.stripeEventId,
+    };
+
+    for (const to of recipients) {
+      const deliveryKey = `dispute-ops:${args.orderId}:${args.stripeEventId}:${to}`;
+      try {
+        await sendNotificationOnce({
+          channel: NotificationChannel.EMAIL,
+          notificationType: "DISPUTE_OPS_EVENT",
+          deliveryKey,
+          ticketOrderId: args.orderId,
+          userId: null,
+          provider: GOV_NOTIFY_PROVIDER,
+          send: async () => {
+            const r = await mailer.sendEmail({
+              templateName: "paymentDisputeOpsAlert",
+              to,
+              personalisation,
+              reference,
+            });
+            return { providerMessageId: r.providerNotificationId ?? null };
+          },
+        });
+      } catch (error) {
+        logger.error("payment ops dispute alert delivery failed", {
+          orderId: args.orderId,
+          stripeEventId: args.stripeEventId,
+          error: sanitizeMailerError(error),
+        });
+      }
+    }
+  } catch (error) {
+    logger.error("payment ops dispute alert failed", {
+      orderId: args.orderId,
+      stripeEventId: args.stripeEventId,
+      error: sanitizeMailerError(error),
+    });
+  }
+}

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -44,6 +44,10 @@ import {
 import { classifyStripeWebhookDomain } from "./stripeWebhookRouting";
 import { govNotifyApiKey, GOV_NOTIFY_PROVIDER } from "./mailer";
 import { sendNotificationOnce } from "./notificationDelivery";
+import {
+  notifyPaymentOpsDisputeSideState,
+  notifyPaymentOpsReconciliationExceptionOpened,
+} from "./paymentOpsInternalAlerts";
 
 const stripeSecret = defineSecret("STRIPE_SECRET");
 const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
@@ -123,6 +127,8 @@ async function upsertReconciliationSnapshot(args: {
     stripePaymentIntentId?: string | null;
     disputeStatus?: string | null;
   };
+  stripeEventId: string;
+  fromDisputeWebhook?: boolean;
 }): Promise<void> {
   const signals = evaluateReconciliationSignals(args.snapshot);
   const signalMap = new Map(signals.map((signal) => [signal.type, signal]));
@@ -137,6 +143,7 @@ async function upsertReconciliationSnapshot(args: {
       exceptionType: type,
     });
     const existingRow = existing.data?.paymentReconciliationExceptions?.[0];
+    const previousStatus = existingRow?.status;
 
     if (existingRow?.id) {
       await updatePaymentReconciliationExceptionById({
@@ -157,6 +164,25 @@ async function upsertReconciliationSnapshot(args: {
         lastAttemptedAt: nowIso,
         resolvedAt: signal ? null : nowIso,
       });
+    }
+
+    if (status === PaymentReconciliationExceptionStatus.OPEN && signal) {
+      const isNewOpen = !existingRow?.id;
+      const reopenedFromResolved =
+        !!existingRow?.id && previousStatus === PaymentReconciliationExceptionStatus.RESOLVED;
+      if (isNewOpen || reopenedFromResolved) {
+        const skipActiveDisputeDuplicateEmail =
+          type === PaymentReconciliationExceptionType.ACTIVE_DISPUTE && args.fromDisputeWebhook === true;
+        if (!skipActiveDisputeDuplicateEmail) {
+          void notifyPaymentOpsReconciliationExceptionOpened({
+            orderId: args.orderId,
+            exceptionType: type,
+            exceptionNote: note,
+            stripeEventId: args.stripeEventId,
+            appBaseUrl: APP_BASE_URL,
+          });
+        }
+      }
     }
   }
 }
@@ -569,6 +595,18 @@ async function handleStripeWebhookRequest(args: {
           stripePaymentIntentId: order.stripePaymentIntentId ?? null,
           disputeStatus: dispute.status ?? normalized.disputeState ?? null,
         },
+        stripeEventId: event.id,
+        fromDisputeWebhook: true,
+      });
+      void notifyPaymentOpsDisputeSideState({
+        orderId: canonicalOrderId,
+        stripeEventId: event.id,
+        stripeEventType: event.type,
+        disputeStripeStatus: dispute.status ?? "",
+        disputeReason: dispute.reason ?? "",
+        disputeLocalState: normalized.disputeState ?? "",
+        stripeDisputeId: dispute.id ?? "",
+        appBaseUrl: APP_BASE_URL,
       });
       res.status(200).send("Dispute side-state acknowledged");
       return;
@@ -707,6 +745,7 @@ async function handleStripeWebhookRequest(args: {
         stripePaymentIntentId: paymentIntentIdFromEvent ?? order.stripePaymentIntentId ?? null,
         disputeStatus: order.disputeStatus ?? null,
       },
+      stripeEventId: event.id,
     });
     res.status(200).send("ok");
   } catch (err) {


### PR DESCRIPTION
## Summary

- Builds on the transactional email stack: notification delivery idempotency (#185), GOV.UK Notify mailer (#196), ticket order lifecycle emails (#186).
- **#187:** Internal ops/finance email via `PAYMENT_OPS_ALERT_EMAILS` when reconciliation exceptions become open or reopen (`sendNotificationOnce`), and for Stripe dispute side-state webhooks; dedupe-skips duplicate `ACTIVE_DISPUTE` reconciliation mail on the dispute webhook path. Adds `paymentOpsInternalAlerts.ts`, extends `GetPaymentReconciliationExceptionByOrderAndType` with `status`, docs for new Notify template env vars, and Vitest for alert email parsing.

## Test plan

- [ ] `cd functions && npm test && npm run build`
- [ ] Root `npm run build`
- [ ] Configure `PAYMENT_OPS_ALERT_EMAILS` and the two `GOV_NOTIFY_TEMPLATE_*` internal templates in a sandbox; trigger reconciliation open and a dispute side-state webhook and confirm deduped Notify sends per recipient


Made with [Cursor](https://cursor.com)