### PR TITLE
Security: prevent self-activation before admin approval (#228)

### DIFF
--- a/dataconnect/AUTH_EXPRESSIONS.md
+++ b/dataconnect/AUTH_EXPRESSIONS.md
@@ -12,10 +12,10 @@ This file documents all auth expressions used in queries and mutations. Use thes
 
 ## Auth Expression Constants
 
-### Basic User Access (Any Authenticated User)
-**Expression:** `@auth(level: USER)`
+### Onboarding Profile Access (Verified Email, Not Enabled)
+**Expression:** `"auth.token.email_verified == true"`
 
-**Usage:** Any authenticated user can access these operations. Used for initial profile creation before the `enabled` claim is set.
+**Usage:** Authenticated users who have verified their email but do not yet have `enabled: true`. Used only for initial profile creation and checking whether a profile exists during onboarding.
 
 **Used in:**
 - `CheckUserProfileExists` query

--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -159,8 +159,8 @@ query GetUserAccessGroups @auth(expr: "auth.token.enabled == true") {
 
 
 # Check if current user's profile exists and get membership status (for users without enabled claim)
-# Allows users to check if they've completed profile registration and see their status
-query CheckUserProfileExists @auth(level: USER) {
+# Requires verified email; used during onboarding before the enabled claim is set
+query CheckUserProfileExists @auth(expr: "auth.token.email_verified == true") {
   user(key: { id_expr: "auth.uid" }) {
     id
     firstName

--- a/dataconnect/api/user-mutations.gql
+++ b/dataconnect/api/user-mutations.gql
@@ -10,9 +10,8 @@
 # See AUTH_EXPRESSIONS.md for complete documentation and usage.
 
 # Create initial user profile during registration (before enabled claim is set)
-# This allows new users to complete their profile after email verification
-# Users can only create their own profile (id_expr: "auth.uid")
-# NOTE: membershipStatus is set to PENDING by default, requestedMembershipStatus stores user's selection
+# Requires verified email; users can only create their own profile (id_expr: "auth.uid")
+# NOTE: membershipStatus is set to PENDING; requestedMembershipStatus stores user's selection
 mutation CreateUserProfile(
   $firstName: String!
   $lastName: String!
@@ -23,7 +22,7 @@ mutation CreateUserProfile(
   $isReserve: Boolean
   $isCivilServant: Boolean
   $isIndustry: Boolean
-) @auth(level: USER) {
+) @auth(expr: "auth.token.email_verified == true") {
   user_upsert(
     data: {
       id_expr: "auth.uid"

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -36,6 +36,7 @@ describe("Data Connect auth contracts", () => {
     const groupMutations = readApiFile("user-group-mutations.gql");
 
     assertAuth(queries, [
+      { op: "query CheckUserProfileExists", mustInclude: '@auth(expr: "auth.token.email_verified == true")' },
       { op: "query ListEventBookingsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
       { op: "query ListGuestTicketRequestsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
       { op: "query ListTicketOrdersForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
@@ -59,7 +60,7 @@ describe("Data Connect auth contracts", () => {
     ]);
 
     assertAuth(userMutations, [
-      { op: "mutation CreateUserProfile", mustInclude: "@auth(level: USER)" },
+      { op: "mutation CreateUserProfile", mustInclude: '@auth(expr: "auth.token.email_verified == true")' },
       { op: "mutation UpsertUser", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
       { op: "mutation UpdateUser", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
     ]);

--- a/functions/src/__tests__/validation.test.ts
+++ b/functions/src/__tests__/validation.test.ts
@@ -108,7 +108,7 @@ describe('validation', () => {
       });
 
       it('should not allow user to self-activate from blank legacy status', () => {
-        const result = canUserChangeStatus('' as never, 'REGULAR', false, false, true);
+        const result = canUserChangeStatus('', 'REGULAR', false, false, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe('Cannot change from restricted status');
       });

--- a/functions/src/__tests__/validation.test.ts
+++ b/functions/src/__tests__/validation.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   isRestrictedStatus,
+  isBlankMembershipStatus,
+  isActivationBlockedStatus,
   canUserChangeStatus,
   NON_RESTRICTED_STATUSES,
   RESTRICTED_STATUSES,
@@ -21,6 +23,25 @@ describe('validation', () => {
       expect(isRestrictedStatus('RESERVE')).toBe(false);
       expect(isRestrictedStatus('INDUSTRY')).toBe(false);
       expect(isRestrictedStatus('CIVIL_SERVICE')).toBe(false);
+    });
+  });
+
+  describe('isBlankMembershipStatus', () => {
+    it('treats null, undefined, and blank as blank', () => {
+      expect(isBlankMembershipStatus(null)).toBe(true);
+      expect(isBlankMembershipStatus(undefined)).toBe(true);
+      expect(isBlankMembershipStatus('')).toBe(true);
+      expect(isBlankMembershipStatus('   ')).toBe(true);
+      expect(isBlankMembershipStatus('REGULAR')).toBe(false);
+    });
+  });
+
+  describe('isActivationBlockedStatus', () => {
+    it('blocks PENDING, blank, and null', () => {
+      expect(isActivationBlockedStatus('PENDING')).toBe(true);
+      expect(isActivationBlockedStatus(null)).toBe(true);
+      expect(isActivationBlockedStatus('')).toBe(true);
+      expect(isActivationBlockedStatus('REGULAR')).toBe(false);
     });
   });
 
@@ -50,6 +71,11 @@ describe('validation', () => {
         expect(result.allowed).toBe(true);
       });
 
+      it('should allow admin activation from null without caller enabled', () => {
+        const result = canUserChangeStatus(null, 'REGULAR', true, false, false);
+        expect(result.allowed).toBe(true);
+      });
+
       it('should not allow admin to set another admin to restricted status', () => {
         const result = canUserChangeStatus('REGULAR', 'PENDING', true, true);
         expect(result.allowed).toBe(false);
@@ -58,23 +84,40 @@ describe('validation', () => {
     });
 
     describe('regular user permissions', () => {
-      it('should allow user to change between non-restricted statuses', () => {
-        const result = canUserChangeStatus('REGULAR', 'RETIRED', false);
+      it('should allow enabled user to change between non-restricted statuses', () => {
+        const result = canUserChangeStatus('REGULAR', 'RETIRED', false, false, true);
         expect(result.allowed).toBe(true);
       });
 
-      it('should not allow user to change from restricted status', () => {
-        const result = canUserChangeStatus('PENDING', 'REGULAR', false);
+      it('should reject when caller is not enabled', () => {
+        const result = canUserChangeStatus('REGULAR', 'RETIRED', false, false, false);
+        expect(result.allowed).toBe(false);
+        expect(result.error).toBe('Account must be enabled');
+      });
+
+      it('should not allow user to change from PENDING', () => {
+        const result = canUserChangeStatus('PENDING', 'REGULAR', false, false, true);
+        expect(result.allowed).toBe(false);
+        expect(result.error).toBe('Cannot change from restricted status');
+      });
+
+      it('should not allow user to self-activate from null status', () => {
+        const result = canUserChangeStatus(null, 'REGULAR', false, false, true);
+        expect(result.allowed).toBe(false);
+        expect(result.error).toBe('Cannot change from restricted status');
+      });
+
+      it('should not allow user to self-activate from blank legacy status', () => {
+        const result = canUserChangeStatus('' as never, 'REGULAR', false, false, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe('Cannot change from restricted status');
       });
 
       it('should not allow user to change to restricted status', () => {
-        const result = canUserChangeStatus('REGULAR', 'PENDING', false);
+        const result = canUserChangeStatus('REGULAR', 'PENDING', false, false, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe('Cannot change to restricted status');
       });
     });
   });
 });
-

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -56,6 +56,7 @@ export const updateMembershipStatus = onCall(
   }
 
   const isAdmin = request.auth!.token.admin === true;
+  const callerEnabled = request.auth!.token.enabled === true;
   if (!isAdmin && request.auth!.uid !== userId) {
     throw new HttpsError("permission-denied", "Users can only update their own profile");
   }
@@ -71,7 +72,8 @@ export const updateMembershipStatus = onCall(
       currentStatus,
       newStatus as MembershipStatus,
       isAdmin,
-      targetUserIsAdmin
+      targetUserIsAdmin,
+      callerEnabled
     );
     
     if (!validation.allowed) {
@@ -129,10 +131,17 @@ async function fetchCurrentStatusFromDataConnect(
 ): Promise<MembershipStatus | null> {
   try {
     const result = await getUserMembershipStatus({ id: userId });
-    return result.data?.user?.membershipStatus as MembershipStatus | null || null;
-  } catch (error: any) {
-    logger.warn(`Could not fetch current status from Data Connect for userId=${userId}:`, error);
-    return null;
+    const status = result.data?.user?.membershipStatus;
+    if (status === undefined || status === null) {
+      return null;
+    }
+    return status as MembershipStatus;
+  } catch (error: unknown) {
+    logger.error(`Could not fetch current status from Data Connect for userId=${userId}:`, error);
+    throw new HttpsError(
+      "internal",
+      "Could not verify membership status"
+    );
   }
 }
 

--- a/functions/src/validation.ts
+++ b/functions/src/validation.ts
@@ -31,6 +31,9 @@ type MembershipStatus =
   | "LOST"
   | "DECEASED";
 
+/** Values from Data Connect or legacy rows (may be blank). */
+export type MembershipStatusInput = MembershipStatus | null | undefined | string;
+
 /**
  * Checks if a membership status is restricted
  */
@@ -47,7 +50,7 @@ export function isNonRestrictedStatus(status: MembershipStatus): boolean {
 
 /** True when status is null, undefined, or whitespace-only (legacy rows). */
 export function isBlankMembershipStatus(
-  status: MembershipStatus | null | undefined
+  status: MembershipStatusInput
 ): boolean {
   if (status == null) {
     return true;
@@ -62,7 +65,7 @@ export function isBlankMembershipStatus(
  * Statuses that block non-admin self-service changes (awaiting admin approval or unknown).
  */
 export function isActivationBlockedStatus(
-  status: MembershipStatus | null | undefined
+  status: MembershipStatusInput
 ): boolean {
   if (isBlankMembershipStatus(status)) {
     return true;
@@ -80,7 +83,7 @@ export function isActivationBlockedStatus(
  * @returns Object with allowed boolean and optional error message
  */
 export function canUserChangeStatus(
-  currentStatus: MembershipStatus | null | undefined,
+  currentStatus: MembershipStatusInput,
   newStatus: MembershipStatus,
   isAdmin: boolean,
   targetUserIsAdmin: boolean = false,
@@ -120,7 +123,10 @@ export function canUserChangeStatus(
     };
   }
 
-  if (!currentStatus || !isNonRestrictedStatus(currentStatus)) {
+  if (
+    typeof currentStatus !== "string" ||
+    !isNonRestrictedStatus(currentStatus as MembershipStatus)
+  ) {
     return {
       allowed: false,
       error: "Cannot change membership status",

--- a/functions/src/validation.ts
+++ b/functions/src/validation.ts
@@ -45,19 +45,46 @@ export function isNonRestrictedStatus(status: MembershipStatus): boolean {
   return NON_RESTRICTED_STATUSES.includes(status);
 }
 
+/** True when status is null, undefined, or whitespace-only (legacy rows). */
+export function isBlankMembershipStatus(
+  status: MembershipStatus | null | undefined
+): boolean {
+  if (status == null) {
+    return true;
+  }
+  if (typeof status === "string" && status.trim() === "") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Statuses that block non-admin self-service changes (awaiting admin approval or unknown).
+ */
+export function isActivationBlockedStatus(
+  status: MembershipStatus | null | undefined
+): boolean {
+  if (isBlankMembershipStatus(status)) {
+    return true;
+  }
+  return isRestrictedStatus(status as MembershipStatus);
+}
+
 /**
  * Validates if a user can change from one membership status to another
- * @param currentStatus - The user's current membership status (null if new user)
+ * @param currentStatus - The user's current membership status (null/blank if unknown or no row)
  * @param newStatus - The desired new membership status
  * @param isAdmin - Whether the user making the change is an admin
  * @param targetUserIsAdmin - Whether the target user (whose status is being changed) is an admin
+ * @param callerEnabled - Whether the caller has auth.token.enabled === true
  * @returns Object with allowed boolean and optional error message
  */
 export function canUserChangeStatus(
-  currentStatus: MembershipStatus | null,
+  currentStatus: MembershipStatus | null | undefined,
   newStatus: MembershipStatus,
   isAdmin: boolean,
-  targetUserIsAdmin: boolean = false
+  targetUserIsAdmin: boolean = false,
+  callerEnabled: boolean = false
 ): { allowed: boolean; error?: string } {
   // If target user is an admin, they cannot have a restricted status
   if (targetUserIsAdmin && isRestrictedStatus(newStatus)) {
@@ -72,15 +99,20 @@ export function canUserChangeStatus(
     return { allowed: true };
   }
 
-  // If current status is restricted, user cannot change it
-  if (currentStatus && isRestrictedStatus(currentStatus)) {
+  if (!callerEnabled) {
+    return {
+      allowed: false,
+      error: "Account must be enabled",
+    };
+  }
+
+  if (isActivationBlockedStatus(currentStatus)) {
     return {
       allowed: false,
       error: "Cannot change from restricted status",
     };
   }
 
-  // If new status is restricted, user cannot change to it
   if (isRestrictedStatus(newStatus)) {
     return {
       allowed: false,
@@ -88,10 +120,15 @@ export function canUserChangeStatus(
     };
   }
 
-  // If both are non-restricted (or current is null for new users), allow the change
+  if (!currentStatus || !isNonRestrictedStatus(currentStatus)) {
+    return {
+      allowed: false,
+      error: "Cannot change membership status",
+    };
+  }
+
   return { allowed: true };
 }
 
 export { NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES };
 export type { MembershipStatus };
-


### PR DESCRIPTION
## Summary

Closes #228 — hardens onboarding auth boundaries discovered during #227 review.

- **`updateMembershipStatus`:** Non-admins must have `enabled: true` and a known non-restricted current status. Blocks self-activation from `PENDING`, blank, or null status. Data Connect status fetch failures fail closed (no longer treated as “no profile”).
- **`CreateUserProfile` / `CheckUserProfileExists`:** Require `auth.token.email_verified == true` at the Data Connect layer.

## Test plan

- [ ] `npm test` in `functions/` passes
- [ ] Deploy Data Connect schema + functions
- [ ] Unenabled user cannot call `updateMembershipStatus` to set `REGULAR` (direct callable)
- [ ] Unverified user cannot call `CreateUserProfile` via SDK
- [ ] Enabled member can still change between non-restricted statuses on Profile page
- [ ] Admin Accept on Approve Users still works (PENDING → requested status)


Made with [Cursor](https://cursor.com)