### PR TITLE
Fix Stripe checkout return URLs to use /payments (#237)

### DIFF
--- a/functions/src/__tests__/paymentsCheckoutUrls.test.ts
+++ b/functions/src/__tests__/paymentsCheckoutUrls.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildStripeCheckoutReturnUrls, MEMBER_PAYMENTS_PATH } from "../payments";
+
+describe("buildStripeCheckoutReturnUrls", () => {
+  const orderId = "550e8400-e29b-41d4-a716-446655440000";
+
+  it("uses /payments path aligned with frontend ROUTES.MY_PAYMENTS", () => {
+    expect(MEMBER_PAYMENTS_PATH).toBe("/payments");
+    const urls = buildStripeCheckoutReturnUrls("https://app.example", orderId);
+    expect(urls.successUrl).toContain("/payments?checkout=success");
+    expect(urls.cancelUrl).toContain("/payments?checkout=cancel");
+    expect(urls.successUrl).not.toContain("/my-payments");
+    expect(urls.cancelUrl).not.toContain("/my-payments");
+  });
+
+  it("strips trailing slash from app base URL", () => {
+    const urls = buildStripeCheckoutReturnUrls("https://app.example/", orderId);
+    expect(urls.successUrl).toBe(
+      `https://app.example/payments?checkout=success&orderId=${encodeURIComponent(orderId)}`
+    );
+    expect(urls.cancelUrl).toBe(
+      `https://app.example/payments?checkout=cancel&orderId=${encodeURIComponent(orderId)}`
+    );
+  });
+
+  it("includes orderId query param on both URLs", () => {
+    const urls = buildStripeCheckoutReturnUrls("http://localhost:5173", orderId);
+    expect(urls.successUrl).toContain(`orderId=${encodeURIComponent(orderId)}`);
+    expect(urls.cancelUrl).toContain(`orderId=${encodeURIComponent(orderId)}`);
+  });
+});

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -55,6 +55,21 @@ const stripeWebhookPaymentsSecret = defineSecret("STRIPE_WEBHOOK_SECRET_PAYMENTS
 const CHECKOUT_CURRENCY = "gbp";
 const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
 
+/** Member payments route — must match frontend `ROUTES.MY_PAYMENTS` (`/payments`). */
+export const MEMBER_PAYMENTS_PATH = "/payments";
+
+export function buildStripeCheckoutReturnUrls(
+  appBaseUrl: string,
+  orderId: string
+): { successUrl: string; cancelUrl: string } {
+  const base = appBaseUrl.replace(/\/$/, "");
+  const orderQuery = encodeURIComponent(orderId);
+  return {
+    successUrl: `${base}${MEMBER_PAYMENTS_PATH}?checkout=success&orderId=${orderQuery}`,
+    cancelUrl: `${base}${MEMBER_PAYMENTS_PATH}?checkout=cancel&orderId=${orderQuery}`,
+  };
+}
+
 const govNotifyTicketOrderDispatcher = createGovNotifyTicketOrderLifecycleDispatcher({
   getMailer: defaultWebhookGovNotifyTicketOrderMailer,
   appBaseUrl: APP_BASE_URL,
@@ -289,11 +304,12 @@ export const createTicketCheckoutSession = onCall({ region: FUNCTIONS_REGION, se
   const orderId = order.data?.ticketOrder_insert?.id;
   if (!orderId) throw new HttpsError("internal", "Failed to create ticket order");
 
+  const { successUrl, cancelUrl } = buildStripeCheckoutReturnUrls(APP_BASE_URL, orderId);
   const session = await stripeClient.checkout.sessions.create({
     mode: "payment",
     customer: customerId ?? undefined,
-    success_url: `${APP_BASE_URL}/my-payments?checkout=success&orderId=${orderId}`,
-    cancel_url: `${APP_BASE_URL}/my-payments?checkout=cancel&orderId=${orderId}`,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
     line_items: [
       {
         quantity,


### PR DESCRIPTION
## Summary

Stripe Checkout `success_url` and `cancel_url` pointed at `/my-payments`, but the app route is `/payments` (`ROUTES.MY_PAYMENTS`). Members could miss `CheckoutStatusNotice` after paying.

- Introduce `buildStripeCheckoutReturnUrls()` and `MEMBER_PAYMENTS_PATH` in `functions/src/payments.ts`
- Use `/payments` for both return URLs
- Add unit tests

Fixes #237

## Test plan

- [x] `npm test -- --run src/__tests__/paymentsCheckoutUrls.test.ts` (functions)
- [ ] Deploy functions to dev and complete a Stripe test checkout; confirm redirect to `/payments?checkout=success&orderId=...` and notice renders

Made with [Cursor](https://cursor.com)