### PR TITLE
Contextual back navigation and breadcrumbs (#248)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import {
   selectedAdminSectionId as getSelectedAdminSectionId,
   selectedAdminUserGroupId as getSelectedAdminUserGroupId,
 } from "./shared/appShell/appRoutingHelpers";
+import { getSectionReturnTo, sectionDetailLocationState } from "./shared/navigation/sectionNavigationState";
 import { useAppAuthSession } from "./shared/appShell/useAppAuthSession";
 import { useCheckoutQueryState } from "./shared/appShell/useCheckoutQueryState";
 import { useOnlineStatus } from "./shared/appShell/useOnlineStatus";
@@ -62,7 +63,7 @@ function SectionDetailRoute() {
   }
 
   const handleBack = () => {
-    navigateBackOrHelper(ROUTES.SECTIONS, location, navigate);
+    navigateBackOrHelper(getSectionReturnTo(location.state), location, navigate);
   };
 
   return <SectionDetail sectionId={sectionId} onBack={handleBack} />;
@@ -505,7 +506,14 @@ function AppContent() {
                   path={ROUTES.SECTIONS}
                   element={protectedRoute(
                       <Suspense fallback={<LoadingFallback />}>
-                        <SectionsList onBack={() => navigateBackOr(ROUTES.HOME)} onSelectSection={(sectionId) => navigate(`/sections/${sectionId}`)} />
+                        <SectionsList
+                          onBack={() => navigateBackOr(ROUTES.HOME)}
+                          onSelectSection={(sectionId) =>
+                            navigate(`/sections/${sectionId}`, {
+                              state: sectionDetailLocationState(ROUTES.SECTIONS),
+                            })
+                          }
+                        />
                       </Suspense>
                   )}
                 />

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -7,6 +7,7 @@ import type { GetSectionsForUserData } from "@dataconnect/generated";
 import { SectionType } from "@dataconnect/generated";
 import App from "../App";
 import { ROUTES } from "../constants";
+import { sectionDetailLocationState } from "../shared/navigation/sectionNavigationState";
 import { createMockUser } from "../test-utils/mocks/firebase";
 
 let currentUser: User | null = null;
@@ -351,6 +352,19 @@ describe("App routing", () => {
     const user = userEvent.setup();
 
     renderApp([ROUTES.HOME, "/sections/section-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME));
+  });
+
+  it("falls back to home when section detail was opened from welcome", async () => {
+    signInEnabledUser();
+    const user = userEvent.setup();
+
+    renderApp([{ pathname: "/sections/section-1", state: sectionDetailLocationState(ROUTES.HOME) }]);
 
     expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Back" }));

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -26,8 +26,9 @@ import { useNavigate } from "react-router-dom";
 import { createTicketCheckoutSession, getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
 import type { SectionUserGroupPurpose, UUIDString } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
-import { ITEMS_PER_PAGE } from "../../../constants";
+import { ITEMS_PER_PAGE, ROUTES } from "../../../constants";
 import "../../../shared/components/PageContainer.css";
+import NavigationBreadcrumbs from "../../../shared/components/NavigationBreadcrumbs";
 import { getSectionAdminDestination } from "../utils/sectionDetailAdminNavigation";
 import {
   getDefaultSectionDetailTab,
@@ -333,6 +334,41 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     setActiveTab("events");
   };
 
+  const handleBackToEvents = useCallback(() => {
+    setSelectedEventId(null);
+    setActiveTab("events");
+  }, []);
+
+  const handleHeaderBack = useCallback(() => {
+    if (selectedEventId) {
+      handleBackToEvents();
+      return;
+    }
+    onBack();
+  }, [selectedEventId, handleBackToEvents, onBack]);
+
+  const eventTitle = eventDetailData?.event?.title;
+  const pageTitle =
+    selectedEventId && eventTitle ? eventTitle : loadedSection?.name ?? "Section Details";
+  const headerBreadcrumbs = useMemo(() => {
+    if (!loadedSection) {
+      return null;
+    }
+    const items = [{ label: "Home", to: ROUTES.HOME }];
+    if (selectedEventId) {
+      return (
+        <NavigationBreadcrumbs
+          items={[
+            ...items,
+            { label: loadedSection.name, onClick: handleBackToEvents },
+            { label: eventTitle ?? "Event" },
+          ]}
+        />
+      );
+    }
+    return <NavigationBreadcrumbs items={[...items, { label: loadedSection.name }]} />;
+  }, [loadedSection, selectedEventId, eventTitle, handleBackToEvents]);
+
   if (loadingSection || loadingMembers || loadingUserGroups) {
     return (
       <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
@@ -379,7 +415,12 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
 
   return (
     <Box className="page-container" sx={{ backgroundColor: colors.background, minHeight: "100vh" }}>
-      <PageHeader title={section.name} onBack={onBack} adminAction={sectionAdminAction} />
+      <PageHeader
+        title={pageTitle}
+        onBack={handleHeaderBack}
+        adminAction={sectionAdminAction}
+        breadcrumbs={headerBreadcrumbs}
+      />
 
       <Tabs
         value={activeTab}
@@ -438,7 +479,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
             isError={errorEventDetail}
             hasCurrentUser={Boolean(currentUser)}
             startingCheckoutId={startingCheckoutId}
-            onBackToEvents={() => setSelectedEventId(null)}
+            onBackToEvents={handleBackToEvents}
             onRetry={() => refetchEventDetail()}
             onStartCheckout={(ticketTypeId) => void handleStartCheckout(ticketTypeId)}
             onBookingComplete={() => {

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -230,7 +230,7 @@ describe('SectionDetail', () => {
     const user = userEvent.setup();
 
     await waitFor(() => {
-      expect(screen.getByText('Test Section')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Test Section', level: 4 })).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole('tab', { name: 'About' }));
@@ -598,7 +598,7 @@ describe('SectionDetail', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Back to events')).toBeInTheDocument();
-      expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Annual Dinner', level: 4 })).toBeInTheDocument();
       expect(screen.getByText('Main Hall')).toBeInTheDocument();
       expect(screen.getByText('Jane Doe')).toBeInTheDocument();
       expect(screen.getByText('Ticket types')).toBeInTheDocument();
@@ -606,6 +606,92 @@ describe('SectionDetail', () => {
       expect(screen.getByText('Member ticket')).toBeInTheDocument();
       expect(screen.getByText('Standard Access')).toBeInTheDocument();
     });
+  });
+
+  it('should show breadcrumbs and return to events list when header Back is clicked from event detail', async () => {
+    const eventId = 'event-1';
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        purposeLinks: [],
+      },
+    };
+    const mockEventsData = {
+      section: {
+        id: sectionId,
+        events: [
+          {
+            id: eventId,
+            title: 'Annual Dinner',
+            ...upcomingEventTimes,
+            location: 'Main Hall',
+            guestOfHonour: null,
+          },
+        ],
+      },
+    };
+    const mockEventDetailData = {
+      event: {
+        id: eventId,
+        title: 'Annual Dinner',
+        ...upcomingEventTimes,
+        location: 'Main Hall',
+        guestOfHonour: null,
+        maxGuestsWithoutModeratorApproval: null,
+        ticketTypes: [],
+      },
+    };
+
+    mockGetSectionById({
+      data: mockSectionData,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetEventsForSection({
+      data: mockEventsData,
+      isLoading: false,
+      isError: false,
+    });
+
+    mockGetEventById({
+      data: mockEventDetailData,
+      isLoading: false,
+      isError: false,
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /annual dinner/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('navigation', { name: 'Breadcrumb' })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Annual Dinner', level: 4 })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Back' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Events Section', level: 4 })).toBeInTheDocument();
+      expect(screen.queryByText('Back to events')).not.toBeInTheDocument();
+    });
+
+    expect(mockOnBack).not.toHaveBeenCalled();
   });
 
   it('should return to events list when Back to events is clicked', async () => {

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -15,6 +15,7 @@ import { colors } from "../../../config/colors";
 import { getSectionTypeLabel } from "../../../shared/utils/sectionTypeLabels";
 import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
 import { ROUTES } from "../../../constants";
+import { sectionDetailLocationState } from "../../../shared/navigation/sectionNavigationState";
 import type { UserData } from "../../../types";
 import { extractAccessibleSections } from "../../../shared/navigation/extractAccessibleSections";
 import { getMemberDisplayName } from "../../../shared/utils/userDisplayName";
@@ -81,6 +82,7 @@ export default function MemberWelcomePage({
                 <CardActionArea
                   component={RouterLink}
                   to={`/sections/${event.sectionId}`}
+                  state={sectionDetailLocationState(ROUTES.HOME)}
                   sx={{ textAlign: "left" }}
                 >
                   <CardContent>
@@ -127,6 +129,7 @@ export default function MemberWelcomePage({
                 <CardActionArea
                   component={RouterLink}
                   to={`/sections/${section.id}`}
+                  state={sectionDetailLocationState(ROUTES.HOME)}
                   sx={{ height: "100%", textAlign: "left" }}
                 >
                   <CardContent>

--- a/src/shared/components/NavigationBreadcrumbs.tsx
+++ b/src/shared/components/NavigationBreadcrumbs.tsx
@@ -1,0 +1,82 @@
+import { Breadcrumbs, Link, Typography } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+
+export interface NavigationBreadcrumbItem {
+  label: string;
+  to?: string;
+  onClick?: () => void;
+}
+
+export interface NavigationBreadcrumbsProps {
+  items: NavigationBreadcrumbItem[];
+}
+
+export default function NavigationBreadcrumbs({ items }: NavigationBreadcrumbsProps) {
+  return (
+    <Breadcrumbs
+      aria-label="Breadcrumb"
+      sx={{
+        mb: 1,
+        "& .MuiBreadcrumbs-li": {
+          maxWidth: { xs: "8rem", sm: "none" },
+        },
+        "& .MuiBreadcrumbs-li:last-of-type .MuiTypography-root": {
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        },
+      }}
+    >
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+        const key = `${item.label}-${index}`;
+
+        if (isLast || (!item.to && !item.onClick)) {
+          return (
+            <Typography key={key} color="text.primary" variant="body2" noWrap>
+              {item.label}
+            </Typography>
+          );
+        }
+
+        if (item.to) {
+          return (
+            <Link
+              key={key}
+              component={RouterLink}
+              to={item.to}
+              underline="hover"
+              color="inherit"
+              variant="body2"
+              noWrap
+            >
+              {item.label}
+            </Link>
+          );
+        }
+
+        return (
+          <Link
+            key={key}
+            component="button"
+            type="button"
+            onClick={item.onClick}
+            underline="hover"
+            color="inherit"
+            variant="body2"
+            sx={{
+              border: 0,
+              background: "none",
+              cursor: "pointer",
+              p: 0,
+              font: "inherit",
+              textAlign: "left",
+            }}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </Breadcrumbs>
+  );
+}

--- a/src/shared/components/PageHeader.tsx
+++ b/src/shared/components/PageHeader.tsx
@@ -17,6 +17,7 @@ interface PageHeaderProps {
   title: string;
   onBack: () => void;
   adminAction?: PageHeaderAdminAction;
+  breadcrumbs?: ReactNode;
 }
 
 interface PageHeaderAdminActionProviderProps {
@@ -32,24 +33,27 @@ export function PageHeaderAdminActionProvider({ value, children }: PageHeaderAdm
   );
 }
 
-export default function PageHeader({ title, onBack, adminAction: adminActionOverride }: PageHeaderProps) {
+export default function PageHeader({ title, onBack, adminAction: adminActionOverride, breadcrumbs }: PageHeaderProps) {
   const contextAdminAction = useContext(PageHeaderAdminActionContext);
   const adminAction = adminActionOverride ?? contextAdminAction;
 
   return (
-    <Box className="page-header">
-      <Typography variant="h4" className="page-header-title">
-        {title}
-      </Typography>
-      <Box className="page-header-actions">
-        {adminAction.visible && (
-          <Button variant="contained" startIcon={<AdminPanelSettings />} onClick={adminAction.onClick}>
-            Admin
+    <Box sx={{ mb: 3 }}>
+      {breadcrumbs}
+      <Box className="page-header" sx={{ mb: 0 }}>
+        <Typography variant="h4" className="page-header-title">
+          {title}
+        </Typography>
+        <Box className="page-header-actions">
+          {adminAction.visible && (
+            <Button variant="contained" startIcon={<AdminPanelSettings />} onClick={adminAction.onClick}>
+              Admin
+            </Button>
+          )}
+          <Button variant="outlined" onClick={onBack}>
+            Back
           </Button>
-        )}
-        <Button variant="outlined" onClick={onBack}>
-          Back
-        </Button>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/shared/components/__tests__/NavigationBreadcrumbs.test.tsx
+++ b/src/shared/components/__tests__/NavigationBreadcrumbs.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import NavigationBreadcrumbs from "../NavigationBreadcrumbs";
+
+describe("NavigationBreadcrumbs", () => {
+  it("renders linked and current breadcrumb items", () => {
+    render(
+      <MemoryRouter>
+        <NavigationBreadcrumbs
+          items={[
+            { label: "Home", to: "/" },
+            { label: "Signals", onClick: vi.fn() },
+            { label: "Annual Dinner" },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Home" })).toHaveAttribute("href", "/");
+    expect(screen.getByRole("button", { name: "Signals" })).toBeInTheDocument();
+    expect(screen.getByText("Annual Dinner")).toBeInTheDocument();
+  });
+
+  it("calls onClick for intermediate breadcrumb actions", async () => {
+    const onSectionClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <NavigationBreadcrumbs
+          items={[
+            { label: "Home", to: "/" },
+            { label: "Signals", onClick: onSectionClick },
+            { label: "Annual Dinner" },
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Signals" }));
+    expect(onSectionClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
+++ b/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { GetSectionsForUserData } from "@dataconnect/generated";
 import { ROUTES } from "../../../constants";
 import { buildNavigationLinks } from "../buildNavigationLinks";
+import { sectionDetailLocationState } from "../sectionNavigationState";
+
+const homeSectionState = sectionDetailLocationState(ROUTES.HOME);
 
 function sectionsData(overrides: Partial<GetSectionsForUserData> = {}): GetSectionsForUserData {
   return {
@@ -60,7 +63,10 @@ describe("buildNavigationLinks", () => {
       } as Partial<GetSectionsForUserData>),
     });
 
-    expect(links.sections).toEqual([{ label: "My Payments", to: ROUTES.MY_PAYMENTS }, { label: "Signals", to: "/sections/section-1" }]);
+    expect(links.sections).toEqual([
+      { label: "My Payments", to: ROUTES.MY_PAYMENTS },
+      { label: "Signals", to: "/sections/section-1", state: homeSectionState },
+    ]);
     expect(links.admin).toEqual([]);
   });
 
@@ -91,6 +97,7 @@ describe("buildNavigationLinks", () => {
       {
         label: "Signals",
         to: "/sections/section-1",
+        state: homeSectionState,
         children: [
           {
             label: "Administer",
@@ -137,6 +144,7 @@ describe("buildNavigationLinks", () => {
       {
         label: "Events",
         to: "/sections/section-2",
+        state: homeSectionState,
         children: [
           {
             label: "Administer",
@@ -221,12 +229,16 @@ describe("buildNavigationLinks", () => {
     });
 
     expect(nonAdmin.admin).toEqual([]);
-    expect(nonAdmin.sections).toEqual([{ label: "My Payments", to: ROUTES.MY_PAYMENTS }, { label: "Signals", to: "/sections/section-1" }]);
+    expect(nonAdmin.sections).toEqual([
+      { label: "My Payments", to: ROUTES.MY_PAYMENTS },
+      { label: "Signals", to: "/sections/section-1", state: homeSectionState },
+    ]);
     expect(admin.sections).toEqual([
       { label: "My Payments", to: ROUTES.MY_PAYMENTS },
       {
         label: "Signals",
         to: "/sections/section-1",
+        state: homeSectionState,
         children: [
           {
             label: "Administer",
@@ -299,6 +311,7 @@ describe("buildNavigationLinks", () => {
       {
         label: "Alpha",
         to: "/sections/section-1",
+        state: homeSectionState,
         children: [
           {
             label: "Administer",
@@ -310,6 +323,7 @@ describe("buildNavigationLinks", () => {
       {
         label: "Zulu",
         to: "/sections/section-2",
+        state: homeSectionState,
         children: [
           {
             label: "Administer",

--- a/src/shared/navigation/__tests__/sectionNavigationState.test.ts
+++ b/src/shared/navigation/__tests__/sectionNavigationState.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { ROUTES } from "../../../constants";
+import { getSectionReturnTo, sectionDetailLocationState } from "../sectionNavigationState";
+
+describe("sectionNavigationState", () => {
+  it("defaults section back navigation to the sections list", () => {
+    expect(getSectionReturnTo(null)).toBe(ROUTES.SECTIONS);
+    expect(getSectionReturnTo({})).toBe(ROUTES.SECTIONS);
+  });
+
+  it("reads the configured return route from location state", () => {
+    expect(getSectionReturnTo(sectionDetailLocationState(ROUTES.HOME))).toBe(ROUTES.HOME);
+    expect(getSectionReturnTo(sectionDetailLocationState(ROUTES.SECTIONS))).toBe(ROUTES.SECTIONS);
+  });
+
+  it("ignores unknown return routes", () => {
+    expect(getSectionReturnTo({ sectionReturnTo: "/elsewhere" })).toBe(ROUTES.SECTIONS);
+  });
+});

--- a/src/shared/navigation/buildNavigationLinks.ts
+++ b/src/shared/navigation/buildNavigationLinks.ts
@@ -1,6 +1,7 @@
 import type { GetSectionsForUserData, SectionUserGroupPurpose } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
 import { ROUTES } from "../../constants";
+import { sectionDetailLocationState } from "./sectionNavigationState";
 
 export interface NavigationLink {
   label: string;
@@ -38,7 +39,11 @@ function addSectionLink(map: Map<string, NavigationLink>, link: SectionLinkSourc
     return;
   }
   const label = section.name || "Untitled section";
-  map.set(section.id, { label, to: `/sections/${section.id}` });
+  map.set(section.id, {
+    label,
+    to: `/sections/${section.id}`,
+    state: sectionDetailLocationState(ROUTES.HOME),
+  });
 }
 
 function markSectionAdministerable(map: Map<string, boolean>, link: SectionLinkSource) {

--- a/src/shared/navigation/sectionNavigationState.ts
+++ b/src/shared/navigation/sectionNavigationState.ts
@@ -1,0 +1,17 @@
+import { ROUTES } from "../../constants";
+
+export interface SectionDetailLocationState {
+  sectionReturnTo?: string;
+}
+
+export function getSectionReturnTo(state: unknown, defaultRoute: string = ROUTES.SECTIONS): string {
+  const returnTo = (state as SectionDetailLocationState | null)?.sectionReturnTo;
+  if (returnTo === ROUTES.HOME || returnTo === ROUTES.SECTIONS) {
+    return returnTo;
+  }
+  return defaultRoute;
+}
+
+export function sectionDetailLocationState(returnTo: string): SectionDetailLocationState {
+  return { sectionReturnTo: returnTo };
+}


### PR DESCRIPTION
## Summary
- Add `sectionReturnTo` location state so section detail back falls back to home (welcome/nav) or `/sections` (sections list) instead of always using browser history or a single default.
- Header **Back** on event detail returns to the section events list without leaving the section; page title and breadcrumbs reflect the current depth.
- Add `NavigationBreadcrumbs` (`Home / Section / Event`) on section detail pages.

Closes #248 (epic #231).

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -- --run`
- [ ] Manual: welcome → section → Back → home
- [ ] Manual: sections list → section → Back → sections list
- [ ] Manual: section → event → header Back → events list (not home)
- [ ] Manual: breadcrumbs visible on event detail; section name link returns to events list


Made with [Cursor](https://cursor.com)