### PR TITLE
Draft GOV.UK Notify template copy and registration runbook (#218)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/environment-and-secrets.md`: environment variables and secrets matrix.
 - `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, deploy flow, and local setup (cloud-backed dev; no emulators).
 - `operations/transactional-email-workflows.md`: transactional email triggers by domain (payments, bookings, membership, guest tickets, ops alerts) with links to GOV.UK Notify template specs.
+- `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 
 ## Domain Guides
 

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -40,6 +40,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 ## Operational notes
 
 - **Transactional email overview** (triggers, idempotency, per-domain flows): [transactional-email-workflows.md](./transactional-email-workflows.md).
+- **Notify template copy and registration** (paste into dashboard, record UUIDs per env): [govuk-notify-template-copy.md](./govuk-notify-template-copy.md), [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
 - Do not commit secret values to repo.
 - Rotate Stripe secrets if compromised and update Firebase secrets before redeploy.
 - Rotate `GOV_NOTIFY_API_KEY` if compromised and update Firebase secrets before redeploy.

--- a/docs/operations/govuk-notify-booking-templates.md
+++ b/docs/operations/govuk-notify-booking-templates.md
@@ -4,6 +4,8 @@ User-facing email after a successful **`submitEventBooking`** callable. Implemen
 
 **No email** when the callable returns **`idempotentReplay: true`**.
 
+**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (bookings section).
+
 ## Configuration
 
 | Logical key (code) | Firebase / runtime env var for template UUID |

--- a/docs/operations/govuk-notify-guest-ticket-request-templates.md
+++ b/docs/operations/govuk-notify-guest-ticket-request-templates.md
@@ -4,6 +4,8 @@ Emails for **additional guest ticket** moderation: notify moderators/admins when
 
 **Source of truth:** Personalisation **keys** must match Notify template placeholders.
 
+**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (guest ticket section).
+
 ## Configuration
 
 | Logical key (code) | Firebase / runtime env var for template UUID |

--- a/docs/operations/govuk-notify-membership-templates.md
+++ b/docs/operations/govuk-notify-membership-templates.md
@@ -4,6 +4,8 @@ User-facing email when **membership status** changes in ways that affect app acc
 
 **Source of truth:** Personalisation **keys** must match the Notify template placeholders.
 
+**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (membership section).
+
 ## Configuration
 
 | Logical key (code) | Firebase / runtime env var for template UUID |

--- a/docs/operations/govuk-notify-payment-ops-internal-templates.md
+++ b/docs/operations/govuk-notify-payment-ops-internal-templates.md
@@ -6,6 +6,8 @@ Recipients are **`PAYMENT_OPS_ALERT_EMAILS`** (comma-separated). If unset or emp
 
 **Source of truth:** Personalisation **keys** in this document must match the object sent to Notify.
 
+**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (payment ops section). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+
 ## Configuration
 
 | Logical key (code) | Firebase / runtime env var for template UUID |
@@ -30,7 +32,7 @@ Functions set short references for Notify logs, e.g. `reconciliation-ops:<orderI
 | `orderId` | Ticket order UUID |
 | `eventTitle` | Event title from order |
 | `customerDisplay` | Booker display, e.g. `Name <email>` |
-| `exceptionType` | Enum string, e.g. `ACTIVE_DISPUTE`, `UNDERPAID`, … |
+| `exceptionType` | Enum string, e.g. `ACTIVE_DISPUTE`, `MISSING_PAYMENT_INTENT`, `REFUND_AMOUNT_MISMATCH` |
 | `exceptionNote` | Stored exception note |
 | `reconciliationDashboardUrl` | `APP_BASE_URL` (normalised) + `/admin/payments/reconciliation` |
 | `stripeEventId` | Stripe webhook event id |

--- a/docs/operations/govuk-notify-sample-personalisation.json
+++ b/docs/operations/govuk-notify-sample-personalisation.json
@@ -1,0 +1,129 @@
+{
+  "ticketOrderPaid": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "ticketTypeTitle": "Member ticket",
+    "quantity": 2,
+    "totalFormatted": "50.00 GBP",
+    "currencyDisplay": "GBP",
+    "orderStatusLabel": "Paid",
+    "orderId": "00000000-0000-0000-0000-000000000001",
+    "myPaymentsUrl": "https://app.example/payments"
+  },
+  "ticketOrderFailed": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "ticketTypeTitle": "Member ticket",
+    "quantity": 1,
+    "totalFormatted": "25.00 GBP",
+    "currencyDisplay": "GBP",
+    "orderStatusLabel": "Payment failed",
+    "orderId": "00000000-0000-0000-0000-000000000002",
+    "myPaymentsUrl": "https://app.example/payments"
+  },
+  "ticketOrderRefunded": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "ticketTypeTitle": "Member ticket",
+    "quantity": 1,
+    "totalFormatted": "25.00 GBP",
+    "currencyDisplay": "GBP",
+    "orderStatusLabel": "Refunded",
+    "orderId": "00000000-0000-0000-0000-000000000003",
+    "myPaymentsUrl": "https://app.example/payments",
+    "refundFormatted": "25.00 GBP"
+  },
+  "paymentReconciliationExceptionAlert": {
+    "orderId": "00000000-0000-0000-0000-000000000001",
+    "eventTitle": "Summer Dinner",
+    "customerDisplay": "Alex Example <alex@example.com>",
+    "exceptionType": "MISSING_PAYMENT_INTENT",
+    "exceptionNote": "Paid order has no payment intent id on record",
+    "reconciliationDashboardUrl": "https://app.example/admin/payments/reconciliation",
+    "stripeEventId": "evt_test_reconciliation"
+  },
+  "paymentDisputeOpsAlert": {
+    "orderId": "00000000-0000-0000-0000-000000000001",
+    "eventTitle": "Summer Dinner",
+    "customerDisplay": "Alex Example <alex@example.com>",
+    "disputeStripeStatus": "needs_response",
+    "disputeReason": "fraudulent",
+    "disputeLocalState": "DISPUTE_OPEN",
+    "stripeDisputeId": "dp_test_123",
+    "stripeEventType": "charge.dispute.created",
+    "reconciliationDashboardUrl": "https://app.example/admin/payments/reconciliation",
+    "stripeEventId": "evt_test_dispute"
+  },
+  "membershipActivated": {
+    "customerFirstName": "Alex",
+    "membershipStatusLabel": "Regular",
+    "appUrl": "https://app.example",
+    "profileUrl": "https://app.example/profile"
+  },
+  "membershipAccessRestricted": {
+    "customerFirstName": "Alex",
+    "membershipStatusLabel": "Resigned",
+    "previousStatusLabel": "Regular",
+    "appUrl": "https://app.example"
+  },
+  "guestTicketRequestSubmittedModerator": {
+    "eventTitle": "Summer Dinner",
+    "sectionName": "Example Section",
+    "bookerDisplay": "Alex Example <alex@example.com>",
+    "guestDisplayName": "Guest Name",
+    "requestedGuestCount": 2,
+    "guestTicketTypeTitle": "Additional guest",
+    "dietaryNote": "Vegetarian",
+    "moderationUrl": "https://app.example/admin/sections"
+  },
+  "guestTicketRequestApproved": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "guestDisplayName": "Guest Name",
+    "requestedGuestCount": 2,
+    "decisionLabel": "Approved",
+    "moderatorNote": "Approved for this event.",
+    "myBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010"
+  },
+  "guestTicketRequestRejected": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "guestDisplayName": "Guest Name",
+    "requestedGuestCount": 2,
+    "decisionLabel": "Rejected",
+    "moderatorNote": "Capacity reached.",
+    "myBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010"
+  },
+  "bookingConfirmation": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
+    "revisionNumber": 1,
+    "ticketLinesSummary": "• Member ticket — Alex Example\n• Guest ticket — Guest Name",
+    "bookerDietaryNote": "None",
+    "accommodationSummary": "Not requested",
+    "bookingTotalFormatted": "35.00 GBP",
+    "sectionBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010",
+    "myPaymentsUrl": "https://app.example/payments"
+  },
+  "bookingRevision": {
+    "customerFirstName": "Alex",
+    "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
+    "revisionNumber": 2,
+    "ticketLinesSummary": "• Member ticket — Alex Example\n• Guest ticket — Guest Name",
+    "bookerDietaryNote": "Vegetarian",
+    "accommodationSummary": "Requested — Ground floor if possible",
+    "bookingTotalFormatted": "50.00 GBP",
+    "sectionBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010",
+    "myPaymentsUrl": "https://app.example/payments",
+    "previousRevisionNumber": 1,
+    "revisedRevisionNumber": 2,
+    "paymentAdjustmentStatus": "Additional payment due",
+    "previousTotalFormatted": "35.00 GBP",
+    "revisedTotalFormatted": "50.00 GBP",
+    "deltaAmountFormatted": "+15.00 GBP"
+  }
+}

--- a/docs/operations/govuk-notify-template-copy.md
+++ b/docs/operations/govuk-notify-template-copy.md
@@ -1,0 +1,346 @@
+# GOV.UK Notify: draft template copy
+
+Ready-to-paste **subject** and **body** text for all transactional email templates. Register each template in the [GOV.UK Notify dashboard](https://www.notifications.service.gov.uk/) per Firebase environment (Dev, Beta, Prod).
+
+**Before publishing**
+
+1. Follow [how to create an email template](https://www.notifications.service.gov.uk/using-notify/how-to-create-email-template) and [personalisation](https://www.notifications.service.gov.uk/using-notify/personalisation).
+2. Placeholder names must match this document **exactly** (`((customerFirstName))`, not `((first_name))`).
+3. Copy the template UUID into the matching `GOV_NOTIFY_TEMPLATE_*` env var — see [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+4. Send a test email using sample values from [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json).
+
+Placeholder specs (keys only): `govuk-notify-*.md`. Workflow index: [transactional-email-workflows.md](./transactional-email-workflows.md).
+
+---
+
+## Ticket order lifecycle
+
+### `ticketOrderPaid` — Payment confirmed
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_PAID`
+
+**Subject:** Payment confirmed for ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your payment for ((eventTitle)) is confirmed.
+
+Ticket: ((ticketTypeTitle))
+Quantity: ((quantity))
+Total: ((totalFormatted))
+Status: ((orderStatusLabel))
+Order reference: ((orderId))
+
+View your payments: ((myPaymentsUrl))
+
+If you did not make this payment, contact your section administrator.
+```
+
+**Placeholders used:** `customerFirstName`, `eventTitle`, `ticketTypeTitle`, `quantity`, `totalFormatted`, `currencyDisplay` (optional in body), `orderStatusLabel`, `orderId`, `myPaymentsUrl`
+
+---
+
+### `ticketOrderFailed` — Payment failed
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_FAILED`
+
+**Subject:** Payment could not be completed for ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+We could not complete your payment for ((eventTitle)).
+
+Ticket: ((ticketTypeTitle))
+Quantity: ((quantity))
+Amount: ((totalFormatted))
+Status: ((orderStatusLabel))
+Order reference: ((orderId))
+
+You can try again from your payments page: ((myPaymentsUrl))
+```
+
+**Placeholders used:** same as `ticketOrderPaid` (status label is sent as `Payment failed`)
+
+---
+
+### `ticketOrderRefunded` — Refund processed
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_REFUNDED`
+
+**Subject:** Refund processed for ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+A refund has been processed for your order for ((eventTitle)).
+
+Ticket: ((ticketTypeTitle))
+Quantity: ((quantity))
+Original total: ((totalFormatted))
+Refund amount: ((refundFormatted))
+Status: ((orderStatusLabel))
+Order reference: ((orderId))
+
+View your payments: ((myPaymentsUrl))
+```
+
+**Placeholders used:** all paid/failed keys plus `refundFormatted`
+
+---
+
+## Internal payment ops
+
+Set `PAYMENT_OPS_ALERT_EMAILS` before these templates will send.
+
+### `paymentReconciliationExceptionAlert`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT`
+
+**Subject:** [Payments] Reconciliation exception — ((exceptionType))
+
+**Body:**
+
+```
+A payment reconciliation exception is open.
+
+Order: ((orderId))
+Event: ((eventTitle))
+Customer: ((customerDisplay))
+Exception type: ((exceptionType))
+Note: ((exceptionNote))
+Stripe event: ((stripeEventId))
+
+Open reconciliation dashboard:
+((reconciliationDashboardUrl))
+```
+
+**Placeholders used:** `orderId`, `eventTitle`, `customerDisplay`, `exceptionType`, `exceptionNote`, `reconciliationDashboardUrl`, `stripeEventId`
+
+---
+
+### `paymentDisputeOpsAlert`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT`
+
+**Subject:** [Payments] Stripe dispute update — ((eventTitle))
+
+**Body:**
+
+```
+Stripe dispute side-state received.
+
+Order: ((orderId))
+Event: ((eventTitle))
+Customer: ((customerDisplay))
+Local state: ((disputeLocalState))
+Stripe dispute status: ((disputeStripeStatus))
+Reason: ((disputeReason))
+Dispute ID: ((stripeDisputeId))
+Stripe event type: ((stripeEventType))
+Stripe event ID: ((stripeEventId))
+
+Open reconciliation dashboard:
+((reconciliationDashboardUrl))
+```
+
+**Placeholders used:** `orderId`, `eventTitle`, `customerDisplay`, `disputeStripeStatus`, `disputeReason`, `disputeLocalState`, `stripeDisputeId`, `stripeEventType`, `reconciliationDashboardUrl`, `stripeEventId`
+
+---
+
+## Membership status
+
+### `membershipActivated`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACTIVATED`
+
+**Subject:** Your account is now active
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your membership status is now ((membershipStatusLabel)). You can sign in and use the application.
+
+Open the app: ((appUrl))
+Your profile: ((profileUrl))
+
+If you have questions, contact your section administrator.
+```
+
+**Placeholders used:** `customerFirstName`, `membershipStatusLabel`, `appUrl`, `profileUrl`
+
+---
+
+### `membershipAccessRestricted`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACCESS_RESTRICTED`
+
+**Subject:** Your account access has changed
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)). You may no longer have full access to the application.
+
+If you believe this is a mistake, contact your section administrator.
+
+Application: ((appUrl))
+```
+
+**Placeholders used:** `customerFirstName`, `membershipStatusLabel`, `previousStatusLabel`, `appUrl`
+
+---
+
+## Guest ticket requests
+
+### `guestTicketRequestSubmittedModerator`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_SUBMITTED_MODERATOR`
+
+**Subject:** Guest ticket request — ((eventTitle))
+
+**Body:**
+
+```
+A booker has submitted a guest ticket request that needs review.
+
+Section: ((sectionName))
+Event: ((eventTitle))
+Booker: ((bookerDisplay))
+Guest name: ((guestDisplayName))
+Ticket type: ((guestTicketTypeTitle))
+Guests requested: ((requestedGuestCount))
+Dietary note: ((dietaryNote))
+
+Review requests (Manage Sections): ((moderationUrl))
+```
+
+**Placeholders used:** `eventTitle`, `sectionName`, `bookerDisplay`, `guestDisplayName`, `requestedGuestCount`, `guestTicketTypeTitle`, `dietaryNote`, `moderationUrl`
+
+---
+
+### `guestTicketRequestApproved`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_APPROVED`
+
+**Subject:** Guest ticket request approved — ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
+
+Guest: ((guestDisplayName))
+Guests requested: ((requestedGuestCount))
+Moderator note: ((moderatorNote))
+
+View your booking: ((myBookingsUrl))
+```
+
+**Placeholders used:** `customerFirstName`, `eventTitle`, `guestDisplayName`, `requestedGuestCount`, `decisionLabel`, `moderatorNote`, `myBookingsUrl`
+
+---
+
+### `guestTicketRequestRejected`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_REJECTED`
+
+**Subject:** Guest ticket request not approved — ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
+
+Guest: ((guestDisplayName))
+Guests requested: ((requestedGuestCount))
+Moderator note: ((moderatorNote))
+
+View your booking: ((myBookingsUrl))
+```
+
+**Placeholders used:** same as approved (`decisionLabel` is sent as `Rejected`)
+
+---
+
+## Bookings
+
+### `bookingConfirmation`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_BOOKING_CONFIRMATION`
+
+**Subject:** Booking confirmed — ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your booking for ((eventTitle)) has been submitted.
+
+When: ((eventDateTime))
+Where: ((eventLocation))
+Revision: ((revisionNumber))
+
+Tickets:
+((ticketLinesSummary))
+
+Dietary requirements: ((bookerDietaryNote))
+Accommodation: ((accommodationSummary))
+Booking total: ((bookingTotalFormatted))
+
+View section bookings: ((sectionBookingsUrl))
+Payments: ((myPaymentsUrl))
+```
+
+**Placeholders used:** `customerFirstName`, `eventTitle`, `eventDateTime`, `eventLocation`, `revisionNumber`, `ticketLinesSummary`, `bookerDietaryNote`, `accommodationSummary`, `bookingTotalFormatted`, `sectionBookingsUrl`, `myPaymentsUrl`
+
+---
+
+### `bookingRevision`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION`
+
+**Subject:** Booking updated — ((eventTitle))
+
+**Body:**
+
+```
+Hello ((customerFirstName)),
+
+Your booking for ((eventTitle)) has been updated (revision ((revisedRevisionNumber)), previously revision ((previousRevisionNumber))).
+
+When: ((eventDateTime))
+Where: ((eventLocation))
+
+Tickets:
+((ticketLinesSummary))
+
+Dietary requirements: ((bookerDietaryNote))
+Accommodation: ((accommodationSummary))
+
+Payment adjustment: ((paymentAdjustmentStatus))
+Previous total: ((previousTotalFormatted))
+Revised total: ((revisedTotalFormatted))
+Change: ((deltaAmountFormatted))
+
+View section bookings: ((sectionBookingsUrl))
+Payments: ((myPaymentsUrl))
+```
+
+**Placeholders used:** all confirmation keys plus `previousRevisionNumber`, `revisedRevisionNumber`, `paymentAdjustmentStatus`, `previousTotalFormatted`, `revisedTotalFormatted`, `deltaAmountFormatted`

--- a/docs/operations/govuk-notify-template-registration.md
+++ b/docs/operations/govuk-notify-template-registration.md
@@ -1,0 +1,62 @@
+# GOV.UK Notify: template registration runbook
+
+Use this checklist when creating templates in Notify for **Dev**, **Beta**, and **Prod**. Do **not** commit API keys or template UUIDs to the repository.
+
+**Draft copy to paste:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md)  
+**Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json)  
+**Env matrix:** [environment-and-secrets.md](./environment-and-secrets.md)
+
+## Per-environment steps
+
+1. Sign in to [GOV.UK Notify](https://www.notifications.service.gov.uk/) for the service linked to that Firebase project.
+2. For each template below:
+   - Create an **email** template ([guidance](https://www.notifications.service.gov.uk/using-notify/how-to-create-email-template)).
+   - Paste **subject** and **body** from [govuk-notify-template-copy.md](./govuk-notify-template-copy.md).
+   - Add every `((placeholder))` listed for that template (Notify validates on send).
+   - Send a **test email** using values from [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json) for that logical key.
+   - Copy the template **UUID** into your secure ops record (table below).
+3. Configure Firebase Functions for that project:
+   - Secret: `GOV_NOTIFY_API_KEY`
+   - Env vars: `GOV_NOTIFY_TEMPLATE_*` (one per row below)
+   - Optional: `GOV_NOTIFY_EMAIL_REPLY_TO_ID`, `APP_BASE_URL`
+   - Internal ops only: `PAYMENT_OPS_ALERT_EMAILS` (comma-separated)
+4. Redeploy Functions after env changes.
+5. Run one **end-to-end** trigger per domain in that environment (see [transactional-email-workflows.md](./transactional-email-workflows.md#manual-qa-beta)).
+
+## Template registry (record UUIDs outside repo)
+
+| Logical key | Env var | Dev UUID | Beta UUID | Prod UUID | Registered |
+|-------------|---------|----------|-----------|-----------|------------|
+| `ticketOrderPaid` | `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_PAID` | | | | [ ] |
+| `ticketOrderFailed` | `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_FAILED` | | | | [ ] |
+| `ticketOrderRefunded` | `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_REFUNDED` | | | | [ ] |
+| `paymentReconciliationExceptionAlert` | `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT` | | | | [ ] |
+| `paymentDisputeOpsAlert` | `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT` | | | | [ ] |
+| `membershipActivated` | `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACTIVATED` | | | | [ ] |
+| `membershipAccessRestricted` | `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACCESS_RESTRICTED` | | | | [ ] |
+| `guestTicketRequestSubmittedModerator` | `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_SUBMITTED_MODERATOR` | | | | [ ] |
+| `guestTicketRequestApproved` | `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_APPROVED` | | | | [ ] |
+| `guestTicketRequestRejected` | `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_REJECTED` | | | | [ ] |
+| `bookingConfirmation` | `GOV_NOTIFY_TEMPLATE_BOOKING_CONFIRMATION` | | | | [ ] |
+| `bookingRevision` | `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION` | | | | [ ] |
+
+## Suggested order
+
+1. Dev — all 12 templates, then E2E smoke tests  
+2. Beta — clone copy, new UUIDs, repeat smoke tests  
+3. Prod — final copy review, register UUIDs, enable sends  
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Notify API `template` error | Wrong UUID in `GOV_NOTIFY_TEMPLATE_*` for this environment |
+| Missing placeholder error | Dashboard placeholder name does not match code (see `govuk-notify-*.md`) |
+| No email sent | `GOV_NOTIFY_API_KEY` missing, template ID env unset, or ops recipient list empty (`PAYMENT_OPS_ALERT_EMAILS`) |
+| Duplicate emails | Expected on webhook retry only if delivery ledger failed; check `NotificationDelivery` |
+
+## Related issues
+
+- Epic: #183  
+- Implementation: #186–#190, #216  
+- This work: #218

--- a/docs/operations/govuk-notify-ticket-order-templates.md
+++ b/docs/operations/govuk-notify-ticket-order-templates.md
@@ -4,6 +4,8 @@ These templates send **app-owned transactional email** when a `TicketOrder` is m
 
 **Source of truth:** Personalisation **keys** in this document must match the object sent to Notify. If the dashboard placeholder names do not match the API payload, sends fail at runtime.
 
+**Draft copy for Notify dashboard:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (ticket order section). **Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json).
+
 ## Configuration
 
 | Logical key (code) | Firebase / runtime env var for template UUID |

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -85,7 +85,7 @@ flowchart LR
 
 ## Manual QA (Beta)
 
-After templates are provisioned per Firebase environment:
+After templates are provisioned per Firebase environment (see [govuk-notify-template-registration.md](./govuk-notify-template-registration.md)):
 
 - [ ] Ticket checkout → paid email; failed/refund paths in test mode
 - [ ] Reconciliation exception opens → internal alert

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -2,7 +2,7 @@
 
 App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts) and idempotent delivery via [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Firebase Auth still sends verification emails.
 
-Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
+Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. **Draft Notify subject/body copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration runbook:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md). Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
 
 ## Shared delivery pattern
 


### PR DESCRIPTION
## Summary

- Add [govuk-notify-template-copy.md](docs/operations/govuk-notify-template-copy.md) with paste-ready **subject** and **body** for all 12 transactional templates, using Notify `((placeholder))` syntax per [official personalisation guidance](https://www.notifications.service.gov.uk/using-notify/personalisation).
- Add [govuk-notify-sample-personalisation.json](docs/operations/govuk-notify-sample-personalisation.json) for Notify test sends / API previews.
- Add [govuk-notify-template-registration.md](docs/operations/govuk-notify-template-registration.md) — per-environment UUID checklist and rollout steps (UUIDs stay outside repo).
- Cross-link from existing `govuk-notify-*.md`, workflows index, and env matrix.

Closes #218. Part of #183.

**Remaining ops work (not in repo):** create templates in Notify dashboard for Dev/Beta/Prod and set `GOV_NOTIFY_TEMPLATE_*` env vars using the registration runbook.

## Test plan

- [x] All placeholders in copy match keys in `functions/src/*EmailDispatcher.ts` and `govuk-notify-*.md`
- [ ] Ops: paste one template into Notify Dev, send test with sample JSON
- [ ] Ops: fill UUID registry and configure Firebase env vars


Made with [Cursor](https://cursor.com)