### PR TITLE
Sections list: card layout with descriptions (#238)

### DIFF
--- a/src/features/sections/components/SectionListCard.tsx
+++ b/src/features/sections/components/SectionListCard.tsx
@@ -1,0 +1,55 @@
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from "@mui/material";
+import type { SectionType } from "@dataconnect/generated";
+import { getSectionTypeLabel } from "../../../shared/utils/sectionTypeLabels";
+
+export interface SectionListCardSection {
+  id: string;
+  name: string;
+  type: SectionType;
+  description?: string | null;
+}
+
+export interface SectionListCardProps {
+  section: SectionListCardSection;
+  onSelect: (sectionId: string) => void;
+}
+
+export default function SectionListCard({ section, onSelect }: SectionListCardProps) {
+  const description = section.description?.trim() || "No description.";
+
+  return (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+      <CardActionArea
+        onClick={() => onSelect(section.id)}
+        sx={{ height: "100%", textAlign: "left" }}
+      >
+        <CardContent>
+          <Typography variant="overline" color="text.secondary">
+            {getSectionTypeLabel(section.type)}
+          </Typography>
+          <Typography variant="subtitle1" fontWeight={600} component="h2">
+            {section.name}
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{
+              mt: 1,
+              display: "-webkit-box",
+              WebkitLineClamp: 3,
+              WebkitBoxOrient: "vertical",
+              overflow: "hidden",
+            }}
+          >
+            {description}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+}

--- a/src/features/sections/components/SectionsList.tsx
+++ b/src/features/sections/components/SectionsList.tsx
@@ -1,17 +1,8 @@
 import { useState, useMemo, useEffect } from "react";
 import {
   Box,
-  Typography,
   Alert,
   CircularProgress,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
-  Chip,
   Button,
 } from "@mui/material";
 import { useGetSectionsForUser, useListSections } from "@dataconnect/generated/react";
@@ -23,7 +14,7 @@ import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import type { SectionType, SectionUserGroupPurpose } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
-import { getSectionTypeLabel, isMembersSectionType } from "../../../shared/utils/sectionTypeLabels";
+import SectionListCard from "./SectionListCard";
 import "../../../shared/components/PageContainer.css";
 
 interface SectionsListProps {
@@ -207,58 +198,24 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
           {searchTerm ? "No sections match your search." : "No sections available."}
         </Alert>
       ) : (
-        <TableContainer component={Paper} sx={{ mt: 2 }}>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell>Name</TableCell>
-                <TableCell>Type</TableCell>
-                <TableCell>Description</TableCell>
-                <TableCell align="right">Actions</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {filteredSections.map((section) => (
-                <TableRow
-                  key={section.id}
-                  hover
-                  sx={{ cursor: "pointer" }}
-                  onClick={() => onSelectSection(section.id)}
-                >
-                  <TableCell>
-                    <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                      {section.name}
-                    </Typography>
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={getSectionTypeLabel(section.type)}
-                      size="small"
-                      color={isMembersSectionType(section.type) ? "primary" : "secondary"}
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {section.description || "—"}
-                    </Typography>
-                  </TableCell>
-                  <TableCell align="right">
-                    <Button
-                      variant="outlined"
-                      size="small"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectSection(section.id);
-                      }}
-                    >
-                      View
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
+        <Box
+          component="ul"
+          sx={{
+            listStyle: "none",
+            m: 0,
+            p: 0,
+            mt: 2,
+            display: "grid",
+            gap: 2,
+            gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr" },
+          }}
+        >
+          {filteredSections.map((section) => (
+            <Box component="li" key={section.id} sx={{ minWidth: 0 }}>
+              <SectionListCard section={section} onSelect={onSelectSection} />
+            </Box>
+          ))}
+        </Box>
       )}
     </Box>
   );

--- a/src/features/sections/components/__tests__/SectionsList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionsList.test.tsx
@@ -373,7 +373,7 @@ describe('SectionsList', () => {
       expect(screen.getByText('Test Section')).toBeInTheDocument();
     });
 
-    const viewButton = screen.getByRole('button', { name: /view/i });
+    const viewButton = screen.getByRole('button', { name: /test section/i });
     await user.click(viewButton);
 
     expect(mockOnSelectSection).toHaveBeenCalledWith('section-1');


### PR DESCRIPTION
## Summary
- Replace the member-facing sections table with a responsive card grid (`SectionListCard`).
- Each card shows human-readable section type, name, and description excerpt; the whole card navigates to section detail.
- Search, empty states, and retry behaviour unchanged. Admin browse via `SectionsList` uses the same cards; admin manage surfaces remain table-based.

Closes #238 (epic #231).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run` (SectionsList tests)
- [ ] Manual: `/sections` shows cards with type, name, description
- [ ] Manual: search filters cards; empty states work
- [ ] Manual: click card opens section detail


Made with [Cursor](https://cursor.com)