### PR TITLE
Redesign My Payments for member-friendly payment history (#239)

### DIFF
--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -1,4 +1,18 @@
-import { Alert, Box, Button, Chip, CircularProgress, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useGetMyBookingPaymentAdjustments, useGetMyTicketOrders } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
@@ -10,16 +24,15 @@ import {
 } from "../../../shared/utils/paymentStatusLabels";
 import { getMyTicketOrderStripeArtifactsBatch } from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
+import {
+  formatPaymentAmount,
+  getBookingAdjustmentSummary,
+  getTicketOrderOutcomeMessage,
+  ticketOrderStatusChipColor,
+} from "../utils/myPaymentsDisplay";
 
 interface MyPaymentsProps {
   onBack: () => void;
-}
-
-function statusChipColor(status: string): "success" | "error" | "warning" | "default" {
-  if (status === "PAID") return "success";
-  if (status === "FAILED") return "error";
-  if (status === "REFUNDED") return "warning";
-  return "default";
 }
 
 function artifactKey(orderId: string): string {
@@ -33,17 +46,15 @@ function artifactKey(orderId: string): string {
 export default function MyPayments({ onBack }: MyPaymentsProps) {
   const { data, isLoading, isError, error, refetch } = useGetMyTicketOrders(dataConnect);
   const { data: adjustmentsData } = useGetMyBookingPaymentAdjustments(dataConnect, { enabled: !isLoading });
-  const [loadingStripeLinks, setLoadingStripeLinks] = useState(false);
   const [stripeArtifactsByOrderId, setStripeArtifactsByOrderId] = useState<
     Record<string, { receiptUrl: string | null }>
   >({});
   const attemptedStripeArtifactOrderIds = useRef<Set<string>>(new Set());
-  const [stripeArtifactError, setStripeArtifactError] = useState<string | null>(null);
   const orders = useMemo(() => data?.user?.ticketOrders ?? [], [data?.user?.ticketOrders]);
   const bookingAdjustments = (adjustmentsData?.user?.bookings ?? []).flatMap((booking) =>
     (booking.adjustments ?? []).map((adjustment) => ({
       bookingId: booking.id,
-      eventTitle: booking.event?.title ?? "—",
+      eventTitle: booking.event?.title ?? "Event",
       revisionNumber: booking.revisionNumber,
       ...adjustment,
     }))
@@ -63,18 +74,14 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
       attemptedStripeArtifactOrderIds.current.add(artifactKey(orderId));
     }
     const load = async (): Promise<void> => {
-      setLoadingStripeLinks(true);
-      setStripeArtifactError(null);
       try {
         const artifacts = await getMyTicketOrderStripeArtifactsBatch({ orderIds: pendingOrderIds });
         const normalizedArtifacts = Object.fromEntries(
           Object.entries(artifacts.artifactsByOrderId).map(([orderId, value]) => [artifactKey(orderId), value])
         );
         setStripeArtifactsByOrderId((prev) => ({ ...prev, ...normalizedArtifacts }));
-      } catch (error) {
-        setStripeArtifactError(error instanceof Error ? error.message : "Failed to load Stripe links.");
-      } finally {
-        setLoadingStripeLinks(false);
+      } catch {
+        // Receipt links are optional; fail silently on the member UI.
       }
     };
     void load();
@@ -83,111 +90,124 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
   return (
     <Box className="page-container">
       <PageHeader title="My Payments" onBack={onBack} />
-      {stripeArtifactError ? <Alert severity="error">{stripeArtifactError}</Alert> : null}
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Your ticket payments and receipts across events.
+      </Typography>
+
       {isLoading ? (
-        <CircularProgress size={24} />
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress size={28} aria-label="Loading payments" />
+        </Box>
       ) : isError ? (
-        <Alert severity="error" action={<Chip label="Retry" onClick={() => refetch()} clickable size="small" />}>
-          {error instanceof Error ? error.message : "Failed to load payment history."}
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={() => refetch()}>
+              Retry
+            </Button>
+          }
+        >
+          {error instanceof Error ? error.message : "We could not load your payment history. Please try again."}
         </Alert>
       ) : orders.length === 0 ? (
-        <Alert severity="info">No payment orders found yet.</Alert>
+        <Alert severity="info">
+          You have not made any ticket payments yet. After you pay for an event, your receipts will appear here.
+        </Alert>
       ) : (
-        <Box sx={{ display: "grid", gap: 2 }}>
-          <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 2 }}>
-            <Table size="small">
-              <TableHead>
-                <TableRow>
-                  <TableCell>Status</TableCell>
-                  <TableCell>Event</TableCell>
-                  <TableCell>Ticket</TableCell>
-                  <TableCell align="right">Qty</TableCell>
-                  <TableCell align="right">Amount</TableCell>
-                  <TableCell>Lifecycle detail</TableCell>
-                  <TableCell>Stripe artifacts</TableCell>
-                  <TableCell>Updated</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {orders.map((order) => (
-                  <TableRow key={order.id}>
-                    <TableCell>
-                      <Chip
+        <Stack spacing={2}>
+          {orders.map((order) => {
+            const receiptUrl = stripeArtifactsByOrderId[artifactKey(order.id)]?.receiptUrl ?? null;
+            const eventWhen = order.event?.startDateTime
+              ? new Date(order.event.startDateTime).toLocaleString(undefined, {
+                  dateStyle: "medium",
+                  timeStyle: "short",
+                })
+              : null;
+
+            return (
+              <Card key={order.id} variant="outlined">
+                <CardContent>
+                  <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={2} sx={{ mb: 1 }}>
+                    <Chip
+                      size="small"
+                      label={getTicketOrderStatusLabel(order.status)}
+                      color={ticketOrderStatusChipColor(order.status)}
+                    />
+                    {receiptUrl ? (
+                      <Button
+                        variant="outlined"
                         size="small"
-                        label={getTicketOrderStatusLabel(order.status)}
-                        color={statusChipColor(order.status)}
-                      />
-                    </TableCell>
-                    <TableCell>{order.event?.title ?? "—"}</TableCell>
-                    <TableCell>{order.ticketType?.title ?? "—"}</TableCell>
-                    <TableCell align="right">{order.quantity}</TableCell>
-                    <TableCell align="right">
-                      {(order.totalAmountMinor / 100).toFixed(2)} {order.currency.toUpperCase()}
-                    </TableCell>
-                    <TableCell>
-                      {order.status === "FAILED"
-                        ? "Payment attempt failed. You can try booking again."
-                        : order.status === "REFUNDED"
-                          ? `Refunded ${((order.refundedAmountMinor ?? 0) / 100).toFixed(2)} ${order.currency.toUpperCase()}`
-                          : order.disputeStatus
-                            ? `Dispute: ${order.disputeStatus}${order.disputeReason ? ` (${order.disputeReason})` : ""}`
-                            : "Payment settled"}
-                    </TableCell>
-                    <TableCell>
-                      {stripeArtifactsByOrderId[artifactKey(order.id)]?.receiptUrl ? (
-                        <Button
-                          variant="text"
-                          size="small"
-                          onClick={() =>
-                            window.open(stripeArtifactsByOrderId[artifactKey(order.id)].receiptUrl as string, "_blank")
-                          }
-                        >
-                          View receipt
-                        </Button>
-                      ) : null}
-                      {!stripeArtifactsByOrderId[artifactKey(order.id)] && loadingStripeLinks ? (
-                        <Chip size="small" label="Loading links..." />
-                      ) : null}
-                    </TableCell>
-                    <TableCell>{new Date(order.updatedAt).toLocaleString()}</TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+                        onClick={() => window.open(receiptUrl, "_blank", "noopener,noreferrer")}
+                      >
+                        View receipt
+                      </Button>
+                    ) : null}
+                  </Stack>
+
+                  <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+                    {order.event?.title ?? "Event ticket"}
+                  </Typography>
+
+                  {eventWhen ? (
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                      Event: {eventWhen}
+                    </Typography>
+                  ) : null}
+
+                  <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                    {order.ticketType?.title ?? "Ticket"}
+                    {order.quantity > 1 ? ` · ${order.quantity} tickets` : ""}
+                    {" · "}
+                    {formatPaymentAmount(order.totalAmountMinor, order.currency)}
+                  </Typography>
+
+                  <Typography variant="body2" sx={{ mb: 1 }}>
+                    {getTicketOrderOutcomeMessage(order)}
+                  </Typography>
+
+                  <Typography variant="caption" color="text.secondary">
+                    Last updated {new Date(order.updatedAt).toLocaleString()}
+                  </Typography>
+                </CardContent>
+              </Card>
+            );
+          })}
+
           {bookingAdjustments.length > 0 ? (
-            <TableContainer component={Paper} variant="outlined" sx={{ borderRadius: 2 }}>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Adjustment status</TableCell>
-                    <TableCell>Event</TableCell>
-                    <TableCell align="right">Delta</TableCell>
-                    <TableCell>Booking revision</TableCell>
-                    <TableCell>Updated</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
+            <Accordion variant="outlined" disableGutters>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography variant="subtitle2">Booking changes ({bookingAdjustments.length})</Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Stack spacing={1.5}>
                   {bookingAdjustments.map((adjustment) => (
-                    <TableRow key={adjustment.id}>
-                      <TableCell>
+                    <Box key={adjustment.id}>
+                      <Stack direction="row" flexWrap="wrap" gap={1} alignItems="center" sx={{ mb: 0.5 }}>
                         <Chip
                           size="small"
                           label={getBookingPaymentAdjustmentStatusLabel(adjustment.status)}
                           color="warning"
+                          variant="outlined"
                         />
-                      </TableCell>
-                      <TableCell>{adjustment.eventTitle}</TableCell>
-                      <TableCell align="right">{(adjustment.deltaAmountMinor / 100).toFixed(2)} GBP</TableCell>
-                      <TableCell>Rev {adjustment.revisionNumber}</TableCell>
-                      <TableCell>{new Date(adjustment.updatedAt).toLocaleString()}</TableCell>
-                    </TableRow>
+                        <Typography variant="body2" color="text.secondary">
+                          {new Date(adjustment.updatedAt).toLocaleString()}
+                        </Typography>
+                      </Stack>
+                      <Typography variant="body2">
+                        {getBookingAdjustmentSummary({
+                          eventTitle: adjustment.eventTitle,
+                          revisionNumber: adjustment.revisionNumber,
+                          deltaAmountMinor: adjustment.deltaAmountMinor,
+                          status: adjustment.status,
+                        })}
+                      </Typography>
+                    </Box>
                   ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
           ) : null}
-        </Box>
+        </Stack>
       )}
     </Box>
   );

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
 import MyPayments from "../MyPayments";
 import * as reactGenerated from "@dataconnect/generated/react";
 import { dataConnectQueryResult } from "../../../../test-utils/dataConnectMocks";
@@ -24,6 +25,13 @@ describe("MyPayments", () => {
   });
 
   beforeEach(() => {
+    vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyBookingPaymentAdjustments>({
+        data: { user: { id: "u-1", bookings: [] } },
+        isLoading: false,
+        isError: false,
+      })
+    );
     vi.mocked(firebaseFunctions.getMyTicketOrderStripeArtifactsBatch).mockResolvedValue({
       artifactsByOrderId: {
         "order-1": {
@@ -36,7 +44,7 @@ describe("MyPayments", () => {
     });
   });
 
-  it("renders booking adjustment statuses alongside payment history", () => {
+  it("renders payment cards without ops-style table headers", () => {
     vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
       dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
         data: {
@@ -49,11 +57,51 @@ describe("MyPayments", () => {
                 quantity: 1,
                 totalAmountMinor: 2500,
                 currency: "gbp",
+                createdAt: "2026-04-01T12:00:00Z",
                 updatedAt: "2026-04-01T12:00:00Z",
                 refundedAmountMinor: null,
                 disputeStatus: null,
                 disputeReason: null,
-                event: { id: "event-1", title: "Spring Ball" },
+                event: { id: "event-1", title: "Spring Ball", startDateTime: "2026-05-01T18:00:00Z" },
+                ticketType: { id: "ticket-1", title: "Member ticket" },
+              },
+            ],
+          },
+        },
+        isLoading: false,
+        isError: false,
+      })
+    );
+
+    render(<MyPayments onBack={() => undefined} />);
+
+    expect(screen.getByText("Spring Ball")).toBeInTheDocument();
+    expect(screen.getByText(/member ticket/i)).toBeInTheDocument();
+    expect(screen.getByText(/25\.00 GBP/i)).toBeInTheDocument();
+    expect(screen.getByText("Paid")).toBeInTheDocument();
+    expect(screen.queryByText("Lifecycle detail")).not.toBeInTheDocument();
+    expect(screen.queryByText("Stripe artifacts")).not.toBeInTheDocument();
+  });
+
+  it("shows booking changes in a collapsible section", async () => {
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
+        data: {
+          user: {
+            id: "u-1",
+            ticketOrders: [
+              {
+                id: "order-1",
+                status: "PAID",
+                quantity: 1,
+                totalAmountMinor: 2500,
+                currency: "gbp",
+                createdAt: "2026-04-01T12:00:00Z",
+                updatedAt: "2026-04-01T12:00:00Z",
+                refundedAmountMinor: null,
+                disputeStatus: null,
+                disputeReason: null,
+                event: { id: "event-1", title: "Spring Ball", startDateTime: "2026-05-01T18:00:00Z" },
                 ticketType: { id: "ticket-1", title: "Member ticket" },
               },
             ],
@@ -93,14 +141,19 @@ describe("MyPayments", () => {
       })
     );
 
+    const user = userEvent.setup();
     render(<MyPayments onBack={() => undefined} />);
 
-    expect(screen.getByText("Refund pending")).toBeInTheDocument();
-    expect(screen.getByText("Rev 2")).toBeInTheDocument();
-    expect(screen.getByText("-5.00 GBP")).toBeInTheDocument();
+    expect(screen.getByText("Booking changes (1)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /booking changes \(1\)/i }));
+
+    expect(
+      screen.getByText(/Spring Ball \(revision 2\): refund pending — refund of 5\.00 GBP\./i)
+    ).toBeInTheDocument();
   });
 
-  it("auto-loads Stripe links and renders receipt action", async () => {
+  it("auto-loads receipt links and renders View receipt", async () => {
     vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
       dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
         data: {
@@ -113,23 +166,17 @@ describe("MyPayments", () => {
                 quantity: 1,
                 totalAmountMinor: 2500,
                 currency: "gbp",
+                createdAt: "2026-04-01T12:00:00Z",
                 updatedAt: "2026-04-01T12:00:00Z",
                 refundedAmountMinor: null,
                 disputeStatus: null,
                 disputeReason: null,
-                event: { id: "event-1", title: "Spring Ball" },
+                event: { id: "event-1", title: "Spring Ball", startDateTime: "2026-05-01T18:00:00Z" },
                 ticketType: { id: "ticket-1", title: "Member ticket" },
               },
             ],
           },
         },
-        isLoading: false,
-        isError: false,
-      })
-    );
-    vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue(
-      dataConnectQueryResult<typeof reactGenerated.useGetMyBookingPaymentAdjustments>({
-        data: { user: { id: "u-1", bookings: [] } },
         isLoading: false,
         isError: false,
       })
@@ -142,5 +189,19 @@ describe("MyPayments", () => {
       });
     });
     expect(await screen.findByRole("button", { name: "View receipt" })).toBeInTheDocument();
+  });
+
+  it("shows a clear empty state", () => {
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
+        data: { user: { id: "u-1", ticketOrders: [] } },
+        isLoading: false,
+        isError: false,
+      })
+    );
+
+    render(<MyPayments onBack={() => undefined} />);
+
+    expect(screen.getByText(/you have not made any ticket payments yet/i)).toBeInTheDocument();
   });
 });

--- a/src/features/sections/utils/__tests__/myPaymentsDisplay.test.ts
+++ b/src/features/sections/utils/__tests__/myPaymentsDisplay.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { TicketOrderStatus } from "@dataconnect/generated";
+import {
+  formatPaymentAmount,
+  getBookingAdjustmentSummary,
+  getTicketOrderOutcomeMessage,
+} from "../myPaymentsDisplay";
+
+describe("myPaymentsDisplay", () => {
+  it("formats payment amounts", () => {
+    expect(formatPaymentAmount(2500, "gbp")).toBe("25.00 GBP");
+  });
+
+  it("describes failed payments in plain language", () => {
+    expect(
+      getTicketOrderOutcomeMessage({
+        status: TicketOrderStatus.FAILED,
+        currency: "gbp",
+        totalAmountMinor: 2500,
+      })
+    ).toMatch(/did not go through/i);
+  });
+
+  it("describes refunds with amount", () => {
+    expect(
+      getTicketOrderOutcomeMessage({
+        status: TicketOrderStatus.REFUNDED,
+        currency: "gbp",
+        totalAmountMinor: 2500,
+        refundedAmountMinor: 500,
+      })
+    ).toMatch(/refunded 5\.00 GBP/i);
+  });
+
+  it("summarises booking adjustments", () => {
+    expect(
+      getBookingAdjustmentSummary({
+        eventTitle: "Spring Ball",
+        revisionNumber: 2,
+        deltaAmountMinor: -500,
+        status: "PENDING_AUTO_REFUND",
+      })
+    ).toMatch(/spring ball/i);
+    expect(
+      getBookingAdjustmentSummary({
+        eventTitle: "Spring Ball",
+        revisionNumber: 2,
+        deltaAmountMinor: -500,
+        status: "PENDING_AUTO_REFUND",
+      })
+    ).toMatch(/refund pending/i);
+  });
+});

--- a/src/features/sections/utils/myPaymentsDisplay.ts
+++ b/src/features/sections/utils/myPaymentsDisplay.ts
@@ -1,0 +1,57 @@
+import { TicketOrderStatus } from "@dataconnect/generated";
+import { getBookingPaymentAdjustmentStatusLabel } from "../../../shared/utils/paymentStatusLabels";
+
+export interface TicketOrderDisplayInput {
+  status: string;
+  currency: string;
+  totalAmountMinor: number;
+  refundedAmountMinor?: number | null;
+  disputeStatus?: string | null;
+  disputeReason?: string | null;
+}
+
+export function formatPaymentAmount(amountMinor: number, currency: string): string {
+  return `${(amountMinor / 100).toFixed(2)} ${currency.toUpperCase()}`;
+}
+
+export function getTicketOrderOutcomeMessage(order: TicketOrderDisplayInput): string {
+  if (order.status === TicketOrderStatus.FAILED) {
+    return "Your payment did not go through. You can try again from the event page.";
+  }
+  if (order.status === TicketOrderStatus.REFUNDED) {
+    const refunded = order.refundedAmountMinor ?? order.totalAmountMinor;
+    return `We refunded ${formatPaymentAmount(refunded, order.currency)} to your payment method.`;
+  }
+  if (order.status === TicketOrderStatus.PENDING) {
+    return "Waiting for your payment to complete.";
+  }
+  if (order.disputeStatus) {
+    const reason = order.disputeReason ? ` (${order.disputeReason})` : "";
+    return `There is an open dispute on this payment: ${order.disputeStatus}${reason}.`;
+  }
+  if (order.status === TicketOrderStatus.PAID) {
+    return "Payment received. Your ticket is confirmed once booking is complete.";
+  }
+  return "Payment update recorded.";
+}
+
+export function getBookingAdjustmentSummary(params: {
+  eventTitle: string;
+  revisionNumber: number;
+  deltaAmountMinor: number;
+  status: string;
+}): string {
+  const amount = formatPaymentAmount(Math.abs(params.deltaAmountMinor), "gbp");
+  const direction = params.deltaAmountMinor < 0 ? "refund" : "charge";
+  const statusLabel = getBookingPaymentAdjustmentStatusLabel(params.status).toLowerCase();
+  return `${params.eventTitle} (revision ${params.revisionNumber}): ${statusLabel} — ${direction} of ${amount}.`;
+}
+
+export function ticketOrderStatusChipColor(
+  status: string
+): "success" | "error" | "warning" | "default" {
+  if (status === TicketOrderStatus.PAID) return "success";
+  if (status === TicketOrderStatus.FAILED) return "error";
+  if (status === TicketOrderStatus.REFUNDED) return "warning";
+  return "default";
+}


### PR DESCRIPTION
## Summary
- Replaces the ops-style payment table on `/payments` with scannable payment cards showing event, ticket, amount, status, and plain-language outcomes.
- Promotes **View receipt** when Stripe returns a URL; receipt load failures are handled silently on the member UI.
- Moves booking payment adjustments into a collapsible **Booking changes** section with readable summaries.

## Test plan
- [x] `MyPayments.test.tsx` — cards, no internal column headers, accordion adjustments, receipts, empty state
- [x] `myPaymentsDisplay.test.ts` — outcome and adjustment copy helpers
- [x] `npm run build` passes


Made with [Cursor](https://cursor.com)