### PR TITLE
Improve section member directory privacy and presentation (#246)

### DIFF
--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -18,7 +18,6 @@ import { TicketAudience, type GetEventByIdData, type GetEventsForSectionData, ty
 import { colors } from "../../../config/colors";
 import PaginationDisplay from "../../../shared/components/PaginationDisplay";
 import SearchBar from "../../../shared/components/SearchBar";
-import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import {
   ACCESS_GROUP_COLUMN_LABEL,
   GUEST_LIMIT_BEFORE_REVIEW_LABEL,
@@ -29,6 +28,7 @@ import type { SectionMember } from "../utils/sectionHelpers";
 import { partitionSectionEventsByTiming } from "../../../shared/utils/sectionEventDisplay";
 import EventBookingWizard from "./EventBookingWizard";
 import SectionEventCard from "./SectionEventCard";
+import SectionMemberCard from "./SectionMemberCard";
 
 type SectionDetailSection = NonNullable<GetSectionByIdData["section"]>;
 type SectionEventRow = NonNullable<NonNullable<GetEventsForSectionData["section"]>["events"]>[number];
@@ -127,8 +127,11 @@ export function SectionMembersView({
 }: SectionMembersViewProps) {
   return (
     <Box sx={{ mt: 1 }}>
-      <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
+      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
         Members ({allMembersCount})
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Names and membership type are shown by default. Email addresses stay hidden until you choose to show them for a member.
       </Typography>
       <SearchBar
         value={searchTerm}
@@ -148,36 +151,21 @@ export function SectionMembersView({
             Showing {paginatedMembers.length} of {filteredMembers.length} {searchTerm ? "filtered " : ""}members
             {totalPages > 1 && ` (page ${page} of ${totalPages})`}
           </Typography>
-          <TableContainer component={Paper} sx={{ mt: 2 }}>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Name</TableCell>
-                  <TableCell>Email</TableCell>
-                  <TableCell>Membership Status</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {paginatedMembers.map((member) => (
-                  <TableRow key={member.userId}>
-                    <TableCell>
-                      <Typography variant="body1">
-                        {member.firstName} {member.lastName}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Typography variant="body2" color="text.secondary">
-                        {member.email}
-                      </Typography>
-                    </TableCell>
-                    <TableCell>
-                      <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" />
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
+          <Box
+            component="ul"
+            sx={{
+              listStyle: "none",
+              m: 0,
+              p: 0,
+              display: "grid",
+              gap: 2,
+              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" },
+            }}
+          >
+            {paginatedMembers.map((member) => (
+              <SectionMemberCard key={member.userId} member={member} />
+            ))}
+          </Box>
           <PaginationDisplay page={page} totalPages={totalPages} onChange={onPageChange} />
         </>
       )}

--- a/src/features/sections/components/SectionMemberCard.tsx
+++ b/src/features/sections/components/SectionMemberCard.tsx
@@ -7,19 +7,16 @@ export interface SectionMemberCardProps {
   member: SectionMember;
 }
 
-export function formatSectionMemberName(member: Pick<SectionMember, "firstName" | "lastName">): string {
-  return `${member.firstName} ${member.lastName}`.trim();
-}
-
 export default function SectionMemberCard({ member }: SectionMemberCardProps) {
   const [showEmail, setShowEmail] = useState(false);
+  const fullName = `${member.firstName} ${member.lastName}`.trim();
 
   return (
     <Card variant="outlined" component="li" sx={{ height: "100%" }}>
       <CardContent>
         <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1} flexWrap="wrap">
           <Typography variant="subtitle1" component="h3" fontWeight={600}>
-            {formatSectionMemberName(member)}
+            {fullName}
           </Typography>
           <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" />
         </Stack>

--- a/src/features/sections/components/SectionMemberCard.tsx
+++ b/src/features/sections/components/SectionMemberCard.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { Button, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
+import type { SectionMember } from "../utils/sectionHelpers";
+
+export interface SectionMemberCardProps {
+  member: SectionMember;
+}
+
+export function formatSectionMemberName(member: Pick<SectionMember, "firstName" | "lastName">): string {
+  return `${member.firstName} ${member.lastName}`.trim();
+}
+
+export default function SectionMemberCard({ member }: SectionMemberCardProps) {
+  const [showEmail, setShowEmail] = useState(false);
+
+  return (
+    <Card variant="outlined" component="li" sx={{ height: "100%" }}>
+      <CardContent>
+        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1} flexWrap="wrap">
+          <Typography variant="subtitle1" component="h3" fontWeight={600}>
+            {formatSectionMemberName(member)}
+          </Typography>
+          <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" />
+        </Stack>
+        {showEmail ? (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, wordBreak: "break-word" }}>
+            {member.email}
+          </Typography>
+        ) : null}
+        <Button
+          size="small"
+          variant="text"
+          onClick={() => setShowEmail((visible) => !visible)}
+          aria-expanded={showEmail}
+          sx={{ mt: 0.5, px: 0, minWidth: 0 }}
+        >
+          {showEmail ? "Hide email" : "Show email"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -315,10 +315,11 @@ describe('SectionDetail', () => {
 
     expect(screen.getByText('John Doe')).toBeInTheDocument();
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
-    expect(screen.getByText('john@example.com')).toBeInTheDocument();
-    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('john@example.com')).not.toBeInTheDocument();
+    expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
     expect(screen.getByText('Regular')).toBeInTheDocument();
     expect(screen.getByText('Reserve')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Show email' })).toHaveLength(2);
   });
 
   it('should show subscribe button when user can subscribe', async () => {

--- a/src/features/sections/components/__tests__/SectionMemberCard.test.tsx
+++ b/src/features/sections/components/__tests__/SectionMemberCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import SectionMemberCard from "../SectionMemberCard";
+import { MembershipStatus } from "@dataconnect/generated";
+
+describe("SectionMemberCard", () => {
+  const member = {
+    userId: "user-1",
+    firstName: "John",
+    lastName: "Doe",
+    email: "john@example.com",
+    membershipStatus: MembershipStatus.REGULAR,
+  };
+
+  it("shows name and membership label without email by default", () => {
+    render(<SectionMemberCard member={member} />);
+
+    expect(screen.getByRole("heading", { name: "John Doe" })).toBeInTheDocument();
+    expect(screen.getByText("Regular")).toBeInTheDocument();
+    expect(screen.queryByText("john@example.com")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show email" })).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("reveals email when Show email is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SectionMemberCard member={member} />);
+
+    await user.click(screen.getByRole("button", { name: "Show email" }));
+
+    expect(screen.getByText("john@example.com")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide email" })).toHaveAttribute("aria-expanded", "true");
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the section **Members** tab table with a responsive card grid suited for club networking rather than admin export.
- **Privacy decision:** names and human-readable membership labels (`Regular`, `Reserve`, etc.) are shown by default; each member's email stays hidden until **Show email** is clicked.
- Search, pagination, and refresh are unchanged — members can still be filtered by name or email even when addresses are collapsed.

## Test plan
- [ ] Open a MEMBERS section → **Members** tab → confirm card layout (no email column)
- [ ] Verify membership chips show readable labels, not raw enum strings
- [ ] Click **Show email** on a card → email appears; **Hide email** collapses it again
- [ ] Search by name and by email still filters correctly
- [ ] Pagination works when member count exceeds one page
- [ ] `npm test -- --run SectionMemberCard SectionDetail` and `npm run build` pass


Made with [Cursor](https://cursor.com)