### PR TITLE
Membership approval and account status emails (#188)

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -173,6 +173,9 @@ query CheckUserProfileExists @auth(level: USER) {
 query GetUserMembershipStatus($id: String!) @auth(level: NO_ACCESS) {
   user(id: $id) {
     membershipStatus
+    firstName
+    lastName
+    email
   }
 }
 

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -47,4 +47,5 @@ Defined via `.env*` files and read from `import.meta.env`:
 - Template env var names are derived from typed template names in `functions/src/mailer.ts`; for example, `paymentConfirmation` maps to `GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION`.
 - Ticket order lifecycle emails (issue #186): template keys `ticketOrderPaid`, `ticketOrderFailed`, `ticketOrderRefunded` — full placeholder spec and env var mapping in [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md).
 - Internal payment ops / finance alerts (reconciliation exceptions and dispute side-state): see [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md).
+- Membership approval / account access emails (#188): template keys `membershipActivated`, `membershipAccessRestricted` — see [govuk-notify-membership-templates.md](./govuk-notify-membership-templates.md).
 - Stripe may send customer receipts/invoices for payment activity when enabled in Stripe. Use GOV.UK Notify for app-owned transactional messages that need application context, links, membership/booking workflow details, or internal operational recipients.

--- a/docs/operations/govuk-notify-membership-templates.md
+++ b/docs/operations/govuk-notify-membership-templates.md
@@ -1,0 +1,52 @@
+# GOV.UK Notify: membership status templates
+
+User-facing email when **membership status** changes in ways that affect app access. Implementation: [`functions/src/membershipStatusEmailDispatcher.ts`](../../functions/src/membershipStatusEmailDispatcher.ts), triggered from [`functions/src/membershipStatus.ts`](../../functions/src/membershipStatus.ts) after a successful `updateMembershipStatus` callable.
+
+**Source of truth:** Personalisation **keys** must match the Notify template placeholders.
+
+## Configuration
+
+| Logical key (code) | Firebase / runtime env var for template UUID |
+|---------------------|-----------------------------------------------|
+| `membershipActivated` | `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACTIVATED` |
+| `membershipAccessRestricted` | `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACCESS_RESTRICTED` |
+
+Also required: `GOV_NOTIFY_API_KEY` (secret), optional `GOV_NOTIFY_EMAIL_REPLY_TO_ID`, and **`APP_BASE_URL`** for links (see [environment-and-secrets.md](./environment-and-secrets.md)).
+
+## Triggers
+
+| Template | When |
+|----------|------|
+| `membershipActivated` | Previous status was **restricted** (`PENDING`, `RESIGNED`, `LOST`, `DECEASED`) or unknown (`null`), and new status is **non-restricted** (`REGULAR`, `RESERVE`, etc.) — typical admin approval from **Approve Users**. |
+| `membershipAccessRestricted` | Previous status was **non-restricted** and new status is **restricted** (access removed / account disabled via `enabled` claim). |
+
+No email for restricted→restricted or non-restricted→non-restricted transitions.
+
+## Notify `reference` field
+
+`MEMBERSHIP_ACTIVATION:{userId}:{from}:{to}` or `MEMBERSHIP_RESTRICTED:…` (see `membershipStatusNotifyReference` in code).
+
+## Template 1: account activated — `membershipActivated`
+
+| Key | Semantics |
+|-----|-----------|
+| `customerFirstName` | User first name, or `there` |
+| `membershipStatusLabel` | Friendly label for new status, e.g. `Regular` |
+| `appUrl` | `APP_BASE_URL` (no trailing slash) |
+| `profileUrl` | `appUrl` + `/profile` |
+
+## Template 2: access restricted — `membershipAccessRestricted`
+
+| Key | Semantics |
+|-----|-----------|
+| `customerFirstName` | User first name, or `there` |
+| `membershipStatusLabel` | Friendly label for new restricted status |
+| `previousStatusLabel` | Friendly label for previous status |
+| `appUrl` | `APP_BASE_URL` |
+
+Use static template copy for “contact your administrator” — do not include admin-only notes in personalisation.
+
+## Related docs
+
+- [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md)
+- [environment-and-secrets.md](./environment-and-secrets.md)

--- a/functions/src/__tests__/membershipStatusEmailDispatcher.test.ts
+++ b/functions/src/__tests__/membershipStatusEmailDispatcher.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as admin from "@dataconnect/admin-generated";
+import {
+  classifyMembershipStatusEmailTransition,
+  membershipStatusCustomerLabel,
+  membershipStatusDeliveryKey,
+  notifyMembershipStatusEmailIfNeeded,
+} from "../membershipStatusEmailDispatcher";
+import * as notificationDelivery from "../notificationDelivery";
+
+const mockGetUser = vi.spyOn(admin, "getUserMembershipStatus");
+const mockSendOnce = vi.spyOn(notificationDelivery, "sendNotificationOnce");
+
+describe("classifyMembershipStatusEmailTransition", () => {
+  it("returns activation when moving from restricted to non-restricted", () => {
+    expect(classifyMembershipStatusEmailTransition("PENDING", "REGULAR")).toBe("activation");
+    expect(classifyMembershipStatusEmailTransition(null, "RESERVE")).toBe("activation");
+  });
+
+  it("returns restricted when moving from non-restricted to restricted", () => {
+    expect(classifyMembershipStatusEmailTransition("REGULAR", "RESIGNED")).toBe("restricted");
+    expect(classifyMembershipStatusEmailTransition("RETIRED", "DECEASED")).toBe("restricted");
+  });
+
+  it("returns null for no-op or non-access-changing transitions", () => {
+    expect(classifyMembershipStatusEmailTransition("REGULAR", "REGULAR")).toBeNull();
+    expect(classifyMembershipStatusEmailTransition("REGULAR", "RETIRED")).toBeNull();
+    expect(classifyMembershipStatusEmailTransition("PENDING", "RESIGNED")).toBeNull();
+  });
+});
+
+describe("membershipStatusDeliveryKey", () => {
+  it("is stable per user and transition", () => {
+    expect(
+      membershipStatusDeliveryKey({
+        userId: "uid-1",
+        kind: "activation",
+        previousStatus: "PENDING",
+        newStatus: "REGULAR",
+      })
+    ).toBe("membership-activation:uid-1:PENDING:REGULAR");
+  });
+});
+
+describe("membershipStatusCustomerLabel", () => {
+  it("maps known statuses", () => {
+    expect(membershipStatusCustomerLabel("CIVIL_SERVICE")).toBe("Civil Service");
+  });
+});
+
+describe("notifyMembershipStatusEmailIfNeeded", () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockSendOnce.mockReset();
+    mockSendOnce.mockResolvedValue({ outcome: "sent" });
+  });
+
+  it("sends activation email via sendNotificationOnce", async () => {
+    mockGetUser.mockResolvedValue({
+      data: {
+        user: {
+          membershipStatus: "REGULAR",
+          firstName: "Alex",
+          lastName: "Member",
+          email: "Alex@Example.COM",
+        },
+      },
+    } as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+
+    const sendEmail = vi.fn().mockResolvedValue({
+      provider: "govuk_notify",
+      providerNotificationId: "notify-1",
+    });
+    const getMailer = () => ({ sendEmail });
+
+    await notifyMembershipStatusEmailIfNeeded({
+      userId: "uid-1",
+      previousStatus: "PENDING",
+      newStatus: "REGULAR",
+      appBaseUrl: "https://app.example/",
+      getMailer,
+    });
+
+    expect(mockSendOnce).toHaveBeenCalledTimes(1);
+    expect(mockSendOnce.mock.calls[0][0].notificationType).toBe("MEMBERSHIP_ACTIVATED");
+    expect(mockSendOnce.mock.calls[0][0].deliveryKey).toBe("membership-activation:uid-1:PENDING:REGULAR");
+
+    await mockSendOnce.mock.calls[0][0].send();
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateName: "membershipActivated",
+        to: "alex@example.com",
+        personalisation: expect.objectContaining({
+          customerFirstName: "Alex",
+          membershipStatusLabel: "Regular",
+          appUrl: "https://app.example",
+          profileUrl: "https://app.example/profile",
+        }),
+      })
+    );
+  });
+
+  it("skips when transition does not warrant email", async () => {
+    await notifyMembershipStatusEmailIfNeeded({
+      userId: "uid-1",
+      previousStatus: "REGULAR",
+      newStatus: "RETIRED",
+      appBaseUrl: "https://app.example",
+      getMailer: () => ({ sendEmail: vi.fn() }),
+    });
+    expect(mockSendOnce).not.toHaveBeenCalled();
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -1119,6 +1119,9 @@ export interface GetUserGroupByNameVariables {
 export interface GetUserMembershipStatusData {
   user?: {
     membershipStatus: MembershipStatus;
+    firstName: string;
+    lastName: string;
+    email: string;
   };
 }
 

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -4,11 +4,15 @@ import * as admin from "firebase-admin";
 import { requireAuth, handleFunctionError } from "./helpers";
 import { canUserChangeStatus, isNonRestrictedStatus, type MembershipStatus } from "./validation";
 import { FUNCTIONS_REGION } from "./constants";
-import { 
-  updateUserMembershipStatus, 
+import {
+  updateUserMembershipStatus,
   getUserMembershipStatus,
-  type MembershipStatus as AdminMembershipStatus
+  type MembershipStatus as AdminMembershipStatus,
 } from "@dataconnect/admin-generated";
+import { govNotifyApiKey } from "./mailer";
+import { notifyMembershipStatusEmailIfNeeded } from "./membershipStatusEmailDispatcher";
+
+const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
 // User groups may include membershipStatuses. Status-based membership is inherited (computed in
 // getSectionMembersMerged and in admin UI); users are not written to UserUserGroup for status-only membership.
@@ -19,7 +23,7 @@ import {
  * Users can only update their own status unless they are an admin.
  */
 export const updateMembershipStatus = onCall(
-  { region: FUNCTIONS_REGION },
+  { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request) => {
   requireAuth(request);
 
@@ -64,7 +68,16 @@ export const updateMembershipStatus = onCall(
     
     // Access group membership by status is computed at read time (admin UI and getSectionMembersMerged)
     // — we do not write UserAccessGroup rows when status changes.
-    
+
+    if (currentStatus !== newStatus) {
+      void notifyMembershipStatusEmailIfNeeded({
+        userId,
+        previousStatus: currentStatus,
+        newStatus: newStatus as MembershipStatus,
+        appBaseUrl: APP_BASE_URL,
+      });
+    }
+
     logger.info(`Membership status updated: userId=${userId}, current=${currentStatus || "unknown"}, new=${newStatus}, admin=${isAdmin}`);
     return { success: true, message: "Membership status updated successfully" };
   } catch (e: any) {

--- a/functions/src/membershipStatusEmailDispatcher.ts
+++ b/functions/src/membershipStatusEmailDispatcher.ts
@@ -1,0 +1,192 @@
+import * as logger from "firebase-functions/logger";
+import { getUserMembershipStatus, NotificationChannel } from "@dataconnect/admin-generated";
+import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import { sanitizeMailerError } from "./mailerErrors";
+import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
+import { sendNotificationOnce } from "./notificationDelivery";
+import {
+  isNonRestrictedStatus,
+  isRestrictedStatus,
+  type MembershipStatus,
+} from "./validation";
+
+export const MEMBERSHIP_MAIL_TEMPLATE_KEYS = ["membershipActivated", "membershipAccessRestricted"] as const;
+
+export type MembershipEmailTemplates = {
+  membershipActivated: {
+    customerFirstName: string;
+    membershipStatusLabel: string;
+    appUrl: string;
+    profileUrl: string;
+  };
+  membershipAccessRestricted: {
+    customerFirstName: string;
+    membershipStatusLabel: string;
+    previousStatusLabel: string;
+    appUrl: string;
+  };
+};
+
+export type MembershipStatusEmailKind = "activation" | "restricted";
+
+const MEMBERSHIP_STATUS_LABELS: Record<MembershipStatus, string> = {
+  PENDING: "Pending",
+  REGULAR: "Regular",
+  RESERVE: "Reserve",
+  CIVIL_SERVICE: "Civil Service",
+  INDUSTRY: "Industry",
+  RETIRED: "Retired",
+  RESIGNED: "Resigned",
+  LOST: "Lost",
+  DECEASED: "Deceased",
+};
+
+export function membershipStatusCustomerLabel(status: MembershipStatus): string {
+  return MEMBERSHIP_STATUS_LABELS[status] ?? status;
+}
+
+/**
+ * Determines whether a successful status update should trigger a user-facing email.
+ */
+export function classifyMembershipStatusEmailTransition(
+  previousStatus: MembershipStatus | null,
+  newStatus: MembershipStatus
+): MembershipStatusEmailKind | null {
+  if (previousStatus === newStatus) {
+    return null;
+  }
+  const wasRestricted = previousStatus === null || isRestrictedStatus(previousStatus);
+  const wasNonRestricted = previousStatus !== null && isNonRestrictedStatus(previousStatus);
+
+  if (wasRestricted && isNonRestrictedStatus(newStatus)) {
+    return "activation";
+  }
+  if (wasNonRestricted && isRestrictedStatus(newStatus)) {
+    return "restricted";
+  }
+  return null;
+}
+
+export function membershipStatusDeliveryKey(args: {
+  userId: string;
+  kind: MembershipStatusEmailKind;
+  previousStatus: MembershipStatus | null;
+  newStatus: MembershipStatus;
+}): string {
+  const from = args.previousStatus ?? "UNKNOWN";
+  return `membership-${args.kind}:${args.userId}:${from}:${args.newStatus}`;
+}
+
+export function membershipStatusNotifyReference(args: {
+  kind: MembershipStatusEmailKind;
+  userId: string;
+  previousStatus: MembershipStatus | null;
+  newStatus: MembershipStatus;
+}): string {
+  const from = args.previousStatus ?? "UNKNOWN";
+  const typeLabel = args.kind === "activation" ? "MEMBERSHIP_ACTIVATED" : "MEMBERSHIP_ACCESS_RESTRICTED";
+  return `${typeLabel}:${args.userId}:${from}:${args.newStatus}`;
+}
+
+export function createMembershipStatusMailer(): ReturnType<
+  typeof createConfiguredGovNotifyMailer<MembershipEmailTemplates>
+> {
+  return createConfiguredGovNotifyMailer([...MEMBERSHIP_MAIL_TEMPLATE_KEYS]);
+}
+
+/**
+ * Non-blocking membership status emails after a successful callable update.
+ */
+export async function notifyMembershipStatusEmailIfNeeded(args: {
+  userId: string;
+  previousStatus: MembershipStatus | null;
+  newStatus: MembershipStatus;
+  appBaseUrl: string;
+  getMailer?: () => ReturnType<typeof createMembershipStatusMailer>;
+}): Promise<void> {
+  const kind = classifyMembershipStatusEmailTransition(args.previousStatus, args.newStatus);
+  if (!kind) {
+    return;
+  }
+
+  try {
+    const row = await getUserMembershipStatus({ id: args.userId });
+    const user = row.data?.user;
+    if (!user?.email?.trim()) {
+      logger.warn("membership status email skipped (user or email missing)", {
+        userId: args.userId,
+        kind,
+      });
+      return;
+    }
+
+    const email = user.email.trim().toLowerCase();
+    const fn = user.firstName?.trim();
+    const customerFirstName = fn && fn.length > 0 ? fn : "there";
+    const base = normaliseAppBaseUrl(args.appBaseUrl);
+    const appUrl = base;
+    const membershipStatusLabel = membershipStatusCustomerLabel(args.newStatus);
+    const mailer = (args.getMailer ?? createMembershipStatusMailer)();
+    const reference = membershipStatusNotifyReference({
+      kind,
+      userId: args.userId,
+      previousStatus: args.previousStatus,
+      newStatus: args.newStatus,
+    });
+    const deliveryKey = membershipStatusDeliveryKey({
+      userId: args.userId,
+      kind,
+      previousStatus: args.previousStatus,
+      newStatus: args.newStatus,
+    });
+    const notificationType = kind === "activation" ? "MEMBERSHIP_ACTIVATED" : "MEMBERSHIP_ACCESS_RESTRICTED";
+
+    await sendNotificationOnce({
+      channel: NotificationChannel.EMAIL,
+      notificationType,
+      deliveryKey,
+      userId: args.userId,
+      provider: GOV_NOTIFY_PROVIDER,
+      send: async () => {
+        if (kind === "activation") {
+          const personalisation: MembershipEmailTemplates["membershipActivated"] = {
+            customerFirstName,
+            membershipStatusLabel,
+            appUrl,
+            profileUrl: `${base}/profile`,
+          };
+          const r = await mailer.sendEmail({
+            templateName: "membershipActivated",
+            to: email,
+            personalisation,
+            reference,
+          });
+          return { providerMessageId: r.providerNotificationId ?? null };
+        }
+        const previousStatusLabel = args.previousStatus
+          ? membershipStatusCustomerLabel(args.previousStatus)
+          : "Unknown";
+        const personalisation: MembershipEmailTemplates["membershipAccessRestricted"] = {
+          customerFirstName,
+          membershipStatusLabel,
+          previousStatusLabel,
+          appUrl,
+        };
+        const r = await mailer.sendEmail({
+          templateName: "membershipAccessRestricted",
+          to: email,
+          personalisation,
+          reference,
+        });
+        return { providerMessageId: r.providerNotificationId ?? null };
+      },
+    });
+  } catch (error) {
+    logger.error("membership status email failed", {
+      userId: args.userId,
+      previousStatus: args.previousStatus,
+      newStatus: args.newStatus,
+      error: sanitizeMailerError(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Sends **GOV.UK Notify** email when `updateMembershipStatus` changes access: **activation** (restricted → non-restricted, e.g. admin approval from pending) and **access restricted** (non-restricted → restricted).
- Uses **`sendNotificationOnce`** for deduped delivery (`MEMBERSHIP_ACTIVATED` / `MEMBERSHIP_ACCESS_RESTRICTED`).
- Extends **`GetUserMembershipStatus`** for `email` / name fields; documents template env vars and placeholders.

Closes #188.

## Test plan

- [ ] `cd functions && npm test && npm run build`
- [ ] Configure `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACTIVATED` and `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACCESS_RESTRICTED` plus `APP_BASE_URL`
- [ ] Approve a pending user in **Approve Users** → user receives activation email
- [ ] Admin moves a regular user to **Resigned** (or other restricted status) → restricted notice email
- [ ] Repeat same transition → no duplicate send (delivery ledger)


Made with [Cursor](https://cursor.com)