### PR TITLE
Epic #183 follow-up: transactional email workflows, CI, and wiring tests

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: npm ci --prefix functions
 
       - name: Run functions test suite
-        run: node .github/scripts/fail-on-warning-output.mjs -- npm --prefix functions test --run
+        run: node .github/scripts/fail-on-warning-output.mjs -- npm --prefix functions run test
 
   functions-security-tests:
     name: Functions security tests

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -55,6 +55,26 @@ jobs:
       - name: Run frontend test suite
         run: node .github/scripts/fail-on-warning-output.mjs -- npm run test:run
 
+  functions-tests:
+    name: Functions full test suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
+
+      - name: Install functions dependencies
+        run: npm ci --prefix functions
+
+      - name: Run functions test suite
+        run: node .github/scripts/fail-on-warning-output.mjs -- npm --prefix functions test --run
+
   functions-security-tests:
     name: Functions security tests
     runs-on: ubuntu-latest

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `architecture/security-and-permissions.md`: auth model across Data Connect and Cloud Functions.
 - `operations/environment-and-secrets.md`: environment variables and secrets matrix.
 - `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, deploy flow, and local setup (cloud-backed dev; no emulators).
+- `operations/transactional-email-workflows.md`: transactional email triggers by domain (payments, bookings, membership, guest tickets, ops alerts) with links to GOV.UK Notify template specs.
 
 ## Domain Guides
 

--- a/docs/architecture/booking-submission-api.md
+++ b/docs/architecture/booking-submission-api.md
@@ -83,8 +83,20 @@ Uses HTTPS callable errors. Prefer inspecting **`error.details.code`** (string) 
 
 Other `invalid-argument` / `not-found` errors apply to bad input or missing event/section.
 
+## Post-submit email
+
+After a successful submit (`idempotentReplay: false`), Functions send a GOV.UK Notify email to the booker:
+
+- **`bookingConfirmation`** — first booking for this submit (no superseded booking).
+- **`bookingRevision`** — submit supersedes a prior booking and records a payment adjustment.
+
+**No email** when the callable returns **`idempotentReplay: true`** (terminal booking already exists for the same `idempotencyKey`).
+
+See [`docs/operations/transactional-email-workflows.md`](../operations/transactional-email-workflows.md) and [`govuk-notify-booking-templates.md`](../operations/govuk-notify-booking-templates.md).
+
 ## Implementation
 
 - Rules: `functions/src/bookingRules.ts`
 - Callable: `functions/src/bookings.ts` (`submitEventBooking`)
+- Email: `functions/src/bookingEmailDispatcher.ts`
 - Draft creation for the callable: `CreateBookingDraftForUser` in `dataconnect/api/admin-mutations.gql` (explicit `bookerId`, **not** `auth.uid` from the Data Connect service account)

--- a/docs/architecture/payment-state-machine.md
+++ b/docs/architecture/payment-state-machine.md
@@ -92,9 +92,13 @@ Signals are evaluated from persisted order metadata and upserted to reconciliati
 
 ## Customer notification emails (issue #186)
 
-After a successful `TicketOrder` status transition applied from the Stripe payments webhook (`PAID`, `FAILED`, `REFUNDED`), Functions send a Gov.UK Notify email to the purchaser’s registered email, using the idempotent `NotificationDelivery` ledger keyed per Stripe event. Dispute side-state updates do not send customer lifecycle emails from this path; internal dispute alerting is tracked separately (e.g. issue #187).
+After a successful `TicketOrder` status transition applied from the Stripe payments webhook (`PAID`, `FAILED`, `REFUNDED`), Functions send a Gov.UK Notify email to the purchaser’s registered email, using the idempotent `NotificationDelivery` ledger keyed per Stripe event. Dispute side-state updates do not send customer lifecycle emails from this path.
 
-Template IDs and personalisation keys: see [`docs/operations/govuk-notify-ticket-order-templates.md`](../operations/govuk-notify-ticket-order-templates.md).
+## Internal ops notification emails (issue #187)
+
+Reconciliation exceptions that newly open or reopen send internal alerts to `PAYMENT_OPS_ALERT_EMAILS`. Dispute side-state webhooks send a separate internal dispute alert (and skip duplicate `ACTIVE_DISPUTE` reconciliation emails when opened from the dispute path).
+
+Workflow index: [`docs/operations/transactional-email-workflows.md`](../operations/transactional-email-workflows.md). Template specs: [`govuk-notify-ticket-order-templates.md`](../operations/govuk-notify-ticket-order-templates.md), [`govuk-notify-payment-ops-internal-templates.md`](../operations/govuk-notify-payment-ops-internal-templates.md).
 
 ## Scope Boundary
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -40,6 +40,10 @@ flowchart LR
 4. **Payment fulfillment**
    - Stripe sends webhook to `stripeWebhook`.
    - Function verifies signature and updates order state.
+   - On applied lifecycle transitions, customer transactional email may be sent via GOV.UK Notify (idempotent ledger).
+5. **Transactional email (app-owned)**
+   - Bookings, membership status, guest ticket moderation, and payment ops alerts use the same Notify + `NotificationDelivery` pattern.
+   - See [`docs/operations/transactional-email-workflows.md`](../operations/transactional-email-workflows.md).
 
 ## Security boundaries
 

--- a/docs/contributor-workflow.md
+++ b/docs/contributor-workflow.md
@@ -46,10 +46,16 @@ npm run test
 cd functions
 npm run test
 
-# Focused security suites
+# Full functions suite (includes mailers, dispatchers, wiring tests)
+cd functions
+npm run test
+
+# Focused security suites (also run in CI)
 cd functions
 npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts --run
 ```
+
+When changing transactional email (callables, webhooks, dispatchers), run the **full** functions suite and update [`operations/transactional-email-workflows.md`](operations/transactional-email-workflows.md) when triggers or delivery keys change.
 
 ## CI and required checks
 
@@ -60,7 +66,9 @@ npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts 
 
 After CI workflows are in place, configure these as required in branch protection:
 
-- `Frontend targeted tests`
+- `Frontend and functions build checks`
+- `Frontend full test suite`
+- `Functions full test suite`
 - `Functions security tests`
 
 Set in GitHub repository settings:

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -39,6 +39,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 
 ## Operational notes
 
+- **Transactional email overview** (triggers, idempotency, per-domain flows): [transactional-email-workflows.md](./transactional-email-workflows.md).
 - Do not commit secret values to repo.
 - Rotate Stripe secrets if compromised and update Firebase secrets before redeploy.
 - Rotate `GOV_NOTIFY_API_KEY` if compromised and update Firebase secrets before redeploy.

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -1,0 +1,102 @@
+# Transactional email workflows
+
+App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts) and idempotent delivery via [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Firebase Auth still sends verification emails.
+
+Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
+
+## Shared delivery pattern
+
+1. A callable or Stripe webhook completes a domain write.
+2. Code calls `sendNotificationOnce` with a stable **`deliveryKey`** (or a dispatcher that does).
+3. On first send, Notify is called and a `NotificationDelivery` row is recorded; retries/replays return without a second email.
+
+```mermaid
+flowchart LR
+  trigger[User action or Stripe webhook]
+  fn[Cloud Function]
+  dc[(Data Connect read)]
+  ledger[NotificationDelivery]
+  notify[GOV.UK Notify]
+
+  trigger --> fn
+  fn --> dc
+  fn --> ledger
+  ledger -->|first delivery only| notify
+```
+
+## Domain workflows
+
+### Ticket order lifecycle (customer)
+
+| | |
+|---|---|
+| **Trigger** | Stripe webhook applies `PAID`, `FAILED`, or `REFUNDED` to a `TicketOrder` |
+| **Entrypoint** | [`functions/src/payments.ts`](../../functions/src/payments.ts) → [`emitPaymentLifecycleNotification`](../../functions/src/paymentNotifications.ts) → [`paymentLifecycleEmailDispatcher.ts`](../../functions/src/paymentLifecycleEmailDispatcher.ts) |
+| **Recipient** | Purchaser email from order query |
+| **No send** | Transition not applied (`noop_replay`, illegal transition); dispute side-state path |
+| **Delivery key** | `payment:{orderId}:{type}:{stripeEventId}` |
+| **Templates** | `ticketOrderPaid`, `ticketOrderFailed`, `ticketOrderRefunded` |
+| **Deep dive** | [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md) |
+
+### Payment ops (internal)
+
+| | |
+|---|---|
+| **Trigger** | Reconciliation exception newly opened or reopened; Stripe dispute side-state webhook |
+| **Entrypoint** | [`payments.ts`](../../functions/src/payments.ts) → [`paymentOpsInternalAlerts.ts`](../../functions/src/paymentOpsInternalAlerts.ts) |
+| **Recipient** | `PAYMENT_OPS_ALERT_EMAILS` (comma-separated); unset = no sends |
+| **No send** | `ACTIVE_DISPUTE` opened from dispute webhook (dispute alert covers it); ops list empty |
+| **Templates** | `paymentReconciliationExceptionAlert`, `paymentDisputeOpsAlert` |
+| **Deep dive** | [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md) |
+
+### Membership access (user)
+
+| | |
+|---|---|
+| **Trigger** | Successful `updateMembershipStatus` when status value changes |
+| **Entrypoint** | [`membershipStatus.ts`](../../functions/src/membershipStatus.ts) → [`membershipStatusEmailDispatcher.ts`](../../functions/src/membershipStatusEmailDispatcher.ts) |
+| **Recipient** | User profile email |
+| **No send** | Same status before/after; transitions that do not map to activated/restricted templates |
+| **Templates** | `membershipActivated`, `membershipAccessRestricted` |
+| **Deep dive** | [govuk-notify-membership-templates.md](./govuk-notify-membership-templates.md) |
+
+### Guest ticket requests (moderators + booker)
+
+| | |
+|---|---|
+| **Trigger** | `submitGuestTicketRequest` (moderators); `reviewGuestTicketRequest` approve/reject (booker) |
+| **Entrypoint** | [`guestTicketRequests.ts`](../../functions/src/guestTicketRequests.ts) → [`guestTicketRequestEmails.ts`](../../functions/src/guestTicketRequestEmails.ts) |
+| **Recipient** | Deduped moderator/admin emails on submit; booker on review |
+| **No send** | Failed DC insert/review; missing booker email |
+| **Delivery keys** | Per moderator: `guest-request-mod:{requestId}:{email}`; booker: `guest-request-booker:{requestId}:{decision}` |
+| **Templates** | `guestTicketRequestSubmittedModerator`, `guestTicketRequestApproved`, `guestTicketRequestRejected` |
+| **Deep dive** | [govuk-notify-guest-ticket-request-templates.md](./govuk-notify-guest-ticket-request-templates.md) |
+
+### Bookings (booker)
+
+| | |
+|---|---|
+| **Trigger** | Successful `submitEventBooking` after status set to `SUBMITTED` |
+| **Entrypoint** | [`bookings.ts`](../../functions/src/bookings.ts) → [`bookingEmailDispatcher.ts`](../../functions/src/bookingEmailDispatcher.ts) |
+| **Recipient** | Booker email |
+| **No send** | Response has **`idempotentReplay: true`** (terminal booking already exists for key) |
+| **Templates** | `bookingConfirmation` (new booking); `bookingRevision` (supersedes prior booking) |
+| **Deep dive** | [govuk-notify-booking-templates.md](./govuk-notify-booking-templates.md) |
+
+## Manual QA (Beta)
+
+After templates are provisioned per Firebase environment:
+
+- [ ] Ticket checkout → paid email; failed/refund paths in test mode
+- [ ] Reconciliation exception opens → internal alert
+- [ ] Dispute webhook → internal dispute alert (no customer lifecycle email)
+- [ ] Admin activates member / restricts member → correct user email
+- [ ] Guest ticket submit → moderator inboxes; approve/reject → booker
+- [ ] New booking → confirmation; revision → revision email; same idempotency key replay → no second email
+
+## Related issues
+
+- Epic: [#183](https://github.com/rafsodc/sodc-web/issues/183)
+- Implementation: [#186](https://github.com/rafsodc/sodc-web/issues/186)–[#190](https://github.com/rafsodc/sodc-web/issues/190)
+- Housekeeping: [#216](https://github.com/rafsodc/sodc-web/issues/216)
+- Future policy: [#191](https://github.com/rafsodc/sodc-web/issues/191)

--- a/functions/src/__tests__/bookingsEmailWiring.test.ts
+++ b/functions/src/__tests__/bookingsEmailWiring.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
+import { scheduleBookingSubmitNotificationEmails } from "../bookings";
+import {
+  notifyBookingConfirmationEmail,
+  notifyBookingRevisionEmail,
+} from "../bookingEmailDispatcher";
+
+vi.mock("../bookingEmailDispatcher", () => ({
+  notifyBookingConfirmationEmail: vi.fn(),
+  notifyBookingRevisionEmail: vi.fn(),
+}));
+
+describe("scheduleBookingSubmitNotificationEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends confirmation email for a new booking", () => {
+    scheduleBookingSubmitNotificationEmails({
+      bookingId: "00000000-0000-0000-0000-000000000001",
+      idempotencyKey: "key-1",
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyBookingConfirmationEmail).toHaveBeenCalledTimes(1);
+    expect(notifyBookingRevisionEmail).not.toHaveBeenCalled();
+    expect(notifyBookingConfirmationEmail).toHaveBeenCalledWith({
+      bookingId: "00000000-0000-0000-0000-000000000001",
+      idempotencyKey: "key-1",
+      appBaseUrl: "https://app.example",
+    });
+  });
+
+  it("sends revision email when superseding a booking", () => {
+    scheduleBookingSubmitNotificationEmails({
+      bookingId: "00000000-0000-0000-0000-000000000002",
+      idempotencyKey: "key-2",
+      appBaseUrl: "https://app.example",
+      supersededBookingId: "00000000-0000-0000-0000-000000000099",
+      paymentDelta: {
+        previousTotalMinor: 1000,
+        revisedTotalMinor: 1500,
+        deltaAmountMinor: 500,
+        status: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
+      },
+    });
+
+    expect(notifyBookingRevisionEmail).toHaveBeenCalledTimes(1);
+    expect(notifyBookingConfirmationEmail).not.toHaveBeenCalled();
+  });
+
+  it("falls back to confirmation when superseded id is set without payment delta", () => {
+    scheduleBookingSubmitNotificationEmails({
+      bookingId: "00000000-0000-0000-0000-000000000003",
+      idempotencyKey: "key-3",
+      appBaseUrl: "https://app.example",
+      supersededBookingId: "00000000-0000-0000-0000-000000000099",
+    });
+
+    expect(notifyBookingConfirmationEmail).toHaveBeenCalledTimes(1);
+    expect(notifyBookingRevisionEmail).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/__tests__/guestTicketRequestsEmailWiring.test.ts
+++ b/functions/src/__tests__/guestTicketRequestsEmailWiring.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GuestTicketRequestStatus } from "@dataconnect/admin-generated";
+import {
+  scheduleGuestTicketRequestReviewedEmails,
+  scheduleGuestTicketRequestSubmittedEmails,
+} from "../guestTicketRequests";
+import {
+  notifyBookerGuestTicketRequestReviewed,
+  notifyModeratorsGuestTicketRequestSubmitted,
+} from "../guestTicketRequestEmails";
+
+vi.mock("../guestTicketRequestEmails", () => ({
+  notifyModeratorsGuestTicketRequestSubmitted: vi.fn(),
+  notifyBookerGuestTicketRequestReviewed: vi.fn(),
+}));
+
+describe("guest ticket request email wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fans out moderator emails on submit", () => {
+    scheduleGuestTicketRequestSubmittedEmails({
+      requestId: "req-1",
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyModeratorsGuestTicketRequestSubmitted).toHaveBeenCalledTimes(1);
+    expect(notifyModeratorsGuestTicketRequestSubmitted).toHaveBeenCalledWith({
+      requestId: "req-1",
+      appBaseUrl: "https://app.example",
+    });
+  });
+
+  it("notifies booker on approve", () => {
+    scheduleGuestTicketRequestReviewedEmails({
+      requestId: "req-2",
+      status: GuestTicketRequestStatus.APPROVED,
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyBookerGuestTicketRequestReviewed).toHaveBeenCalledWith({
+      requestId: "req-2",
+      status: GuestTicketRequestStatus.APPROVED,
+      appBaseUrl: "https://app.example",
+    });
+  });
+
+  it("notifies booker on reject", () => {
+    scheduleGuestTicketRequestReviewedEmails({
+      requestId: "req-3",
+      status: GuestTicketRequestStatus.REJECTED,
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyBookerGuestTicketRequestReviewed).toHaveBeenCalledWith({
+      requestId: "req-3",
+      status: GuestTicketRequestStatus.REJECTED,
+      appBaseUrl: "https://app.example",
+    });
+  });
+});

--- a/functions/src/__tests__/membershipStatusEmailWiring.test.ts
+++ b/functions/src/__tests__/membershipStatusEmailWiring.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { scheduleMembershipStatusEmailIfChanged } from "../membershipStatus";
+import { notifyMembershipStatusEmailIfNeeded } from "../membershipStatusEmailDispatcher";
+
+vi.mock("../membershipStatusEmailDispatcher", () => ({
+  notifyMembershipStatusEmailIfNeeded: vi.fn(),
+}));
+
+describe("scheduleMembershipStatusEmailIfChanged", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("notifies when status changes", () => {
+    scheduleMembershipStatusEmailIfChanged({
+      userId: "uid-1",
+      previousStatus: "PENDING",
+      newStatus: "REGULAR",
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyMembershipStatusEmailIfNeeded).toHaveBeenCalledTimes(1);
+    expect(notifyMembershipStatusEmailIfNeeded).toHaveBeenCalledWith({
+      userId: "uid-1",
+      previousStatus: "PENDING",
+      newStatus: "REGULAR",
+      appBaseUrl: "https://app.example",
+    });
+  });
+
+  it("does not notify when status is unchanged", () => {
+    scheduleMembershipStatusEmailIfChanged({
+      userId: "uid-1",
+      previousStatus: "REGULAR",
+      newStatus: "REGULAR",
+      appBaseUrl: "https://app.example",
+    });
+
+    expect(notifyMembershipStatusEmailIfNeeded).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/__tests__/paymentsEmailWiring.test.ts
+++ b/functions/src/__tests__/paymentsEmailWiring.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  PaymentReconciliationExceptionStatus,
+  PaymentReconciliationExceptionType,
+} from "@dataconnect/admin-generated";
+import { shouldSendReconciliationExceptionOpenedAlert } from "../payments";
+
+describe("shouldSendReconciliationExceptionOpenedAlert", () => {
+  const base = {
+    status: PaymentReconciliationExceptionStatus.OPEN,
+    hasSignal: true,
+    isNewOpen: true,
+    reopenedFromResolved: false,
+    exceptionType: PaymentReconciliationExceptionType.MISSING_PAYMENT_INTENT,
+    fromDisputeWebhook: false,
+  };
+
+  it("sends when a new open exception is created", () => {
+    expect(shouldSendReconciliationExceptionOpenedAlert(base)).toBe(true);
+  });
+
+  it("sends when reopened from resolved", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        isNewOpen: false,
+        reopenedFromResolved: true,
+      })
+    ).toBe(true);
+  });
+
+  it("does not send when exception is resolved", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        status: PaymentReconciliationExceptionStatus.RESOLVED,
+      })
+    ).toBe(false);
+  });
+
+  it("does not send when there is no active signal", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        hasSignal: false,
+      })
+    ).toBe(false);
+  });
+
+  it("does not send when already open and not reopened", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        isNewOpen: false,
+        reopenedFromResolved: false,
+      })
+    ).toBe(false);
+  });
+
+  it("skips ACTIVE_DISPUTE opened from dispute webhook (dispute alert covers it)", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        exceptionType: PaymentReconciliationExceptionType.ACTIVE_DISPUTE,
+        fromDisputeWebhook: true,
+      })
+    ).toBe(false);
+  });
+
+  it("still sends ACTIVE_DISPUTE opened outside dispute webhook path", () => {
+    expect(
+      shouldSendReconciliationExceptionOpenedAlert({
+        ...base,
+        exceptionType: PaymentReconciliationExceptionType.ACTIVE_DISPUTE,
+        fromDisputeWebhook: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -38,6 +38,30 @@ import {
 
 const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
+/** Schedules confirmation or revision email after a successful submit (not on idempotent replay). */
+export function scheduleBookingSubmitNotificationEmails(args: {
+  bookingId: UUIDString;
+  idempotencyKey: string;
+  appBaseUrl: string;
+  supersededBookingId?: string | null;
+  paymentDelta?: BookingPaymentDelta;
+}): void {
+  if (args.supersededBookingId && args.paymentDelta) {
+    void notifyBookingRevisionEmail({
+      bookingId: args.bookingId,
+      idempotencyKey: args.idempotencyKey,
+      appBaseUrl: args.appBaseUrl,
+      paymentDelta: args.paymentDelta,
+    });
+  } else {
+    void notifyBookingConfirmationEmail({
+      bookingId: args.bookingId,
+      idempotencyKey: args.idempotencyKey,
+      appBaseUrl: args.appBaseUrl,
+    });
+  }
+}
+
 function bookingRulesToHttps(e: BookingRulesFailure): HttpsError {
   if (
     e.code === BOOKING_RULE_ERROR_CODES.NO_SECTION_ACCESS ||
@@ -376,21 +400,13 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [g
       });
     }
 
-    const bookingIdUuid = bookingId as UUIDString;
-    if (revisionPlan.supersedesBookingId && paymentDelta) {
-      void notifyBookingRevisionEmail({
-        bookingId: bookingIdUuid,
-        idempotencyKey,
-        appBaseUrl: APP_BASE_URL,
-        paymentDelta,
-      });
-    } else {
-      void notifyBookingConfirmationEmail({
-        bookingId: bookingIdUuid,
-        idempotencyKey,
-        appBaseUrl: APP_BASE_URL,
-      });
-    }
+    scheduleBookingSubmitNotificationEmails({
+      bookingId: bookingId as UUIDString,
+      idempotencyKey,
+      appBaseUrl: APP_BASE_URL,
+      supersededBookingId: revisionPlan.supersedesBookingId,
+      paymentDelta,
+    });
 
     logger.info(`submitEventBooking: uid=${uid} eventId=${eventId} bookingId=${bookingId} key=${idempotencyKey}`);
     return { bookingId, status: BookingStatus.SUBMITTED, idempotentReplay: false };

--- a/functions/src/guestTicketRequests.ts
+++ b/functions/src/guestTicketRequests.ts
@@ -17,6 +17,28 @@ import {
 
 const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
+export function scheduleGuestTicketRequestSubmittedEmails(args: {
+  requestId: string;
+  appBaseUrl: string;
+}): void {
+  void notifyModeratorsGuestTicketRequestSubmitted({
+    requestId: args.requestId,
+    appBaseUrl: args.appBaseUrl,
+  });
+}
+
+export function scheduleGuestTicketRequestReviewedEmails(args: {
+  requestId: string;
+  status: typeof GuestTicketRequestStatus.APPROVED | typeof GuestTicketRequestStatus.REJECTED;
+  appBaseUrl: string;
+}): void {
+  void notifyBookerGuestTicketRequestReviewed({
+    requestId: args.requestId,
+    status: args.status,
+    appBaseUrl: args.appBaseUrl,
+  });
+}
+
 export const submitGuestTicketRequest = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request) => {
@@ -61,7 +83,7 @@ export const submitGuestTicketRequest = onCall(
         throw new HttpsError("internal", "Guest ticket request was not created");
       }
 
-      void notifyModeratorsGuestTicketRequestSubmitted({
+      scheduleGuestTicketRequestSubmittedEmails({
         requestId,
         appBaseUrl: APP_BASE_URL,
       });
@@ -104,7 +126,7 @@ export const reviewGuestTicketRequest = onCall(
         moderatorNote,
       });
 
-      void notifyBookerGuestTicketRequestReviewed({
+      scheduleGuestTicketRequestReviewedEmails({
         requestId: id,
         status,
         appBaseUrl: APP_BASE_URL,

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -14,6 +14,24 @@ import { notifyMembershipStatusEmailIfNeeded } from "./membershipStatusEmailDisp
 
 const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
+/** Sends membership access email when the stored status value changes. */
+export function scheduleMembershipStatusEmailIfChanged(args: {
+  userId: string;
+  previousStatus: MembershipStatus | null;
+  newStatus: MembershipStatus;
+  appBaseUrl: string;
+}): void {
+  if (args.previousStatus === args.newStatus) {
+    return;
+  }
+  void notifyMembershipStatusEmailIfNeeded({
+    userId: args.userId,
+    previousStatus: args.previousStatus,
+    newStatus: args.newStatus,
+    appBaseUrl: args.appBaseUrl,
+  });
+}
+
 // User groups may include membershipStatuses. Status-based membership is inherited (computed in
 // getSectionMembersMerged and in admin UI); users are not written to UserUserGroup for status-only membership.
 
@@ -69,14 +87,12 @@ export const updateMembershipStatus = onCall(
     // Access group membership by status is computed at read time (admin UI and getSectionMembersMerged)
     // — we do not write UserAccessGroup rows when status changes.
 
-    if (currentStatus !== newStatus) {
-      void notifyMembershipStatusEmailIfNeeded({
-        userId,
-        previousStatus: currentStatus,
-        newStatus: newStatus as MembershipStatus,
-        appBaseUrl: APP_BASE_URL,
-      });
-    }
+    scheduleMembershipStatusEmailIfChanged({
+      userId,
+      previousStatus: currentStatus,
+      newStatus: newStatus as MembershipStatus,
+      appBaseUrl: APP_BASE_URL,
+    });
 
     logger.info(`Membership status updated: userId=${userId}, current=${currentStatus || "unknown"}, new=${newStatus}, admin=${isAdmin}`);
     return { success: true, message: "Membership status updated successfully" };

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -118,6 +118,30 @@ const RECONCILIATION_EXCEPTION_TYPES = [
   PaymentReconciliationExceptionType.ACTIVE_DISPUTE,
 ] as const;
 
+/** Whether to send the internal ops email when a reconciliation exception is open. */
+export function shouldSendReconciliationExceptionOpenedAlert(args: {
+  status: PaymentReconciliationExceptionStatus;
+  hasSignal: boolean;
+  isNewOpen: boolean;
+  reopenedFromResolved: boolean;
+  exceptionType: PaymentReconciliationExceptionType;
+  fromDisputeWebhook: boolean;
+}): boolean {
+  if (args.status !== PaymentReconciliationExceptionStatus.OPEN || !args.hasSignal) {
+    return false;
+  }
+  if (!args.isNewOpen && !args.reopenedFromResolved) {
+    return false;
+  }
+  if (
+    args.exceptionType === PaymentReconciliationExceptionType.ACTIVE_DISPUTE &&
+    args.fromDisputeWebhook === true
+  ) {
+    return false;
+  }
+  return true;
+}
+
 async function upsertReconciliationSnapshot(args: {
   orderId: UUIDString;
   snapshot: {
@@ -166,23 +190,26 @@ async function upsertReconciliationSnapshot(args: {
       });
     }
 
-    if (status === PaymentReconciliationExceptionStatus.OPEN && signal) {
-      const isNewOpen = !existingRow?.id;
-      const reopenedFromResolved =
-        !!existingRow?.id && previousStatus === PaymentReconciliationExceptionStatus.RESOLVED;
-      if (isNewOpen || reopenedFromResolved) {
-        const skipActiveDisputeDuplicateEmail =
-          type === PaymentReconciliationExceptionType.ACTIVE_DISPUTE && args.fromDisputeWebhook === true;
-        if (!skipActiveDisputeDuplicateEmail) {
-          void notifyPaymentOpsReconciliationExceptionOpened({
-            orderId: args.orderId,
-            exceptionType: type,
-            exceptionNote: note,
-            stripeEventId: args.stripeEventId,
-            appBaseUrl: APP_BASE_URL,
-          });
-        }
-      }
+    const isNewOpen = !existingRow?.id;
+    const reopenedFromResolved =
+      !!existingRow?.id && previousStatus === PaymentReconciliationExceptionStatus.RESOLVED;
+    if (
+      shouldSendReconciliationExceptionOpenedAlert({
+        status,
+        hasSignal: !!signal,
+        isNewOpen,
+        reopenedFromResolved,
+        exceptionType: type,
+        fromDisputeWebhook: args.fromDisputeWebhook === true,
+      })
+    ) {
+      void notifyPaymentOpsReconciliationExceptionOpened({
+        orderId: args.orderId,
+        exceptionType: type,
+        exceptionNote: note,
+        stripeEventId: args.stripeEventId,
+        appBaseUrl: APP_BASE_URL,
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add [`docs/operations/transactional-email-workflows.md`](docs/operations/transactional-email-workflows.md) as a per-domain index (payments, ops alerts, membership, guest tickets, bookings) with triggers, idempotency rules, and links to existing GOV.UK Notify template docs.
- Cross-link architecture and contributor docs; update `contributor-workflow.md` with current CI job names.
- Add **Functions full test suite** GitHub Actions job so mailer/dispatcher/wiring tests run on every PR.
- Extract testable email schedulers and add wiring tests for bookings, payments reconciliation alerts, membership status, and guest ticket requests.

Closes #216. Part of #183.

## Test plan

- [x] `cd functions && npm test` (111 tests)
- [x] `npm --prefix functions run build`
- [x] `npm run build`
- [ ] CI: `Functions full test suite` job passes on this PR


Made with [Cursor](https://cursor.com)