### PR TITLE
Add My Payments to header account dropdown (#252)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,7 @@ function AppContent() {
       userData={userData}
       onAccountClick={() => navigate(ROUTES.ACCOUNT)}
       onProfileClick={() => navigate(ROUTES.PROFILE)}
+      onMyPaymentsClick={() => navigate(ROUTES.MY_PAYMENTS)}
       onNavMenuOpen={user && isEnabled ? () => setMobileNavOpen(true) : undefined}
     />
   );

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -14,6 +14,7 @@ interface HeaderProps {
   onJoinClick?: () => void;
   onProfileClick?: () => void;
   onSecurityClick?: () => void;
+  onMyPaymentsClick?: () => void;
   /** When set, shows a hamburger on small screens that opens the side navigation. */
   onNavMenuOpen?: () => void;
 }
@@ -36,6 +37,7 @@ export default function Header({
   onJoinClick,
   onProfileClick,
   onSecurityClick,
+  onMyPaymentsClick,
   onNavMenuOpen,
 }: HeaderProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -65,6 +67,13 @@ export default function Header({
       onSecurityClick();
     } else {
       onAccountClick();
+    }
+  };
+
+  const handleMyPayments = () => {
+    handleMenuClose();
+    if (onMyPaymentsClick) {
+      onMyPaymentsClick();
     }
   };
 
@@ -220,6 +229,21 @@ export default function Header({
                   }}
                 >
                   Security
+                </MenuItem>
+              )}
+              {isEnabled && (
+                <MenuItem
+                  onClick={handleMyPayments}
+                  sx={{
+                    "&:focus": {
+                      outline: "none",
+                    },
+                    "&:focus-visible": {
+                      outline: "none",
+                    },
+                  }}
+                >
+                  My Payments
                 </MenuItem>
               )}
               <MenuItem

--- a/src/shared/components/__tests__/Header.test.tsx
+++ b/src/shared/components/__tests__/Header.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import type { User } from "firebase/auth";
+import Header from "../Header";
+import { createMockUser } from "../../../test-utils/mocks/firebase";
+
+const enabledUser = createMockUser({ uid: "user-1" });
+
+vi.mock("firebase/auth", () => ({
+  signOut: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../features/users/hooks/useEnabledClaim", () => ({
+  useEnabledClaim: vi.fn((user: User | null) => Boolean(user)),
+}));
+
+describe("Header account menu", () => {
+  it("shows My Payments for enabled users and invokes callback", async () => {
+    const user = userEvent.setup();
+    const onMyPaymentsClick = vi.fn();
+
+    render(
+      <Header
+        user={enabledUser}
+        userData={null}
+        onAccountClick={vi.fn()}
+        onMyPaymentsClick={onMyPaymentsClick}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "My Payments" }));
+
+    expect(onMyPaymentsClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show My Payments when user is not enabled", async () => {
+    const { useEnabledClaim } = await import("../../../features/users/hooks/useEnabledClaim");
+    vi.mocked(useEnabledClaim).mockReturnValue(false);
+
+    const user = userEvent.setup();
+
+    render(
+      <Header
+        user={enabledUser}
+        userData={null}
+        onAccountClick={vi.fn()}
+        onMyPaymentsClick={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+
+    expect(screen.queryByRole("menuitem", { name: "My Payments" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **My Payments** to the header account dropdown for enabled members, linking to `ROUTES.MY_PAYMENTS`.

Side nav entry unchanged (both entry points for now).

Part of #231. Closes #252 when merged to epic branch.

## Test plan

- [x] `Header.test.tsx` — menu item visible for enabled users; callback invoked
- [x] `npm run lint` and `npm run build`
- [ ] Manual: account menu → My Payments → `/payments`

Made with [Cursor](https://cursor.com)