### PR TITLE
Security: comprehensive GQL auth contract tests + schema integrity suite

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -93,4 +93,4 @@ jobs:
         run: npm ci --prefix functions
 
       - name: Run functions security suites
-        run: node .github/scripts/fail-on-warning-output.mjs -- npm --prefix functions run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts --run
+        run: node .github/scripts/fail-on-warning-output.mjs -- npm --prefix functions run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts gqlSchemaIntegrity --run

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -23,9 +23,14 @@ function extractOperationBlock(source: string, operationName: string): string {
 function assertAuth(source: string, checks: AuthExpectation[]): void {
   for (const check of checks) {
     const block = extractOperationBlock(source, check.op);
-    expect(block).toContain(check.mustInclude);
+    expect(block, `${check.op} must include: ${check.mustInclude}`).toContain(check.mustInclude);
   }
 }
+
+const ADMIN_EXPR = '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")';
+const USER_EXPR = '@auth(expr: "auth.token.enabled == true")';
+const EMAIL_VERIFIED_EXPR = '@auth(expr: "auth.token.email_verified == true")';
+const NO_ACCESS = "@auth(level: NO_ACCESS)";
 
 describe("Data Connect auth contracts", () => {
   it("Phase A: critical booking/payment/admin operations keep strict auth", () => {
@@ -36,44 +41,44 @@ describe("Data Connect auth contracts", () => {
     const groupMutations = readApiFile("user-group-mutations.gql");
 
     assertAuth(queries, [
-      { op: "query CheckUserProfileExists", mustInclude: '@auth(expr: "auth.token.email_verified == true")' },
-      { op: "query ListEventBookingsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "query ListGuestTicketRequestsForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "query ListTicketOrdersForAdmin", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "query GetMyTicketOrderById", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
-      { op: "query GetMyBookings", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
+      { op: "query CheckUserProfileExists", mustInclude: EMAIL_VERIFIED_EXPR },
+      { op: "query ListEventBookingsForAdmin", mustInclude: ADMIN_EXPR },
+      { op: "query ListGuestTicketRequestsForAdmin", mustInclude: ADMIN_EXPR },
+      { op: "query ListTicketOrdersForAdmin", mustInclude: ADMIN_EXPR },
+      { op: "query GetMyTicketOrderById", mustInclude: USER_EXPR },
+      { op: "query GetMyBookings", mustInclude: USER_EXPR },
     ]);
 
     assertAuth(bookingMutations, [
-      { op: "mutation CreateGuestTicketRequest", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
-      { op: "mutation AdminReviewGuestTicketRequest", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateGuestTicketRequest", mustInclude: USER_EXPR },
+      { op: "mutation AdminReviewGuestTicketRequest", mustInclude: ADMIN_EXPR },
     ]);
 
     assertAuth(adminSdk, [
-      { op: "query GetUserForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "query GetTicketTypeForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "mutation CreateTicketOrderForCheckout", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "query GetTicketOrderForWebhook", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "mutation MarkTicketOrderPaidFromWebhook", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "query GetBookingsForBookerAndEvent", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "mutation UpdateBookingStatusFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "mutation UpdateBookingPreferencesFromCallable", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "query ListStaleDraftBookingsForScheduler", mustInclude: "@auth(level: NO_ACCESS)" },
-      { op: "query ListStalePendingTicketOrdersForScheduler", mustInclude: "@auth(level: NO_ACCESS)" },
+      { op: "query GetUserForCheckout", mustInclude: NO_ACCESS },
+      { op: "query GetTicketTypeForCheckout", mustInclude: NO_ACCESS },
+      { op: "mutation CreateTicketOrderForCheckout", mustInclude: NO_ACCESS },
+      { op: "query GetTicketOrderForWebhook", mustInclude: NO_ACCESS },
+      { op: "mutation MarkTicketOrderPaidFromWebhook", mustInclude: NO_ACCESS },
+      { op: "query GetBookingsForBookerAndEvent", mustInclude: NO_ACCESS },
+      { op: "mutation UpdateBookingStatusFromCallable", mustInclude: NO_ACCESS },
+      { op: "mutation UpdateBookingPreferencesFromCallable", mustInclude: NO_ACCESS },
+      { op: "query ListStaleDraftBookingsForScheduler", mustInclude: NO_ACCESS },
+      { op: "query ListStalePendingTicketOrdersForScheduler", mustInclude: NO_ACCESS },
     ]);
 
     assertAuth(userMutations, [
-      { op: "mutation CreateUserProfile", mustInclude: '@auth(expr: "auth.token.email_verified == true")' },
-      { op: "mutation UpsertUser", mustInclude: '@auth(expr: "auth.token.enabled == true")' },
-      { op: "mutation UpdateUser", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateUserProfile", mustInclude: EMAIL_VERIFIED_EXPR },
+      { op: "mutation UpsertUser", mustInclude: USER_EXPR },
+      { op: "mutation UpdateUser", mustInclude: ADMIN_EXPR },
     ]);
 
     assertAuth(groupMutations, [
-      { op: "mutation CreateSection", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "mutation CreateUserGroup", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "mutation GrantUserGroupToSectionForPurpose", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "mutation CreateEvent", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
-      { op: "mutation CreateTicketType", mustInclude: '@auth(expr: "auth.token.admin == true && auth.token.enabled == true")' },
+      { op: "mutation CreateSection", mustInclude: ADMIN_EXPR },
+      { op: "mutation CreateUserGroup", mustInclude: ADMIN_EXPR },
+      { op: "mutation GrantUserGroupToSectionForPurpose", mustInclude: ADMIN_EXPR },
+      { op: "mutation CreateEvent", mustInclude: ADMIN_EXPR },
+      { op: "mutation CreateTicketType", mustInclude: ADMIN_EXPR },
     ]);
   });
 
@@ -90,8 +95,185 @@ describe("Data Connect auth contracts", () => {
         const start = m.index ?? 0;
         const end = source.indexOf("{", start);
         const header = source.slice(start, end >= 0 ? end : start + 400);
-        expect(header).toContain("@auth(");
+        expect(header, `${file}: operation at offset ${start} missing @auth`).toContain("@auth(");
       }
     }
+  });
+
+  it("Phase C: every operation in admin-mutations.gql is NO_ACCESS", () => {
+    const adminSdk = readApiFile("admin-mutations.gql");
+
+    // User management
+    assertAuth(adminSdk, [
+      { op: "mutation UpdateUserMembershipStatus", mustInclude: NO_ACCESS },
+      { op: "mutation DeleteUser", mustInclude: NO_ACCESS },
+      { op: "mutation CreateUser", mustInclude: NO_ACCESS },
+      { op: "mutation UpdateUserStripeCustomerId", mustInclude: NO_ACCESS },
+    ]);
+
+    // User group management
+    assertAuth(adminSdk, [
+      { op: "mutation CreateUserGroupAdmin", mustInclude: NO_ACCESS },
+      { op: "mutation AddUserToUserGroupAdmin", mustInclude: NO_ACCESS },
+      { op: "mutation RemoveUserFromUserGroupAdmin", mustInclude: NO_ACCESS },
+      { op: "query GetUserGroupByName", mustInclude: NO_ACCESS },
+      { op: "query GetUserUserGroupsForAdmin", mustInclude: NO_ACCESS },
+    ]);
+
+    // Checkout and ticket orders
+    assertAuth(adminSdk, [
+      { op: "query GetEventByIdForCallable", mustInclude: NO_ACCESS },
+      { op: "query GetSectionByIdForCallable", mustInclude: NO_ACCESS },
+      { op: "query GetTicketOrderStripeArtifactsForCallable", mustInclude: NO_ACCESS },
+    ]);
+
+    // Booking callables
+    assertAuth(adminSdk, [
+      { op: "mutation CreateBookingDraftForUser", mustInclude: NO_ACCESS },
+      { op: "mutation CreateBookingDraftRevisionForUser", mustInclude: NO_ACCESS },
+      { op: "mutation MarkBookingSupersededFromCallable", mustInclude: NO_ACCESS },
+      { op: "mutation CreateBookingPaymentAdjustmentFromCallable", mustInclude: NO_ACCESS },
+      { op: "mutation AddBookingLineFromCallable", mustInclude: NO_ACCESS },
+      { op: "mutation DeleteBookingLineFromCallable", mustInclude: NO_ACCESS },
+      { op: "query GetTicketOrdersForBookerAndEvent", mustInclude: NO_ACCESS },
+    ]);
+
+    // Guest ticket request callables
+    assertAuth(adminSdk, [
+      { op: "mutation CreateGuestTicketRequestFromCallable", mustInclude: NO_ACCESS },
+      { op: "mutation AdminReviewGuestTicketRequestFromCallable", mustInclude: NO_ACCESS },
+      { op: "query GetBookingForGuestTicketCallable", mustInclude: NO_ACCESS },
+    ]);
+
+    // Notification callables
+    assertAuth(adminSdk, [
+      { op: "query GetBookingForNotification", mustInclude: NO_ACCESS },
+      { op: "query GetGuestTicketRequestForNotification", mustInclude: NO_ACCESS },
+      { op: "query GetNotificationDeliveryByChannelAndKey", mustInclude: NO_ACCESS },
+      { op: "mutation CreateNotificationDelivery", mustInclude: NO_ACCESS },
+      { op: "mutation MarkNotificationDeliveryPendingById", mustInclude: NO_ACCESS },
+      { op: "mutation MarkNotificationDeliverySentById", mustInclude: NO_ACCESS },
+      { op: "mutation MarkNotificationDeliveryFailedById", mustInclude: NO_ACCESS },
+    ]);
+
+    // Stripe webhook mutations
+    assertAuth(adminSdk, [
+      { op: "mutation MarkTicketOrderFailedFromWebhook", mustInclude: NO_ACCESS },
+      { op: "mutation MarkTicketOrderRefundedFromWebhook", mustInclude: NO_ACCESS },
+      { op: "mutation UpsertTicketOrderDisputeFromWebhook", mustInclude: NO_ACCESS },
+      { op: "query GetPaymentWebhookEventByStripeEventId", mustInclude: NO_ACCESS },
+      { op: "mutation CreatePaymentWebhookEvent", mustInclude: NO_ACCESS },
+    ]);
+
+    // Payment reconciliation
+    assertAuth(adminSdk, [
+      { op: "query GetPaymentReconciliationExceptionByOrderAndType", mustInclude: NO_ACCESS },
+      { op: "mutation CreatePaymentReconciliationException", mustInclude: NO_ACCESS },
+      { op: "mutation UpdatePaymentReconciliationExceptionById", mustInclude: NO_ACCESS },
+    ]);
+  });
+
+  it("Phase D: all queries.gql operations have correct auth level", () => {
+    const queries = readApiFile("queries.gql");
+
+    // User-level (enabled) queries
+    assertAuth(queries, [
+      { op: "query GetCurrentUser", mustInclude: USER_EXPR },
+      { op: "query GetSectionsForUser", mustInclude: USER_EXPR },
+      { op: "query GetUserAccessGroups", mustInclude: USER_EXPR },
+      { op: "query GetEventsForSection", mustInclude: USER_EXPR },
+      { op: "query GetEventById", mustInclude: USER_EXPR },
+      { op: "query GetSectionById", mustInclude: USER_EXPR },
+      { op: "query GetSectionMembers", mustInclude: USER_EXPR },
+      { op: "query GetMyBookingsForEvent", mustInclude: USER_EXPR },
+      { op: "query GetMyTicketOrders", mustInclude: USER_EXPR },
+      { op: "query GetMyBookingPaymentAdjustments", mustInclude: USER_EXPR },
+    ]);
+
+    // Admin-only queries (require both admin and enabled claims)
+    assertAuth(queries, [
+      { op: "query GetUserById", mustInclude: ADMIN_EXPR },
+      { op: "query ListUsers", mustInclude: ADMIN_EXPR },
+      { op: "query ListSections", mustInclude: ADMIN_EXPR },
+      { op: "query ListUserGroups", mustInclude: ADMIN_EXPR },
+      { op: "query GetUserWithAccessGroups", mustInclude: ADMIN_EXPR },
+      { op: "query GetUserAccessGroupsById", mustInclude: ADMIN_EXPR },
+      { op: "query GetUserGroupById", mustInclude: ADMIN_EXPR },
+      { op: "query ListBookingPaymentAdjustmentsForAdmin", mustInclude: ADMIN_EXPR },
+      { op: "query ListOpenPaymentReconciliationExceptions", mustInclude: ADMIN_EXPR },
+    ]);
+
+    // System-only queries (NO_ACCESS — callable from Firebase Functions only)
+    assertAuth(queries, [
+      { op: "query GetUserMembershipStatus", mustInclude: NO_ACCESS },
+      { op: "query GetAllUserGroupsWithStatuses", mustInclude: NO_ACCESS },
+    ]);
+  });
+
+  it("Phase E: all user-group-mutations.gql operations require admin", () => {
+    const groupMutations = readApiFile("user-group-mutations.gql");
+
+    // Section operations
+    assertAuth(groupMutations, [
+      { op: "mutation UpdateSection", mustInclude: ADMIN_EXPR },
+      { op: "mutation DeleteSection", mustInclude: ADMIN_EXPR },
+    ]);
+
+    // User group CRUD
+    assertAuth(groupMutations, [
+      { op: "mutation AddUserToUserGroup", mustInclude: ADMIN_EXPR },
+      { op: "mutation RemoveUserFromUserGroup", mustInclude: ADMIN_EXPR },
+      { op: "mutation RevokeUserGroupFromSectionForPurpose", mustInclude: ADMIN_EXPR },
+      { op: "mutation UpdateUserGroup", mustInclude: ADMIN_EXPR },
+      { op: "mutation DeleteUserGroup", mustInclude: ADMIN_EXPR },
+    ]);
+
+    // Event CRUD
+    assertAuth(groupMutations, [
+      { op: "mutation UpdateEvent", mustInclude: ADMIN_EXPR },
+      { op: "mutation DeleteEvent", mustInclude: ADMIN_EXPR },
+    ]);
+
+    // Ticket type CRUD
+    assertAuth(groupMutations, [
+      { op: "mutation UpdateTicketType", mustInclude: ADMIN_EXPR },
+      { op: "mutation DeleteTicketType", mustInclude: ADMIN_EXPR },
+    ]);
+  });
+
+  it("Phase F: all booking-mutations.gql operations have correct auth level", () => {
+    const bookingMutations = readApiFile("booking-mutations.gql");
+
+    // Member-facing booking operations (enabled user)
+    // NOTE: CreateBookingDraft, AddBookingLine, and UpdateBookingStatus operate on
+    // booking IDs supplied by the client without row-level ownership enforcement at
+    // the Data Connect layer. Business-logic ownership is enforced in the
+    // submitEventBooking callable; these direct mutations exist for the draft flow.
+    // Tracked for row-level auth hardening in issue #46.
+    assertAuth(bookingMutations, [
+      { op: "mutation CreateBookingDraft", mustInclude: USER_EXPR },
+      { op: "mutation AddBookingLine", mustInclude: USER_EXPR },
+      { op: "mutation UpdateBookingStatus", mustInclude: USER_EXPR },
+    ]);
+
+    // Admin-only booking operations
+    assertAuth(bookingMutations, [
+      { op: "mutation AdminDeleteGuestTicketRequest", mustInclude: ADMIN_EXPR },
+      { op: "mutation AdminDeleteBookingLine", mustInclude: ADMIN_EXPR },
+      { op: "mutation AdminDeleteBooking", mustInclude: ADMIN_EXPR },
+      { op: "mutation ResolvePaymentReconciliationException", mustInclude: ADMIN_EXPR },
+    ]);
+  });
+
+  it("Phase G: all user-mutations.gql operations have correct auth level", () => {
+    const userMutations = readApiFile("user-mutations.gql");
+
+    // Self-service section/group operations (enabled user)
+    assertAuth(userMutations, [
+      { op: "mutation RegisterForSection", mustInclude: USER_EXPR },
+      { op: "mutation UnregisterFromSection", mustInclude: USER_EXPR },
+      { op: "mutation SubscribeToUserGroup", mustInclude: USER_EXPR },
+      { op: "mutation UnsubscribeFromUserGroup", mustInclude: USER_EXPR },
+    ]);
   });
 });

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+
+function readApiFile(fileName: string): string {
+  const p = path.resolve(process.cwd(), "..", "dataconnect", "api", fileName);
+  return fs.readFileSync(p, "utf8");
+}
+
+function readSchemaFile(): string {
+  const p = path.resolve(process.cwd(), "..", "dataconnect", "schema", "schema.gql");
+  return fs.readFileSync(p, "utf8");
+}
+
+function extractAllOperationHeaders(source: string): Array<{ name: string; header: string }> {
+  const opHeader = /(query|mutation)\s+([A-Za-z0-9_]+)/g;
+  const results: Array<{ name: string; header: string }> = [];
+  for (const m of source.matchAll(opHeader)) {
+    const start = m.index ?? 0;
+    const end = source.indexOf("{", start);
+    const header = source.slice(start, end >= 0 ? end : start + 500);
+    results.push({ name: m[2], header });
+  }
+  return results;
+}
+
+describe("GQL schema integrity", () => {
+  it("user-facing mutation files must not use NO_ACCESS", () => {
+    // These files are callable from the client SDK. NO_ACCESS would make them
+    // unreachable from the frontend while silently appearing in the generated SDK.
+    const userFacingFiles = [
+      "user-mutations.gql",
+      "user-group-mutations.gql",
+      "booking-mutations.gql",
+    ];
+
+    for (const fileName of userFacingFiles) {
+      const source = readApiFile(fileName);
+      const ops = extractAllOperationHeaders(source);
+      for (const { name, header } of ops) {
+        expect(
+          header,
+          `${fileName}: ${name} must not use NO_ACCESS — it is client-callable`,
+        ).not.toContain("NO_ACCESS");
+      }
+    }
+  });
+
+  it("admin-mutations.gql must not contain user-level or email-verified auth expressions", () => {
+    // This file is the server-SDK-only boundary. Any user-level auth expression
+    // here would mean a frontend user could call it directly.
+    const adminSdk = readApiFile("admin-mutations.gql");
+    const ops = extractAllOperationHeaders(adminSdk);
+
+    for (const { name, header } of ops) {
+      expect(
+        header,
+        `admin-mutations.gql: ${name} must not use enabled-user auth expression`,
+      ).not.toContain('"auth.token.enabled == true"');
+
+      expect(
+        header,
+        `admin-mutations.gql: ${name} must not use email_verified auth expression`,
+      ).not.toContain('"auth.token.email_verified == true"');
+    }
+  });
+
+  it("self-ownership mutations use server-side auth.uid expressions, not client-supplied user IDs", () => {
+    // These mutations act on the calling user's own data. If a client-supplied
+    // userId were substituted for auth.uid, a user could manipulate another
+    // user's memberships or profile.
+    const userMutations = readApiFile("user-mutations.gql");
+
+    // Section and group self-service mutations must bind userId to auth.uid server-side
+    expect(userMutations).toContain(
+      'userId_expr: "auth.uid"',
+    );
+
+    // CreateUserProfile must bind the profile id to auth.uid so users can't
+    // create profiles for arbitrary auth UIDs
+    expect(userMutations).toContain('id_expr: "auth.uid"');
+
+    // Verify each self-service mutation explicitly uses the server expression
+    const selfServiceMutations = [
+      "RegisterForSection",
+      "UnregisterFromSection",
+      "SubscribeToUserGroup",
+      "UnsubscribeFromUserGroup",
+    ];
+
+    for (const mutName of selfServiceMutations) {
+      const idx = userMutations.indexOf(`mutation ${mutName}`);
+      expect(idx, `mutation ${mutName} not found`).toBeGreaterThanOrEqual(0);
+      const end = userMutations.indexOf("\n}", idx);
+      const block = userMutations.slice(idx, end + 2);
+      expect(
+        block,
+        `${mutName} must use userId_expr: "auth.uid" to prevent acting on behalf of other users`,
+      ).toContain('userId_expr: "auth.uid"');
+    }
+  });
+
+  it("CreateBookingDraft binds bookerId to auth.uid server-side", () => {
+    // If bookerId were client-supplied a user could create bookings attributed
+    // to another user's account.
+    const bookingMutations = readApiFile("booking-mutations.gql");
+
+    const idx = bookingMutations.indexOf("mutation CreateBookingDraft");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const end = bookingMutations.indexOf("\n}", idx);
+    const block = bookingMutations.slice(idx, end + 2);
+
+    expect(
+      block,
+      'CreateBookingDraft must use bookerId_expr: "auth.uid" — not a client-supplied bookerId',
+    ).toContain('bookerId_expr: "auth.uid"');
+  });
+
+  it("admin-only operations in user-group-mutations.gql require both admin and enabled claims", () => {
+    // Requiring only admin without enabled would let a disabled admin retain write access.
+    const groupMutations = readApiFile("user-group-mutations.gql");
+    const ops = extractAllOperationHeaders(groupMutations);
+
+    for (const { name, header } of ops) {
+      // Every operation in this file is admin-only; none should be user-level or onboarding
+      expect(
+        header,
+        `user-group-mutations.gql: ${name} must not use user-level auth (enabled only)`,
+      ).not.toMatch(/@auth\(expr: "auth\.token\.enabled == true"\)/);
+
+      expect(
+        header,
+        `user-group-mutations.gql: ${name} must not use email_verified auth`,
+      ).not.toContain("email_verified");
+
+      // Verify the admin expression includes both claims
+      expect(
+        header,
+        `user-group-mutations.gql: ${name} must require admin claim`,
+      ).toContain("auth.token.admin == true");
+
+      expect(
+        header,
+        `user-group-mutations.gql: ${name} must require enabled claim alongside admin`,
+      ).toContain("auth.token.enabled == true");
+    }
+  });
+
+  it("deprecated mutations.gql contains no active query or mutation operations", () => {
+    // This file is deprecated and should only contain comments.
+    // Active operations here would be callable from the client SDK.
+    const legacy = readApiFile("mutations.gql");
+    const opHeader = /^\s*(query|mutation)\s+[A-Za-z0-9_]+/m;
+    expect(
+      legacy,
+      "mutations.gql is deprecated and must not define any active operations",
+    ).not.toMatch(opHeader);
+  });
+
+  it("schema.gql defines the expected core tables", () => {
+    // Guards against accidental table deletions that could break auth or data integrity
+    const schema = readSchemaFile();
+
+    const requiredTypes = [
+      "type User",
+      "type Section",
+      "type UserGroup",
+      "type UserUserGroup",
+      "type Event",
+      "type TicketType",
+      "type Booking",
+      "type BookingLine",
+      "type TicketOrder",
+      "type GuestTicketRequest",
+      "type PaymentWebhookEvent",
+      "type NotificationDelivery",
+    ];
+
+    for (const typeName of requiredTypes) {
+      expect(schema, `schema.gql must define ${typeName}`).toContain(typeName);
+    }
+  });
+
+  it("schema.gql User type has auth-critical fields", () => {
+    // These fields drive the auth claim model. Removing them would silently
+    // break all auth expressions without a compile error.
+    const schema = readSchemaFile();
+
+    const userTypeStart = schema.indexOf("type User");
+    expect(userTypeStart).toBeGreaterThanOrEqual(0);
+    const userTypeEnd = schema.indexOf("\n}", userTypeStart);
+    const userBlock = schema.slice(userTypeStart, userTypeEnd + 2);
+
+    expect(userBlock, "User must have membershipStatus field").toContain("membershipStatus");
+    expect(userBlock, "User must have email field for notifications").toContain("email:");
+    expect(userBlock, "User must have firstName for identification").toContain("firstName");
+    expect(userBlock, "User must have lastName for identification").toContain("lastName");
+  });
+});


### PR DESCRIPTION
## Summary

- Expands `dataconnectAuthContracts.test.ts` with Phases C–G to cover **every** operation across all `.gql` files (previously only ~10 of 40+ operations in `admin-mutations.gql` were asserted as `NO_ACCESS`)
- Adds new `gqlSchemaIntegrity.test.ts` with 8 structural invariant tests covering security boundaries that can't be caught by operation-level auth checks alone
- Adds `gqlSchemaIntegrity` to the `functions-security-tests` CI gate so it runs on every PR

## What's now tested

**Expanded `dataconnectAuthContracts.test.ts`:**
- **Phase C**: All ~35 operations in `admin-mutations.gql` verified `NO_ACCESS`
- **Phase D**: All remaining `queries.gql` operations (user-level, admin-only, and system-only)
- **Phase E**: All 14 operations in `user-group-mutations.gql` verified admin-only
- **Phase F**: All operations in `booking-mutations.gql` (with documented note on issue #46 row-level gap)
- **Phase G**: All remaining `user-mutations.gql` self-service operations

**New `gqlSchemaIntegrity.test.ts`:**
- User-facing mutation files must not use `NO_ACCESS`
- `admin-mutations.gql` must not contain user-level auth expressions
- Self-ownership mutations (`RegisterForSection`, `SubscribeToUserGroup`, etc.) must use `userId_expr: "auth.uid"` not client-supplied IDs
- `CreateBookingDraft` must bind `bookerId_expr: "auth.uid"` — prevents creating bookings attributed to other users
- All operations in `user-group-mutations.gql` must include both `admin` and `enabled` claims
- Deprecated `mutations.gql` must contain no active operations
- `schema.gql` must define all core tables and auth-critical User fields

## Test plan

- [x] All 24 security tests pass locally (`authGuards`, `dataconnectAuthContracts`, `functionEntryGuardContracts`, `gqlSchemaIntegrity`)
- [x] Full functions test suite continues to pass

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)