### PR TITLE
Add functions env template

### DIFF
--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -23,10 +23,16 @@ Defined via `.env*` files and read from `import.meta.env`:
 
 ## Functions runtime env / secrets
 
+The committed `functions/.env` file is a comment-only template. For local
+emulator overrides, copy it to `functions/.env.local` and add real non-secret
+values there. Local secret overrides belong in `functions/.secret.local`.
+Both local files are ignored by git.
+
 | Name | Type | Used by | Required |
 |---|---|---|---|
 | `STRIPE_SECRET` | Firebase secret | `createTicketCheckoutSession`, `stripeWebhook` | yes for payments |
 | `STRIPE_WEBHOOK_SECRET` | Firebase secret | `stripeWebhook` | yes for webhook processing |
+| `STRIPE_WEBHOOK_SECRET_PAYMENTS` | Firebase secret | `stripeWebhook` payments endpoint | preferred for payment webhook processing; falls back to `STRIPE_WEBHOOK_SECRET` |
 | `APP_BASE_URL` | env var | Checkout success/cancel URLs | yes for non-local |
 | `ENV_NAME` | env var | dev reset guardrail | required for reset tooling |
 | `PERMITTED_PROJECT_IDS` | env var | dev reset guardrail | required for reset tooling |
@@ -34,5 +40,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 ## Operational notes
 
 - Do not commit secret values to repo.
+- Keep committed dotenv templates comment-only; put developer-specific values in
+  `.env.local` or `.secret.local`.
 - Rotate Stripe secrets if compromised and update Firebase secrets before redeploy.
 - Keep environment docs and deployment settings aligned when adding new variables.

--- a/functions/.env
+++ b/functions/.env
@@ -1,0 +1,20 @@
+# Firebase Functions environment template.
+#
+# Copy this file to .env.local for local emulator overrides. The .env.local
+# file is ignored by git and takes precedence when running the emulator.
+#
+# Keep this committed .env file comment-only. The Firebase CLI can load .env
+# during deploy, so uncommented placeholder assignments here could become
+# deployed runtime configuration.
+
+# Non-secret runtime environment variables
+# APP_BASE_URL=http://localhost:5173
+# ENV_NAME=dev
+# PERMITTED_PROJECT_IDS=sodc-dev-project-id
+
+# Secret values are managed with Firebase Secret Manager in deployed
+# environments. For local emulator secret overrides, use .secret.local instead
+# of .env.local.
+# STRIPE_SECRET=sk_test_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_WEBHOOK_SECRET_PAYMENTS=whsec_...

--- a/functions/.gitignore
+++ b/functions/.gitignore
@@ -7,4 +7,9 @@ typings/
 
 # Node.js dependency directory
 node_modules/
+
+# Local Firebase Functions dotenv/secret overrides
+.env.local
+.env.*.local
+.secret.local
 *.local


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements environment-file cleanup for Functions local configuration

## Changes

- Add a committed, comment-only `functions/.env` template.
- Explicitly ignore `functions/.env.local`, `functions/.env.*.local`, and `functions/.secret.local` for developer-specific values.
- Document the Functions dotenv split between committed templates, local non-secret overrides, and local secret overrides.

## Related Issue

Related to #185

## Testing

- [ ] Security tests pass
- [ ] Functionality tests pass
- [ ] Manual testing completed
- `git diff --check`

## Checklist

- [x] Code follows project style guidelines
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0fb2bcd-1d78-49ff-b86a-c22d7e4d293c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0fb2bcd-1d78-49ff-b86a-c22d7e4d293c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

