### PR TITLE
Add post-booking status summary on event detail (#247)

### DIFF
--- a/src/features/sections/components/EventBookingStatusSummary.tsx
+++ b/src/features/sections/components/EventBookingStatusSummary.tsx
@@ -1,0 +1,184 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import type { GetMyBookingsForEventData } from "@dataconnect/generated";
+import { colors } from "../../../config/colors";
+import { ROUTES } from "../../../constants/routes";
+import { getBookingStatusLabel } from "../../../shared/utils/paymentStatusLabels";
+import {
+  getEventBookingNextSteps,
+  getEventBookingStatusHeading,
+  summarizeEventBookingPayment,
+  summarizeGuestTicketRequests,
+  type EventBookingPaymentAdjustmentInput,
+  type EventBookingPaymentOrderInput,
+  type EventBookingPaymentSummary,
+} from "../utils/eventBookingStatusSummary";
+
+type TerminalBooking = NonNullable<GetMyBookingsForEventData["user"]>["bookings"][number];
+
+export interface EventBookingStatusSummaryProps {
+  booking: TerminalBooking;
+  eventId: string;
+  eventTitle: string;
+  ticketOrders: EventBookingPaymentOrderInput[];
+  paymentAdjustments: EventBookingPaymentAdjustmentInput[];
+  onEditBooking: () => void;
+  onPayNow?: (ticketTypeId: string) => void;
+  payingTicketTypeId?: string | null;
+}
+
+function paymentChipColor(
+  summary: EventBookingPaymentSummary
+): "success" | "warning" | "error" | "info" | "default" {
+  switch (summary.severity) {
+    case "success":
+      return "success";
+    case "warning":
+      return "warning";
+    case "error":
+      return "error";
+    case "info":
+      return "info";
+    default:
+      return "default";
+  }
+}
+
+function guestStatusLabel(summary: ReturnType<typeof summarizeGuestTicketRequests>): string {
+  if (summary.pendingCount > 0) {
+    return `${summary.pendingCount} pending review`;
+  }
+  if (summary.approvedCount > 0 && summary.rejectedCount > 0) {
+    return `${summary.approvedCount} approved, ${summary.rejectedCount} declined`;
+  }
+  if (summary.approvedCount > 0) {
+    return `${summary.approvedCount} approved`;
+  }
+  if (summary.rejectedCount > 0) {
+    return `${summary.rejectedCount} declined`;
+  }
+  return "None";
+}
+
+export default function EventBookingStatusSummary({
+  booking,
+  eventId,
+  eventTitle,
+  ticketOrders,
+  paymentAdjustments,
+  onEditBooking,
+  onPayNow,
+  payingTicketTypeId,
+}: EventBookingStatusSummaryProps) {
+  const paymentSummary = summarizeEventBookingPayment({
+    booking,
+    eventId,
+    ticketOrders,
+    adjustments: paymentAdjustments,
+  });
+  const guestSummary = summarizeGuestTicketRequests(booking.guestTicketRequests);
+  const nextSteps = getEventBookingNextSteps({
+    bookingStatus: booking.status,
+    paymentSummary,
+    guestSummary,
+  });
+  const showPayNow =
+    Boolean(onPayNow) &&
+    paymentSummary.unpaidTicketTypeId != null &&
+    paymentSummary.kind !== "paid" &&
+    paymentSummary.kind !== "adjustment_refund";
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mt: 3 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1.5, fontWeight: 600 }}>
+        Your booking
+      </Typography>
+
+      <Stack direction="row" flexWrap="wrap" gap={1} sx={{ mb: 2 }}>
+        <Chip
+          size="small"
+          label={getBookingStatusLabel(booking.status)}
+          color={booking.status === "CONFIRMED" ? "success" : "default"}
+        />
+        <Chip size="small" label={`Revision ${booking.revisionNumber}`} variant="outlined" />
+        <Chip size="small" label={paymentSummary.label} color={paymentChipColor(paymentSummary)} />
+        <Chip
+          size="small"
+          label={`Guest requests: ${guestStatusLabel(guestSummary)}`}
+          color={guestSummary.hasPending ? "warning" : "default"}
+          variant={guestSummary.hasPending ? "filled" : "outlined"}
+        />
+      </Stack>
+
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        {getEventBookingStatusHeading(booking)} for <strong>{eventTitle}</strong>.
+      </Typography>
+
+      {(booking.lines ?? []).length > 0 ? (
+        <Table size="small" sx={{ mb: 2 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Ticket</TableCell>
+              <TableCell>Guest</TableCell>
+              <TableCell>Price</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {(booking.lines ?? []).map((line) => (
+              <TableRow key={line.id}>
+                <TableCell>{line.ticketType?.title ?? "—"}</TableCell>
+                <TableCell>{line.guestDisplayName ?? "—"}</TableCell>
+                <TableCell>{line.ticketType?.price != null ? String(line.ticketType.price) : "—"}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      ) : null}
+
+      <Alert
+        severity={
+          paymentSummary.kind === "failed"
+            ? "error"
+            : guestSummary.hasPending || paymentSummary.kind === "pending" || paymentSummary.kind === "not_started"
+              ? "warning"
+              : "info"
+        }
+        sx={{ mb: 2 }}
+      >
+        {nextSteps}
+      </Alert>
+
+      <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+        {showPayNow ? (
+          <Button
+            variant="contained"
+            disabled={payingTicketTypeId === paymentSummary.unpaidTicketTypeId}
+            onClick={() => onPayNow?.(paymentSummary.unpaidTicketTypeId as string)}
+            sx={{ backgroundColor: colors.callToAction }}
+          >
+            {payingTicketTypeId === paymentSummary.unpaidTicketTypeId ? "Starting checkout…" : "Pay now"}
+          </Button>
+        ) : null}
+        <Button variant="outlined" onClick={onEditBooking}>
+          Edit booking
+        </Button>
+        <Button component={RouterLink} to={ROUTES.MY_PAYMENTS} variant="text">
+          View in My Bookings
+        </Button>
+      </Box>
+    </Paper>
+  );
+}

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -19,7 +19,9 @@ import {
 } from "@mui/material";
 import {
   useGetCurrentUser,
+  useGetMyBookingPaymentAdjustments,
   useGetMyBookingsForEvent,
+  useGetMyTicketOrders,
   useGetUserAccessGroups,
 } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
@@ -28,10 +30,15 @@ import type { GetEventByIdData, GetSectionByIdData, UUIDString } from "@dataconn
 import { BookingStatus, TicketAudience } from "@dataconnect/generated";
 import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import { getBookingStatusLabel } from "../../../shared/utils/paymentStatusLabels";
-import { getSectionMembersMerged, submitEventBooking } from "../../../shared/utils/firebaseFunctions";
+import {
+  createTicketCheckoutSession,
+  getSectionMembersMerged,
+  submitEventBooking,
+} from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
 import { evaluateBookingGatePreview, userMatchesUserGroup } from "../utils/bookingEligibility";
 import AdditionalGuestRequestSection from "./AdditionalGuestRequestSection";
+import EventBookingStatusSummary from "./EventBookingStatusSummary";
 
 type EventDetail = NonNullable<GetEventByIdData["event"]>;
 type SectionDetail = NonNullable<GetSectionByIdData["section"]>;
@@ -67,7 +74,8 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
   const [seatingOptions, setSeatingOptions] = useState<Array<{ id: string; label: string }>>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-  const [editingExistingBooking, setEditingExistingBooking] = useState(false);
+  const [isEditingBooking, setIsEditingBooking] = useState(false);
+  const [payingTicketTypeId, setPayingTicketTypeId] = useState<string | null>(null);
 
   const idempotencyKeyRef = useRef<string | null>(null);
   const hydratedBookingIdRef = useRef<string | null>(null);
@@ -128,6 +136,21 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       }, null);
   }, [myBookingsData]);
 
+  const { data: ticketOrdersData } = useGetMyTicketOrders(dataConnect, {
+    enabled: Boolean(existingTerminalBooking),
+  });
+  const { data: paymentAdjustmentsData } = useGetMyBookingPaymentAdjustments(dataConnect, {
+    enabled: Boolean(existingTerminalBooking),
+  });
+
+  const bookingPaymentAdjustments = useMemo(() => {
+    if (!existingTerminalBooking) return [];
+    const bookingRow = paymentAdjustmentsData?.user?.bookings?.find(
+      (row) => row.id === existingTerminalBooking.id
+    );
+    return bookingRow?.adjustments ?? [];
+  }, [existingTerminalBooking, paymentAdjustmentsData]);
+
   /** Server draft for this event — reuse its idempotency key after refresh (new random UUID would conflict). */
   const existingDraft = useMemo(() => {
     const list = myBookingsData?.user?.bookings ?? [];
@@ -150,14 +173,14 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     const booking = existingTerminalBooking;
     if (!booking) {
       hydratedBookingIdRef.current = null;
-      setEditingExistingBooking(false);
+      setIsEditingBooking(false);
       return;
     }
     if (hydratedBookingIdRef.current === booking.id) {
       return;
     }
     hydratedBookingIdRef.current = booking.id;
-    setEditingExistingBooking(true);
+    setIsEditingBooking(false);
     const memberLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.MEMBER);
     const guestLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.GUEST);
     setMemberTicketTypeId(memberLine?.ticketType?.id ?? null);
@@ -303,6 +326,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
         accommodationNote,
       });
       await refetchMyBookings();
+      setIsEditingBooking(false);
       onBookingComplete?.();
     } catch (err: unknown) {
       const code = extractCallableErrorCode(err);
@@ -344,6 +368,25 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     }
   };
 
+  const handlePayNow = async (ticketTypeId: string) => {
+    setPayingTicketTypeId(ticketTypeId);
+    try {
+      const { url } = await createTicketCheckoutSession({ ticketTypeId, quantity: 1 });
+      window.location.assign(url);
+    } catch (err: unknown) {
+      const message =
+        err && typeof (err as { message?: string }).message === "string"
+          ? (err as { message: string }).message
+          : "Could not start checkout. Please try again.";
+      setSubmitError(message);
+    } finally {
+      setPayingTicketTypeId(null);
+    }
+  };
+
+  const showBookingSummary = Boolean(existingTerminalBooking) && !isEditingBooking;
+  const editingExistingBooking = isEditingBooking && Boolean(existingTerminalBooking);
+
   if (loadingProfile || loadingBookings) {
     return (
       <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
@@ -378,32 +421,66 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
 
   return (
     <Box sx={{ mt: 3 }}>
-      <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
-        {editingExistingBooking ? "Edit your booking" : "Book this event"}
-      </Typography>
-      {editingExistingBooking && existingTerminalBooking ? (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          Editing revision {existingTerminalBooking.revisionNumber} (
-          {getBookingStatusLabel(existingTerminalBooking.status).toLowerCase()}).
-          Saving will create a new booking revision.
-        </Alert>
-      ) : null}
+      {showBookingSummary && existingTerminalBooking ? (
+        <>
+          <EventBookingStatusSummary
+            booking={existingTerminalBooking}
+            eventId={event.id}
+            eventTitle={event.title}
+            ticketOrders={ticketOrdersData?.user?.ticketOrders ?? []}
+            paymentAdjustments={bookingPaymentAdjustments}
+            onEditBooking={() => setIsEditingBooking(true)}
+            onPayNow={(ticketTypeId) => void handlePayNow(ticketTypeId)}
+            payingTicketTypeId={payingTicketTypeId}
+          />
+          {submitError ? (
+            <Alert severity="error" sx={{ mt: 2 }} onClose={() => setSubmitError(null)}>
+              {submitError}
+            </Alert>
+          ) : null}
+          <Box sx={{ mt: 2 }}>
+            <AdditionalGuestRequestSection
+              bookingId={existingTerminalBooking.id}
+              eventTitle={event.title}
+              maxGuestsWithoutModeratorApproval={event.maxGuestsWithoutModeratorApproval}
+              guestTicketTypes={guestTicketTypes.map((tt) => ({
+                id: tt.id,
+                title: tt.title,
+                price: tt.price ?? null,
+              }))}
+              requests={existingTerminalBooking.guestTicketRequests ?? []}
+              onRequestCreated={() => void refetchMyBookings()}
+            />
+          </Box>
+        </>
+      ) : (
+        <>
+          <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
+            {editingExistingBooking ? "Edit your booking" : "Book this event"}
+          </Typography>
+          {editingExistingBooking && existingTerminalBooking ? (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              Editing revision {existingTerminalBooking.revisionNumber} (
+              {getBookingStatusLabel(existingTerminalBooking.status).toLowerCase()}).
+              Saving will create a new booking revision.
+            </Alert>
+          ) : null}
 
-      <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
-        {STEPS.map((label) => (
-          <Step key={label}>
-            <StepLabel>{label}</StepLabel>
-          </Step>
-        ))}
-      </Stepper>
+          <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+            {STEPS.map((label) => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
 
-      {submitError && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setSubmitError(null)}>
-          {submitError}
-        </Alert>
-      )}
+          {submitError && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setSubmitError(null)}>
+              {submitError}
+            </Alert>
+          )}
 
-      <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+          <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
         {activeStep === 0 && (
           <FormControl component="fieldset" fullWidth>
             <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
@@ -617,22 +694,13 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
           Start over
         </Button>
       )}
-      {existingTerminalBooking ? (
-        <Box sx={{ mt: 2 }}>
-          <AdditionalGuestRequestSection
-            bookingId={existingTerminalBooking.id}
-            eventTitle={event.title}
-            maxGuestsWithoutModeratorApproval={event.maxGuestsWithoutModeratorApproval}
-            guestTicketTypes={guestTicketTypes.map((tt) => ({
-              id: tt.id,
-              title: tt.title,
-              price: tt.price ?? null,
-            }))}
-            requests={existingTerminalBooking.guestTicketRequests ?? []}
-            onRequestCreated={() => void refetchMyBookings()}
-          />
-        </Box>
+      {editingExistingBooking ? (
+        <Button size="small" onClick={() => setIsEditingBooking(false)} disabled={submitting} sx={{ mt: 1, ml: 1 }}>
+          Cancel editing
+        </Button>
       ) : null}
+        </>
+      )}
     </Box>
   );
 }

--- a/src/features/sections/components/__tests__/EventBookingStatusSummary.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingStatusSummary.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReactElement } from "react";
+import { render, screen } from "../../../../test-utils";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import EventBookingStatusSummary from "../EventBookingStatusSummary";
+import { BookingStatus, TicketOrderStatus } from "@dataconnect/generated";
+
+describe("EventBookingStatusSummary", () => {
+  const onEditBooking = vi.fn();
+  const onPayNow = vi.fn();
+
+  const renderSummary = (ui: ReactElement) =>
+    render(<MemoryRouter>{ui}</MemoryRouter>);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows pending payment and guest review actions", () => {
+    renderSummary(
+      <EventBookingStatusSummary
+        booking={{
+          id: "booking-1",
+          status: BookingStatus.SUBMITTED,
+          revisionNumber: 2,
+          lines: [
+            {
+              id: "line-1",
+              guestDisplayName: null,
+              ticketType: { id: "ticket-member", title: "Member standard", price: 50 },
+            },
+          ],
+          guestTicketRequests: [{ id: "gtr-1", status: "PENDING", requestedGuestCount: 1 }],
+        } as never}
+        eventId="event-1"
+        eventTitle="Annual Dinner"
+        ticketOrders={[]}
+        paymentAdjustments={[]}
+        onEditBooking={onEditBooking}
+        onPayNow={onPayNow}
+      />
+    );
+
+    expect(screen.getByText("Your booking")).toBeInTheDocument();
+    expect(screen.getByText("Payment not started")).toBeInTheDocument();
+    expect(screen.getByText(/1 pending review/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pay now" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit booking" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View in My Bookings" })).toBeInTheDocument();
+  });
+
+  it("hides Pay now when payment is complete", () => {
+    renderSummary(
+      <EventBookingStatusSummary
+        booking={{
+          id: "booking-1",
+          status: BookingStatus.CONFIRMED,
+          revisionNumber: 1,
+          lines: [
+            {
+              id: "line-1",
+              guestDisplayName: null,
+              ticketType: { id: "ticket-member", title: "Member standard", price: 50 },
+            },
+          ],
+          guestTicketRequests: [],
+        } as never}
+        eventId="event-1"
+        eventTitle="Annual Dinner"
+        ticketOrders={[
+          {
+            status: TicketOrderStatus.PAID,
+            event: { id: "event-1" },
+            ticketType: { id: "ticket-member" },
+          },
+        ]}
+        paymentAdjustments={[]}
+        onEditBooking={onEditBooking}
+        onPayNow={onPayNow}
+      />
+    );
+
+    expect(screen.getByText("Paid")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Pay now" })).not.toBeInTheDocument();
+  });
+
+  it("calls edit handler from action button", async () => {
+    const user = userEvent.setup();
+    renderSummary(
+      <EventBookingStatusSummary
+        booking={{
+          id: "booking-1",
+          status: BookingStatus.SUBMITTED,
+          revisionNumber: 1,
+          lines: [],
+          guestTicketRequests: [],
+        } as never}
+        eventId="event-1"
+        eventTitle="Annual Dinner"
+        ticketOrders={[]}
+        paymentAdjustments={[]}
+        onEditBooking={onEditBooking}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Edit booking" }));
+    expect(onEditBooking).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "../../../../test-utils";
+import { MemoryRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import EventBookingWizard from "../EventBookingWizard";
 import { BookingStatus, TicketAudience } from "@dataconnect/generated";
@@ -9,6 +10,8 @@ import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 vi.mock("@dataconnect/generated/react", () => ({
   useGetCurrentUser: vi.fn(),
   useGetMyBookingsForEvent: vi.fn(),
+  useGetMyTicketOrders: vi.fn(),
+  useGetMyBookingPaymentAdjustments: vi.fn(),
   useGetUserAccessGroups: vi.fn(),
 }));
 
@@ -22,6 +25,7 @@ vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
     bookingId: "booking-new",
     status: "SUBMITTED",
   }),
+  createTicketCheckoutSession: vi.fn(),
 }));
 
 describe("EventBookingWizard", () => {
@@ -69,12 +73,59 @@ describe("EventBookingWizard", () => {
       isLoading: false,
       refetch: vi.fn().mockResolvedValue({ data: { user: { bookings: [] } } }),
     } as never);
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue({
+      data: { user: { ticketOrders: [] } },
+      isLoading: false,
+    } as never);
+    vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue({
+      data: { user: { bookings: [] } },
+      isLoading: false,
+    } as never);
+  });
+
+  it("shows booking summary by default for submitted bookings", () => {
+    render(
+      <MemoryRouter>
+        <EventBookingWizard
+        section={{
+          id: "section-1",
+          name: "Events",
+          type: "EVENTS",
+          description: null,
+          purposeLinks: [
+            { purposes: ["ACCESS", "BOOKER"], userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] } },
+          ],
+        } as never}
+        event={{
+          id: "event-1",
+          title: "Annual Dinner",
+          bookingStartDateTime: "2025-01-01T00:00:00Z",
+          bookingEndDateTime: "2030-01-01T00:00:00Z",
+          maxGuestsWithoutModeratorApproval: 1,
+          ticketTypes: [
+            {
+              id: "ticket-member",
+              title: "Member standard",
+              audience: TicketAudience.MEMBER,
+              price: 50,
+              userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+            },
+          ],
+        } as never}
+      />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText("Your booking")).toBeInTheDocument();
+    expect(screen.getAllByText("Revision 2").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Edit your booking")).not.toBeInTheDocument();
   });
 
   it("submits booking edits with base revision metadata", async () => {
     const user = userEvent.setup();
     render(
-      <EventBookingWizard
+      <MemoryRouter>
+        <EventBookingWizard
         section={{
           id: "section-1",
           name: "Events",
@@ -108,8 +159,10 @@ describe("EventBookingWizard", () => {
           ],
         } as never}
       />
+      </MemoryRouter>
     );
 
+    await user.click(screen.getByRole("button", { name: "Edit booking" }));
     expect(screen.getByText("Edit your booking")).toBeInTheDocument();
     expect(screen.getByText(/editing revision 2/i)).toBeInTheDocument();
 

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -18,6 +18,8 @@ vi.mock('@dataconnect/generated/react', () => ({
   useGetEventById: vi.fn(),
   useGetCurrentUser: vi.fn(),
   useGetMyBookingsForEvent: vi.fn(),
+  useGetMyTicketOrders: vi.fn(),
+  useGetMyBookingPaymentAdjustments: vi.fn(),
 }));
 
 vi.mock('../../../../shared/utils/firebaseFunctions', () => ({
@@ -96,6 +98,18 @@ function mockGetMyBookingsForEvent(overrides: DataConnectQueryResultOverrides) {
   );
 }
 
+function mockGetMyTicketOrders(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>(overrides)
+  );
+}
+
+function mockGetMyBookingPaymentAdjustments(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetMyBookingPaymentAdjustments>(overrides)
+  );
+}
+
 describe('SectionDetail', () => {
   const mockOnBack = vi.fn();
   const sectionId = 'section-1';
@@ -138,6 +152,16 @@ describe('SectionDetail', () => {
       isError: false,
     });
     mockGetMyBookingsForEvent({
+      data: { user: { bookings: [] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetMyTicketOrders({
+      data: { user: { ticketOrders: [] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetMyBookingPaymentAdjustments({
       data: { user: { bookings: [] } },
       isLoading: false,
       isError: false,
@@ -544,6 +568,8 @@ describe('SectionDetail', () => {
         id: eventId,
         title: 'Annual Dinner',
         ...upcomingEventTimes,
+        bookingStartDateTime: '2020-01-01T00:00:00Z',
+        bookingEndDateTime: '2030-12-31T23:59:59Z',
         location: 'Main Hall',
         guestOfHonour: 'Jane Doe',
         maxGuestsWithoutModeratorApproval: null,
@@ -608,6 +634,145 @@ describe('SectionDetail', () => {
     });
   });
 
+  it('should show booking status summary when member has a submitted booking', async () => {
+    const eventId = 'event-1';
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        description: 'Events description',
+        purposeLinks: [
+          {
+            purposes: ['ACCESS', 'BOOKER'],
+            userGroup: { id: 'group-1', membershipStatuses: ['REGULAR'] },
+          },
+        ],
+      },
+    };
+    const mockEventsData = {
+      section: {
+        id: sectionId,
+        events: [
+          {
+            id: eventId,
+            title: 'Annual Dinner',
+            ...upcomingEventTimes,
+            location: 'Main Hall',
+            guestOfHonour: 'Jane Doe',
+          },
+        ],
+      },
+    };
+    const mockEventDetailData = {
+      event: {
+        id: eventId,
+        title: 'Annual Dinner',
+        ...upcomingEventTimes,
+        bookingStartDateTime: '2020-01-01T00:00:00Z',
+        bookingEndDateTime: '2030-12-31T23:59:59Z',
+        location: 'Main Hall',
+        guestOfHonour: 'Jane Doe',
+        maxGuestsWithoutModeratorApproval: 1,
+        ticketTypes: [
+          {
+            id: 'tt-1',
+            title: 'Standard',
+            description: 'Standard ticket',
+            price: 25,
+            sortOrder: 0,
+            audience: 'MEMBER',
+            userGroup: { id: 'group-1', name: 'Standard Access', membershipStatuses: ['REGULAR'] },
+          },
+        ],
+      },
+    };
+
+    mockGetSectionById({
+      data: mockSectionData,
+      isLoading: false,
+      isError: false,
+    });
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [{ userGroup: { id: 'group-1' } }] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetEventsForSection({
+      data: mockEventsData,
+      isLoading: false,
+      isError: false,
+    });
+    mockGetEventById({
+      data: mockEventDetailData,
+      isLoading: false,
+      isError: false,
+    });
+    mockGetMyBookingsForEvent({
+      data: {
+        user: {
+          bookings: [
+            {
+              id: 'booking-1',
+              status: 'SUBMITTED',
+              revisionNumber: 2,
+              clientSubmissionKey: null,
+              bookerDietaryNote: null,
+              sitNextToUserIds: [],
+              accommodationRequested: false,
+              accommodationNote: null,
+              lines: [
+                {
+                  id: 'line-1',
+                  sortOrder: 0,
+                  guestDisplayName: null,
+                  dietaryNote: null,
+                  ticketType: {
+                    id: 'tt-1',
+                    title: 'Standard',
+                    audience: 'MEMBER',
+                    price: 25,
+                  },
+                },
+              ],
+              guestTicketRequests: [{ id: 'gtr-1', status: 'PENDING', requestedGuestCount: 1 }],
+            },
+          ],
+        },
+      },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetMyTicketOrders({
+      data: { user: { ticketOrders: [] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetMyBookingPaymentAdjustments({
+      data: { user: { bookings: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Annual Dinner')).toBeInTheDocument();
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /annual dinner/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Your booking')).toBeInTheDocument();
+      expect(screen.getByText('Payment not started')).toBeInTheDocument();
+      expect(screen.getByText(/1 pending review/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Pay now' })).toBeInTheDocument();
+      expect(screen.queryByText('Book this event')).not.toBeInTheDocument();
+    });
+  });
+
   it('should show breadcrumbs and return to events list when header Back is clicked from event detail', async () => {
     const eventId = 'event-1';
     const mockSectionData = {
@@ -637,6 +802,8 @@ describe('SectionDetail', () => {
         id: eventId,
         title: 'Annual Dinner',
         ...upcomingEventTimes,
+        bookingStartDateTime: '2020-01-01T00:00:00Z',
+        bookingEndDateTime: '2030-12-31T23:59:59Z',
         location: 'Main Hall',
         guestOfHonour: null,
         maxGuestsWithoutModeratorApproval: null,

--- a/src/features/sections/utils/__tests__/eventBookingStatusSummary.test.ts
+++ b/src/features/sections/utils/__tests__/eventBookingStatusSummary.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  BookingPaymentAdjustmentStatus,
+  BookingStatus,
+  GuestTicketRequestStatus,
+  TicketOrderStatus,
+} from "@dataconnect/generated";
+import {
+  getEventBookingNextSteps,
+  summarizeEventBookingPayment,
+  summarizeGuestTicketRequests,
+} from "../eventBookingStatusSummary";
+
+const booking = {
+  id: "booking-1",
+  status: BookingStatus.SUBMITTED,
+  revisionNumber: 2,
+  lines: [
+    {
+      id: "line-1",
+      ticketType: { id: "ticket-member", title: "Member", price: 50, audience: "MEMBER" },
+      guestDisplayName: null,
+    },
+  ],
+  guestTicketRequests: [],
+} as never;
+
+describe("summarizeGuestTicketRequests", () => {
+  it("counts pending, approved, and rejected requests", () => {
+    const summary = summarizeGuestTicketRequests([
+      { status: GuestTicketRequestStatus.PENDING },
+      { status: GuestTicketRequestStatus.APPROVED },
+      { status: GuestTicketRequestStatus.REJECTED },
+    ] as never);
+
+    expect(summary).toEqual({
+      pendingCount: 1,
+      approvedCount: 1,
+      rejectedCount: 1,
+      hasPending: true,
+    });
+  });
+});
+
+describe("summarizeEventBookingPayment", () => {
+  it("returns not started when no orders exist for booked ticket types", () => {
+    const summary = summarizeEventBookingPayment({
+      booking,
+      eventId: "event-1",
+      ticketOrders: [],
+      adjustments: [],
+    });
+
+    expect(summary.kind).toBe("not_started");
+    expect(summary.unpaidTicketTypeId).toBe("ticket-member");
+  });
+
+  it("returns pending when a matching order is pending payment", () => {
+    const summary = summarizeEventBookingPayment({
+      booking,
+      eventId: "event-1",
+      ticketOrders: [
+        {
+          status: TicketOrderStatus.PENDING,
+          event: { id: "event-1" },
+          ticketType: { id: "ticket-member" },
+        },
+      ],
+      adjustments: [],
+    });
+
+    expect(summary.kind).toBe("pending");
+    expect(summary.label).toBe("Pending payment");
+  });
+
+  it("returns paid when a matching order is paid", () => {
+    const summary = summarizeEventBookingPayment({
+      booking,
+      eventId: "event-1",
+      ticketOrders: [
+        {
+          status: TicketOrderStatus.PAID,
+          event: { id: "event-1" },
+          ticketType: { id: "ticket-member" },
+        },
+      ],
+      adjustments: [],
+    });
+
+    expect(summary.kind).toBe("paid");
+  });
+
+  it("prioritizes pending booking payment adjustments", () => {
+    const summary = summarizeEventBookingPayment({
+      booking,
+      eventId: "event-1",
+      ticketOrders: [
+        {
+          status: TicketOrderStatus.PAID,
+          event: { id: "event-1" },
+          ticketType: { id: "ticket-member" },
+        },
+      ],
+      adjustments: [{ status: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE }],
+    });
+
+    expect(summary.kind).toBe("adjustment_charge");
+  });
+});
+
+describe("getEventBookingNextSteps", () => {
+  it("highlights unpaid and pending guest review states", () => {
+    const message = getEventBookingNextSteps({
+      bookingStatus: BookingStatus.SUBMITTED,
+      paymentSummary: summarizeEventBookingPayment({
+        booking,
+        eventId: "event-1",
+        ticketOrders: [],
+        adjustments: [],
+      }),
+      guestSummary: summarizeGuestTicketRequests([
+        { status: GuestTicketRequestStatus.PENDING },
+      ] as never),
+    });
+
+    expect(message).toMatch(/complete payment/i);
+    expect(message).toMatch(/moderator review/i);
+  });
+});

--- a/src/features/sections/utils/eventBookingStatusSummary.ts
+++ b/src/features/sections/utils/eventBookingStatusSummary.ts
@@ -1,0 +1,222 @@
+import {
+  BookingPaymentAdjustmentStatus,
+  BookingStatus,
+  GuestTicketRequestStatus,
+  TicketOrderStatus,
+  type GetMyBookingsForEventData,
+} from "@dataconnect/generated";
+import {
+  getBookingPaymentAdjustmentStatusLabel,
+  getBookingStatusLabel,
+  getTicketOrderStatusLabel,
+} from "../../../shared/utils/paymentStatusLabels";
+
+type TerminalBooking = NonNullable<GetMyBookingsForEventData["user"]>["bookings"][number];
+
+export interface EventBookingPaymentOrderInput {
+  status: TicketOrderStatus | string;
+  event?: { id: string } | null;
+  ticketType?: { id: string } | null;
+}
+
+export interface EventBookingPaymentAdjustmentInput {
+  status: BookingPaymentAdjustmentStatus | string;
+}
+
+export type EventBookingPaymentSummaryKind =
+  | "paid"
+  | "pending"
+  | "failed"
+  | "not_started"
+  | "partial"
+  | "adjustment_charge"
+  | "adjustment_refund";
+
+export interface EventBookingPaymentSummary {
+  kind: EventBookingPaymentSummaryKind;
+  label: string;
+  severity: "success" | "warning" | "error" | "info" | "default";
+  unpaidTicketTypeId: string | null;
+}
+
+export interface EventBookingGuestRequestSummary {
+  pendingCount: number;
+  approvedCount: number;
+  rejectedCount: number;
+  hasPending: boolean;
+}
+
+function ticketTypeIdsFromBooking(booking: TerminalBooking): string[] {
+  return (booking.lines ?? [])
+    .map((line) => line.ticketType?.id)
+    .filter((id): id is string => Boolean(id));
+}
+
+export function summarizeGuestTicketRequests(
+  requests: TerminalBooking["guestTicketRequests"]
+): EventBookingGuestRequestSummary {
+  const list = requests ?? [];
+  return {
+    pendingCount: list.filter((r) => r.status === GuestTicketRequestStatus.PENDING).length,
+    approvedCount: list.filter((r) => r.status === GuestTicketRequestStatus.APPROVED).length,
+    rejectedCount: list.filter((r) => r.status === GuestTicketRequestStatus.REJECTED).length,
+    hasPending: list.some((r) => r.status === GuestTicketRequestStatus.PENDING),
+  };
+}
+
+export function summarizeEventBookingPayment(params: {
+  booking: TerminalBooking;
+  eventId: string;
+  ticketOrders: EventBookingPaymentOrderInput[];
+  adjustments: EventBookingPaymentAdjustmentInput[];
+}): EventBookingPaymentSummary {
+  const { booking, eventId, ticketOrders, adjustments } = params;
+  const pendingCharge = adjustments.find(
+    (a) => a.status === BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE
+  );
+  if (pendingCharge) {
+    return {
+      kind: "adjustment_charge",
+      label: getBookingPaymentAdjustmentStatusLabel(pendingCharge.status),
+      severity: "warning",
+      unpaidTicketTypeId: null,
+    };
+  }
+
+  const pendingRefund = adjustments.find(
+    (a) => a.status === BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND
+  );
+  if (pendingRefund) {
+    return {
+      kind: "adjustment_refund",
+      label: getBookingPaymentAdjustmentStatusLabel(pendingRefund.status),
+      severity: "info",
+      unpaidTicketTypeId: null,
+    };
+  }
+
+  const bookedTicketTypeIds = ticketTypeIdsFromBooking(booking);
+  if (bookedTicketTypeIds.length === 0) {
+    return {
+      kind: "not_started",
+      label: "Payment not started",
+      severity: "warning",
+      unpaidTicketTypeId: null,
+    };
+  }
+
+  const eventOrders = ticketOrders.filter((order) => order.event?.id === eventId);
+  const relevantOrders = eventOrders.filter((order) =>
+    bookedTicketTypeIds.includes(order.ticketType?.id ?? "")
+  );
+
+  if (relevantOrders.length === 0) {
+    const memberLine = (booking.lines ?? []).find((line) => line.ticketType?.id);
+    return {
+      kind: "not_started",
+      label: "Payment not started",
+      severity: "warning",
+      unpaidTicketTypeId: memberLine?.ticketType?.id ?? null,
+    };
+  }
+
+  const statusesByTicketType = new Map<string, TicketOrderStatus[]>();
+  for (const order of relevantOrders) {
+    const ticketTypeId = order.ticketType?.id;
+    if (!ticketTypeId) continue;
+    const existing = statusesByTicketType.get(ticketTypeId) ?? [];
+    existing.push(order.status as TicketOrderStatus);
+    statusesByTicketType.set(ticketTypeId, existing);
+  }
+
+  const perTypeSummary = bookedTicketTypeIds.map((ticketTypeId) => {
+    const statuses = statusesByTicketType.get(ticketTypeId) ?? [];
+    if (statuses.includes(TicketOrderStatus.PAID)) return "paid" as const;
+    if (statuses.includes(TicketOrderStatus.PENDING)) return "pending" as const;
+    if (statuses.includes(TicketOrderStatus.FAILED)) return "failed" as const;
+    return "missing" as const;
+  });
+
+  const firstUnpaidTicketTypeId = bookedTicketTypeIds.find((_, index) => perTypeSummary[index] !== "paid") ?? null;
+
+  if (perTypeSummary.every((status) => status === "paid")) {
+    return {
+      kind: "paid",
+      label: getTicketOrderStatusLabel(TicketOrderStatus.PAID),
+      severity: "success",
+      unpaidTicketTypeId: null,
+    };
+  }
+
+  if (perTypeSummary.some((status) => status === "failed")) {
+    return {
+      kind: "failed",
+      label: getTicketOrderStatusLabel(TicketOrderStatus.FAILED),
+      severity: "error",
+      unpaidTicketTypeId: firstUnpaidTicketTypeId,
+    };
+  }
+
+  if (perTypeSummary.some((status) => status === "pending")) {
+    return {
+      kind: "pending",
+      label: getTicketOrderStatusLabel(TicketOrderStatus.PENDING),
+      severity: "warning",
+      unpaidTicketTypeId: firstUnpaidTicketTypeId,
+    };
+  }
+
+  if (perTypeSummary.some((status) => status === "paid")) {
+    return {
+      kind: "partial",
+      label: "Partially paid",
+      severity: "warning",
+      unpaidTicketTypeId: firstUnpaidTicketTypeId,
+    };
+  }
+
+  return {
+    kind: "not_started",
+    label: "Payment not started",
+    severity: "warning",
+    unpaidTicketTypeId: firstUnpaidTicketTypeId,
+  };
+}
+
+export function getEventBookingNextSteps(params: {
+  bookingStatus: BookingStatus | string;
+  paymentSummary: EventBookingPaymentSummary;
+  guestSummary: EventBookingGuestRequestSummary;
+}): string {
+  const { bookingStatus, paymentSummary, guestSummary } = params;
+  const steps: string[] = [];
+
+  if (paymentSummary.kind === "pending" || paymentSummary.kind === "not_started" || paymentSummary.kind === "partial") {
+    steps.push("Complete payment to secure your place.");
+  } else if (paymentSummary.kind === "failed") {
+    steps.push("Your last payment attempt failed. Use Pay now to try again.");
+  } else if (paymentSummary.kind === "adjustment_charge") {
+    steps.push("An additional payment is being processed for your latest booking revision.");
+  } else if (paymentSummary.kind === "adjustment_refund") {
+    steps.push("A refund for your booking revision is being processed.");
+  }
+
+  if (guestSummary.hasPending) {
+    steps.push("Your extra guest ticket request is awaiting moderator review.");
+  } else if (guestSummary.rejectedCount > 0 && guestSummary.approvedCount === 0) {
+    steps.push("A guest ticket request was declined. You can submit a revised request below.");
+  }
+
+  if (steps.length === 0) {
+    if (bookingStatus === BookingStatus.CONFIRMED) {
+      return "Your booking is confirmed. You can edit it until the booking window closes.";
+    }
+    return "Your booking is submitted. We'll confirm your place once everything is in order.";
+  }
+
+  return steps.join(" ");
+}
+
+export function getEventBookingStatusHeading(booking: TerminalBooking): string {
+  return `${getBookingStatusLabel(booking.status)} · revision ${booking.revisionNumber}`;
+}


### PR DESCRIPTION
## Summary
- Adds a **Your booking** status panel on event detail when a member has a submitted or confirmed booking, showing booking status, revision, payment state, and guest-request approval at a glance.
- Refactors `EventBookingWizard` to show the summary by default and only open the edit wizard when the member chooses **Edit booking**; **Pay now** starts checkout from the summary.
- **View in My Bookings** links to `/payments` until the dedicated hub in #240 is built.

## Test plan
- [x] Unit tests for payment/guest summary helpers
- [x] Component tests for summary states (unpaid, paid, edit action)
- [x] `EventBookingWizard` tests: summary-first flow and edit-submit path
- [x] `SectionDetail` test: submitted booking shows summary with Pay now and pending guest review
- [x] `npm run build` passes


Made with [Cursor](https://cursor.com)