### PR TITLE
Section detail: tabbed layout (Events, Members, About) (#245)

### DIFF
--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -1,10 +1,12 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, type SyntheticEvent } from "react";
 import {
   Box,
   Alert,
   CircularProgress,
   Button,
   Snackbar,
+  Tab,
+  Tabs,
 } from "@mui/material";
 import { useGetSectionById, useGetUserAccessGroups, useGetEventsForSection, useGetEventById } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
@@ -27,6 +29,12 @@ import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generate
 import { ITEMS_PER_PAGE } from "../../../constants";
 import "../../../shared/components/PageContainer.css";
 import { getSectionAdminDestination } from "../utils/sectionDetailAdminNavigation";
+import {
+  getDefaultSectionDetailTab,
+  getSectionDetailTabs,
+  sectionDetailTabLabel,
+  type SectionDetailTab,
+} from "../utils/sectionDetailTabs";
 import {
   SectionEventDetailView,
   SectionEventsListView,
@@ -54,6 +62,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [errorMembers, setErrorMembers] = useState<string | null>(null);
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
   const [startingCheckoutId, setStartingCheckoutId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<SectionDetailTab>("about");
 
   const currentUser = auth.currentUser;
   const isAdmin = useAdminClaim(currentUser);
@@ -300,6 +309,30 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     }
   };
 
+  const loadedSection = sectionData?.section;
+  const isMembersSectionType = loadedSection ? isMembersSection(loadedSection as any) : false;
+  const sectionTabs = getSectionDetailTabs(isMembersSectionType);
+
+  useEffect(() => {
+    if (!loadedSection) {
+      return;
+    }
+    setActiveTab(getDefaultSectionDetailTab(isMembersSectionType));
+    setSelectedEventId(null);
+  }, [sectionId, isMembersSectionType, loadedSection]);
+
+  const handleTabChange = (_event: SyntheticEvent, newTab: SectionDetailTab) => {
+    setActiveTab(newTab);
+    if (newTab !== "events") {
+      setSelectedEventId(null);
+    }
+  };
+
+  const handleSelectEvent = (eventId: string) => {
+    setSelectedEventId(eventId);
+    setActiveTab("events");
+  };
+
   if (loadingSection || loadingMembers || loadingUserGroups) {
     return (
       <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
@@ -333,7 +366,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   }
 
   const section = sectionData.section;
-  const isMembers = isMembersSection(section as any);
+  const isMembers = isMembersSectionType;
   const hasSubscribableMemberGroup = memberGroups.some((group) => group.subscribable === true);
   const eventRows = eventsData?.section?.events ?? [];
   const sectionAdminAction = {
@@ -348,19 +381,40 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
       <PageHeader title={section.name} onBack={onBack} adminAction={sectionAdminAction} />
 
-      <SectionInformationView
-        section={section}
-        isMembers={isMembers}
-        hasCurrentUser={Boolean(currentUser)}
-        canSubscribe={canSubscribe}
-        userIsMember={userIsMember}
-        hasSubscribableMemberGroup={hasSubscribableMemberGroup}
-        subscribing={subscribing}
-        onSubscribe={handleSubscribe}
-        onUnsubscribe={handleUnsubscribe}
-      />
+      <Tabs
+        value={activeTab}
+        onChange={handleTabChange}
+        sx={{
+          mt: 2,
+          mb: 2,
+          borderBottom: 1,
+          borderColor: "divider",
+          "& .MuiTab-root": {
+            "&:focus": { outline: "none" },
+            "&:focus-visible": { outline: "none" },
+          },
+        }}
+      >
+        {sectionTabs.map((tab) => (
+          <Tab key={tab} label={sectionDetailTabLabel(tab)} value={tab} />
+        ))}
+      </Tabs>
 
-      {isMembers ? (
+      {activeTab === "about" && (
+        <SectionInformationView
+          section={section}
+          isMembers={isMembers}
+          hasCurrentUser={Boolean(currentUser)}
+          canSubscribe={canSubscribe}
+          userIsMember={userIsMember}
+          hasSubscribableMemberGroup={hasSubscribableMemberGroup}
+          subscribing={subscribing}
+          onSubscribe={handleSubscribe}
+          onUnsubscribe={handleUnsubscribe}
+        />
+      )}
+
+      {activeTab === "members" && (
         <SectionMembersView
           allMembersCount={allMembers.length}
           filteredMembers={filteredMembers}
@@ -373,30 +427,33 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
           onRefresh={() => refetchSection()}
           onPageChange={setPage}
         />
-      ) : selectedEventId ? (
-        <SectionEventDetailView
-          section={section}
-          event={eventDetailData?.event ?? null}
-          loading={loadingEventDetail}
-          isError={errorEventDetail}
-          hasCurrentUser={Boolean(currentUser)}
-          startingCheckoutId={startingCheckoutId}
-          onBackToEvents={() => setSelectedEventId(null)}
-          onRetry={() => refetchEventDetail()}
-          onStartCheckout={(ticketTypeId) => void handleStartCheckout(ticketTypeId)}
-          onBookingComplete={() => {
-            void refetchEventDetail();
-          }}
-        />
-      ) : (
-        <SectionEventsListView
-          events={eventRows}
-          loading={loadingEvents}
-          isError={errorEvents}
-          onRetry={() => refetchEvents()}
-          onSelectEvent={setSelectedEventId}
-        />
       )}
+
+      {activeTab === "events" &&
+        (selectedEventId ? (
+          <SectionEventDetailView
+            section={section}
+            event={eventDetailData?.event ?? null}
+            loading={loadingEventDetail}
+            isError={errorEventDetail}
+            hasCurrentUser={Boolean(currentUser)}
+            startingCheckoutId={startingCheckoutId}
+            onBackToEvents={() => setSelectedEventId(null)}
+            onRetry={() => refetchEventDetail()}
+            onStartCheckout={(ticketTypeId) => void handleStartCheckout(ticketTypeId)}
+            onBookingComplete={() => {
+              void refetchEventDetail();
+            }}
+          />
+        ) : (
+          <SectionEventsListView
+            events={eventRows}
+            loading={loadingEvents}
+            isError={errorEvents}
+            onRetry={() => refetchEvents()}
+            onSelectEvent={handleSelectEvent}
+          />
+        ))}
 
       <Snackbar
         open={snackbar.open}

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -55,22 +55,17 @@ export function SectionInformationView({
   onUnsubscribe,
 }: SectionInformationViewProps) {
   return (
-    <Box sx={{ mt: 3, mb: 3 }}>
-      <Typography variant="h6" sx={{ mb: 1 }}>
-        Section Information
-      </Typography>
+    <Box sx={{ mt: 1 }}>
       <Box sx={{ display: "flex", gap: 2, alignItems: "center", mb: 2 }}>
         <Chip
           label={getSectionTypeLabel(section.type)}
           size="small"
           color={isMembersSectionType(section.type) ? "primary" : "secondary"}
         />
-        {section.description && (
-          <Typography variant="body2" color="text.secondary">
-            {section.description}
-          </Typography>
-        )}
       </Box>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+        {section.description?.trim() || "No description provided for this section."}
+      </Typography>
 
       {isMembers && hasCurrentUser && (
         <Box sx={{ mt: 2 }}>
@@ -128,8 +123,8 @@ export function SectionMembersView({
   onPageChange,
 }: SectionMembersViewProps) {
   return (
-    <>
-      <Typography variant="h6" sx={{ mb: 2 }}>
+    <Box sx={{ mt: 1 }}>
+      <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
         Members ({allMembersCount})
       </Typography>
       <SearchBar
@@ -183,7 +178,7 @@ export function SectionMembersView({
           <PaginationDisplay page={page} totalPages={totalPages} onChange={onPageChange} />
         </>
       )}
-    </>
+    </Box>
   );
 }
 
@@ -203,10 +198,7 @@ export function SectionEventsListView({
   onSelectEvent,
 }: SectionEventsListViewProps) {
   return (
-    <Box sx={{ mt: 2 }}>
-      <Typography variant="h6" sx={{ mb: 2 }}>
-        Events
-      </Typography>
+    <Box sx={{ mt: 1 }}>
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
           <CircularProgress />

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -174,7 +174,7 @@ describe('SectionDetail', () => {
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 
-  it('should render section information', async () => {
+  it('should render section information on the About tab', async () => {
     const mockSectionData = {
       section: {
         id: sectionId,
@@ -214,12 +214,17 @@ describe('SectionDetail', () => {
 
     renderSectionDetail();
 
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
     await waitFor(() => {
       expect(screen.getByText('Test Section')).toBeInTheDocument();
     });
 
+    await user.click(screen.getByRole('tab', { name: 'About' }));
+
+    expect(screen.getByRole('tab', { name: 'About', selected: true })).toBeInTheDocument();
     expect(screen.getByText('Test description')).toBeInTheDocument();
-    expect(screen.getByText('Members')).toBeInTheDocument();
   });
 
   it('should render member list for MEMBERS sections', async () => {
@@ -328,6 +333,15 @@ describe('SectionDetail', () => {
 
     renderSectionDetail();
 
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Members', selected: true })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'About' }));
+
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /subscribe/i })).toBeInTheDocument();
     });
@@ -381,6 +395,15 @@ describe('SectionDetail', () => {
     });
 
     renderSectionDetail();
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Members', selected: true })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'About' }));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /unsubscribe/i })).toBeInTheDocument();
@@ -474,7 +497,7 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Events', selected: true })).toBeInTheDocument();
       expect(screen.getByText(/no events yet/i)).toBeInTheDocument();
     });
   });
@@ -559,7 +582,7 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Events', selected: true })).toBeInTheDocument();
       expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
     });
 
@@ -650,9 +673,55 @@ describe('SectionDetail', () => {
     await user.click(screen.getByRole('button', { name: /back to events/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Events' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Events', selected: true })).toBeInTheDocument();
       expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /back to events/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should switch between About and Members tabs on MEMBERS sections', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Test Section',
+        type: 'MEMBERS',
+        description: 'Test description',
+        purposeLinks: [],
+      },
+    };
+
+    mockGetSectionById({
+      data: mockSectionData,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Members', selected: true })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'About' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test description')).toBeInTheDocument();
+      expect(screen.queryByLabelText(/search members/i)).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('tab', { name: 'Members' }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/search members/i)).toBeInTheDocument();
     });
   });
 });

--- a/src/features/sections/utils/__tests__/sectionDetailTabs.test.ts
+++ b/src/features/sections/utils/__tests__/sectionDetailTabs.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDefaultSectionDetailTab,
+  getSectionDetailTabs,
+  sectionDetailTabLabel,
+} from "../sectionDetailTabs";
+
+describe("sectionDetailTabs", () => {
+  it("returns About and Members tabs for member sections", () => {
+    expect(getSectionDetailTabs(true)).toEqual(["about", "members"]);
+    expect(getDefaultSectionDetailTab(true)).toBe("members");
+  });
+
+  it("returns About and Events tabs for event sections", () => {
+    expect(getSectionDetailTabs(false)).toEqual(["about", "events"]);
+    expect(getDefaultSectionDetailTab(false)).toBe("events");
+  });
+
+  it("maps tab ids to labels", () => {
+    expect(sectionDetailTabLabel("about")).toBe("About");
+    expect(sectionDetailTabLabel("events")).toBe("Events");
+    expect(sectionDetailTabLabel("members")).toBe("Members");
+  });
+});

--- a/src/features/sections/utils/sectionDetailTabs.ts
+++ b/src/features/sections/utils/sectionDetailTabs.ts
@@ -1,0 +1,15 @@
+export type SectionDetailTab = "about" | "events" | "members";
+
+export function getSectionDetailTabs(isMembersSection: boolean): SectionDetailTab[] {
+  return isMembersSection ? ["about", "members"] : ["about", "events"];
+}
+
+export function getDefaultSectionDetailTab(isMembersSection: boolean): SectionDetailTab {
+  return isMembersSection ? "members" : "events";
+}
+
+export function sectionDetailTabLabel(tab: SectionDetailTab): string {
+  if (tab === "about") return "About";
+  if (tab === "events") return "Events";
+  return "Members";
+}


### PR DESCRIPTION
## Summary
- Add About / Members / Events tabs to section detail, shown based on section type.
- Move description, type chip, and subscribe/unsubscribe actions into the About tab; member directory and events list/detail live in their respective tabs.
- Default to the primary content tab (Members or Events); event drill-in stays within the Events tab.

Closes #245 (epic #231).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run`
- [ ] Manual: MEMBERS section — switch About ↔ Members; subscribe/unsubscribe on About
- [ ] Manual: EVENTS section — Events tab lists events; View opens detail; Back to events returns to list
- [ ] Manual: admin action still visible in page header


Made with [Cursor](https://cursor.com)