### PR TITLE
Member welcome dashboard for enabled users (#232)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ const MyPayments = lazy(() => import("./features/sections/components/MyPayments"
 const AccountStatusMessage = lazy(() => import("./features/users/components/AccountStatusMessage"));
 const ProfileCompletion = lazy(() => import("./features/auth/components/ProfileCompletion"));
 const EmailVerificationMessage = lazy(() => import("./features/auth/components/EmailVerificationMessage"));
+const MemberWelcomePage = lazy(() => import("./features/welcome/components/MemberWelcomePage"));
 
 // Loading fallback component
 const LoadingFallback = () => (
@@ -358,15 +359,34 @@ function AppContent() {
                 </Box>
               )}
               <Routes>
-                <Route path={ROUTES.HOME} element={<HomePage />} />
+                <Route
+                  path={ROUTES.HOME}
+                  element={
+                    user && isEnabled ? (
+                      <Suspense fallback={<LoadingFallback />}>
+                        <MemberWelcomePage
+                          userData={userData}
+                          userEmail={user.email}
+                          sectionsData={userSectionsData}
+                        />
+                      </Suspense>
+                    ) : (
+                      <HomePage />
+                    )
+                  }
+                />
                 <Route
                   path={ROUTES.ACCOUNT}
                   element={
-                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
-                      <Suspense fallback={<LoadingFallback />}>
-                        <AuthGate userData={userData} onBack={() => navigateBackOr(ROUTES.HOME)} />
-                      </Suspense>
-                    </Box>
+                    user && isEnabled ? (
+                      <Navigate to={ROUTES.HOME} replace />
+                    ) : (
+                      <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                        <Suspense fallback={<LoadingFallback />}>
+                          <AuthGate userData={userData} onBack={() => navigateBackOr(ROUTES.HOME)} />
+                        </Suspense>
+                      </Box>
+                    )
                   }
                 />
                 <Route

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -138,6 +138,10 @@ vi.mock("../shared/components/HomePage", () => ({
   default: () => <h1>Home Page</h1>,
 }));
 
+vi.mock("../features/welcome/components/MemberWelcomePage", () => ({
+  default: () => <h1>Welcome Dashboard</h1>,
+}));
+
 vi.mock("../features/auth/components/AuthGate", () => ({
   default: ({ onBack }: { onBack?: () => void }) => (
     <div>
@@ -249,11 +253,29 @@ describe("App routing", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the account page from a direct deep link", async () => {
+  it("renders the account page from a direct deep link when logged out", async () => {
     renderApp([ROUTES.ACCOUNT]);
 
     expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.ACCOUNT);
+  });
+
+  it("renders welcome dashboard for enabled users at home", async () => {
+    signInEnabledUser();
+
+    renderApp([ROUTES.HOME]);
+
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME);
+  });
+
+  it("redirects enabled users from account to home", async () => {
+    signInEnabledUser();
+
+    renderApp([ROUTES.ACCOUNT]);
+
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
   });
 
   it("redirects unauthenticated section deep links to account", async () => {
@@ -289,7 +311,7 @@ describe("App routing", () => {
     expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Back" }));
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
   });
 
@@ -344,7 +366,7 @@ describe("App routing", () => {
 
     renderApp([ROUTES.HOME]);
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Signals" })).toHaveAttribute("href", "/sections/section-1");
     expect(screen.queryByRole("link", { name: "Administer" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Manage Users" })).not.toBeInTheDocument();
@@ -373,7 +395,7 @@ describe("App routing", () => {
 
     renderApp([ROUTES.HOME]);
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Administer" })).toHaveAttribute("href", ROUTES.MANAGE_SECTIONS);
     expect(screen.getByRole("link", { name: "Manage Sections" })).toHaveAttribute("href", ROUTES.MANAGE_SECTIONS);
     expect(screen.queryByRole("link", { name: "Manage Users" })).not.toBeInTheDocument();
@@ -386,7 +408,7 @@ describe("App routing", () => {
 
     renderApp([ROUTES.HOME]);
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await user.click(screen.getByRole("link", { name: "Administer" }));
 
     expect(await screen.findByRole("heading", { name: "Manage Sections Page" })).toBeInTheDocument();
@@ -402,7 +424,7 @@ describe("App routing", () => {
 
     renderApp([ROUTES.HOME]);
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await user.click(screen.getByRole("link", { name: "Administer" }));
     await screen.findByRole("heading", { name: "Manage Sections Page" });
     expect(screen.getByTestId("location-state")).toHaveTextContent("section-1");
@@ -430,7 +452,7 @@ describe("App routing", () => {
 
     renderApp([ROUTES.HOME]);
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await user.click(screen.getByRole("link", { name: "Access group" }));
 
     expect(await screen.findByRole("heading", { name: "User Groups Page" })).toBeInTheDocument();
@@ -447,7 +469,7 @@ describe("App routing", () => {
     expect(await screen.findByRole("heading", { name: "Manage Users Page" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Back" }));
 
-    expect(await screen.findByRole("heading", { name: "Home Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
   });
 

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -62,18 +62,6 @@ export default function AuthGate({ userData, onBack, onRegisterComplete, onProfi
     }
   }
 
-  async function handleSignOut() {
-    setError(null);
-    setSubmitting(true);
-    try {
-      await signOut(auth);
-    } catch (e: any) {
-      setError(e?.message ?? "Sign-out failed");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   if (initialising) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", mt: 6 }}>

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
 import {
   Alert,
   Box,
@@ -9,7 +10,7 @@ import {
   Typography,
   Link,
 } from "@mui/material";
-import { onAuthStateChanged, signInWithEmailAndPassword, signOut, type User } from "firebase/auth";
+import { onAuthStateChanged, signInWithEmailAndPassword, type User } from "firebase/auth";
 import { auth } from "../../../config/firebase";
 import { useEnabledClaim } from "../../users/hooks/useEnabledClaim";
 import AccountStatusMessage from "../../users/components/AccountStatusMessage";
@@ -17,6 +18,7 @@ import type { UserData } from "../../../types";
 import Register from "./Register";
 import EmailVerificationMessage from "./EmailVerificationMessage";
 import { colors } from "../../../config/colors";
+import { ROUTES } from "../../../constants";
 
 interface AuthGateProps {
   userData?: UserData | null;
@@ -102,29 +104,8 @@ export default function AuthGate({ userData, onBack, onRegisterComplete, onProfi
       return <AccountStatusMessage userData={userData ?? null} onBack={onBack} />;
     }
 
-    // User is signed in and enabled
-    return (
-      <Stack spacing={2} sx={{ mt: 2 }}>
-        <Alert severity="success">Signed in</Alert>
-        <Typography>
-          <strong>UID:</strong> {user.uid}
-        </Typography>
-        {user.email ? (
-          <Typography>
-            <strong>Email:</strong> {user.email}
-          </Typography>
-        ) : null}
-
-        <Button variant="contained" onClick={handleSignOut} disabled={submitting}>
-          Sign out
-        </Button>
-        {onBack && (
-          <Button variant="outlined" onClick={onBack}>
-            Back to Home
-          </Button>
-        )}
-      </Stack>
-    );
+    // Enabled members use the welcome dashboard at home, not this sign-in surface.
+    return <Navigate to={ROUTES.HOME} replace />;
   }
 
   if (showRegister) {

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -1,0 +1,168 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  CircularProgress,
+  Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import type { GetSectionsForUserData } from "@dataconnect/generated";
+import { SectionType } from "@dataconnect/generated";
+import { colors } from "../../../config/colors";
+import { ROUTES } from "../../../constants";
+import type { UserData } from "../../../types";
+import { extractAccessibleSections } from "../../../shared/navigation/extractAccessibleSections";
+import { getMemberDisplayName } from "../../../shared/utils/userDisplayName";
+import { useUpcomingEventsForUser } from "../hooks/useUpcomingEventsForUser";
+
+export interface MemberWelcomePageProps {
+  userData: UserData | null;
+  userEmail?: string | null;
+  sectionsData?: GetSectionsForUserData;
+}
+
+function formatSectionType(type: SectionType): string {
+  return type === SectionType.EVENTS ? "Events" : "Members";
+}
+
+function formatEventWhen(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  return `${start.toLocaleString()} – ${end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+}
+
+export default function MemberWelcomePage({
+  userData,
+  userEmail,
+  sectionsData,
+}: MemberWelcomePageProps) {
+  const displayName = getMemberDisplayName(userData, userEmail);
+  const sections = extractAccessibleSections(sectionsData);
+  const { events, loading: loadingEvents, isError: errorEvents } = useUpcomingEventsForUser(sections);
+
+  return (
+    <Box sx={{ maxWidth: "900px", mx: "auto", px: { xs: 2, sm: 3 }, py: 2 }}>
+      <Typography
+        variant="h4"
+        component="h1"
+        sx={{ color: colors.titlePrimary, fontWeight: 500, mb: 1 }}
+      >
+        Welcome, {displayName}
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+        Here are your upcoming events and sections you can access.
+      </Typography>
+
+      <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+        Upcoming events
+      </Typography>
+      {loadingEvents ? (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
+          <CircularProgress size={28} />
+        </Box>
+      ) : errorEvents ? (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          Failed to load upcoming events. Please try again later.
+        </Alert>
+      ) : events.length === 0 ? (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          No upcoming events right now. Open a section below to browse when new events are published.
+        </Alert>
+      ) : (
+        <Box
+          component="ul"
+          sx={{
+            listStyle: "none",
+            m: 0,
+            p: 0,
+            mb: 4,
+            display: "grid",
+            gap: 2,
+          }}
+        >
+          {events.map((event) => (
+            <Box component="li" key={event.id}>
+              <Card variant="outlined">
+                <CardActionArea
+                  component={RouterLink}
+                  to={`/sections/${event.sectionId}`}
+                  sx={{ textAlign: "left" }}
+                >
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600}>
+                      {event.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatEventWhen(event.startDateTime, event.endDateTime)}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {event.sectionName}
+                      {event.location ? ` · ${event.location}` : ""}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
+        Your sections
+      </Typography>
+      {sections.length === 0 ? (
+        <Alert severity="info">
+          You do not have access to any sections yet. Contact an administrator if this looks wrong.
+        </Alert>
+      ) : (
+        <Box
+          component="ul"
+          sx={{
+            listStyle: "none",
+            m: 0,
+            p: 0,
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+          }}
+        >
+          {sections.map((section) => (
+            <Box component="li" key={section.id}>
+              <Card variant="outlined" sx={{ height: "100%" }}>
+                <CardActionArea
+                  component={RouterLink}
+                  to={`/sections/${section.id}`}
+                  sx={{ height: "100%", textAlign: "left" }}
+                >
+                  <CardContent>
+                    <Typography variant="overline" color="text.secondary">
+                      {formatSectionType(section.type)}
+                    </Typography>
+                    <Typography variant="subtitle1" fontWeight={600}>
+                      {section.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                      {section.description?.trim() || "No description."}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <Box sx={{ mt: 4, display: "flex", flexWrap: "wrap", gap: 2 }}>
+        <Button component={RouterLink} to={ROUTES.SECTIONS} variant="outlined">
+          Browse all sections
+        </Button>
+        <Button component={RouterLink} to={ROUTES.MY_PAYMENTS} variant="outlined">
+          My payments
+        </Button>
+      </Box>
+    </Box>
+  );
+}

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import {
   Alert,
   Box,
@@ -40,7 +41,7 @@ export default function MemberWelcomePage({
   sectionsData,
 }: MemberWelcomePageProps) {
   const displayName = getMemberDisplayName(userData, userEmail);
-  const sections = extractAccessibleSections(sectionsData);
+  const sections = useMemo(() => extractAccessibleSections(sectionsData), [sectionsData]);
   const { events, loading: loadingEvents, isError: errorEvents } = useUpcomingEventsForUser(sections);
 
   return (

--- a/src/features/welcome/components/__tests__/MemberWelcomePage.test.tsx
+++ b/src/features/welcome/components/__tests__/MemberWelcomePage.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { SectionType } from "@dataconnect/generated";
+import type { GetSectionsForUserData } from "@dataconnect/generated";
+import MemberWelcomePage from "../MemberWelcomePage";
+
+vi.mock("../../hooks/useUpcomingEventsForUser", () => ({
+  useUpcomingEventsForUser: () => ({
+    events: [
+      {
+        id: "event-1",
+        title: "Summer Dinner",
+        location: "RAF Club",
+        guestOfHonour: null,
+        startDateTime: "2030-06-01T18:00:00.000Z",
+        endDateTime: "2030-06-01T22:00:00.000Z",
+        sectionId: "section-1",
+        sectionName: "Signals",
+      },
+    ],
+    loading: false,
+    isError: false,
+  }),
+}));
+
+const sectionsData = {
+  user: {
+    id: "user-1",
+    membershipStatus: "REGULAR",
+    userGroups: [
+      {
+        userGroup: {
+          id: "group-1",
+          name: "Group",
+          membershipStatuses: null,
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              section: {
+                id: "section-1",
+                name: "Signals",
+                type: SectionType.EVENTS,
+                description: "Signals section",
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  allUserGroups: [],
+} as GetSectionsForUserData;
+
+describe("MemberWelcomePage", () => {
+  it("greets the member by name and does not show UID", () => {
+    render(
+      <MemoryRouter>
+        <MemberWelcomePage
+          userData={{
+            id: "user-1",
+            firstName: "Alex",
+            lastName: "Smith",
+            email: "alex@example.com",
+            serviceNumber: "123",
+            membershipStatus: "REGULAR",
+            createdAt: "",
+            updatedAt: "",
+          }}
+          sectionsData={sectionsData}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: /welcome, alex smith/i })).toBeInTheDocument();
+    expect(screen.queryByText(/uid/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Summer Dinner")).toBeInTheDocument();
+    expect(screen.getByText("Signals")).toBeInTheDocument();
+    expect(screen.getByText("Signals section")).toBeInTheDocument();
+  });
+});

--- a/src/features/welcome/components/__tests__/MemberWelcomePage.test.tsx
+++ b/src/features/welcome/components/__tests__/MemberWelcomePage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { SectionType } from "@dataconnect/generated";
+import { SectionType, MembershipStatus } from "@dataconnect/generated";
 import type { GetSectionsForUserData } from "@dataconnect/generated";
 import MemberWelcomePage from "../MemberWelcomePage";
 
@@ -63,7 +63,7 @@ describe("MemberWelcomePage", () => {
             lastName: "Smith",
             email: "alex@example.com",
             serviceNumber: "123",
-            membershipStatus: "REGULAR",
+            membershipStatus: MembershipStatus.REGULAR,
             createdAt: "",
             updatedAt: "",
           }}

--- a/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
+++ b/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { SectionType } from "@dataconnect/generated";
+import { getEventsForSection } from "@dataconnect/generated";
+import { sectionsFingerprint, useUpcomingEventsForUser } from "../useUpcomingEventsForUser";
+import type { AccessibleSection } from "../../../../shared/navigation/extractAccessibleSections";
+
+vi.mock("@dataconnect/generated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+  return {
+    ...actual,
+    getEventsForSection: vi.fn(),
+  };
+});
+
+const eventSection: AccessibleSection = {
+  id: "section-1",
+  name: "Signals",
+  type: SectionType.EVENTS,
+  description: "Events section",
+};
+
+describe("sectionsFingerprint", () => {
+  it("is equal for arrays with the same sections in different order", () => {
+    const a = [eventSection];
+    const b = [{ ...eventSection }];
+    expect(sectionsFingerprint(a)).toBe(sectionsFingerprint(b));
+  });
+});
+
+describe("useUpcomingEventsForUser", () => {
+  beforeEach(() => {
+    vi.mocked(getEventsForSection).mockReset();
+    vi.mocked(getEventsForSection).mockResolvedValue({
+      data: {
+        section: {
+          id: "section-1",
+          name: "Signals",
+          events: [
+            {
+              id: "event-1",
+              title: "Dinner",
+              location: "Club",
+              guestOfHonour: null,
+              startDateTime: "2030-01-01T18:00:00.000Z",
+              endDateTime: "2030-01-01T22:00:00.000Z",
+              bookingStartDateTime: "2029-01-01T00:00:00.000Z",
+              bookingEndDateTime: "2030-01-01T00:00:00.000Z",
+              maxGuestsWithoutModeratorApproval: null,
+            },
+          ],
+        },
+      },
+    } as Awaited<ReturnType<typeof getEventsForSection>>);
+  });
+
+  it("does not refetch when the sections array reference changes but content is the same", async () => {
+    const { result, rerender } = renderHook(
+      ({ sections }) => useUpcomingEventsForUser(sections),
+      { initialProps: { sections: [eventSection] } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(getEventsForSection).toHaveBeenCalledTimes(1);
+
+    rerender({ sections: [{ ...eventSection }] });
+
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(getEventsForSection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
+++ b/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
@@ -35,7 +35,6 @@ describe("useUpcomingEventsForUser", () => {
       data: {
         section: {
           id: "section-1",
-          name: "Signals",
           events: [
             {
               id: "event-1",
@@ -51,7 +50,7 @@ describe("useUpcomingEventsForUser", () => {
           ],
         },
       },
-    } as Awaited<ReturnType<typeof getEventsForSection>>);
+    } as unknown as Awaited<ReturnType<typeof getEventsForSection>>);
   });
 
   it("does not refetch when the sections array reference changes but content is the same", async () => {

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { getEventsForSection } from "@dataconnect/generated";
 import type { UUIDString } from "@dataconnect/generated";
 import { SectionType } from "@dataconnect/generated";
@@ -16,36 +16,58 @@ export interface UpcomingEventRow {
   sectionName: string;
 }
 
+/** Stable key so effect does not re-run when parent passes a new array reference with the same sections. */
+export function sectionsFingerprint(sections: AccessibleSection[]): string {
+  return sections
+    .map((s) => `${s.id}:${s.type}:${s.name}`)
+    .sort()
+    .join("|");
+}
+
 export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
-  const eventSectionIds = useMemo(
-    () =>
-      sections
-        .filter((s) => s.type === SectionType.EVENTS)
-        .map((s) => s.id as UUIDString),
-    [sections]
-  );
+  const fingerprint = sectionsFingerprint(sections);
+
+  const { eventSectionIds, sectionNameById } = useMemo(() => {
+    const eventSections = sections.filter((s) => s.type === SectionType.EVENTS);
+    const names: Record<string, string> = {};
+    for (const section of eventSections) {
+      names[section.id] = section.name;
+    }
+    return {
+      eventSectionIds: eventSections.map((s) => s.id as UUIDString).sort(),
+      sectionNameById: names,
+    };
+  }, [fingerprint]);
+
+  const eventSectionIdsKey = eventSectionIds.join(",");
 
   const [events, setEvents] = useState<UpcomingEventRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [isError, setIsError] = useState(false);
+  const lastFetchedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (eventSectionIds.length === 0) {
       setEvents([]);
       setIsError(false);
       setLoading(false);
+      lastFetchedKeyRef.current = "";
       return;
     }
 
     let alive = true;
-    setLoading(true);
-    setIsError(false);
+    const isNewFetch = lastFetchedKeyRef.current !== eventSectionIdsKey;
+    lastFetchedKeyRef.current = eventSectionIdsKey;
+
+    if (isNewFetch) {
+      setLoading(true);
+      setIsError(false);
+    }
 
     void (async () => {
       try {
         const results = await Promise.all(
           eventSectionIds.map(async (sectionId) => {
-            const sectionMeta = sections.find((s) => s.id === sectionId);
             const result = await getEventsForSection(dataConnect, { sectionId });
             const section = result.data?.section;
             return (section?.events ?? []).map((event) => ({
@@ -56,7 +78,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
               startDateTime: event.startDateTime,
               endDateTime: event.endDateTime,
               sectionId,
-              sectionName: sectionMeta?.name ?? section?.name ?? "Section",
+              sectionName: sectionNameById[sectionId] ?? section?.name ?? "Section",
             }));
           })
         );
@@ -72,6 +94,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
 
         if (alive) {
           setEvents(upcoming);
+          setIsError(false);
         }
       } catch {
         if (alive) {
@@ -88,7 +111,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
     return () => {
       alive = false;
     };
-  }, [eventSectionIds, sections]);
+  }, [eventSectionIdsKey, eventSectionIds, sectionNameById]);
 
   return { events, loading, isError };
 }

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -1,0 +1,94 @@
+import { useEffect, useMemo, useState } from "react";
+import { getEventsForSection } from "@dataconnect/generated";
+import type { UUIDString } from "@dataconnect/generated";
+import { SectionType } from "@dataconnect/generated";
+import { dataConnect } from "../../../config/firebase";
+import type { AccessibleSection } from "../../../shared/navigation/extractAccessibleSections";
+
+export interface UpcomingEventRow {
+  id: string;
+  title: string;
+  location?: string | null;
+  guestOfHonour?: string | null;
+  startDateTime: string;
+  endDateTime: string;
+  sectionId: string;
+  sectionName: string;
+}
+
+export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
+  const eventSectionIds = useMemo(
+    () =>
+      sections
+        .filter((s) => s.type === SectionType.EVENTS)
+        .map((s) => s.id as UUIDString),
+    [sections]
+  );
+
+  const [events, setEvents] = useState<UpcomingEventRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (eventSectionIds.length === 0) {
+      setEvents([]);
+      setIsError(false);
+      setLoading(false);
+      return;
+    }
+
+    let alive = true;
+    setLoading(true);
+    setIsError(false);
+
+    void (async () => {
+      try {
+        const results = await Promise.all(
+          eventSectionIds.map(async (sectionId) => {
+            const sectionMeta = sections.find((s) => s.id === sectionId);
+            const result = await getEventsForSection(dataConnect, { sectionId });
+            const section = result.data?.section;
+            return (section?.events ?? []).map((event) => ({
+              id: event.id,
+              title: event.title,
+              location: event.location,
+              guestOfHonour: event.guestOfHonour,
+              startDateTime: event.startDateTime,
+              endDateTime: event.endDateTime,
+              sectionId,
+              sectionName: sectionMeta?.name ?? section?.name ?? "Section",
+            }));
+          })
+        );
+
+        const now = Date.now();
+        const upcoming = results
+          .flat()
+          .filter((event) => new Date(event.endDateTime).getTime() >= now)
+          .sort(
+            (a, b) =>
+              new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime()
+          );
+
+        if (alive) {
+          setEvents(upcoming);
+        }
+      } catch {
+        if (alive) {
+          setIsError(true);
+          setEvents([]);
+        }
+      } finally {
+        if (alive) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+  }, [eventSectionIds, sections]);
+
+  return { events, loading, isError };
+}

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -37,6 +37,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
       eventSectionIds: eventSections.map((s) => s.id as UUIDString).sort(),
       sectionNameById: names,
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- fingerprint encodes sections content without unstable array refs
   }, [fingerprint]);
 
   const eventSectionIdsKey = eventSectionIds.join(",");
@@ -47,7 +48,11 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
   const lastFetchedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (eventSectionIds.length === 0) {
+    const ids = eventSectionIdsKey
+      ? (eventSectionIdsKey.split(",").filter(Boolean) as UUIDString[])
+      : [];
+
+    if (ids.length === 0) {
       setEvents([]);
       setIsError(false);
       setLoading(false);
@@ -67,7 +72,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
     void (async () => {
       try {
         const results = await Promise.all(
-          eventSectionIds.map(async (sectionId) => {
+          ids.map(async (sectionId) => {
             const result = await getEventsForSection(dataConnect, { sectionId });
             const section = result.data?.section;
             return (section?.events ?? []).map((event) => ({
@@ -78,7 +83,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
               startDateTime: event.startDateTime,
               endDateTime: event.endDateTime,
               sectionId,
-              sectionName: sectionNameById[sectionId] ?? section?.name ?? "Section",
+              sectionName: sectionNameById[sectionId] ?? "Section",
             }));
           })
         );
@@ -111,7 +116,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
     return () => {
       alive = false;
     };
-  }, [eventSectionIdsKey, eventSectionIds, sectionNameById]);
+  }, [eventSectionIdsKey, sectionNameById]);
 
   return { events, loading, isError };
 }

--- a/src/shared/navigation/__tests__/extractAccessibleSections.test.ts
+++ b/src/shared/navigation/__tests__/extractAccessibleSections.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import type { GetSectionsForUserData } from "@dataconnect/generated";
+import { SectionType } from "@dataconnect/generated";
+import { extractAccessibleSections } from "../extractAccessibleSections";
+
+function purposeLink(purpose: "ACCESS" | "MODERATOR", id: string, name: string, type = SectionType.EVENTS) {
+  return {
+    purposes: [purpose],
+    section: { id, name, type, description: `${name} description` },
+  };
+}
+
+describe("extractAccessibleSections", () => {
+  it("returns empty when sections data is undefined", () => {
+    expect(extractAccessibleSections(undefined)).toEqual([]);
+  });
+
+  it("includes sections from explicit user groups with ACCESS", () => {
+    const data = {
+      user: {
+        id: "u1",
+        membershipStatus: "REGULAR",
+        userGroups: [
+          {
+            userGroup: {
+              id: "g1",
+              name: "G1",
+              membershipStatuses: null,
+              purposeLinks: [purposeLink("ACCESS", "s1", "Signals")],
+            },
+          },
+        ],
+      },
+      allUserGroups: [],
+    } as GetSectionsForUserData;
+
+    expect(extractAccessibleSections(data)).toEqual([
+      {
+        id: "s1",
+        name: "Signals",
+        type: SectionType.EVENTS,
+        description: "Signals description",
+      },
+    ]);
+  });
+
+  it("includes sections inherited via membership status on allUserGroups", () => {
+    const data = {
+      user: {
+        id: "u1",
+        membershipStatus: "REGULAR",
+        userGroups: [],
+      },
+      allUserGroups: [
+        {
+          id: "g2",
+          name: "Regular pool",
+          membershipStatuses: ["REGULAR"],
+          purposeLinks: [purposeLink("ACCESS", "s2", "Dinners")],
+        },
+      ],
+    } as GetSectionsForUserData;
+
+    const sections = extractAccessibleSections(data);
+    expect(sections).toHaveLength(1);
+    expect(sections[0]?.id).toBe("s2");
+  });
+
+  it("dedupes sections linked from multiple groups", () => {
+    const data = {
+      user: {
+        id: "u1",
+        membershipStatus: "REGULAR",
+        userGroups: [
+          {
+            userGroup: {
+              id: "g1",
+              name: "G1",
+              membershipStatuses: null,
+              purposeLinks: [purposeLink("ACCESS", "s1", "Signals")],
+            },
+          },
+        ],
+      },
+      allUserGroups: [
+        {
+          id: "g2",
+          name: "G2",
+          membershipStatuses: ["REGULAR"],
+          purposeLinks: [purposeLink("MODERATOR", "s1", "Signals")],
+        },
+      ],
+    } as GetSectionsForUserData;
+
+    expect(extractAccessibleSections(data)).toHaveLength(1);
+  });
+});

--- a/src/shared/navigation/extractAccessibleSections.ts
+++ b/src/shared/navigation/extractAccessibleSections.ts
@@ -1,0 +1,79 @@
+import type { GetSectionsForUserData, SectionType, SectionUserGroupPurpose } from "@dataconnect/generated";
+import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
+
+export interface AccessibleSection {
+  id: string;
+  name: string;
+  type: SectionType;
+  description?: string | null;
+}
+
+type SectionLinkSource = {
+  purposes?: SectionUserGroupPurpose[] | null;
+  section?: {
+    id?: string | null;
+    name?: string | null;
+    type?: SectionType | null;
+    description?: string | null;
+  } | null;
+};
+
+function linkHasPurpose(link: SectionLinkSource, target: SectionUserGroupPurpose): boolean {
+  return link.purposes?.includes(target) ?? false;
+}
+
+function addSection(map: Map<string, AccessibleSection>, link: SectionLinkSource) {
+  const section = link.section;
+  if (!section?.id || map.has(section.id)) {
+    return;
+  }
+  map.set(section.id, {
+    id: section.id,
+    name: section.name || "Untitled section",
+    type: section.type!,
+    description: section.description,
+  });
+}
+
+/**
+ * Sections the member can access via ACCESS or MODERATOR purpose links.
+ * Mirrors rules in `buildNavigationLinks` (excluding nav-only entries like My Payments).
+ */
+export function extractAccessibleSections(sectionsData?: GetSectionsForUserData): AccessibleSection[] {
+  if (!sectionsData) {
+    return [];
+  }
+
+  const sectionMap = new Map<string, AccessibleSection>();
+  const explicitGroups = sectionsData.user?.userGroups ?? [];
+
+  for (const groupRelation of explicitGroups) {
+    for (const purposeLink of groupRelation?.userGroup?.purposeLinks ?? []) {
+      if (
+        linkHasPurpose(purposeLink, SectionPurpose.ACCESS) ||
+        linkHasPurpose(purposeLink, SectionPurpose.MODERATOR)
+      ) {
+        addSection(sectionMap, purposeLink);
+      }
+    }
+  }
+
+  const userStatus = sectionsData.user?.membershipStatus;
+  if (userStatus) {
+    for (const userGroup of sectionsData.allUserGroups ?? []) {
+      if (!userGroup?.membershipStatuses?.includes(userStatus)) {
+        continue;
+      }
+      for (const purposeLink of userGroup.purposeLinks ?? []) {
+        if (
+          linkHasPurpose(purposeLink, SectionPurpose.ACCESS) ||
+          linkHasPurpose(purposeLink, SectionPurpose.MODERATOR)
+        ) {
+          addSection(sectionMap, purposeLink);
+        }
+      }
+    }
+  }
+
+  return Array.from(sectionMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/shared/utils/userDisplayName.ts
+++ b/src/shared/utils/userDisplayName.ts
@@ -1,0 +1,10 @@
+import type { UserData } from "../../types";
+
+export function getMemberDisplayName(
+  userData: UserData | null,
+  fallbackEmail?: string | null
+): string {
+  const name = `${userData?.firstName ?? ""} ${userData?.lastName ?? ""}`.trim();
+  if (name) return name;
+  return fallbackEmail?.trim() || "Member";
+}


### PR DESCRIPTION
## Summary

Replaces the post-login UID/account dump with a member **welcome dashboard** at `/` for enabled users.

- `MemberWelcomePage`: personalised greeting, upcoming events (from accessible EVENTS sections), section cards with descriptions
- `extractAccessibleSections` shared helper (same access rules as nav)
- Enabled users at `/account` redirect to home; `AuthGate` redirects after sign-in
- Logged-out users still see branding `HomePage`

Part of #231. Closes #232 when merged to epic branch (close manually on merge).

## Test plan

- [x] `extractAccessibleSections.test.ts`
- [x] `MemberWelcomePage.test.tsx`
- [x] `App.routing.test.tsx` (27 tests)
- [ ] Manual: sign in as enabled member → welcome at `/`, no UID; section/event cards navigate correctly
- [ ] Manual: log out → `/` shows public home; `/account` shows sign-in


Made with [Cursor](https://cursor.com)