### PR TITLE
Redesign section events list: upcoming cards, past events view (#233)

### DIFF
--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import {
   Alert,
   Box,
@@ -25,7 +26,9 @@ import {
 import { getSectionTypeLabel, isMembersSectionType } from "../../../shared/utils/sectionTypeLabels";
 import { getTicketCategoryLabel, TICKET_CATEGORY_LABEL } from "../../../shared/utils/ticketAudienceLabels";
 import type { SectionMember } from "../utils/sectionHelpers";
+import { partitionSectionEventsByTiming } from "../../../shared/utils/sectionEventDisplay";
 import EventBookingWizard from "./EventBookingWizard";
+import SectionEventCard from "./SectionEventCard";
 
 type SectionDetailSection = NonNullable<GetSectionByIdData["section"]>;
 type SectionEventRow = NonNullable<NonNullable<GetEventsForSectionData["section"]>["events"]>[number];
@@ -190,6 +193,8 @@ interface SectionEventsListViewProps {
   onSelectEvent: (eventId: string) => void;
 }
 
+type SectionEventsListMode = "upcoming" | "past";
+
 export function SectionEventsListView({
   events,
   loading,
@@ -197,8 +202,39 @@ export function SectionEventsListView({
   onRetry,
   onSelectEvent,
 }: SectionEventsListViewProps) {
+  const [listMode, setListMode] = useState<SectionEventsListMode>("upcoming");
+  const { upcoming, past } = useMemo(() => partitionSectionEventsByTiming(events), [events]);
+  const visibleEvents = listMode === "upcoming" ? upcoming : past;
+
   return (
     <Box sx={{ mt: 1 }}>
+      {!loading && !isError && (upcoming.length > 0 || past.length > 0) ? (
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            flexWrap: "wrap",
+            gap: 1,
+            mb: 2,
+          }}
+        >
+          <Typography variant="subtitle1" component="h2" fontWeight={600}>
+            {listMode === "upcoming" ? "Upcoming events" : "Past events"}
+          </Typography>
+          {listMode === "upcoming" && past.length > 0 ? (
+            <Button size="small" onClick={() => setListMode("past")}>
+              View past events
+            </Button>
+          ) : null}
+          {listMode === "past" ? (
+            <Button size="small" onClick={() => setListMode("upcoming")}>
+              Back to upcoming events
+            </Button>
+          ) : null}
+        </Box>
+      ) : null}
+
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
           <CircularProgress />
@@ -210,65 +246,36 @@ export function SectionEventsListView({
             Retry
           </Button>
         </Alert>
-      ) : !events.length ? (
-        <Alert severity="info">No events yet.</Alert>
+      ) : listMode === "upcoming" && upcoming.length === 0 ? (
+        <Alert severity="info">
+          {past.length > 0
+            ? "No upcoming events right now. View past events to see what has already happened."
+            : "No upcoming events yet. Check back when new events are published."}
+        </Alert>
+      ) : listMode === "past" && past.length === 0 ? (
+        <Alert severity="info">No past events yet.</Alert>
       ) : (
-        <TableContainer component={Paper}>
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Title</TableCell>
-                <TableCell>Date / time</TableCell>
-                <TableCell>Location</TableCell>
-                <TableCell>Guest of honour</TableCell>
-                <TableCell />
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {events.map((event) => (
-                <TableRow
-                  key={event.id}
-                  hover
-                  sx={{ cursor: "pointer" }}
-                  onClick={() => onSelectEvent(event.id)}
-                >
-                  <TableCell>
-                    <Typography variant="body2" fontWeight={500}>
-                      {event.title}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {new Date(event.startDateTime).toLocaleString()} -{" "}
-                      {new Date(event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {event.location || "-"}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {event.guestOfHonour || "-"}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Button
-                      size="small"
-                      onClick={(clickEvent) => {
-                        clickEvent.stopPropagation();
-                        onSelectEvent(event.id);
-                      }}
-                    >
-                      View
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <Box
+          component="ul"
+          sx={{
+            listStyle: "none",
+            m: 0,
+            p: 0,
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: { xs: "1fr", md: "1fr 1fr" },
+          }}
+        >
+          {visibleEvents.map((event) => (
+            <Box component="li" key={event.id} sx={{ minWidth: 0 }}>
+              <SectionEventCard
+                event={event}
+                variant={listMode}
+                onSelect={onSelectEvent}
+              />
+            </Box>
+          ))}
+        </Box>
       )}
     </Box>
   );

--- a/src/features/sections/components/SectionEventCard.tsx
+++ b/src/features/sections/components/SectionEventCard.tsx
@@ -1,0 +1,73 @@
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  CardMedia,
+  Typography,
+} from "@mui/material";
+import type { SectionEventListItem } from "../../../shared/utils/sectionEventDisplay";
+import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
+
+export interface SectionEventCardProps {
+  event: SectionEventListItem;
+  variant?: "upcoming" | "past";
+  onSelect: (eventId: string) => void;
+}
+
+export default function SectionEventCard({
+  event,
+  variant = "upcoming",
+  onSelect,
+}: SectionEventCardProps) {
+  const isPast = variant === "past";
+
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: "100%",
+        opacity: isPast ? 0.92 : 1,
+        bgcolor: isPast ? "action.hover" : "background.paper",
+      }}
+    >
+      <CardActionArea
+        onClick={() => onSelect(event.id)}
+        sx={{
+          height: "100%",
+          textAlign: "left",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+        }}
+      >
+        {event.imageUrl ? (
+          <CardMedia
+            component="img"
+            height={140}
+            image={event.imageUrl}
+            alt=""
+            sx={{ objectFit: "cover" }}
+          />
+        ) : null}
+        <CardContent sx={{ flexGrow: 1, width: "100%" }}>
+          <Typography variant="subtitle1" component="h3" fontWeight={600} gutterBottom>
+            {event.title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {formatSectionEventWhen(event.startDateTime, event.endDateTime)}
+          </Typography>
+          {event.location ? (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {event.location}
+            </Typography>
+          ) : null}
+          {event.guestOfHonour ? (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              Guest of honour: {event.guestOfHonour}
+            </Typography>
+          ) : null}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -99,6 +99,18 @@ function mockGetMyBookingsForEvent(overrides: DataConnectQueryResultOverrides) {
 describe('SectionDetail', () => {
   const mockOnBack = vi.fn();
   const sectionId = 'section-1';
+  const upcomingEventTimes = {
+    startDateTime: '2030-03-01T18:00:00Z',
+    endDateTime: '2030-03-01T22:00:00Z',
+    bookingStartDateTime: '2030-02-01T00:00:00Z',
+    bookingEndDateTime: '2030-02-28T23:59:59Z',
+  };
+  const pastEventTimes = {
+    startDateTime: '2024-03-01T18:00:00Z',
+    endDateTime: '2024-03-01T22:00:00Z',
+    bookingStartDateTime: '2024-02-01T00:00:00Z',
+    bookingEndDateTime: '2024-02-28T23:59:59Z',
+  };
 
   const renderSectionDetail = () =>
     render(
@@ -498,7 +510,7 @@ describe('SectionDetail', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Events', selected: true })).toBeInTheDocument();
-      expect(screen.getByText(/no events yet/i)).toBeInTheDocument();
+      expect(screen.getByText(/no upcoming events yet/i)).toBeInTheDocument();
     });
   });
 
@@ -520,10 +532,7 @@ describe('SectionDetail', () => {
           {
             id: eventId,
             title: 'Annual Dinner',
-            startDateTime: '2025-03-01T18:00:00Z',
-            endDateTime: '2025-03-01T22:00:00Z',
-            bookingStartDateTime: '2025-02-01T00:00:00Z',
-            bookingEndDateTime: '2025-02-28T23:59:59Z',
+            ...upcomingEventTimes,
             location: 'Main Hall',
             guestOfHonour: 'Jane Doe',
           },
@@ -534,10 +543,7 @@ describe('SectionDetail', () => {
       event: {
         id: eventId,
         title: 'Annual Dinner',
-        startDateTime: '2025-03-01T18:00:00Z',
-        endDateTime: '2025-03-01T22:00:00Z',
-        bookingStartDateTime: '2025-02-01T00:00:00Z',
-        bookingEndDateTime: '2025-02-28T23:59:59Z',
+        ...upcomingEventTimes,
         location: 'Main Hall',
         guestOfHonour: 'Jane Doe',
         maxGuestsWithoutModeratorApproval: null,
@@ -588,7 +594,7 @@ describe('SectionDetail', () => {
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /view/i }));
+    await user.click(screen.getByRole('button', { name: /annual dinner/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Back to events')).toBeInTheDocument();
@@ -615,17 +621,14 @@ describe('SectionDetail', () => {
     const mockEventsData = {
       section: {
         id: sectionId,
-        events: [{ id: eventId, title: 'Annual Dinner', startDateTime: '2025-03-01T18:00:00Z', endDateTime: '2025-03-01T22:00:00Z', bookingStartDateTime: '2025-02-01T00:00:00Z', bookingEndDateTime: '2025-02-28T23:59:59Z', location: null, guestOfHonour: null }],
+        events: [{ id: eventId, title: 'Annual Dinner', ...upcomingEventTimes, location: null, guestOfHonour: null }],
       },
     };
     const mockEventDetailData = {
       event: {
         id: eventId,
         title: 'Annual Dinner',
-        startDateTime: '2025-03-01T18:00:00Z',
-        endDateTime: '2025-03-01T22:00:00Z',
-        bookingStartDateTime: '2025-02-01T00:00:00Z',
-        bookingEndDateTime: '2025-02-28T23:59:59Z',
+        ...upcomingEventTimes,
         location: null,
         guestOfHonour: null,
         ticketTypes: [],
@@ -664,7 +667,7 @@ describe('SectionDetail', () => {
 
     const userEvent = (await import('@testing-library/user-event')).userEvent;
     const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /view/i }));
+    await user.click(screen.getByRole('button', { name: /annual dinner/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Back to events')).toBeInTheDocument();
@@ -676,6 +679,122 @@ describe('SectionDetail', () => {
       expect(screen.getByRole('tab', { name: 'Events', selected: true })).toBeInTheDocument();
       expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /back to events/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('should hide past events from the default upcoming list', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        purposeLinks: [],
+      },
+    };
+
+    mockGetSectionById({
+      data: mockSectionData,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetEventsForSection({
+      data: {
+        section: {
+          id: sectionId,
+          events: [
+            {
+              id: 'past-1',
+              title: 'Old Dinner',
+              ...pastEventTimes,
+              location: 'Hall',
+              guestOfHonour: null,
+            },
+            {
+              id: 'upcoming-1',
+              title: 'Spring Dinner',
+              ...upcomingEventTimes,
+              location: 'Hall',
+              guestOfHonour: null,
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Spring Dinner')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Old Dinner')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view past events/i })).toBeInTheDocument();
+  });
+
+  it('should show past events when View past events is clicked', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        purposeLinks: [],
+      },
+    };
+
+    mockGetSectionById({
+      data: mockSectionData,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetEventsForSection({
+      data: {
+        section: {
+          id: sectionId,
+          events: [
+            {
+              id: 'past-1',
+              title: 'Old Dinner',
+              ...pastEventTimes,
+              location: 'Hall',
+              guestOfHonour: 'Guest',
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no upcoming events right now/i)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /view past events/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Old Dinner')).toBeInTheDocument();
+      expect(screen.getByText('Guest of honour: Guest')).toBeInTheDocument();
     });
   });
 

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -13,6 +13,7 @@ import { Link as RouterLink } from "react-router-dom";
 import type { GetSectionsForUserData } from "@dataconnect/generated";
 import { colors } from "../../../config/colors";
 import { getSectionTypeLabel } from "../../../shared/utils/sectionTypeLabels";
+import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
 import { ROUTES } from "../../../constants";
 import type { UserData } from "../../../types";
 import { extractAccessibleSections } from "../../../shared/navigation/extractAccessibleSections";
@@ -23,12 +24,6 @@ export interface MemberWelcomePageProps {
   userData: UserData | null;
   userEmail?: string | null;
   sectionsData?: GetSectionsForUserData;
-}
-
-function formatEventWhen(startDateTime: string, endDateTime: string): string {
-  const start = new Date(startDateTime);
-  const end = new Date(endDateTime);
-  return `${start.toLocaleString()} – ${end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
 }
 
 export default function MemberWelcomePage({
@@ -93,7 +88,7 @@ export default function MemberWelcomePage({
                       {event.title}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
-                      {formatEventWhen(event.startDateTime, event.endDateTime)}
+                      {formatSectionEventWhen(event.startDateTime, event.endDateTime)}
                     </Typography>
                     <Typography variant="body2" color="text.secondary">
                       {event.sectionName}

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -4,6 +4,10 @@ import type { UUIDString } from "@dataconnect/generated";
 import { SectionType } from "@dataconnect/generated";
 import { dataConnect } from "../../../config/firebase";
 import type { AccessibleSection } from "../../../shared/navigation/extractAccessibleSections";
+import {
+  isUpcomingSectionEvent,
+  sortUpcomingSectionEvents,
+} from "../../../shared/utils/sectionEventDisplay";
 
 export interface UpcomingEventRow {
   id: string;
@@ -89,13 +93,9 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
         );
 
         const now = Date.now();
-        const upcoming = results
-          .flat()
-          .filter((event) => new Date(event.endDateTime).getTime() >= now)
-          .sort(
-            (a, b) =>
-              new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime()
-          );
+        const upcoming = sortUpcomingSectionEvents(
+          results.flat().filter((event) => isUpcomingSectionEvent(event, now))
+        );
 
         if (alive) {
           setEvents(upcoming);

--- a/src/shared/utils/__tests__/sectionEventDisplay.test.ts
+++ b/src/shared/utils/__tests__/sectionEventDisplay.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatSectionEventWhen,
+  isUpcomingSectionEvent,
+  partitionSectionEventsByTiming,
+} from "../sectionEventDisplay";
+
+const nowMs = new Date("2026-06-01T12:00:00.000Z").getTime();
+
+describe("sectionEventDisplay", () => {
+  it("treats events as upcoming until endDateTime has passed", () => {
+    expect(
+      isUpcomingSectionEvent(
+        { endDateTime: "2026-06-01T13:00:00.000Z" },
+        nowMs
+      )
+    ).toBe(true);
+    expect(
+      isUpcomingSectionEvent(
+        { endDateTime: "2026-06-01T11:00:00.000Z" },
+        nowMs
+      )
+    ).toBe(false);
+  });
+
+  it("partitions and sorts upcoming soonest-first and past most-recent-first", () => {
+    const { upcoming, past } = partitionSectionEventsByTiming(
+      [
+        {
+          id: "past-old",
+          title: "Old",
+          startDateTime: "2026-01-01T18:00:00.000Z",
+          endDateTime: "2026-01-01T22:00:00.000Z",
+        },
+        {
+          id: "upcoming-later",
+          title: "Later",
+          startDateTime: "2026-08-01T18:00:00.000Z",
+          endDateTime: "2026-08-01T22:00:00.000Z",
+        },
+        {
+          id: "past-recent",
+          title: "Recent past",
+          startDateTime: "2026-05-01T18:00:00.000Z",
+          endDateTime: "2026-05-01T22:00:00.000Z",
+        },
+        {
+          id: "upcoming-soon",
+          title: "Soon",
+          startDateTime: "2026-07-01T18:00:00.000Z",
+          endDateTime: "2026-07-01T22:00:00.000Z",
+        },
+      ],
+      nowMs
+    );
+
+    expect(upcoming.map((e) => e.id)).toEqual(["upcoming-soon", "upcoming-later"]);
+    expect(past.map((e) => e.id)).toEqual(["past-recent", "past-old"]);
+  });
+
+  it("formats event date/time for display", () => {
+    const formatted = formatSectionEventWhen(
+      "2026-07-01T18:00:00.000Z",
+      "2026-07-01T22:00:00.000Z"
+    );
+    expect(formatted).toContain("–");
+    expect(formatted.length).toBeGreaterThan(10);
+  });
+});

--- a/src/shared/utils/sectionEventDisplay.ts
+++ b/src/shared/utils/sectionEventDisplay.ts
@@ -1,0 +1,59 @@
+export interface SectionEventListItem {
+  id: string;
+  title: string;
+  location?: string | null;
+  guestOfHonour?: string | null;
+  startDateTime: string;
+  endDateTime: string;
+  /** Optional hero image URL when Event.imageUrl is added to schema/admin UI. */
+  imageUrl?: string | null;
+}
+
+/**
+ * Upcoming events: endDateTime is still in the future (includes events currently in progress).
+ * Matches the welcome dashboard rule in useUpcomingEventsForUser (#232).
+ */
+export function isUpcomingSectionEvent(
+  event: Pick<SectionEventListItem, "endDateTime">,
+  nowMs = Date.now()
+): boolean {
+  return new Date(event.endDateTime).getTime() >= nowMs;
+}
+
+export function sortUpcomingSectionEvents<T extends SectionEventListItem>(events: T[]): T[] {
+  return [...events].sort(
+    (a, b) => new Date(a.startDateTime).getTime() - new Date(b.startDateTime).getTime()
+  );
+}
+
+/** Past events: most recently ended first. */
+export function sortPastSectionEvents<T extends SectionEventListItem>(events: T[]): T[] {
+  return [...events].sort(
+    (a, b) => new Date(b.endDateTime).getTime() - new Date(a.endDateTime).getTime()
+  );
+}
+
+export function partitionSectionEventsByTiming<T extends SectionEventListItem>(
+  events: T[],
+  nowMs = Date.now()
+): { upcoming: T[]; past: T[] } {
+  const upcoming: T[] = [];
+  const past: T[] = [];
+  for (const event of events) {
+    if (isUpcomingSectionEvent(event, nowMs)) {
+      upcoming.push(event);
+    } else {
+      past.push(event);
+    }
+  }
+  return {
+    upcoming: sortUpcomingSectionEvents(upcoming),
+    past: sortPastSectionEvents(past),
+  };
+}
+
+export function formatSectionEventWhen(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  return `${start.toLocaleString()} – ${end.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}`;
+}


### PR DESCRIPTION
## Summary
- Replace the member section events table with a responsive card grid (`SectionEventCard`).
- Default list shows **upcoming events only** (rule: `endDateTime >= now`, same as welcome dashboard #232); past events are available via **View past events**, ordered most-recent-first.
- Extract shared event display helpers (`sectionEventDisplay.ts`) used by section events list and welcome dashboard.
- Cards support optional `imageUrl` when schema/admin tooling is added later; no image block shown until then.

Closes #233 (epic #231).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run`
- [ ] Manual: EVENTS section → Events tab shows upcoming cards only
- [ ] Manual: **View past events** shows ended events with subdued styling
- [ ] Manual: click card opens event detail; Back to events returns to list
- [ ] Manual: empty states for no upcoming / no past events


Made with [Cursor](https://cursor.com)