### PR TITLE
Redesign event detail and unify booking, guests, and payment flow (#234)

### DIFF
--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -17,6 +17,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
 import {
   useGetCurrentUser,
   useGetMyBookingPaymentAdjustments,
@@ -26,6 +27,7 @@ import {
 } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
+import { ROUTES } from "../../../constants/routes";
 import type { GetEventByIdData, GetSectionByIdData, UUIDString } from "@dataconnect/generated";
 import { BookingStatus, TicketAudience } from "@dataconnect/generated";
 import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
@@ -34,16 +36,34 @@ import {
   createTicketCheckoutSession,
   getSectionMembersMerged,
   submitEventBooking,
+  submitGuestTicketRequest,
 } from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
 import { evaluateBookingGatePreview, userMatchesUserGroup } from "../utils/bookingEligibility";
-import AdditionalGuestRequestSection from "./AdditionalGuestRequestSection";
+import {
+  formatEventGuestPolicy,
+  guestCountNeedsModerationNotice,
+} from "../utils/eventGuestPolicy";
+import {
+  summarizeEventBookingPayment,
+} from "../utils/eventBookingStatusSummary";
 import EventBookingStatusSummary from "./EventBookingStatusSummary";
 
 type EventDetail = NonNullable<GetEventByIdData["event"]>;
 type SectionDetail = NonNullable<GetSectionByIdData["section"]>;
 
-const STEPS = ["Your ticket", "Guest (optional)", "Summary"];
+const FULL_STEPS = [
+  "Your ticket",
+  "Number of guests",
+  "Guest details",
+  "Review",
+  "Payment",
+  "Confirmation",
+] as const;
+
+const ADDITIONAL_GUEST_STEPS = ["Extra guests", "Guest details", "Review"] as const;
+
+type WizardMode = "full" | "additionalGuests";
 
 function extractCallableErrorCode(err: unknown): string | undefined {
   const e = err as {
@@ -58,15 +78,30 @@ function extractCallableErrorCode(err: unknown): string | undefined {
 export interface EventBookingWizardProps {
   section: SectionDetail;
   event: EventDetail;
+  wizardOpen?: boolean;
+  onWizardOpenChange?: (open: boolean) => void;
   onBookingComplete?: () => void;
+  onHasExistingBookingChange?: (hasBooking: boolean) => void;
 }
 
-export default function EventBookingWizard({ section, event, onBookingComplete }: EventBookingWizardProps) {
+export default function EventBookingWizard({
+  section,
+  event,
+  wizardOpen = false,
+  onWizardOpenChange,
+  onBookingComplete,
+  onHasExistingBookingChange,
+}: EventBookingWizardProps) {
+  const [wizardMode, setWizardMode] = useState<WizardMode>("full");
   const [activeStep, setActiveStep] = useState(0);
   const [memberTicketTypeId, setMemberTicketTypeId] = useState<string | null>(null);
-  const [includeGuest, setIncludeGuest] = useState(false);
+  const [totalGuestCount, setTotalGuestCount] = useState(0);
+  const [requestedExtraGuestCount, setRequestedExtraGuestCount] = useState(1);
   const [guestTicketTypeId, setGuestTicketTypeId] = useState<string | null>(null);
   const [guestDisplayName, setGuestDisplayName] = useState("");
+  const [extraGuestTicketTypeId, setExtraGuestTicketTypeId] = useState<string | null>(null);
+  const [extraGuestDisplayName, setExtraGuestDisplayName] = useState("");
+  const [extraGuestDietaryNote, setExtraGuestDietaryNote] = useState("");
   const [bookerDietaryNote, setBookerDietaryNote] = useState("");
   const [sitNextToUserIds, setSitNextToUserIds] = useState<string[]>([]);
   const [accommodationRequested, setAccommodationRequested] = useState(false);
@@ -76,9 +111,15 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
   const [submitting, setSubmitting] = useState(false);
   const [isEditingBooking, setIsEditingBooking] = useState(false);
   const [payingTicketTypeId, setPayingTicketTypeId] = useState<string | null>(null);
+  const [postSubmitFlow, setPostSubmitFlow] = useState(false);
 
   const idempotencyKeyRef = useRef<string | null>(null);
   const hydratedBookingIdRef = useRef<string | null>(null);
+
+  const includeGuest = wizardMode === "additionalGuests" ? false : totalGuestCount >= 1;
+  const extraGuestRequestCount =
+    wizardMode === "additionalGuests" ? requestedExtraGuestCount : Math.max(0, totalGuestCount - 1);
+  const steps = wizardMode === "additionalGuests" ? ADDITIONAL_GUEST_STEPS : FULL_STEPS;
 
   const { data: currentUserData, isLoading: loadingProfile } = useGetCurrentUser(dataConnect, {});
   const { data: accessData } = useGetUserAccessGroups(dataConnect, {});
@@ -136,11 +177,15 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       }, null);
   }, [myBookingsData]);
 
+  useEffect(() => {
+    onHasExistingBookingChange?.(Boolean(existingTerminalBooking));
+  }, [existingTerminalBooking, onHasExistingBookingChange]);
+
   const { data: ticketOrdersData } = useGetMyTicketOrders(dataConnect, {
-    enabled: Boolean(existingTerminalBooking),
+    enabled: Boolean(existingTerminalBooking) || postSubmitFlow,
   });
   const { data: paymentAdjustmentsData } = useGetMyBookingPaymentAdjustments(dataConnect, {
-    enabled: Boolean(existingTerminalBooking),
+    enabled: Boolean(existingTerminalBooking) || postSubmitFlow,
   });
 
   const bookingPaymentAdjustments = useMemo(() => {
@@ -151,7 +196,6 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     return bookingRow?.adjustments ?? [];
   }, [existingTerminalBooking, paymentAdjustmentsData]);
 
-  /** Server draft for this event — reuse its idempotency key after refresh (new random UUID would conflict). */
   const existingDraft = useMemo(() => {
     const list = myBookingsData?.user?.bookings ?? [];
     return list.find((b) => b.status === BookingStatus.DRAFT) ?? null;
@@ -184,7 +228,11 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     const memberLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.MEMBER);
     const guestLine = (booking.lines ?? []).find((line) => line.ticketType?.audience === TicketAudience.GUEST);
     setMemberTicketTypeId(memberLine?.ticketType?.id ?? null);
-    setIncludeGuest(Boolean(guestLine?.ticketType?.id));
+    const guestLines = (booking.guestTicketRequests ?? []).reduce(
+      (sum, request) => sum + request.requestedGuestCount,
+      guestLine ? 1 : 0
+    );
+    setTotalGuestCount(guestLines);
     setGuestTicketTypeId(guestLine?.ticketType?.id ?? null);
     setGuestDisplayName(guestLine?.guestDisplayName ?? "");
     setBookerDietaryNote(booking.bookerDietaryNote ?? "");
@@ -194,6 +242,22 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     setActiveStep(0);
     setSubmitError(null);
   }, [existingTerminalBooking]);
+
+  useEffect(() => {
+    if (!guestTicketTypes.length) {
+      setGuestTicketTypeId(null);
+      setExtraGuestTicketTypeId(null);
+      return;
+    }
+    setGuestTicketTypeId((prev) => {
+      if (prev && guestTicketTypes.some((t) => t.id === prev)) return prev;
+      return guestTicketTypes[0].id;
+    });
+    setExtraGuestTicketTypeId((prev) => {
+      if (prev && guestTicketTypes.some((t) => t.id === prev)) return prev;
+      return guestTicketTypes[0].id;
+    });
+  }, [guestTicketTypes]);
 
   const selectedMember = memberTicketTypes.find((t) => t.id === memberTicketTypeId);
   const selectedGuest = guestTicketTypes.find((t) => t.id === guestTicketTypeId);
@@ -221,22 +285,96 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
   const resetWizardState = useCallback(() => {
     setActiveStep(0);
     setMemberTicketTypeId(null);
-    setIncludeGuest(false);
-    setGuestTicketTypeId(null);
+    setTotalGuestCount(0);
+    setRequestedExtraGuestCount(1);
+    setGuestTicketTypeId(guestTicketTypes[0]?.id ?? null);
     setGuestDisplayName("");
+    setExtraGuestDisplayName("");
+    setExtraGuestDietaryNote("");
     setBookerDietaryNote("");
     setSitNextToUserIds([]);
     setAccommodationRequested(false);
     setAccommodationNote("");
     setSubmitError(null);
-    // Keep idempotency key when a server draft exists; otherwise clear so the next submit starts fresh.
+    setPostSubmitFlow(false);
     if (!existingDraft?.clientSubmissionKey?.trim()) {
       idempotencyKeyRef.current = null;
     }
-  }, [existingDraft?.clientSubmissionKey]);
+  }, [existingDraft?.clientSubmissionKey, guestTicketTypes]);
+
+  const closeWizard = useCallback(() => {
+    setWizardMode("full");
+    setPostSubmitFlow(false);
+    setIsEditingBooking(false);
+    onWizardOpenChange?.(false);
+  }, [onWizardOpenChange]);
+
+  const paymentSummaryForBooking = useMemo(() => {
+    if (!existingTerminalBooking) return null;
+    return summarizeEventBookingPayment({
+      booking: existingTerminalBooking,
+      eventId: event.id,
+      ticketOrders: ticketOrdersData?.user?.ticketOrders ?? [],
+      adjustments: bookingPaymentAdjustments,
+    });
+  }, [existingTerminalBooking, event.id, ticketOrdersData, bookingPaymentAdjustments]);
+
+  const validateGuestCountStep = (): boolean => {
+    if (wizardMode === "additionalGuests") {
+      if (extraGuestRequestCount < 1) {
+        setSubmitError("Enter how many extra guest tickets you need.");
+        return false;
+      }
+      return true;
+    }
+    if (totalGuestCount > 0 && !guestTicketTypes.length) {
+      setSubmitError("Guest tickets are not available for this event.");
+      return false;
+    }
+    return true;
+  };
+
+  const validateGuestDetailsStep = (): boolean => {
+    if (wizardMode === "additionalGuests" || includeGuest) {
+      const typeId = wizardMode === "additionalGuests" ? extraGuestTicketTypeId : guestTicketTypeId;
+      const name = wizardMode === "additionalGuests" ? extraGuestDisplayName : guestDisplayName;
+      if (!typeId) {
+        setSubmitError("Choose a guest ticket type.");
+        return false;
+      }
+      if (!name.trim()) {
+        setSubmitError("Enter a name for your guest.");
+        return false;
+      }
+    }
+    if (wizardMode === "full" && extraGuestRequestCount > 0) {
+      if (!extraGuestTicketTypeId) {
+        setSubmitError("Choose a ticket type for additional guests.");
+        return false;
+      }
+      if (!extraGuestDisplayName.trim()) {
+        setSubmitError("Enter a contact name for the additional guest request.");
+        return false;
+      }
+    }
+    return true;
+  };
 
   const handleNext = () => {
     setSubmitError(null);
+    if (wizardMode === "additionalGuests") {
+      if (activeStep === 0) {
+        if (!validateGuestCountStep()) return;
+        setActiveStep(1);
+        return;
+      }
+      if (activeStep === 1) {
+        if (!validateGuestDetailsStep()) return;
+        setActiveStep(2);
+      }
+      return;
+    }
+
     if (activeStep === 0) {
       if (!memberTicketTypeId) {
         setSubmitError("Choose a ticket for yourself.");
@@ -246,17 +384,13 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
       return;
     }
     if (activeStep === 1) {
-      if (includeGuest) {
-        if (!guestTicketTypeId) {
-          setSubmitError("Choose a guest ticket type, or turn off the guest option.");
-          return;
-        }
-        if (!guestDisplayName.trim()) {
-          setSubmitError("Enter a name for your guest.");
-          return;
-        }
-      }
+      if (!validateGuestCountStep()) return;
       setActiveStep(2);
+      return;
+    }
+    if (activeStep === 2) {
+      if (!validateGuestDetailsStep()) return;
+      setActiveStep(3);
     }
   };
 
@@ -267,55 +401,77 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     }
   };
 
-  const handleConfirm = async () => {
-    if (!memberTicketTypeId || !membershipStatus || gate.ok !== true) return;
+  const submitAdditionalGuestRequest = async (bookingId: string) => {
+    if (extraGuestRequestCount < 1 || !extraGuestTicketTypeId) return;
+    await submitGuestTicketRequest({
+      bookingId,
+      requestedGuestCount: extraGuestRequestCount,
+      guestTicketTypeId: extraGuestTicketTypeId,
+      guestDisplayName: extraGuestDisplayName.trim(),
+      dietaryNote: extraGuestDietaryNote.trim() || null,
+    });
+  };
 
+  const handleConfirm = async () => {
     setSubmitting(true);
     setSubmitError(null);
 
-    if (!idempotencyKeyRef.current) {
-      const fromDraft = existingDraft?.clientSubmissionKey?.trim();
-      if (fromDraft) {
-        try {
-          idempotencyKeyRef.current = toCanonicalUuid(fromDraft);
-        } catch {
+    try {
+      if (wizardMode === "additionalGuests") {
+        if (!existingTerminalBooking) {
+          setSubmitError("Submit your main booking before requesting additional guests.");
+          return;
+        }
+        await submitAdditionalGuestRequest(existingTerminalBooking.id);
+        await refetchMyBookings();
+        onBookingComplete?.();
+        closeWizard();
+        return;
+      }
+
+      if (!memberTicketTypeId || !membershipStatus || gate.ok !== true) return;
+
+      if (!idempotencyKeyRef.current) {
+        const fromDraft = existingDraft?.clientSubmissionKey?.trim();
+        if (fromDraft) {
+          try {
+            idempotencyKeyRef.current = toCanonicalUuid(fromDraft);
+          } catch {
+            idempotencyKeyRef.current = crypto.randomUUID();
+          }
+        } else {
           idempotencyKeyRef.current = crypto.randomUUID();
         }
-      } else {
-        idempotencyKeyRef.current = crypto.randomUUID();
       }
-    }
-    const idempotencyKey = idempotencyKeyRef.current;
 
-    const lines: {
-      ticketTypeId: string;
-      sortOrder: number;
-      guestUserId: string | null;
-      guestDisplayName: string | null;
-      dietaryNote: string | null;
-    }[] = [
-      {
-        ticketTypeId: memberTicketTypeId,
-        sortOrder: 0,
-        guestUserId: null,
-        guestDisplayName: null,
-        dietaryNote: null,
-      },
-    ];
+      const lines: {
+        ticketTypeId: string;
+        sortOrder: number;
+        guestUserId: string | null;
+        guestDisplayName: string | null;
+        dietaryNote: string | null;
+      }[] = [
+        {
+          ticketTypeId: memberTicketTypeId,
+          sortOrder: 0,
+          guestUserId: null,
+          guestDisplayName: null,
+          dietaryNote: null,
+        },
+      ];
 
-    if (includeGuest && guestTicketTypeId) {
-      lines.push({
-        ticketTypeId: guestTicketTypeId,
-        sortOrder: 1,
-        guestUserId: null,
-        guestDisplayName: guestDisplayName.trim(),
-        dietaryNote: null,
-      });
-    }
+      if (includeGuest && guestTicketTypeId) {
+        lines.push({
+          ticketTypeId: guestTicketTypeId,
+          sortOrder: 1,
+          guestUserId: null,
+          guestDisplayName: guestDisplayName.trim(),
+          dietaryNote: null,
+        });
+      }
 
-    try {
-      await submitEventBooking({
-        idempotencyKey,
+      const result = await submitEventBooking({
+        idempotencyKey: idempotencyKeyRef.current,
         eventId: event.id,
         baseBookingId: existingTerminalBooking?.id,
         baseRevisionNumber: existingTerminalBooking?.revisionNumber,
@@ -325,8 +481,15 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
         accommodationRequested,
         accommodationNote,
       });
+
+      if (extraGuestRequestCount > 0) {
+        await submitAdditionalGuestRequest(result.bookingId);
+      }
+
       await refetchMyBookings();
       setIsEditingBooking(false);
+      setPostSubmitFlow(true);
+      setActiveStep(4);
       onBookingComplete?.();
     } catch (err: unknown) {
       const code = extractCallableErrorCode(err);
@@ -384,8 +547,23 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     }
   };
 
-  const showBookingSummary = Boolean(existingTerminalBooking) && !isEditingBooking;
+  const showBookingSummary =
+    Boolean(existingTerminalBooking) &&
+    !isEditingBooking &&
+    !postSubmitFlow &&
+    wizardMode === "full" &&
+    !wizardOpen;
+
+  const showWizard =
+    wizardOpen ||
+    isEditingBooking ||
+    postSubmitFlow ||
+    wizardMode === "additionalGuests";
+
   const editingExistingBooking = isEditingBooking && Boolean(existingTerminalBooking);
+  const pendingAdditionalGuestRequest = (existingTerminalBooking?.guestTicketRequests ?? []).some(
+    (request) => request.status === "PENDING"
+  );
 
   if (loadingProfile || loadingBookings) {
     return (
@@ -411,7 +589,7 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     );
   }
 
-  if (!memberTicketTypes.length) {
+  if (!memberTicketTypes.length && wizardMode === "full") {
     return (
       <Alert severity="warning" sx={{ mt: 2 }}>
         There are no member ticket types you are eligible for. If you believe this is wrong, contact a moderator.
@@ -419,8 +597,12 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
     );
   }
 
+  if (!showWizard && !showBookingSummary) {
+    return null;
+  }
+
   return (
-    <Box sx={{ mt: 3 }}>
+    <Box sx={{ mt: 1 }}>
       {showBookingSummary && existingTerminalBooking ? (
         <>
           <EventBookingStatusSummary
@@ -429,7 +611,11 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
             eventTitle={event.title}
             ticketOrders={ticketOrdersData?.user?.ticketOrders ?? []}
             paymentAdjustments={bookingPaymentAdjustments}
-            onEditBooking={() => setIsEditingBooking(true)}
+            onEditBooking={() => {
+              setWizardMode("full");
+              setIsEditingBooking(true);
+              onWizardOpenChange?.(true);
+            }}
             onPayNow={(ticketTypeId) => void handlePayNow(ticketTypeId)}
             payingTicketTypeId={payingTicketTypeId}
           />
@@ -438,155 +624,201 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
               {submitError}
             </Alert>
           ) : null}
-          <Box sx={{ mt: 2 }}>
-            <AdditionalGuestRequestSection
-              bookingId={existingTerminalBooking.id}
-              eventTitle={event.title}
-              maxGuestsWithoutModeratorApproval={event.maxGuestsWithoutModeratorApproval}
-              guestTicketTypes={guestTicketTypes.map((tt) => ({
-                id: tt.id,
-                title: tt.title,
-                price: tt.price ?? null,
-              }))}
-              requests={existingTerminalBooking.guestTicketRequests ?? []}
-              onRequestCreated={() => void refetchMyBookings()}
-            />
+          <Box sx={{ mt: 2, display: "flex", flexWrap: "wrap", gap: 1 }}>
+            <Button
+              variant="outlined"
+              disabled={pendingAdditionalGuestRequest || !guestTicketTypes.length}
+              onClick={() => {
+                setWizardMode("additionalGuests");
+                setRequestedExtraGuestCount(1);
+                setActiveStep(0);
+                onWizardOpenChange?.(true);
+              }}
+            >
+              Request additional guests
+            </Button>
+            {pendingAdditionalGuestRequest ? (
+              <Typography variant="body2" color="text.secondary" sx={{ alignSelf: "center" }}>
+                You already have a pending guest request awaiting review.
+              </Typography>
+            ) : null}
           </Box>
         </>
-      ) : (
+      ) : null}
+
+      {showWizard ? (
         <>
           <Typography variant="subtitle1" sx={{ mb: 2, fontWeight: 600 }}>
-            {editingExistingBooking ? "Edit your booking" : "Book this event"}
+            {wizardMode === "additionalGuests"
+              ? "Request additional guest tickets"
+              : editingExistingBooking
+                ? "Edit your booking"
+                : postSubmitFlow
+                  ? "Complete your booking"
+                  : "Book this event"}
           </Typography>
           {editingExistingBooking && existingTerminalBooking ? (
             <Alert severity="info" sx={{ mb: 2 }}>
               Editing revision {existingTerminalBooking.revisionNumber} (
-              {getBookingStatusLabel(existingTerminalBooking.status).toLowerCase()}).
-              Saving will create a new booking revision.
+              {getBookingStatusLabel(existingTerminalBooking.status).toLowerCase()}). Saving will create a new
+              booking revision.
             </Alert>
           ) : null}
 
           <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
-            {STEPS.map((label) => (
+            {steps.map((label) => (
               <Step key={label}>
                 <StepLabel>{label}</StepLabel>
               </Step>
             ))}
           </Stepper>
 
-          {submitError && (
+          {submitError ? (
             <Alert severity="error" sx={{ mb: 2 }} onClose={() => setSubmitError(null)}>
               {submitError}
             </Alert>
-          )}
+          ) : null}
 
           <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-        {activeStep === 0 && (
-          <FormControl component="fieldset" fullWidth>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              Select your member ticket category.
-            </Typography>
-            <RadioGroup
-              value={memberTicketTypeId ?? ""}
-              onChange={(_, v) => setMemberTicketTypeId(v || null)}
-            >
-              {memberTicketTypes.map((tt) => (
-                <FormControlLabel
-                  key={tt.id}
-                  value={tt.id}
-                  control={<Radio />}
-                  label={
-                    <Box>
-                      <Typography variant="body2" component="span">
-                        {tt.title}
-                      </Typography>
-                      <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
-                        {tt.price != null ? String(tt.price) : "—"}
-                      </Typography>
-                    </Box>
-                  }
-                />
-              ))}
-            </RadioGroup>
-            <TextField
-              label="Dietary requirements (you)"
-              fullWidth
-              size="small"
-              value={bookerDietaryNote}
-              onChange={(e) => setBookerDietaryNote(e.target.value)}
-              sx={{ mt: 2 }}
-            />
-            <Autocomplete
-              multiple
-              options={seatingOptions}
-              value={seatingOptions.filter((o) => sitNextToUserIds.includes(o.id))}
-              onChange={(_, next) => setSitNextToUserIds(next.map((n) => n.id))}
-              getOptionLabel={(o) => o.label}
-              isOptionEqualToValue={(a, b) => a.id === b.id}
-              renderInput={(params) => (
+            {wizardMode === "additionalGuests" && activeStep === 0 ? (
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  {formatEventGuestPolicy(event.maxGuestsWithoutModeratorApproval)}
+                </Typography>
                 <TextField
-                  {...params}
-                  label="Sit next to (optional)"
-                  helperText="Member picker sourced from section member list."
+                  label="How many extra guest tickets?"
+                  type="number"
                   size="small"
+                  inputProps={{ min: 1, step: 1 }}
+                  value={requestedExtraGuestCount}
+                  onChange={(e) => {
+                    const n = Number.parseInt(e.target.value, 10);
+                    setRequestedExtraGuestCount(Number.isFinite(n) && n >= 1 ? n : 1);
+                  }}
+                  helperText="Moderator review may be required depending on event policy."
+                  sx={{ minWidth: 260 }}
+                />
+              </Box>
+            ) : null}
+
+            {wizardMode === "full" && activeStep === 0 ? (
+              <FormControl component="fieldset" fullWidth>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                  Select your member ticket category.
+                </Typography>
+                <RadioGroup
+                  value={memberTicketTypeId ?? ""}
+                  onChange={(_, v) => setMemberTicketTypeId(v || null)}
+                >
+                  {memberTicketTypes.map((tt) => (
+                    <FormControlLabel
+                      key={tt.id}
+                      value={tt.id}
+                      control={<Radio />}
+                      label={
+                        <Box>
+                          <Typography variant="body2" component="span">
+                            {tt.title}
+                          </Typography>
+                          <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                            {tt.price != null ? String(tt.price) : "—"}
+                          </Typography>
+                        </Box>
+                      }
+                    />
+                  ))}
+                </RadioGroup>
+                <TextField
+                  label="Dietary requirements (you)"
+                  fullWidth
+                  size="small"
+                  value={bookerDietaryNote}
+                  onChange={(e) => setBookerDietaryNote(e.target.value)}
                   sx={{ mt: 2 }}
                 />
-              )}
-            />
-            <FormControlLabel
-              sx={{ mt: 1 }}
-              control={<Checkbox checked={accommodationRequested} onChange={(_, checked) => setAccommodationRequested(checked)} />}
-              label="Request accommodation (booker only)"
-              disabled={!canRequestAccommodation}
-            />
-            {accommodationRequested && (
-              <TextField
-                label="Accommodation details (optional)"
-                fullWidth
-                size="small"
-                value={accommodationNote}
-                onChange={(e) => setAccommodationNote(e.target.value)}
-              />
-            )}
-            {!canRequestAccommodation && (
-              <Typography variant="caption" color="text.secondary">
-                Accommodation requests are only available for{" "}
-                {getMembershipStatusLabel("REGULAR")} or {getMembershipStatusLabel("RESERVE")} members.
-              </Typography>
-            )}
-          </FormControl>
-        )}
+                <Autocomplete
+                  multiple
+                  options={seatingOptions}
+                  value={seatingOptions.filter((o) => sitNextToUserIds.includes(o.id))}
+                  onChange={(_, next) => setSitNextToUserIds(next.map((n) => n.id))}
+                  getOptionLabel={(o) => o.label}
+                  isOptionEqualToValue={(a, b) => a.id === b.id}
+                  renderInput={(params) => (
+                    <TextField
+                      {...params}
+                      label="Sit next to (optional)"
+                      helperText="Choose members you would like to sit near."
+                      size="small"
+                      sx={{ mt: 2 }}
+                    />
+                  )}
+                />
+                <FormControlLabel
+                  sx={{ mt: 1 }}
+                  control={
+                    <Checkbox
+                      checked={accommodationRequested}
+                      onChange={(_, checked) => setAccommodationRequested(checked)}
+                    />
+                  }
+                  label="Request accommodation (booker only)"
+                  disabled={!canRequestAccommodation}
+                />
+                {accommodationRequested ? (
+                  <TextField
+                    label="Accommodation details (optional)"
+                    fullWidth
+                    size="small"
+                    value={accommodationNote}
+                    onChange={(e) => setAccommodationNote(e.target.value)}
+                  />
+                ) : null}
+                {!canRequestAccommodation ? (
+                  <Typography variant="caption" color="text.secondary">
+                    Accommodation requests are only available for{" "}
+                    {getMembershipStatusLabel("REGULAR")} or {getMembershipStatusLabel("RESERVE")} members.
+                  </Typography>
+                ) : null}
+              </FormControl>
+            ) : null}
 
-        {activeStep === 1 && (
-          <Box>
-            {!guestTicketTypes.length ? (
-              <Typography variant="body2" color="text.secondary">
-                No guest ticket types are available for this event. Continue to review your booking.
-              </Typography>
-            ) : (
-              <>
-                <RadioGroup
-                  value={includeGuest ? "guest" : "self"}
-                  onChange={(_, v) => {
-                    const next = v === "guest";
-                    setIncludeGuest(next);
-                    if (!next) {
-                      setGuestTicketTypeId(null);
-                      setGuestDisplayName("");
-                    } else if (!guestTicketTypeId && guestTicketTypes[0]) {
-                      setGuestTicketTypeId(guestTicketTypes[0].id);
-                    }
-                  }}
-                >
-                  <FormControlLabel value="self" control={<Radio />} label="No guest — just my ticket" />
-                  <FormControlLabel value="guest" control={<Radio />} label="Add one guest ticket" />
-                </RadioGroup>
-                {includeGuest && (
-                  <Box sx={{ mt: 2, pl: 1, borderLeft: 2, borderColor: "divider" }}>
+            {wizardMode === "full" && activeStep === 1 ? (
+              <Box>
+                {!guestTicketTypes.length ? (
+                  <Typography variant="body2" color="text.secondary">
+                    No guest ticket types are available. Continue with just your ticket.
+                  </Typography>
+                ) : (
+                  <>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                      {formatEventGuestPolicy(event.maxGuestsWithoutModeratorApproval)}
+                    </Typography>
+                    <TextField
+                      label="How many guest tickets in total?"
+                      type="number"
+                      size="small"
+                      inputProps={{ min: 0, step: 1 }}
+                      value={totalGuestCount}
+                      onChange={(e) => {
+                        const n = Number.parseInt(e.target.value, 10);
+                        setTotalGuestCount(Number.isFinite(n) && n >= 0 ? n : 0);
+                      }}
+                      helperText="One guest can be included in your booking. Additional guests are submitted for organiser review."
+                      sx={{ minWidth: 280 }}
+                    />
+                  </>
+                )}
+              </Box>
+            ) : null}
+
+            {(wizardMode === "full" && activeStep === 2) || (wizardMode === "additionalGuests" && activeStep === 1) ? (
+              <Box>
+                {wizardMode === "full" && includeGuest ? (
+                  <Box sx={{ mb: 2, pl: 1, borderLeft: 2, borderColor: "divider" }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                      Guest on your booking
+                    </Typography>
                     <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
-                      <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
-                        Guest ticket category
-                      </Typography>
                       <RadioGroup
                         value={guestTicketTypeId ?? ""}
                         onChange={(_, v) => setGuestTicketTypeId(v || null)}
@@ -610,97 +842,220 @@ export default function EventBookingWizard({ section, event, onBookingComplete }
                       helperText="Shown on the guest ticket"
                     />
                   </Box>
+                ) : null}
+                {(wizardMode === "additionalGuests" || extraGuestRequestCount > 0) ? (
+                  <Box sx={{ pl: 1, borderLeft: 2, borderColor: "divider" }}>
+                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                      {wizardMode === "additionalGuests" ? "Guest request details" : "Additional guest request"}
+                    </Typography>
+                    <FormControl component="fieldset" fullWidth sx={{ mb: 2 }}>
+                      <RadioGroup
+                        value={extraGuestTicketTypeId ?? ""}
+                        onChange={(_, v) => setExtraGuestTicketTypeId(v || null)}
+                      >
+                        {guestTicketTypes.map((tt) => (
+                          <FormControlLabel
+                            key={tt.id}
+                            value={tt.id}
+                            control={<Radio size="small" />}
+                            label={`${tt.title} (${tt.price != null ? String(tt.price) : "—"})`}
+                          />
+                        ))}
+                      </RadioGroup>
+                    </FormControl>
+                    <TextField
+                      label="Guest name"
+                      fullWidth
+                      size="small"
+                      value={extraGuestDisplayName}
+                      onChange={(e) => setExtraGuestDisplayName(e.target.value)}
+                      sx={{ mb: 2 }}
+                    />
+                    <TextField
+                      label="Dietary requirements (optional)"
+                      fullWidth
+                      size="small"
+                      value={extraGuestDietaryNote}
+                      onChange={(e) => setExtraGuestDietaryNote(e.target.value)}
+                    />
+                  </Box>
+                ) : null}
+                {wizardMode === "full" && !includeGuest && extraGuestRequestCount === 0 ? (
+                  <Typography variant="body2" color="text.secondary">
+                    No guest tickets selected. Continue to review your booking.
+                  </Typography>
+                ) : null}
+              </Box>
+            ) : null}
+
+            {(wizardMode === "full" && activeStep === 3) || (wizardMode === "additionalGuests" && activeStep === 2) ? (
+              <Box>
+                {guestCountNeedsModerationNotice(
+                  wizardMode === "additionalGuests" ? extraGuestRequestCount : totalGuestCount,
+                  event.maxGuestsWithoutModeratorApproval
+                ) ? (
+                  <Alert severity="warning" sx={{ mb: 2 }}>
+                    Your guest count may require organiser review before all guest tickets are confirmed.
+                  </Alert>
+                ) : null}
+                {wizardMode === "full" ? (
+                  <Box component="dl" sx={{ m: 0, "& dt": { fontWeight: 600, mt: 1.5 }, "& dd": { m: 0 } }}>
+                    <Typography component="dt" variant="body2">
+                      Your ticket
+                    </Typography>
+                    <Typography component="dd" variant="body2" color="text.secondary">
+                      {selectedMember?.title ?? "—"}
+                      {selectedMember?.price != null ? ` · ${String(selectedMember.price)}` : ""}
+                    </Typography>
+                    <Typography component="dt" variant="body2">
+                      Guest tickets
+                    </Typography>
+                    <Typography component="dd" variant="body2" color="text.secondary">
+                      {totalGuestCount === 0
+                        ? "None"
+                        : `${totalGuestCount} total${extraGuestRequestCount > 0 ? ` (${extraGuestRequestCount} via organiser review)` : ""}`}
+                    </Typography>
+                    {includeGuest ? (
+                      <>
+                        <Typography component="dt" variant="body2">
+                          Guest on booking
+                        </Typography>
+                        <Typography component="dd" variant="body2" color="text.secondary">
+                          {selectedGuest?.title ?? "—"} — {guestDisplayName.trim()}
+                        </Typography>
+                      </>
+                    ) : null}
+                  </Box>
+                ) : (
+                  <Typography variant="body2" color="text.secondary">
+                    Requesting {extraGuestRequestCount} additional guest ticket
+                    {extraGuestRequestCount === 1 ? "" : "s"} for {extraGuestDisplayName.trim() || "your guest"}.
+                  </Typography>
                 )}
-              </>
-            )}
-          </Box>
-        )}
+              </Box>
+            ) : null}
 
-        {activeStep === 2 && (
-          <Box component="dl" sx={{ m: 0, "& dt": { fontWeight: 600, mt: 1.5 }, "& dd": { m: 0 } }}>
-            <Typography component="dt" variant="body2">
-              Your ticket
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {selectedMember?.title ?? "—"}
-              {selectedMember?.price != null ? ` · ${String(selectedMember.price)}` : ""}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Guest
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {includeGuest && selectedGuest
-                ? `${selectedGuest.title} (${String(selectedGuest.price ?? "—")}) — ${guestDisplayName.trim()}`
-                : "None"}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Event
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {event.title}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Dietary (you)
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {bookerDietaryNote.trim() || "None"}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Sit next to
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {sitNextToUserIds.length > 0
-                ? seatingOptions
-                    .filter((o) => sitNextToUserIds.includes(o.id))
-                    .map((o) => o.label)
-                    .join(", ")
-                : "No preference"}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Accommodation
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary">
-              {accommodationRequested ? accommodationNote.trim() || "Requested" : "Not requested"}
-            </Typography>
-          </Box>
-        )}
-      </Paper>
+            {wizardMode === "full" && activeStep === 4 && existingTerminalBooking && paymentSummaryForBooking ? (
+              <Box>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                  Pay for each ticket type below to secure your place. You can also finish later from your booking
+                  summary.
+                </Typography>
+                {(existingTerminalBooking.lines ?? []).map((line) => {
+                  const ticketTypeId = line.ticketType?.id;
+                  if (!ticketTypeId) return null;
+                  const isUnpaid = paymentSummaryForBooking.unpaidTicketTypeId === ticketTypeId;
+                  return (
+                    <Box
+                      key={line.id}
+                      sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1.5 }}
+                    >
+                      <Typography variant="body2">
+                        {line.ticketType?.title ?? "Ticket"}
+                        {line.guestDisplayName ? ` — ${line.guestDisplayName}` : ""}
+                      </Typography>
+                      {isUnpaid ? (
+                        <Button
+                          size="small"
+                          variant="contained"
+                          disabled={payingTicketTypeId === ticketTypeId}
+                          onClick={() => void handlePayNow(ticketTypeId)}
+                          sx={{ backgroundColor: colors.callToAction }}
+                        >
+                          {payingTicketTypeId === ticketTypeId ? "Starting checkout…" : "Pay now"}
+                        </Button>
+                      ) : (
+                        <Typography variant="caption" color="success.main">
+                          Paid
+                        </Typography>
+                      )}
+                    </Box>
+                  );
+                })}
+              </Box>
+            ) : null}
 
-      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2 }}>
-        <Button onClick={handleBack} disabled={activeStep === 0 || submitting}>
-          Back
-        </Button>
-        <Box sx={{ display: "flex", gap: 1 }}>
-          {activeStep < 2 && (
-            <Button variant="contained" onClick={handleNext} disabled={submitting} sx={{ backgroundColor: colors.callToAction }}>
-              Next
+            {wizardMode === "full" && activeStep === 5 ? (
+              <Alert severity="success">
+                Your booking has been submitted. Payment and guest-request updates will appear in your booking summary.
+              </Alert>
+            ) : null}
+          </Paper>
+
+          <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2 }}>
+            <Button onClick={handleBack} disabled={activeStep === 0 || submitting}>
+              Back
             </Button>
-          )}
-          {activeStep === 2 && (
-            <Button
-              variant="contained"
-              onClick={handleConfirm}
-              disabled={submitting}
-              sx={{ backgroundColor: colors.callToAction }}
-            >
-              {submitting ? "Submitting…" : editingExistingBooking ? "Save booking changes" : "Confirm booking"}
-            </Button>
-          )}
-        </Box>
-      </Box>
+            <Box sx={{ display: "flex", gap: 1 }}>
+              {wizardMode === "full" && activeStep === 4 ? (
+                <>
+                  <Button variant="outlined" onClick={() => setActiveStep(5)} disabled={submitting}>
+                    Skip for now
+                  </Button>
+                  {paymentSummaryForBooking?.kind === "paid" ? (
+                    <Button variant="contained" onClick={() => setActiveStep(5)} sx={{ backgroundColor: colors.callToAction }}>
+                      Continue
+                    </Button>
+                  ) : null}
+                </>
+              ) : null}
+              {activeStep < steps.length - 1 &&
+              !(wizardMode === "full" && activeStep === 4) ? (
+                <Button
+                  variant="contained"
+                  onClick={handleNext}
+                  disabled={submitting}
+                  sx={{ backgroundColor: colors.callToAction }}
+                >
+                  Next
+                </Button>
+              ) : null}
+              {(wizardMode === "full" && activeStep === 3) || (wizardMode === "additionalGuests" && activeStep === 2) ? (
+                <Button
+                  variant="contained"
+                  onClick={() => void handleConfirm()}
+                  disabled={submitting}
+                  sx={{ backgroundColor: colors.callToAction }}
+                >
+                  {submitting
+                    ? "Submitting…"
+                    : wizardMode === "additionalGuests"
+                      ? "Submit request"
+                      : editingExistingBooking
+                        ? "Save booking changes"
+                        : "Confirm booking"}
+                </Button>
+              ) : null}
+              {wizardMode === "full" && activeStep === 5 ? (
+                <Button variant="contained" onClick={closeWizard} sx={{ backgroundColor: colors.callToAction }}>
+                  Done
+                </Button>
+              ) : null}
+            </Box>
+          </Box>
 
-      {activeStep > 0 && (
-        <Button size="small" onClick={resetWizardState} disabled={submitting} sx={{ mt: 1 }}>
-          Start over
-        </Button>
-      )}
-      {editingExistingBooking ? (
-        <Button size="small" onClick={() => setIsEditingBooking(false)} disabled={submitting} sx={{ mt: 1, ml: 1 }}>
-          Cancel editing
-        </Button>
-      ) : null}
+          {activeStep > 0 && wizardMode === "full" && !postSubmitFlow ? (
+            <Button size="small" onClick={resetWizardState} disabled={submitting} sx={{ mt: 1 }}>
+              Start over
+            </Button>
+          ) : null}
+          {editingExistingBooking ? (
+            <Button size="small" onClick={() => setIsEditingBooking(false)} disabled={submitting} sx={{ mt: 1, ml: 1 }}>
+              Cancel editing
+            </Button>
+          ) : null}
+          {wizardMode === "additionalGuests" ? (
+            <Button size="small" onClick={closeWizard} disabled={submitting} sx={{ mt: 1, ml: 1 }}>
+              Cancel
+            </Button>
+          ) : null}
+          {wizardMode === "full" && activeStep === 5 ? (
+            <Button component={RouterLink} to={ROUTES.MY_BOOKINGS} size="small" sx={{ mt: 1, ml: 1 }}>
+              View in My Bookings
+            </Button>
+          ) : null}
         </>
-      )}
+      ) : null}
     </Box>
   );
 }

--- a/src/features/sections/components/EventDetailHero.tsx
+++ b/src/features/sections/components/EventDetailHero.tsx
@@ -1,0 +1,75 @@
+import { Box, Button, Chip, Paper, Stack, Typography } from "@mui/material";
+import type { GetEventByIdData } from "@dataconnect/generated";
+import { colors } from "../../../config/colors";
+import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
+import { formatEventGuestPolicy } from "../utils/eventGuestPolicy";
+
+type EventDetail = NonNullable<GetEventByIdData["event"]>;
+
+export interface EventDetailHeroProps {
+  event: EventDetail;
+  hasCurrentUser: boolean;
+  showBookButton: boolean;
+  onBookClick: () => void;
+}
+
+export default function EventDetailHero({
+  event,
+  hasCurrentUser,
+  showBookButton,
+  onBookClick,
+}: EventDetailHeroProps) {
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h5" component="h2" fontWeight={600} gutterBottom>
+        {event.title}
+      </Typography>
+
+      <Stack spacing={1} sx={{ mb: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          {formatSectionEventWhen(event.startDateTime, event.endDateTime)}
+        </Typography>
+        {event.location ? (
+          <Typography variant="body2" color="text.secondary">
+            {event.location}
+          </Typography>
+        ) : null}
+        {event.guestOfHonour ? (
+          <Typography variant="body2" color="text.secondary">
+            Guest of honour: {event.guestOfHonour}
+          </Typography>
+        ) : null}
+        <Typography variant="body2" color="text.secondary">
+          Booking window: {new Date(event.bookingStartDateTime).toLocaleString()} –{" "}
+          {new Date(event.bookingEndDateTime).toLocaleString()}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {formatEventGuestPolicy(event.maxGuestsWithoutModeratorApproval)}
+        </Typography>
+      </Stack>
+
+      {(event.ticketTypes ?? []).length > 0 ? (
+        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: showBookButton ? 2 : 0 }}>
+          {(event.ticketTypes ?? []).map((ticketType) => (
+            <Chip
+              key={ticketType.id}
+              size="small"
+              variant="outlined"
+              label={`${ticketType.title}${ticketType.price != null ? ` · ${String(ticketType.price)}` : ""}`}
+            />
+          ))}
+        </Box>
+      ) : (
+        <Typography variant="body2" color="text.secondary" sx={{ mb: showBookButton ? 2 : 0 }}>
+          Ticket types will be published soon.
+        </Typography>
+      )}
+
+      {showBookButton && hasCurrentUser ? (
+        <Button variant="contained" onClick={onBookClick} sx={{ backgroundColor: colors.callToAction }}>
+          Book this event
+        </Button>
+      ) : null}
+    </Paper>
+  );
+}

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -23,7 +23,7 @@ import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { useNavigate, useLocation } from "react-router-dom";
-import { createTicketCheckoutSession, getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
+import { getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
 import type { SectionUserGroupPurpose, UUIDString } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
 import { ITEMS_PER_PAGE, ROUTES } from "../../../constants";
@@ -65,7 +65,6 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingMembers, setLoadingMembers] = useState(true);
   const [errorMembers, setErrorMembers] = useState<string | null>(null);
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
-  const [startingCheckoutId, setStartingCheckoutId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<SectionDetailTab>("about");
 
   const currentUser = auth.currentUser;
@@ -297,22 +296,6 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     setSnackbar({ ...snackbar, open: false });
   };
 
-  const handleStartCheckout = async (ticketTypeId: string) => {
-    setStartingCheckoutId(ticketTypeId);
-    try {
-      const { url } = await createTicketCheckoutSession({ ticketTypeId, quantity: 1 });
-      window.location.assign(url);
-    } catch (error: unknown) {
-      const message =
-        error && typeof (error as { message?: string }).message === "string"
-          ? (error as { message: string }).message
-          : "Could not start checkout. Please try again.";
-      setSnackbar({ open: true, message, severity: "error" });
-    } finally {
-      setStartingCheckoutId(null);
-    }
-  };
-
   const loadedSection = sectionData?.section;
   const isMembersSectionType = loadedSection ? isMembersSection(loadedSection as any) : false;
   const sectionTabs = getSectionDetailTabs(isMembersSectionType);
@@ -487,10 +470,8 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
             loading={loadingEventDetail}
             isError={errorEventDetail}
             hasCurrentUser={Boolean(currentUser)}
-            startingCheckoutId={startingCheckoutId}
             onBackToEvents={handleBackToEvents}
             onRetry={() => refetchEventDetail()}
-            onStartCheckout={(ticketTypeId) => void handleStartCheckout(ticketTypeId)}
             onBookingComplete={() => {
               void refetchEventDetail();
             }}

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -5,28 +5,17 @@ import {
   Button,
   Chip,
   CircularProgress,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
   Typography,
 } from "@mui/material";
-import { TicketAudience, type GetEventByIdData, type GetEventsForSectionData, type GetSectionByIdData } from "@dataconnect/generated";
+import { type GetEventByIdData, type GetEventsForSectionData, type GetSectionByIdData } from "@dataconnect/generated";
 import { colors } from "../../../config/colors";
 import PaginationDisplay from "../../../shared/components/PaginationDisplay";
 import SearchBar from "../../../shared/components/SearchBar";
-import {
-  ACCESS_GROUP_COLUMN_LABEL,
-  GUEST_LIMIT_BEFORE_REVIEW_LABEL,
-} from "../../../shared/utils/sectionDisplayLabels";
 import { getSectionTypeLabel, isMembersSectionType } from "../../../shared/utils/sectionTypeLabels";
-import { getTicketCategoryLabel, TICKET_CATEGORY_LABEL } from "../../../shared/utils/ticketAudienceLabels";
 import type { SectionMember } from "../utils/sectionHelpers";
 import { partitionSectionEventsByTiming } from "../../../shared/utils/sectionEventDisplay";
 import EventBookingWizard from "./EventBookingWizard";
+import EventDetailHero from "./EventDetailHero";
 import SectionEventCard from "./SectionEventCard";
 import SectionMemberCard from "./SectionMemberCard";
 
@@ -275,10 +264,8 @@ interface SectionEventDetailViewProps {
   loading: boolean;
   isError: boolean;
   hasCurrentUser: boolean;
-  startingCheckoutId: string | null;
   onBackToEvents: () => void;
   onRetry: () => void;
-  onStartCheckout: (ticketTypeId: string) => void;
   onBookingComplete: () => void;
 }
 
@@ -288,12 +275,13 @@ export function SectionEventDetailView({
   loading,
   isError,
   hasCurrentUser,
-  startingCheckoutId,
   onBackToEvents,
   onRetry,
-  onStartCheckout,
   onBookingComplete,
 }: SectionEventDetailViewProps) {
+  const [bookingWizardOpen, setBookingWizardOpen] = useState(false);
+  const [hasExistingBooking, setHasExistingBooking] = useState(false);
+
   return (
     <Box sx={{ mt: 2 }}>
       <Button size="small" onClick={onBackToEvents} sx={{ mb: 2 }}>
@@ -314,101 +302,22 @@ export function SectionEventDetailView({
         <Alert severity="info">Event not found.</Alert>
       ) : (
         <>
-          <Typography variant="h6" sx={{ mb: 2 }}>
-            {event.title}
-          </Typography>
-          <Box component="dl" sx={{ "& dd": { m: 0 }, "& dt": { fontWeight: 500, mt: 1 } }}>
-            <Typography component="dt" variant="body2">
-              Date / time
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {new Date(event.startDateTime).toLocaleString()} -{" "}
-              {new Date(event.endDateTime).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Location
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {event.location || "-"}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Guest of honour
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {event.guestOfHonour || "-"}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              Booking window
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-              {new Date(event.bookingStartDateTime).toLocaleString()} -{" "}
-              {new Date(event.bookingEndDateTime).toLocaleString()}
-            </Typography>
-            <Typography component="dt" variant="body2">
-              {GUEST_LIMIT_BEFORE_REVIEW_LABEL}
-            </Typography>
-            <Typography component="dd" variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              {event.maxGuestsWithoutModeratorApproval != null
-                ? String(event.maxGuestsWithoutModeratorApproval)
-                : "-"}
-            </Typography>
-          </Box>
-          <Typography variant="subtitle2" sx={{ mb: 1 }}>
-            Ticket types
-          </Typography>
-          {!event.ticketTypes?.length ? (
-            <Typography variant="body2" color="text.secondary">
-              No ticket types.
-            </Typography>
-          ) : (
-            <TableContainer component={Paper}>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Title</TableCell>
-                    <TableCell>Description</TableCell>
-                    <TableCell>Price</TableCell>
-                    <TableCell>{TICKET_CATEGORY_LABEL}</TableCell>
-                    <TableCell>{ACCESS_GROUP_COLUMN_LABEL}</TableCell>
-                    <TableCell align="right">Purchase</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {event.ticketTypes.map((ticketType) => (
-                    <TableRow key={ticketType.id}>
-                      <TableCell>{ticketType.title}</TableCell>
-                      <TableCell>{ticketType.description ?? "-"}</TableCell>
-                      <TableCell>{ticketType.price}</TableCell>
-                      <TableCell>{getTicketCategoryLabel(ticketType.audience)}</TableCell>
-                      <TableCell>{ticketType.userGroup?.name ?? "-"}</TableCell>
-                      <TableCell align="right">
-                        {hasCurrentUser && ticketType.audience === TicketAudience.MEMBER ? (
-                          <Button
-                            size="small"
-                            variant="contained"
-                            disabled={startingCheckoutId === ticketType.id}
-                            onClick={() => onStartCheckout(ticketType.id)}
-                            sx={{ backgroundColor: colors.callToAction }}
-                          >
-                            {startingCheckoutId === ticketType.id ? "Starting..." : "Pay"}
-                          </Button>
-                        ) : (
-                          "-"
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          )}
-          {hasCurrentUser && (
+          <EventDetailHero
+            event={event}
+            hasCurrentUser={hasCurrentUser}
+            showBookButton={hasCurrentUser && !bookingWizardOpen && !hasExistingBooking}
+            onBookClick={() => setBookingWizardOpen(true)}
+          />
+          {hasCurrentUser ? (
             <EventBookingWizard
               section={section}
               event={event}
+              wizardOpen={bookingWizardOpen}
+              onWizardOpenChange={setBookingWizardOpen}
+              onHasExistingBookingChange={setHasExistingBooking}
               onBookingComplete={onBookingComplete}
             />
-          )}
+          ) : null}
         </>
       )}
     </Box>

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
     status: "SUBMITTED",
   }),
   createTicketCheckoutSession: vi.fn(),
+  submitGuestTicketRequest: vi.fn().mockResolvedValue({ success: true, requestId: "req-1" }),
 }));
 
 describe("EventBookingWizard", () => {
@@ -168,6 +169,7 @@ describe("EventBookingWizard", () => {
 
     await user.click(screen.getByRole("button", { name: "Next" }));
     await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next" }));
     await user.click(screen.getByRole("button", { name: "Save booking changes" }));
 
     await waitFor(() => {
@@ -179,5 +181,71 @@ describe("EventBookingWizard", () => {
         })
       );
     });
+  });
+
+  it("shows moderation notice when guest count exceeds policy on review step", async () => {
+    const user = userEvent.setup();
+    vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
+      data: { user: { bookings: [] } },
+      isLoading: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(
+      <MemoryRouter>
+        <EventBookingWizard
+          wizardOpen
+          section={{
+            id: "section-1",
+            name: "Events",
+            type: "EVENTS",
+            description: null,
+            purposeLinks: [
+              { purposes: ["ACCESS", "BOOKER"], userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] } },
+            ],
+          } as never}
+          event={{
+            id: "event-1",
+            title: "Annual Dinner",
+            bookingStartDateTime: "2025-01-01T00:00:00Z",
+            bookingEndDateTime: "2030-01-01T00:00:00Z",
+            maxGuestsWithoutModeratorApproval: 1,
+            ticketTypes: [
+              {
+                id: "ticket-member",
+                title: "Member standard",
+                audience: TicketAudience.MEMBER,
+                price: 50,
+                userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+              },
+              {
+                id: "ticket-guest",
+                title: "Guest standard",
+                audience: TicketAudience.GUEST,
+                price: 25,
+                userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+              },
+            ],
+          } as never}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByLabelText(/member standard/i));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    const guestCountInput = screen.getByLabelText(/how many guest tickets in total/i);
+    await user.clear(guestCountInput);
+    await user.type(guestCountInput, "2");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await user.type(screen.getAllByLabelText("Guest name")[0], "Alex Guest");
+    const extraGuestName = screen.getAllByLabelText("Guest name")[1];
+    if (extraGuestName) {
+      await user.type(extraGuestName, "Alex Guest");
+    }
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    expect(screen.getByText(/may require organiser review/i)).toBeInTheDocument();
   });
 });

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -582,7 +582,7 @@ describe('SectionDetail', () => {
             price: 25,
             sortOrder: 0,
             audience: 'MEMBER',
-            userGroup: { id: 'ag-1', name: 'Standard Access' },
+            userGroup: { id: 'ag-1', name: 'Standard Access', membershipStatuses: ['REGULAR'] },
           },
         ],
       },
@@ -625,13 +625,13 @@ describe('SectionDetail', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Back to events')).toBeInTheDocument();
-      expect(screen.getByRole('heading', { name: 'Annual Dinner', level: 4 })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Annual Dinner', level: 2 })).toBeInTheDocument();
       expect(screen.getByText('Main Hall')).toBeInTheDocument();
-      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
-      expect(screen.getByText('Ticket types')).toBeInTheDocument();
-      expect(screen.getByText('Standard')).toBeInTheDocument();
-      expect(screen.getByText('Member ticket')).toBeInTheDocument();
-      expect(screen.getByText('Standard Access')).toBeInTheDocument();
+      expect(screen.getByText(/Guest of honour: Jane Doe/)).toBeInTheDocument();
+      expect(screen.getByText(/Standard · 25/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Book this event' })).toBeInTheDocument();
+      expect(screen.queryByText('Ticket types')).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/sections/utils/__tests__/eventGuestPolicy.test.ts
+++ b/src/features/sections/utils/__tests__/eventGuestPolicy.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatEventGuestPolicy, guestCountNeedsModerationNotice } from "../eventGuestPolicy";
+
+describe("eventGuestPolicy", () => {
+  it("formats guest policy copy without exposing raw field names", () => {
+    expect(formatEventGuestPolicy(null)).toMatch(/organiser review/i);
+    expect(formatEventGuestPolicy(0)).toMatch(/require organiser review/i);
+    expect(formatEventGuestPolicy(1)).toMatch(/up to 1 guest ticket/i);
+    expect(formatEventGuestPolicy(2)).toMatch(/up to 2 guest tickets/i);
+  });
+
+  it("flags when guest count exceeds auto-approval threshold", () => {
+    expect(guestCountNeedsModerationNotice(0, 1)).toBe(false);
+    expect(guestCountNeedsModerationNotice(1, 1)).toBe(false);
+    expect(guestCountNeedsModerationNotice(2, 1)).toBe(true);
+    expect(guestCountNeedsModerationNotice(1, null)).toBe(true);
+  });
+});

--- a/src/features/sections/utils/eventGuestPolicy.ts
+++ b/src/features/sections/utils/eventGuestPolicy.ts
@@ -1,0 +1,23 @@
+/**
+ * Member-facing copy for extra-guest rules (replaces raw maxGuestsWithoutModeratorApproval in UI).
+ */
+export function formatEventGuestPolicy(maxGuestsWithoutModeratorApproval?: number | null): string {
+  if (maxGuestsWithoutModeratorApproval == null) {
+    return "Extra guest tickets may require organiser review before they are confirmed.";
+  }
+  if (maxGuestsWithoutModeratorApproval === 0) {
+    return "Any guest tickets beyond your own place require organiser review.";
+  }
+  const n = maxGuestsWithoutModeratorApproval;
+  return `You can include up to ${n} guest ticket${n === 1 ? "" : "s"} without organiser review. Additional guests need approval.`;
+}
+
+export function guestCountNeedsModerationNotice(
+  totalGuestTickets: number,
+  maxGuestsWithoutModeratorApproval?: number | null
+): boolean {
+  if (maxGuestsWithoutModeratorApproval == null) {
+    return totalGuestTickets > 0;
+  }
+  return totalGuestTickets > maxGuestsWithoutModeratorApproval;
+}


### PR DESCRIPTION
## Summary
- Replaces the event detail `<dl>` dump and per-ticket **Pay** table with an `EventDetailHero` (summary, ticket chips, friendly guest-policy copy) and a single **Book this event** CTA.
- Expands `EventBookingWizard` into a six-step flow: your ticket → number of guests → guest details → review (moderation notice when over policy) → payment → confirmation.
- Folds additional guest requests into the wizard (including **Request additional guests** from the post-booking summary); payment runs from the wizard step via `createTicketCheckoutSession` instead of inline Pay buttons on the detail page.

## Test plan
- [ ] Open an EVENTS section → select an event → confirm hero layout (no Pay table, no raw guest cap)
- [ ] Click **Book this event** → walk through all wizard steps for a new booking
- [ ] Book with 2+ guests → review step shows organiser-review notice when over policy
- [ ] After confirm → payment step lists unpaid lines and **Pay now** starts Stripe checkout
- [ ] Existing booking → status summary shows; **Edit booking** and **Request additional guests** work
- [ ] `npm run lint`, targeted section/wizard tests, and `npm run build` pass
- [ ] Manual Stripe test-mode checkout after booking (post-#237 return URLs)


Made with [Cursor](https://cursor.com)