### PR TITLE
Account hub: settings page, password change, resign membership (#236)

### DIFF
--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -31,6 +31,7 @@ describe("function entry guard contracts", () => {
 
     const membership = readSource("membershipStatus.ts");
     assertOnCallGuard(membership, "updateMembershipStatus", "requireAuth(request);");
+    assertOnCallGuard(membership, "resignMembership", "requireAuth(request);");
 
     const sections = readSource("sections.ts");
     assertOnCallGuard(sections, "getSectionMembersMerged", "requireAuth(request);");

--- a/functions/src/__tests__/validation.test.ts
+++ b/functions/src/__tests__/validation.test.ts
@@ -4,6 +4,7 @@ import {
   isBlankMembershipStatus,
   isActivationBlockedStatus,
   canUserChangeStatus,
+  canUserResignMembership,
   NON_RESTRICTED_STATUSES,
   RESTRICTED_STATUSES,
 } from '../validation';
@@ -118,6 +119,31 @@ describe('validation', () => {
         expect(result.allowed).toBe(false);
         expect(result.error).toBe('Cannot change to restricted status');
       });
+    });
+  });
+
+  describe("canUserResignMembership", () => {
+    it("allows enabled non-admin member with non-restricted status to resign", () => {
+      const result = canUserResignMembership("REGULAR", false, true);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects when caller is not enabled", () => {
+      const result = canUserResignMembership("REGULAR", false, false);
+      expect(result.allowed).toBe(false);
+      expect(result.error).toBe("Account must be enabled");
+    });
+
+    it("rejects admin accounts", () => {
+      const result = canUserResignMembership("REGULAR", true, true);
+      expect(result.allowed).toBe(false);
+      expect(result.error).toBe("Admin accounts cannot resign through this flow");
+    });
+
+    it("rejects restricted current statuses", () => {
+      expect(canUserResignMembership("PENDING", false, true).allowed).toBe(false);
+      expect(canUserResignMembership("RESIGNED", false, true).allowed).toBe(false);
+      expect(canUserResignMembership(null, false, true).allowed).toBe(false);
     });
   });
 });

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -2,7 +2,7 @@ import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
 import { requireAuth, handleFunctionError } from "./helpers";
-import { canUserChangeStatus, isNonRestrictedStatus, type MembershipStatus } from "./validation";
+import { canUserChangeStatus, canUserResignMembership, isNonRestrictedStatus, type MembershipStatus } from "./validation";
 import { FUNCTIONS_REGION } from "./constants";
 import {
   updateUserMembershipStatus,
@@ -101,6 +101,54 @@ export const updateMembershipStatus = onCall(
   } catch (e: any) {
     handleFunctionError(e, "updating membership status");
   }
+  }
+);
+
+/**
+ * Self-service resignation: transitions the caller from a non-restricted status to RESIGNED.
+ */
+export const resignMembership = onCall(
+  { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
+  async (request) => {
+    requireAuth(request);
+
+    const userId = request.auth!.uid;
+    const callerEnabled = request.auth!.token.enabled === true;
+
+    try {
+      const targetUser = await admin.auth().getUser(userId);
+      const targetUserIsAdmin = targetUser.customClaims?.admin === true;
+      const currentStatus = await fetchCurrentStatusFromDataConnect(userId);
+      const newStatus = "RESIGNED" as MembershipStatus;
+
+      const validation = canUserResignMembership(
+        currentStatus,
+        targetUserIsAdmin,
+        callerEnabled
+      );
+
+      if (!validation.allowed) {
+        logger.warn(
+          `Resign membership rejected: userId=${userId}, current=${currentStatus || "unknown"}, targetIsAdmin=${targetUserIsAdmin}`
+        );
+        throw new HttpsError("permission-denied", validation.error || "Cannot resign membership");
+      }
+
+      await updateMembershipStatusInDataConnect(userId, newStatus);
+      await updateEnabledClaim(userId, newStatus);
+
+      scheduleMembershipStatusEmailIfChanged({
+        userId,
+        previousStatus: currentStatus,
+        newStatus,
+        appBaseUrl: APP_BASE_URL,
+      });
+
+      logger.info(`Membership resigned: userId=${userId}, previous=${currentStatus || "unknown"}`);
+      return { success: true, message: "Membership resigned successfully" };
+    } catch (e: any) {
+      handleFunctionError(e, "resigning membership");
+    }
   }
 );
 

--- a/functions/src/validation.ts
+++ b/functions/src/validation.ts
@@ -136,5 +136,47 @@ export function canUserChangeStatus(
   return { allowed: true };
 }
 
+/**
+ * Whether an enabled non-admin member may resign (transition to RESIGNED).
+ */
+export function canUserResignMembership(
+  currentStatus: MembershipStatusInput,
+  targetUserIsAdmin: boolean,
+  callerEnabled: boolean
+): { allowed: boolean; error?: string } {
+  if (targetUserIsAdmin) {
+    return {
+      allowed: false,
+      error: "Admin accounts cannot resign through this flow",
+    };
+  }
+
+  if (!callerEnabled) {
+    return {
+      allowed: false,
+      error: "Account must be enabled",
+    };
+  }
+
+  if (isActivationBlockedStatus(currentStatus)) {
+    return {
+      allowed: false,
+      error: "Cannot resign from current membership status",
+    };
+  }
+
+  if (
+    typeof currentStatus !== "string" ||
+    !isNonRestrictedStatus(currentStatus as MembershipStatus)
+  ) {
+    return {
+      allowed: false,
+      error: "Cannot resign from current membership status",
+    };
+  }
+
+  return { allowed: true };
+}
+
 export { NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES };
 export type { MembershipStatus };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ const AccountStatusMessage = lazy(() => import("./features/users/components/Acco
 const ProfileCompletion = lazy(() => import("./features/auth/components/ProfileCompletion"));
 const EmailVerificationMessage = lazy(() => import("./features/auth/components/EmailVerificationMessage"));
 const MemberWelcomePage = lazy(() => import("./features/welcome/components/MemberWelcomePage"));
+const AccountSettingsPage = lazy(() => import("./features/account/components/AccountSettingsPage"));
 
 // Loading fallback component
 const LoadingFallback = () => (
@@ -131,6 +132,7 @@ function AppContent() {
       userData={userData}
       onAccountClick={() => navigate(ROUTES.ACCOUNT)}
       onProfileClick={() => navigate(ROUTES.PROFILE)}
+      onAccountSettingsClick={() => navigate(ROUTES.ACCOUNT_SETTINGS)}
       onMyPaymentsClick={() => navigate(ROUTES.MY_PAYMENTS)}
       onNavMenuOpen={user && isEnabled ? () => setMobileNavOpen(true) : undefined}
     />
@@ -398,6 +400,28 @@ function AppContent() {
                         <Suspense fallback={<LoadingFallback />}>
                           <Profile key={user.uid} userData={userData} userEmail={user?.email || ""} onBack={() => navigateBackOr(ROUTES.HOME)} onUpdate={handleProfileUpdate} />
                         </Suspense>
+                      ) : (
+                        <Navigate to={ROUTES.ACCOUNT} replace />
+                      )}
+                    </Box>
+                  }
+                />
+                <Route
+                  path={ROUTES.ACCOUNT_SETTINGS}
+                  element={
+                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                      {user && isEnabled ? (
+                        <Suspense fallback={<LoadingFallback />}>
+                          <AccountSettingsPage
+                            key={user.uid}
+                            user={user}
+                            userData={userData}
+                            isAdmin={isAdmin}
+                            onBack={() => navigateBackOr(ROUTES.HOME)}
+                          />
+                        </Suspense>
+                      ) : user ? (
+                        <Navigate to={ROUTES.HOME} replace />
                       ) : (
                         <Navigate to={ROUTES.ACCOUNT} replace />
                       )}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -5,6 +5,7 @@
 export const ROUTES = {
   HOME: "/",
   ACCOUNT: "/account",
+  ACCOUNT_SETTINGS: "/account/settings",
   PROFILE: "/profile",
   PERMISSIONS: "/admin/permissions",
   MANAGE_USERS: "/admin/users",

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -1,0 +1,306 @@
+import { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import {
+  EmailAuthProvider,
+  reauthenticateWithCredential,
+  signOut,
+  updatePassword,
+  type User,
+} from "firebase/auth";
+import { MembershipStatus } from "@dataconnect/generated";
+import { auth } from "../../../config/firebase";
+import { colors } from "../../../config/colors";
+import { MEMBERSHIP_STATUS_OPTIONS, ROUTES, SUCCESS_MESSAGE_TIMEOUT } from "../../../constants";
+import type { UserData } from "../../../types";
+import { resignMembership } from "../../../shared/utils/firebaseFunctions";
+import { canUserResignMembership } from "../../users/utils/membershipStatusValidation";
+
+export interface AccountSettingsPageProps {
+  user: User;
+  userData: UserData | null;
+  isAdmin: boolean;
+  onBack?: () => void;
+}
+
+function getMembershipStatusLabel(status: MembershipStatus | null | undefined): string {
+  if (!status) {
+    return "Unknown";
+  }
+  const option = MEMBERSHIP_STATUS_OPTIONS.find((entry) => entry.value === status);
+  return option?.label ?? status;
+}
+
+function getAuthErrorMessage(error: unknown): string {
+  const code = (error as { code?: string })?.code;
+  switch (code) {
+    case "auth/wrong-password":
+    case "auth/invalid-credential":
+      return "Current password is incorrect";
+    case "auth/weak-password":
+      return "New password is too weak";
+    case "auth/requires-recent-login":
+      return "Please sign out and sign in again, then try changing your password";
+    default:
+      return (error as Error)?.message ?? "Something went wrong";
+  }
+}
+
+function usesEmailPassword(user: User): boolean {
+  return user.providerData.some((provider) => provider.providerId === "password");
+}
+
+export default function AccountSettingsPage({
+  user,
+  userData,
+  isAdmin,
+  onBack,
+}: AccountSettingsPageProps) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccess, setPasswordSuccess] = useState(false);
+
+  const [resignDialogOpen, setResignDialogOpen] = useState(false);
+  const [resignSubmitting, setResignSubmitting] = useState(false);
+  const [resignError, setResignError] = useState<string | null>(null);
+
+  const canChangePassword = usesEmailPassword(user);
+  const membershipStatus = userData?.membershipStatus ?? null;
+  const membershipLabel = getMembershipStatusLabel(membershipStatus);
+
+  const canResign = useMemo(
+    () => canUserResignMembership(membershipStatus, isAdmin).allowed,
+    [membershipStatus, isAdmin]
+  );
+
+  const handlePasswordSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setPasswordError(null);
+    setPasswordSuccess(false);
+
+    if (newPassword.length < 6) {
+      setPasswordError("New password must be at least 6 characters");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError("New passwords do not match");
+      return;
+    }
+    if (!user.email) {
+      setPasswordError("Your account does not have an email address for re-authentication");
+      return;
+    }
+
+    setPasswordSubmitting(true);
+    try {
+      const credential = EmailAuthProvider.credential(user.email, currentPassword);
+      await reauthenticateWithCredential(user, credential);
+      await updatePassword(user, newPassword);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setPasswordSuccess(true);
+      window.setTimeout(() => setPasswordSuccess(false), SUCCESS_MESSAGE_TIMEOUT);
+    } catch (error) {
+      setPasswordError(getAuthErrorMessage(error));
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
+  const handleResignConfirm = async () => {
+    setResignError(null);
+    setResignSubmitting(true);
+    try {
+      const result = await resignMembership();
+      if (!result.success) {
+        setResignError(result.error ?? "Failed to resign membership");
+        return;
+      }
+      setResignDialogOpen(false);
+      await signOut(auth);
+    } catch (error) {
+      setResignError(getAuthErrorMessage(error));
+    } finally {
+      setResignSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: "600px", mx: "auto", py: 2 }}>
+      <Typography variant="h4" gutterBottom sx={{ color: colors.titlePrimary, mb: 3 }}>
+        Account
+      </Typography>
+
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+            Membership
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 1 }}>
+            Status: <strong>{membershipLabel}</strong>
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Contact an administrator if your status needs to be updated.
+          </Typography>
+          <Button component={RouterLink} to={ROUTES.PROFILE} variant="outlined">
+            Edit profile details
+          </Button>
+        </Box>
+
+        <Divider />
+
+        <Box component="section" aria-labelledby="change-password-heading">
+          <Typography id="change-password-heading" variant="h6" component="h2" sx={{ mb: 1 }}>
+            Change password
+          </Typography>
+          {!canChangePassword ? (
+            <Alert severity="info">
+              Password changes are only available for email and password sign-in.
+            </Alert>
+          ) : (
+            <>
+              {passwordSuccess && (
+                <Alert severity="success" sx={{ mb: 2 }}>
+                  Password updated successfully.
+                </Alert>
+              )}
+              {passwordError && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {passwordError}
+                </Alert>
+              )}
+              <Box component="form" onSubmit={handlePasswordSubmit}>
+                <Stack spacing={2}>
+                  <TextField
+                    label="Current password"
+                    type="password"
+                    value={currentPassword}
+                    onChange={(event) => setCurrentPassword(event.target.value)}
+                    autoComplete="current-password"
+                    required
+                    fullWidth
+                    disabled={passwordSubmitting}
+                  />
+                  <TextField
+                    label="New password"
+                    type="password"
+                    value={newPassword}
+                    onChange={(event) => setNewPassword(event.target.value)}
+                    autoComplete="new-password"
+                    required
+                    fullWidth
+                    disabled={passwordSubmitting}
+                    helperText="At least 6 characters"
+                  />
+                  <TextField
+                    label="Confirm new password"
+                    type="password"
+                    value={confirmPassword}
+                    onChange={(event) => setConfirmPassword(event.target.value)}
+                    autoComplete="new-password"
+                    required
+                    fullWidth
+                    disabled={passwordSubmitting}
+                  />
+                  <Box>
+                    <Button
+                      type="submit"
+                      variant="contained"
+                      disabled={
+                        passwordSubmitting ||
+                        !currentPassword ||
+                        newPassword.length < 6 ||
+                        newPassword !== confirmPassword
+                      }
+                      sx={{
+                        backgroundColor: colors.callToAction,
+                        "&:hover": {
+                          backgroundColor: colors.callToAction,
+                          opacity: 0.9,
+                        },
+                      }}
+                    >
+                      {passwordSubmitting ? <CircularProgress size={24} color="inherit" /> : "Update password"}
+                    </Button>
+                  </Box>
+                </Stack>
+              </Box>
+            </>
+          )}
+        </Box>
+
+        {canResign && (
+          <>
+            <Divider />
+            <Box component="section" aria-labelledby="resign-heading">
+              <Typography id="resign-heading" variant="h6" component="h2" sx={{ mb: 1 }}>
+                Resign membership
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                Resigning deactivates your account. You will be signed out and will need to contact an
+                administrator to rejoin.
+              </Typography>
+              {resignError && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                  {resignError}
+                </Alert>
+              )}
+              <Button
+                variant="outlined"
+                color="error"
+                onClick={() => {
+                  setResignError(null);
+                  setResignDialogOpen(true);
+                }}
+              >
+                Resign membership
+              </Button>
+            </Box>
+          </>
+        )}
+      </Stack>
+
+      {onBack && (
+        <Button variant="text" onClick={onBack} sx={{ mt: 3 }}>
+          Back
+        </Button>
+      )}
+
+      <Dialog open={resignDialogOpen} onClose={() => !resignSubmitting && setResignDialogOpen(false)}>
+        <DialogTitle>Resign membership?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This will set your membership status to Resigned and sign you out. You can contact an
+            administrator if you wish to return later.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResignDialogOpen(false)} disabled={resignSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleResignConfirm} color="error" disabled={resignSubmitting}>
+            {resignSubmitting ? <CircularProgress size={22} color="inherit" /> : "Confirm resign"}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ComponentProps } from "react";
+import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import AccountSettingsPage from "../AccountSettingsPage";
+import { MembershipStatus } from "@dataconnect/generated";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
+import type { UserData } from "../../../../types";
+import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("firebase/auth", () => ({
+  EmailAuthProvider: {
+    credential: vi.fn(() => ({})),
+  },
+  reauthenticateWithCredential: vi.fn().mockResolvedValue(undefined),
+  updatePassword: vi.fn().mockResolvedValue(undefined),
+  signOut: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  resignMembership: vi.fn(),
+}));
+
+const mockUser = createMockUser({
+  uid: "user-1",
+  email: "member@example.com",
+  providerData: [{ providerId: "password", uid: "member@example.com", displayName: null, email: "member@example.com", phoneNumber: null, photoURL: null }],
+});
+
+const userData: UserData = {
+  id: "user-1",
+  firstName: "Alex",
+  lastName: "Member",
+  email: "member@example.com",
+  serviceNumber: "12345",
+  membershipStatus: MembershipStatus.REGULAR,
+  isRegular: true,
+  isReserve: false,
+  isCivilServant: false,
+  isIndustry: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function renderAccountSettings(props: ComponentProps<typeof AccountSettingsPage>) {
+  return render(
+    <MemoryRouter>
+      <AccountSettingsPage {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe("AccountSettingsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows read-only membership status and profile link", () => {
+    renderAccountSettings(
+      { user: mockUser, userData, isAdmin: false }
+    );
+
+    expect(screen.getByText(/Status:/)).toHaveTextContent("Regular");
+    expect(screen.getByRole("link", { name: "Edit profile details" })).toHaveAttribute(
+      "href",
+      "/profile"
+    );
+  });
+
+  it("updates password after re-authentication", async () => {
+    const user = userEvent.setup();
+    const { reauthenticateWithCredential, updatePassword } = await import("firebase/auth");
+
+    renderAccountSettings(
+      { user: mockUser, userData, isAdmin: false }
+    );
+
+    const currentPasswordInput = document.querySelector(
+      'input[autocomplete="current-password"]'
+    ) as HTMLInputElement;
+    const newPasswordInput = document.querySelector(
+      'input[autocomplete="new-password"]'
+    ) as HTMLInputElement;
+    const confirmPasswordInputs = document.querySelectorAll(
+      'input[autocomplete="new-password"]'
+    );
+
+    await user.type(currentPasswordInput, "old-pass");
+    await user.type(newPasswordInput, "new-pass");
+    await user.type(confirmPasswordInputs[1]!, "new-pass");
+    await user.click(screen.getByRole("button", { name: "Update password" }));
+
+    await waitFor(() => {
+      expect(reauthenticateWithCredential).toHaveBeenCalled();
+      expect(updatePassword).toHaveBeenCalledWith(mockUser, "new-pass");
+    });
+    expect(screen.getByText("Password updated successfully.")).toBeInTheDocument();
+  });
+
+  it("resigns membership and signs out", async () => {
+    const user = userEvent.setup();
+    vi.mocked(firebaseFunctions.resignMembership).mockResolvedValue({ success: true });
+    const { signOut } = await import("firebase/auth");
+
+    renderAccountSettings(
+      { user: mockUser, userData, isAdmin: false }
+    );
+
+    await user.click(screen.getByRole("button", { name: "Resign membership" }));
+    await user.click(screen.getByRole("button", { name: "Confirm resign" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.resignMembership).toHaveBeenCalledTimes(1);
+      expect(signOut).toHaveBeenCalled();
+    });
+  });
+
+  it("does not offer resign for admin users", () => {
+    renderAccountSettings(
+      { user: mockUser, userData, isAdmin: true }
+    );
+
+    expect(screen.queryByRole("button", { name: "Resign membership" })).not.toBeInTheDocument();
+  });
+});

--- a/src/features/users/utils/__tests__/membershipStatusValidation.test.ts
+++ b/src/features/users/utils/__tests__/membershipStatusValidation.test.ts
@@ -4,6 +4,7 @@ import {
   NON_RESTRICTED_STATUSES,
   RESTRICTED_STATUSES,
   canUserChangeStatus,
+  canUserResignMembership,
 } from '../membershipStatusValidation';
 import { MembershipStatus } from '../../../../dataconnect-generated';
 
@@ -217,6 +218,24 @@ describe('membershipStatusValidation', () => {
         expect(result.allowed).toBe(false);
         expect(result.error).toBe('Cannot change to restricted status');
       });
+    });
+  });
+
+  describe('canUserResignMembership', () => {
+    it('allows non-admin member with non-restricted status', () => {
+      expect(canUserResignMembership(MembershipStatus.REGULAR, false).allowed).toBe(true);
+    });
+
+    it('rejects admin accounts', () => {
+      const result = canUserResignMembership(MembershipStatus.REGULAR, true);
+      expect(result.allowed).toBe(false);
+      expect(result.error).toBe('Admin accounts cannot resign through this flow');
+    });
+
+    it('rejects restricted statuses', () => {
+      expect(canUserResignMembership(MembershipStatus.PENDING, false).allowed).toBe(false);
+      expect(canUserResignMembership(MembershipStatus.RESIGNED, false).allowed).toBe(false);
+      expect(canUserResignMembership(null, false).allowed).toBe(false);
     });
   });
 });

--- a/src/features/users/utils/membershipStatusValidation.ts
+++ b/src/features/users/utils/membershipStatusValidation.ts
@@ -82,3 +82,34 @@ export function canUserChangeStatus(
   return { allowed: true };
 }
 
+/**
+ * Whether a non-admin member may self-resign from their current status.
+ */
+export function canUserResignMembership(
+  currentStatus: MembershipStatus | null,
+  targetUserIsAdmin: boolean
+): { allowed: boolean; error?: string } {
+  if (targetUserIsAdmin) {
+    return {
+      allowed: false,
+      error: "Admin accounts cannot resign through this flow",
+    };
+  }
+
+  if (!currentStatus || isRestrictedStatus(currentStatus)) {
+    return {
+      allowed: false,
+      error: "Cannot resign from current membership status",
+    };
+  }
+
+  if (!isNonRestrictedStatus(currentStatus)) {
+    return {
+      allowed: false,
+      error: "Cannot resign from current membership status",
+    };
+  }
+
+  return { allowed: true };
+}
+

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -13,7 +13,7 @@ interface HeaderProps {
   onAccountClick: () => void;
   onJoinClick?: () => void;
   onProfileClick?: () => void;
-  onSecurityClick?: () => void;
+  onAccountSettingsClick?: () => void;
   onMyPaymentsClick?: () => void;
   /** When set, shows a hamburger on small screens that opens the side navigation. */
   onNavMenuOpen?: () => void;
@@ -36,7 +36,7 @@ export default function Header({
   onAccountClick,
   onJoinClick,
   onProfileClick,
-  onSecurityClick,
+  onAccountSettingsClick,
   onMyPaymentsClick,
   onNavMenuOpen,
 }: HeaderProps) {
@@ -61,10 +61,10 @@ export default function Header({
     }
   };
 
-  const handleSecurity = () => {
+  const handleAccountSettings = () => {
     handleMenuClose();
-    if (onSecurityClick) {
-      onSecurityClick();
+    if (onAccountSettingsClick) {
+      onAccountSettingsClick();
     } else {
       onAccountClick();
     }
@@ -218,7 +218,7 @@ export default function Header({
               )}
               {isEnabled && (
                 <MenuItem
-                  onClick={handleSecurity}
+                  onClick={handleAccountSettings}
                   sx={{
                     "&:focus": {
                       outline: "none",
@@ -228,7 +228,7 @@ export default function Header({
                     },
                   }}
                 >
-                  Security
+                  Account
                 </MenuItem>
               )}
               {isEnabled && (

--- a/src/shared/components/__tests__/Header.test.tsx
+++ b/src/shared/components/__tests__/Header.test.tsx
@@ -35,6 +35,25 @@ describe("Header account menu", () => {
     expect(onMyPaymentsClick).toHaveBeenCalledTimes(1);
   });
 
+  it("shows Account settings for enabled users and invokes callback", async () => {
+    const user = userEvent.setup();
+    const onAccountSettingsClick = vi.fn();
+
+    render(
+      <Header
+        user={enabledUser}
+        userData={null}
+        onAccountClick={vi.fn()}
+        onAccountSettingsClick={onAccountSettingsClick}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Account menu" }));
+    await user.click(screen.getByRole("menuitem", { name: "Account" }));
+
+    expect(onAccountSettingsClick).toHaveBeenCalledTimes(1);
+  });
+
   it("does not show My Payments when user is not enabled", async () => {
     const { useEnabledClaim } = await import("../../../features/users/hooks/useEnabledClaim");
     vi.mocked(useEnabledClaim).mockReturnValue(false);

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -301,6 +301,31 @@ export async function updateMembershipStatus(
   }
 }
 
+interface ResignMembershipResponse {
+  success: boolean;
+  message?: string;
+}
+
+/**
+ * Resigns the current user's membership (non-restricted status → RESIGNED).
+ */
+export async function resignMembership(): Promise<{ success: boolean; error?: string }> {
+  try {
+    const resignMembershipCallable = httpsCallable<
+      Record<string, never>,
+      ResignMembershipResponse
+    >(functions, "resignMembership");
+
+    const result = await resignMembershipCallable({});
+    return { success: result.data.success };
+  } catch (error: any) {
+    return {
+      success: false,
+      error: error?.message || "Failed to resign membership",
+    };
+  }
+}
+
 // ============================================================================
 // Section members (merged: explicit + inherited by status)
 // ============================================================================


### PR DESCRIPTION
## Summary
- Renames header **Security** → **Account** and routes enabled members to `/account/settings`.
- Adds **AccountSettingsPage** with read-only membership status, profile link, password change (Firebase reauth), and self-service resign with confirmation.
- Adds **`resignMembership`** callable and validation so enabled non-admin members can transition from a non-restricted status to `RESIGNED` (updates claims and sends status email).

Closes #236 (child of epic #231).

## Test plan
- [ ] Sign in as enabled member → header **Account** → lands on `/account/settings`
- [ ] Change password with correct current password succeeds; wrong password shows error
- [ ] Resign membership (test account) → confirm → signed out, account deactivated
- [ ] Admin user does not see resign option
- [ ] Logged-out **Log In** still goes to `/account` (auth gate)
- [ ] Unit tests pass (`AccountSettingsPage`, Header, validation, function guard contracts)


Made with [Cursor](https://cursor.com)