### PR TITLE
Simplify Profile: identity only, membership actions in Account (#241)

### DIFF
--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -10,18 +10,13 @@ import {
   FormControlLabel,
   Checkbox,
   Divider,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
 } from "@mui/material";
 import { dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
 import { executeMutation, mutationRef } from "firebase/data-connect";
 import { MembershipStatus } from "@dataconnect/generated";
 import { validateUserForm } from "../../users/utils/userHelpers";
-import { NON_RESTRICTED_STATUSES } from "../../users/utils/membershipStatusValidation";
-import { MEMBERSHIP_STATUS_OPTIONS, MAX_NAME_LENGTH, MAX_SERVICE_NUMBER_LENGTH } from "../../../constants";
+import { MAX_NAME_LENGTH, MAX_SERVICE_NUMBER_LENGTH } from "../../../constants";
 import { auth } from "../../../config/firebase";
 import { syncPendingUserClaims, updateDisplayName } from "../../../shared/utils/firebaseFunctions";
 
@@ -44,9 +39,6 @@ export default function ProfileCompletion({
   const [isReserve, setIsReserve] = useState(false);
   const [isCivilServant, setIsCivilServant] = useState(false);
   const [isIndustry, setIsIndustry] = useState(false);
-  const [requestedMembershipStatus, setRequestedMembershipStatus] = useState<MembershipStatus>(
-    MembershipStatus.REGULAR
-  );
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -83,7 +75,7 @@ export default function ProfileCompletion({
         lastName: lastName.trim(),
         email: email.trim(),
         serviceNumber: serviceNumber.trim(),
-        requestedMembershipStatus,
+        requestedMembershipStatus: MembershipStatus.REGULAR,
         isRegular,
         isReserve,
         isCivilServant,
@@ -212,26 +204,10 @@ export default function ProfileCompletion({
             helperText={`${serviceNumber.length}/${MAX_SERVICE_NUMBER_LENGTH} characters`}
           />
 
-          <FormControl fullWidth required>
-            <InputLabel>Desired Membership Status</InputLabel>
-            <Select
-              value={requestedMembershipStatus}
-              label="Desired Membership Status"
-              onChange={(e) => setRequestedMembershipStatus(e.target.value as MembershipStatus)}
-              disabled={submitting}
-            >
-              {MEMBERSHIP_STATUS_OPTIONS.filter(option => 
-                NON_RESTRICTED_STATUSES.includes(option.value)
-              ).map((status) => (
-                <MenuItem key={status.value} value={status.value}>
-                  {status.label}
-                </MenuItem>
-              ))}
-            </Select>
-            <Typography variant="caption" sx={{ color: colors.titleSecondary, mt: 1, ml: 1.5 }}>
-              Your account will start as PENDING until an admin approves your requested status.
-            </Typography>
-          </FormControl>
+          <Alert severity="info">
+            An administrator will review your service background and assign your membership status during
+            approval. You do not need to choose a status here.
+          </Alert>
 
           <Divider sx={{ my: 2 }} />
 

--- a/src/features/auth/components/__tests__/ProfileCompletion.test.tsx
+++ b/src/features/auth/components/__tests__/ProfileCompletion.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import ProfileCompletion from "../ProfileCompletion";
+import { MembershipStatus } from "@dataconnect/generated";
+
+const executeMutation = vi.fn().mockResolvedValue({ data: { user: { id: "user-1" } } });
+const mutationRef = vi.fn((_dc: unknown, _name: unknown, vars: unknown) => vars);
+
+vi.mock("firebase/data-connect", () => ({
+  executeMutation: (mutation: unknown) => executeMutation(mutation),
+  mutationRef: (dc: unknown, name: unknown, vars: unknown) => mutationRef(dc, name, vars),
+}));
+
+vi.mock("../../../../config/firebase", () => ({
+  auth: {
+    currentUser: {
+      uid: "user-1",
+      getIdToken: vi.fn().mockResolvedValue("token"),
+    },
+  },
+  dataConnect: {},
+}));
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  syncPendingUserClaims: vi.fn().mockResolvedValue({ success: true }),
+  updateDisplayName: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+describe("ProfileCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not show a membership status picker", () => {
+    render(<ProfileCompletion userEmail="new@example.com" />);
+
+    expect(screen.queryByLabelText(/Desired Membership Status/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/An administrator will review your service background/i)
+    ).toBeInTheDocument();
+  });
+
+  it("submits profile with default requested membership status", async () => {
+    const user = userEvent.setup();
+    render(<ProfileCompletion userEmail="new@example.com" />);
+
+    const [firstNameInput, lastNameInput, , serviceNumberInput] = screen.getAllByRole("textbox");
+    await user.type(firstNameInput, "New");
+    await user.type(lastNameInput, "Member");
+    await user.type(serviceNumberInput, "99999");
+    await user.click(screen.getByRole("button", { name: "Submit Profile" }));
+
+    await waitFor(() => {
+      expect(mutationRef).toHaveBeenCalledWith(
+        {},
+        "CreateUserProfile",
+        expect.objectContaining({
+          requestedMembershipStatus: MembershipStatus.REGULAR,
+          firstName: "New",
+          lastName: "Member",
+        })
+      );
+    });
+  });
+});

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -10,18 +10,14 @@ import {
   FormControlLabel,
   Checkbox,
   Divider,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
 } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
 import { dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
 import { upsertUser, type UpsertUserVariables, MembershipStatus } from "@dataconnect/generated";
 import type { UserData } from "../../../types";
-import { updateDisplayName, updateMembershipStatus } from "../../../shared/utils/firebaseFunctions";
-import { MEMBERSHIP_STATUS_OPTIONS, MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SERVICE_NUMBER_LENGTH } from "../../../constants";
-import { NON_RESTRICTED_STATUSES, isRestrictedStatus } from "../../users/utils/membershipStatusValidation";
+import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
+import { MEMBERSHIP_STATUS_OPTIONS, MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SERVICE_NUMBER_LENGTH, ROUTES } from "../../../constants";
 import { auth } from "../../../config/firebase";
 
 interface ProfileProps {
@@ -29,6 +25,14 @@ interface ProfileProps {
   userEmail: string;
   onBack?: () => void;
   onUpdate?: () => void;
+}
+
+function getMembershipStatusLabel(status: MembershipStatus | null | undefined): string {
+  if (!status) {
+    return "Unknown";
+  }
+  const option = MEMBERSHIP_STATUS_OPTIONS.find((entry) => entry.value === status);
+  return option?.label ?? status;
 }
 
 export default function Profile({ userData, userEmail, onBack, onUpdate }: ProfileProps) {
@@ -40,7 +44,6 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
   const [isReserve, setIsReserve] = useState(false);
   const [isCivilServant, setIsCivilServant] = useState(false);
   const [isIndustry, setIsIndustry] = useState(false);
-  const [membershipStatus, setMembershipStatus] = useState<MembershipStatus>(MembershipStatus.PENDING);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -55,11 +58,8 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
       setIsReserve(userData.isReserve ?? false);
       setIsCivilServant(userData.isCivilServant ?? false);
       setIsIndustry(userData.isIndustry ?? false);
-      setMembershipStatus(userData.membershipStatus || MembershipStatus.PENDING);
     } else {
-      // New user - populate with email from Firebase Auth
       setEmail(userEmail);
-      setMembershipStatus(MembershipStatus.PENDING);
     }
   }, [userData, userEmail]);
 
@@ -77,7 +77,6 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
         return;
       }
 
-      // Update profile fields (excluding membershipStatus)
       const vars: UpsertUserVariables = {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
@@ -90,28 +89,14 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
       };
       await upsertUser(dataConnect, vars);
 
-      // Update membership status separately via Firebase Function (validates and enforces rules)
-      // Only call if the status has actually changed
-      const currentStatus = userData?.membershipStatus || null;
-      if (membershipStatus && membershipStatus !== currentStatus) {
-        const statusResult = await updateMembershipStatus(currentUser.uid, membershipStatus);
-        if (!statusResult.success) {
-          setError(statusResult.error || "Failed to update membership status");
-          setSubmitting(false);
-          return;
-        }
-      }
-      
-      // Update displayName in Firebase Auth
       const displayName = `${lastName.trim()}, ${firstName.trim()}`.trim();
       if (displayName) {
         const displayNameResult = await updateDisplayName(displayName);
         if (!displayNameResult.success) {
-          // Log error but don't fail the whole operation
           console.warn("Failed to update display name:", displayNameResult.error);
         }
       }
-      
+
       setSuccess(true);
       if (onUpdate) {
         onUpdate();
@@ -122,6 +107,8 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
       setSubmitting(false);
     }
   };
+
+  const membershipLabel = getMembershipStatusLabel(userData?.membershipStatus);
 
   return (
     <Box sx={{ maxWidth: "600px", mx: "auto" }}>
@@ -140,6 +127,20 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
           {error}
         </Alert>
       )}
+
+      <Box sx={{ mb: 3 }}>
+        <Typography variant="body1" sx={{ mb: 0.5 }}>
+          Membership status: <strong>{membershipLabel}</strong>
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+          Password, resignation, and other account actions are managed in Account settings.
+        </Typography>
+        <Button component={RouterLink} to={ROUTES.ACCOUNT_SETTINGS} variant="outlined" size="small">
+          Account settings
+        </Button>
+      </Box>
+
+      <Divider sx={{ mb: 3 }} />
 
       <form onSubmit={handleSubmit}>
         <Stack spacing={3}>
@@ -187,41 +188,6 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
             inputProps={{ maxLength: MAX_SERVICE_NUMBER_LENGTH }}
             helperText={`${serviceNumber.length}/${MAX_SERVICE_NUMBER_LENGTH} characters`}
           />
-
-          <FormControl fullWidth required>
-            <InputLabel>Membership Status</InputLabel>
-            <Select
-              value={membershipStatus}
-              label="Membership Status"
-              onChange={(e) => setMembershipStatus(e.target.value as MembershipStatus)}
-              disabled={submitting || (userData?.membershipStatus && isRestrictedStatus(userData.membershipStatus))}
-            >
-              {(() => {
-                // If current status is restricted, show only the current status (disabled)
-                // Otherwise, show all non-restricted statuses
-                const currentStatus = userData?.membershipStatus;
-                if (currentStatus && isRestrictedStatus(currentStatus)) {
-                  const currentOption = MEMBERSHIP_STATUS_OPTIONS.find(opt => opt.value === currentStatus);
-                  return currentOption ? (
-                    <MenuItem key={currentOption.value} value={currentOption.value}>
-                      {currentOption.label}
-                    </MenuItem>
-                  ) : null;
-                }
-                // Show non-restricted options
-                return MEMBERSHIP_STATUS_OPTIONS.filter(option => NON_RESTRICTED_STATUSES.includes(option.value)).map((status) => (
-                  <MenuItem key={status.value} value={status.value}>
-                    {status.label}
-                  </MenuItem>
-                ));
-              })()}
-            </Select>
-            {userData?.membershipStatus && isRestrictedStatus(userData.membershipStatus) && (
-              <Typography variant="caption" sx={{ color: colors.titleSecondary, mt: 1, ml: 1.5 }}>
-                Cannot change from restricted status
-              </Typography>
-            )}
-          </FormControl>
 
           <Divider sx={{ my: 2 }} />
 
@@ -303,4 +269,3 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
     </Box>
   );
 }
-

--- a/src/features/profile/components/__tests__/Profile.test.tsx
+++ b/src/features/profile/components/__tests__/Profile.test.tsx
@@ -71,11 +71,9 @@ describe("Profile", () => {
     const user = userEvent.setup();
     renderProfile({ userData, userEmail: userData.email });
 
-    const [firstNameInput, lastNameInput, serviceNumberInput] = screen.getAllByRole("textbox");
+    const [firstNameInput] = screen.getAllByRole("textbox");
     await user.clear(firstNameInput);
     await user.type(firstNameInput, "Jordan");
-    expect(lastNameInput).toHaveValue("Member");
-    expect(serviceNumberInput).toHaveValue("12345");
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => {

--- a/src/features/profile/components/__tests__/Profile.test.tsx
+++ b/src/features/profile/components/__tests__/Profile.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ComponentProps } from "react";
+import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import Profile from "../Profile";
+import { MembershipStatus } from "@dataconnect/generated";
+import type { UserData } from "../../../../types";
+import * as dataconnect from "@dataconnect/generated";
+import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("@dataconnect/generated", () => ({
+  upsertUser: vi.fn().mockResolvedValue({ data: {} }),
+  MembershipStatus: {
+    REGULAR: "REGULAR",
+    PENDING: "PENDING",
+  },
+}));
+
+vi.mock("../../../../config/firebase", () => ({
+  auth: { currentUser: { uid: "user-1" } },
+  dataConnect: {},
+}));
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  updateDisplayName: vi.fn().mockResolvedValue({ success: true }),
+  updateMembershipStatus: vi.fn(),
+}));
+
+const userData: UserData = {
+  id: "user-1",
+  firstName: "Alex",
+  lastName: "Member",
+  email: "member@example.com",
+  serviceNumber: "12345",
+  membershipStatus: MembershipStatus.REGULAR,
+  isRegular: true,
+  isReserve: false,
+  isCivilServant: false,
+  isIndustry: false,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function renderProfile(props: ComponentProps<typeof Profile>) {
+  return render(
+    <MemoryRouter>
+      <Profile {...props} />
+    </MemoryRouter>
+  );
+}
+
+describe("Profile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows read-only membership status and account settings link", () => {
+    renderProfile({ userData, userEmail: userData.email });
+
+    expect(screen.getByText(/Membership status:/)).toHaveTextContent("Regular");
+    expect(screen.getByRole("link", { name: "Account settings" })).toHaveAttribute(
+      "href",
+      "/account/settings"
+    );
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Membership Status/i)).not.toBeInTheDocument();
+  });
+
+  it("saves identity fields without updating membership status", async () => {
+    const user = userEvent.setup();
+    renderProfile({ userData, userEmail: userData.email });
+
+    const [firstNameInput, lastNameInput, serviceNumberInput] = screen.getAllByRole("textbox");
+    await user.clear(firstNameInput);
+    await user.type(firstNameInput, "Jordan");
+    expect(lastNameInput).toHaveValue("Member");
+    expect(serviceNumberInput).toHaveValue("12345");
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(dataconnect.upsertUser).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          firstName: "Jordan",
+          lastName: "Member",
+        })
+      );
+    });
+
+    expect(firebaseFunctions.updateMembershipStatus).not.toHaveBeenCalled();
+    expect(screen.getByText("Profile updated successfully!")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Removes the membership status dropdown from **Profile**; status is read-only with a link to **Account settings** (#236).
- Profile save no longer calls `updateMembershipStatus` — identity and service background fields only.
- **ProfileCompletion** drops the “Desired Membership Status” picker; admin assigns status during approval (defaults `requestedMembershipStatus` to REGULAR).

Closes #241 (child of epic #231). Builds on #236 Account hub.

## Test plan
- [ ] Open **Profile** as enabled member — no status dropdown; status shown as text; **Account settings** link works
- [ ] Save profile changes — name/email/service fields update; membership status unchanged
- [ ] New user **Complete Your Profile** — no status picker; info message about admin approval
- [ ] Resign and password change still only available under **Account** (#236)
- [ ] Unit tests pass (`Profile.test.tsx`, `ProfileCompletion.test.tsx`)


Made with [Cursor](https://cursor.com)