### PR TITLE
Human-readable labels for membership, sections, and tickets (#242)

### DIFF
--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -22,12 +22,12 @@ import {
   updatePassword,
   type User,
 } from "firebase/auth";
-import { MembershipStatus } from "@dataconnect/generated";
 import { auth } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
-import { MEMBERSHIP_STATUS_OPTIONS, ROUTES, SUCCESS_MESSAGE_TIMEOUT } from "../../../constants";
+import { ROUTES, SUCCESS_MESSAGE_TIMEOUT } from "../../../constants";
 import type { UserData } from "../../../types";
 import { resignMembership } from "../../../shared/utils/firebaseFunctions";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import { canUserResignMembership } from "../../users/utils/membershipStatusValidation";
 
 export interface AccountSettingsPageProps {
@@ -35,14 +35,6 @@ export interface AccountSettingsPageProps {
   userData: UserData | null;
   isAdmin: boolean;
   onBack?: () => void;
-}
-
-function getMembershipStatusLabel(status: MembershipStatus | null | undefined): string {
-  if (!status) {
-    return "Unknown";
-  }
-  const option = MEMBERSHIP_STATUS_OPTIONS.find((entry) => entry.value === status);
-  return option?.label ?? status;
 }
 
 function getAuthErrorMessage(error: unknown): string {

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -14,10 +14,11 @@ import {
 import { Link as RouterLink } from "react-router-dom";
 import { dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
-import { upsertUser, type UpsertUserVariables, MembershipStatus } from "@dataconnect/generated";
+import { upsertUser, type UpsertUserVariables } from "@dataconnect/generated";
 import type { UserData } from "../../../types";
 import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
-import { MEMBERSHIP_STATUS_OPTIONS, MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SERVICE_NUMBER_LENGTH, ROUTES } from "../../../constants";
+import { MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SERVICE_NUMBER_LENGTH, ROUTES } from "../../../constants";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import { auth } from "../../../config/firebase";
 
 interface ProfileProps {
@@ -25,14 +26,6 @@ interface ProfileProps {
   userEmail: string;
   onBack?: () => void;
   onUpdate?: () => void;
-}
-
-function getMembershipStatusLabel(status: MembershipStatus | null | undefined): string {
-  if (!status) {
-    return "Unknown";
-  }
-  const option = MEMBERSHIP_STATUS_OPTIONS.find((entry) => entry.value === status);
-  return option?.label ?? status;
 }
 
 export default function Profile({ userData, userEmail, onBack, onUpdate }: ProfileProps) {

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -26,6 +26,8 @@ import { dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
 import type { GetEventByIdData, GetSectionByIdData, UUIDString } from "@dataconnect/generated";
 import { BookingStatus, TicketAudience } from "@dataconnect/generated";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
+import { getBookingStatusLabel } from "../../../shared/utils/paymentStatusLabels";
 import { getSectionMembersMerged, submitEventBooking } from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
 import { evaluateBookingGatePreview, userMatchesUserGroup } from "../utils/bookingEligibility";
@@ -381,7 +383,8 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       </Typography>
       {editingExistingBooking && existingTerminalBooking ? (
         <Alert severity="info" sx={{ mb: 2 }}>
-          Editing revision {existingTerminalBooking.revisionNumber} ({existingTerminalBooking.status.toLowerCase()}).
+          Editing revision {existingTerminalBooking.revisionNumber} (
+          {getBookingStatusLabel(existingTerminalBooking.status).toLowerCase()}).
           Saving will create a new booking revision.
         </Alert>
       ) : null}
@@ -470,7 +473,8 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
             )}
             {!canRequestAccommodation && (
               <Typography variant="caption" color="text.secondary">
-                Accommodation requests are only available for REGULAR or RESERVE members.
+                Accommodation requests are only available for{" "}
+                {getMembershipStatusLabel("REGULAR")} or {getMembershipStatusLabel("RESERVE")} members.
               </Typography>
             )}
           </FormControl>

--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -4,6 +4,10 @@ import { useGetMyBookingPaymentAdjustments, useGetMyTicketOrders } from "@dataco
 import { dataConnect } from "../../../config/firebase";
 import PageHeader from "../../../shared/components/PageHeader";
 import "../../../shared/components/PageContainer.css";
+import {
+  getBookingPaymentAdjustmentStatusLabel,
+  getTicketOrderStatusLabel,
+} from "../../../shared/utils/paymentStatusLabels";
 import { getMyTicketOrderStripeArtifactsBatch } from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
 
@@ -108,7 +112,11 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
                 {orders.map((order) => (
                   <TableRow key={order.id}>
                     <TableCell>
-                      <Chip size="small" label={order.status} color={statusChipColor(order.status)} />
+                      <Chip
+                        size="small"
+                        label={getTicketOrderStatusLabel(order.status)}
+                        color={statusChipColor(order.status)}
+                      />
                     </TableCell>
                     <TableCell>{order.event?.title ?? "—"}</TableCell>
                     <TableCell>{order.ticketType?.title ?? "—"}</TableCell>
@@ -163,7 +171,11 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
                   {bookingAdjustments.map((adjustment) => (
                     <TableRow key={adjustment.id}>
                       <TableCell>
-                        <Chip size="small" label={adjustment.status.replaceAll("_", " ")} color="warning" />
+                        <Chip
+                          size="small"
+                          label={getBookingPaymentAdjustmentStatusLabel(adjustment.status)}
+                          color="warning"
+                        />
                       </TableCell>
                       <TableCell>{adjustment.eventTitle}</TableCell>
                       <TableCell align="right">{(adjustment.deltaAmountMinor / 100).toFixed(2)} GBP</TableCell>

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -17,6 +17,12 @@ import { TicketAudience, type GetEventByIdData, type GetEventsForSectionData, ty
 import { colors } from "../../../config/colors";
 import PaginationDisplay from "../../../shared/components/PaginationDisplay";
 import SearchBar from "../../../shared/components/SearchBar";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
+import {
+  ACCESS_GROUP_COLUMN_LABEL,
+  GUEST_LIMIT_BEFORE_REVIEW_LABEL,
+} from "../../../shared/utils/sectionDisplayLabels";
+import { getSectionTypeLabel, isMembersSectionType } from "../../../shared/utils/sectionTypeLabels";
 import { getTicketCategoryLabel, TICKET_CATEGORY_LABEL } from "../../../shared/utils/ticketAudienceLabels";
 import type { SectionMember } from "../utils/sectionHelpers";
 import EventBookingWizard from "./EventBookingWizard";
@@ -55,9 +61,9 @@ export function SectionInformationView({
       </Typography>
       <Box sx={{ display: "flex", gap: 2, alignItems: "center", mb: 2 }}>
         <Chip
-          label={section.type}
+          label={getSectionTypeLabel(section.type)}
           size="small"
-          color={section.type === "MEMBERS" ? "primary" : "secondary"}
+          color={isMembersSectionType(section.type) ? "primary" : "secondary"}
         />
         {section.description && (
           <Typography variant="body2" color="text.secondary">
@@ -167,7 +173,7 @@ export function SectionMembersView({
                       </Typography>
                     </TableCell>
                     <TableCell>
-                      <Chip label={member.membershipStatus} size="small" />
+                      <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" />
                     </TableCell>
                   </TableRow>
                 ))}
@@ -352,7 +358,7 @@ export function SectionEventDetailView({
               {new Date(event.bookingEndDateTime).toLocaleString()}
             </Typography>
             <Typography component="dt" variant="body2">
-              Max guests without moderator approval
+              {GUEST_LIMIT_BEFORE_REVIEW_LABEL}
             </Typography>
             <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 2 }}>
               {event.maxGuestsWithoutModeratorApproval != null
@@ -376,7 +382,7 @@ export function SectionEventDetailView({
                     <TableCell>Description</TableCell>
                     <TableCell>Price</TableCell>
                     <TableCell>{TICKET_CATEGORY_LABEL}</TableCell>
-                    <TableCell>User group</TableCell>
+                    <TableCell>{ACCESS_GROUP_COLUMN_LABEL}</TableCell>
                     <TableCell align="right">Purchase</TableCell>
                   </TableRow>
                 </TableHead>

--- a/src/features/sections/components/SectionsList.tsx
+++ b/src/features/sections/components/SectionsList.tsx
@@ -23,6 +23,7 @@ import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import type { SectionType, SectionUserGroupPurpose } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
+import { getSectionTypeLabel, isMembersSectionType } from "../../../shared/utils/sectionTypeLabels";
 import "../../../shared/components/PageContainer.css";
 
 interface SectionsListProps {
@@ -231,9 +232,9 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
                   </TableCell>
                   <TableCell>
                     <Chip
-                      label={section.type}
+                      label={getSectionTypeLabel(section.type)}
                       size="small"
-                      color={section.type === "MEMBERS" ? "primary" : "secondary"}
+                      color={isMembersSectionType(section.type) ? "primary" : "secondary"}
                     />
                   </TableCell>
                   <TableCell>

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -95,7 +95,7 @@ describe("MyPayments", () => {
 
     render(<MyPayments onBack={() => undefined} />);
 
-    expect(screen.getByText("PENDING AUTO REFUND")).toBeInTheDocument();
+    expect(screen.getByText("Refund pending")).toBeInTheDocument();
     expect(screen.getByText("Rev 2")).toBeInTheDocument();
     expect(screen.getByText("-5.00 GBP")).toBeInTheDocument();
   });

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -219,7 +219,7 @@ describe('SectionDetail', () => {
     });
 
     expect(screen.getByText('Test description')).toBeInTheDocument();
-    expect(screen.getByText('MEMBERS')).toBeInTheDocument();
+    expect(screen.getByText('Members')).toBeInTheDocument();
   });
 
   it('should render member list for MEMBERS sections', async () => {
@@ -276,8 +276,8 @@ describe('SectionDetail', () => {
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     expect(screen.getByText('john@example.com')).toBeInTheDocument();
     expect(screen.getByText('jane@example.com')).toBeInTheDocument();
-    expect(screen.getByText('REGULAR')).toBeInTheDocument();
-    expect(screen.getByText('RESERVE')).toBeInTheDocument();
+    expect(screen.getByText('Regular')).toBeInTheDocument();
+    expect(screen.getByText('Reserve')).toBeInTheDocument();
   });
 
   it('should show subscribe button when user can subscribe', async () => {
@@ -474,7 +474,7 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByText('Events')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
       expect(screen.getByText(/no events yet/i)).toBeInTheDocument();
     });
   });
@@ -559,7 +559,7 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByText('Events')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
       expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
     });
 
@@ -650,7 +650,7 @@ describe('SectionDetail', () => {
     await user.click(screen.getByRole('button', { name: /back to events/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Events')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
       expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /back to events/i })).not.toBeInTheDocument();
     });

--- a/src/features/sections/components/__tests__/SectionsList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionsList.test.tsx
@@ -133,7 +133,7 @@ describe('SectionsList', () => {
       expect(screen.getByText('Test Section')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('MEMBERS')).toBeInTheDocument();
+    expect(screen.getByText('Members')).toBeInTheDocument();
     expect(screen.getByText('Test description')).toBeInTheDocument();
   });
 

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -11,8 +11,8 @@ import {
 } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import type { GetSectionsForUserData } from "@dataconnect/generated";
-import { SectionType } from "@dataconnect/generated";
 import { colors } from "../../../config/colors";
+import { getSectionTypeLabel } from "../../../shared/utils/sectionTypeLabels";
 import { ROUTES } from "../../../constants";
 import type { UserData } from "../../../types";
 import { extractAccessibleSections } from "../../../shared/navigation/extractAccessibleSections";
@@ -23,10 +23,6 @@ export interface MemberWelcomePageProps {
   userData: UserData | null;
   userEmail?: string | null;
   sectionsData?: GetSectionsForUserData;
-}
-
-function formatSectionType(type: SectionType): string {
-  return type === SectionType.EVENTS ? "Events" : "Members";
 }
 
 function formatEventWhen(startDateTime: string, endDateTime: string): string {
@@ -140,7 +136,7 @@ export default function MemberWelcomePage({
                 >
                   <CardContent>
                     <Typography variant="overline" color="text.secondary">
-                      {formatSectionType(section.type)}
+                      {getSectionTypeLabel(section.type)}
                     </Typography>
                     <Typography variant="subtitle1" fontWeight={600}>
                       {section.name}

--- a/src/shared/utils/__tests__/memberDisplayLabels.test.ts
+++ b/src/shared/utils/__tests__/memberDisplayLabels.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  BookingPaymentAdjustmentStatus,
+  BookingStatus,
+  MembershipStatus,
+  SectionType,
+  TicketAudience,
+  TicketOrderStatus,
+} from "@dataconnect/generated";
+import { getMembershipStatusLabel } from "../membershipStatusLabels";
+import {
+  getBookingPaymentAdjustmentStatusLabel,
+  getBookingStatusLabel,
+  getTicketOrderStatusLabel,
+} from "../paymentStatusLabels";
+import { getSectionTypeLabel, isMembersSectionType } from "../sectionTypeLabels";
+import { getTicketCategoryLabel } from "../ticketAudienceLabels";
+
+describe("member display labels", () => {
+  it("maps membership statuses to readable labels", () => {
+    expect(getMembershipStatusLabel(MembershipStatus.REGULAR)).toBe("Regular");
+    expect(getMembershipStatusLabel(MembershipStatus.CIVIL_SERVICE)).toBe("Civil Service");
+    expect(getMembershipStatusLabel("UNKNOWN")).toBe("UNKNOWN");
+  });
+
+  it("maps section types to readable labels", () => {
+    expect(getSectionTypeLabel(SectionType.MEMBERS)).toBe("Members");
+    expect(getSectionTypeLabel(SectionType.EVENTS)).toBe("Events");
+    expect(isMembersSectionType(SectionType.MEMBERS)).toBe(true);
+  });
+
+  it("maps ticket audience categories", () => {
+    expect(getTicketCategoryLabel(TicketAudience.MEMBER)).toBe("Member ticket");
+  });
+
+  it("maps payment and booking statuses", () => {
+    expect(getTicketOrderStatusLabel(TicketOrderStatus.PAID)).toBe("Paid");
+    expect(getTicketOrderStatusLabel(TicketOrderStatus.FAILED)).toBe("Payment failed");
+    expect(getBookingPaymentAdjustmentStatusLabel(BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND)).toBe(
+      "Refund pending"
+    );
+    expect(getBookingStatusLabel(BookingStatus.CONFIRMED)).toBe("Confirmed");
+  });
+});

--- a/src/shared/utils/membershipStatusLabels.ts
+++ b/src/shared/utils/membershipStatusLabels.ts
@@ -1,0 +1,12 @@
+import type { MembershipStatus } from "@dataconnect/generated";
+import { MEMBERSHIP_STATUS_OPTIONS } from "../../constants";
+
+export function getMembershipStatusLabel(
+  status: MembershipStatus | string | null | undefined
+): string {
+  if (!status) {
+    return "Unknown";
+  }
+  const option = MEMBERSHIP_STATUS_OPTIONS.find((entry) => entry.value === status);
+  return option?.label ?? status;
+}

--- a/src/shared/utils/paymentStatusLabels.ts
+++ b/src/shared/utils/paymentStatusLabels.ts
@@ -1,0 +1,42 @@
+import {
+  BookingPaymentAdjustmentStatus,
+  BookingStatus,
+  TicketOrderStatus,
+} from "@dataconnect/generated";
+
+const TICKET_ORDER_STATUS_LABELS: Record<TicketOrderStatus, string> = {
+  [TicketOrderStatus.PENDING]: "Pending payment",
+  [TicketOrderStatus.PAID]: "Paid",
+  [TicketOrderStatus.FAILED]: "Payment failed",
+  [TicketOrderStatus.REFUNDED]: "Refunded",
+};
+
+const BOOKING_PAYMENT_ADJUSTMENT_STATUS_LABELS: Record<BookingPaymentAdjustmentStatus, string> = {
+  [BookingPaymentAdjustmentStatus.NOT_REQUIRED]: "No payment change",
+  [BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND]: "Refund pending",
+  [BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE]: "Additional payment pending",
+};
+
+const BOOKING_STATUS_LABELS: Record<BookingStatus, string> = {
+  [BookingStatus.DRAFT]: "Draft",
+  [BookingStatus.SUBMITTED]: "Submitted",
+  [BookingStatus.CONFIRMED]: "Confirmed",
+  [BookingStatus.CANCELLED]: "Cancelled",
+};
+
+export function getTicketOrderStatusLabel(status: TicketOrderStatus | string): string {
+  return TICKET_ORDER_STATUS_LABELS[status as TicketOrderStatus] ?? String(status);
+}
+
+export function getBookingPaymentAdjustmentStatusLabel(
+  status: BookingPaymentAdjustmentStatus | string
+): string {
+  return (
+    BOOKING_PAYMENT_ADJUSTMENT_STATUS_LABELS[status as BookingPaymentAdjustmentStatus] ??
+    String(status).replaceAll("_", " ").toLowerCase()
+  );
+}
+
+export function getBookingStatusLabel(status: BookingStatus | string): string {
+  return BOOKING_STATUS_LABELS[status as BookingStatus] ?? String(status).toLowerCase();
+}

--- a/src/shared/utils/sectionDisplayLabels.ts
+++ b/src/shared/utils/sectionDisplayLabels.ts
@@ -1,0 +1,5 @@
+/** Member-facing column heading for ticket type access rules. */
+export const ACCESS_GROUP_COLUMN_LABEL = "Access group";
+
+/** Member-facing label for guest cap before moderator review (#234 will refine further). */
+export const GUEST_LIMIT_BEFORE_REVIEW_LABEL = "Guests allowed before moderator review";

--- a/src/shared/utils/sectionTypeLabels.ts
+++ b/src/shared/utils/sectionTypeLabels.ts
@@ -1,0 +1,15 @@
+import { SectionType } from "@dataconnect/generated";
+
+export function getSectionTypeLabel(type: SectionType | string): string {
+  if (type === SectionType.EVENTS || type === "EVENTS") {
+    return "Events";
+  }
+  if (type === SectionType.MEMBERS || type === "MEMBERS") {
+    return "Members";
+  }
+  return String(type);
+}
+
+export function isMembersSectionType(type: SectionType | string): boolean {
+  return type === SectionType.MEMBERS || type === "MEMBERS";
+}


### PR DESCRIPTION
## Summary
- Add shared label helpers for membership status, section type, payment/booking status, and section display copy (access group column, guest cap).
- Apply helpers across member-facing surfaces: sections list/detail, welcome dashboard, event booking wizard, My Payments, Profile, and Account settings.
- Update component tests to expect human-readable labels instead of raw enum strings.

Closes #242 (epic #231).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run`
- [ ] Manual: open Sections list — type chips show "Members" / "Events"
- [ ] Manual: open a Members section — member directory shows "Regular", "Reserve", etc.
- [ ] Manual: open event detail — "Access group" column and guest cap label are readable
- [ ] Manual: My Payments — order/adjustment status chips show "Paid", "Refund pending", etc.


Made with [Cursor](https://cursor.com)