### PR TITLE
fix: security and reliability bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Environment variables — keep only .env.example in version control
+.env
+.env.*
+!.env.example
+!.env.*.example
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/functions/src/admin.ts
+++ b/functions/src/admin.ts
@@ -70,7 +70,8 @@ export const revokeAdmin = onCall(
       throw new HttpsError("failed-precondition", "User is not an admin");
     }
 
-    await admin.auth().setCustomUserClaims(uid, { admin: false });
+    const { admin: _removed, ...remainingClaims } = targetUserClaims;
+    await admin.auth().setCustomUserClaims(uid, { ...remainingClaims, admin: false });
     logger.info(`Admin claim removed for uid=${uid} by caller=${request.auth!.uid}`);
     return { success: true, message: `Admin claim removed for uid=${uid}` };
   } catch (e: any) {

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -26,7 +26,7 @@ import {
   type LineInputForRules,
   type TicketTypeForRules,
 } from "./bookingRules";
-import { requireEnabled, requireString, validateUUID, handleFunctionError } from "./helpers";
+import { requireEnabled, requireString, validateUUID, handleFunctionError, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from "./helpers";
 import { FUNCTIONS_REGION } from "./constants";
 import { computeRevisionPlan } from "./bookingRevisionEngine";
 import { computeBookingPaymentDelta, type BookingPaymentDelta } from "./bookingPaymentAdjustments";
@@ -36,7 +36,11 @@ import {
   notifyBookingRevisionEmail,
 } from "./bookingEmailDispatcher";
 
-const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
+const APP_BASE_URL = (() => {
+  const url = process.env.APP_BASE_URL || "http://localhost:5173";
+  try { new URL(url); } catch { throw new Error(`APP_BASE_URL is not a valid URL: "${url}"`); }
+  return url;
+})();
 
 /** Schedules confirmation or revision email after a successful submit (not on idempotent replay). */
 export function scheduleBookingSubmitNotificationEmails(args: {
@@ -92,12 +96,20 @@ function parseBookingLines(raw: unknown): LineInputForRules[] {
     if (!Number.isInteger(sortOrder)) {
       throw new HttpsError("invalid-argument", `lines[${i}].sortOrder must be an integer`);
     }
+    const rawGuestName = typeof o.guestDisplayName === "string" ? o.guestDisplayName.trim() : null;
+    if (rawGuestName && rawGuestName.length > MAX_NAME_LENGTH) {
+      throw new HttpsError("invalid-argument", `lines[${i}].guestDisplayName must be no more than ${MAX_NAME_LENGTH} characters`);
+    }
+    const rawDietaryNote = typeof o.dietaryNote === "string" ? o.dietaryNote.trim() : null;
+    if (rawDietaryNote && rawDietaryNote.length > MAX_DESCRIPTION_LENGTH) {
+      throw new HttpsError("invalid-argument", `lines[${i}].dietaryNote must be no more than ${MAX_DESCRIPTION_LENGTH} characters`);
+    }
     out.push({
       ticketTypeId,
       sortOrder,
       guestUserId: typeof o.guestUserId === "string" ? o.guestUserId : null,
-      guestDisplayName: typeof o.guestDisplayName === "string" ? o.guestDisplayName : null,
-      dietaryNote: typeof o.dietaryNote === "string" ? o.dietaryNote : null,
+      guestDisplayName: rawGuestName || null,
+      dietaryNote: rawDietaryNote || null,
     });
   }
   return out;
@@ -117,8 +129,7 @@ function parseSitNextTo(raw: unknown, uid: string): string[] {
     if (typeof v !== "string") {
       throw new HttpsError("invalid-argument", "sitNextToUserIds must be an array of user ids");
     }
-    const id = v.trim();
-    if (!id) continue;
+    const id = validateUUID(v.trim(), "sitNextToUserIds");
     if (id === uid) {
       throw new HttpsError("invalid-argument", "You cannot select yourself in sit-next-to preferences");
     }

--- a/functions/src/guestTicketRequests.ts
+++ b/functions/src/guestTicketRequests.ts
@@ -8,7 +8,7 @@ import {
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
-import { requireAdmin, requireEnabled, validateUUID, handleFunctionError } from "./helpers";
+import { requireAdmin, requireEnabled, validateUUID, handleFunctionError, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from "./helpers";
 import { govNotifyApiKey } from "./mailer";
 import {
   notifyBookerGuestTicketRequestReviewed,
@@ -21,7 +21,11 @@ import {
   resolveGuestTicketRequestSubmission,
 } from "./guestTicketRequestCarryForward";
 
-const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
+const APP_BASE_URL = (() => {
+  const url = process.env.APP_BASE_URL || "http://localhost:5173";
+  try { new URL(url); } catch { throw new Error(`APP_BASE_URL is not a valid URL: "${url}"`); }
+  return url;
+})();
 
 export function scheduleGuestTicketRequestSubmittedEmails(args: {
   requestId: string;
@@ -62,10 +66,14 @@ export const submitGuestTicketRequest = onCall(
     if (!guestDisplayName) {
       throw new HttpsError("invalid-argument", "guestDisplayName is required");
     }
-    const dietaryNote =
-      typeof request.data?.dietaryNote === "string" && request.data.dietaryNote.trim().length > 0
-        ? request.data.dietaryNote.trim()
-        : null;
+    if (guestDisplayName.length > MAX_NAME_LENGTH) {
+      throw new HttpsError("invalid-argument", `guestDisplayName must be no more than ${MAX_NAME_LENGTH} characters`);
+    }
+    const rawDietaryNote = typeof request.data?.dietaryNote === "string" ? request.data.dietaryNote.trim() : null;
+    if (rawDietaryNote && rawDietaryNote.length > MAX_DESCRIPTION_LENGTH) {
+      throw new HttpsError("invalid-argument", `dietaryNote must be no more than ${MAX_DESCRIPTION_LENGTH} characters`);
+    }
+    const dietaryNote = rawDietaryNote || null;
 
     try {
       const bookingRow = await getBookingForGuestTicketCallable({ bookingId });
@@ -144,10 +152,11 @@ export const reviewGuestTicketRequest = onCall(
     if (status !== GuestTicketRequestStatus.APPROVED && status !== GuestTicketRequestStatus.REJECTED) {
       throw new HttpsError("invalid-argument", "status must be APPROVED or REJECTED");
     }
-    const moderatorNote =
-      typeof request.data?.moderatorNote === "string" && request.data.moderatorNote.trim().length > 0
-        ? request.data.moderatorNote.trim()
-        : null;
+    const rawModeratorNote = typeof request.data?.moderatorNote === "string" ? request.data.moderatorNote.trim() : null;
+    if (rawModeratorNote && rawModeratorNote.length > MAX_DESCRIPTION_LENGTH) {
+      throw new HttpsError("invalid-argument", `moderatorNote must be no more than ${MAX_DESCRIPTION_LENGTH} characters`);
+    }
+    const moderatorNote = rawModeratorNote || null;
 
     try {
       await adminReviewGuestTicketRequestFromCallable({

--- a/functions/src/helpers.ts
+++ b/functions/src/helpers.ts
@@ -113,14 +113,26 @@ export function mapUserRecord(userRecord: admin.auth.UserRecord) {
 }
 
 /**
+ * Pages through all Firebase Auth users, returning every record.
+ * listUsers() caps at 1000 per call; this handles arbitrarily large tenants.
+ */
+export async function listAllAuthUsers(): Promise<admin.auth.UserRecord[]> {
+  const users: admin.auth.UserRecord[] = [];
+  let nextPageToken: string | undefined;
+  do {
+    const result = await admin.auth().listUsers(1000, nextPageToken);
+    users.push(...result.users);
+    nextPageToken = result.pageToken;
+  } while (nextPageToken);
+  return users;
+}
+
+/**
  * Gets all admin users from Firebase Auth
  */
 export async function getAdminUsers(): Promise<admin.auth.UserRecord[]> {
-  const listUsersResult = await admin.auth().listUsers();
-  return listUsersResult.users.filter((userRecord) => {
-    const customClaims = userRecord.customClaims || {};
-    return customClaims.admin === true;
-  });
+  const users = await listAllAuthUsers();
+  return users.filter((u) => (u.customClaims || {}).admin === true);
 }
 
 /**
@@ -136,6 +148,6 @@ export function handleFunctionError(error: any, context: string): never {
     throw error;
   }
   logger.error(`Error ${context}:`, error);
-  throw new HttpsError("internal", error?.message ?? `Error ${context}`);
+  throw new HttpsError("internal", "Internal server error");
 }
 

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -12,7 +12,11 @@ import {
 import { govNotifyApiKey } from "./mailer";
 import { notifyMembershipStatusEmailIfNeeded } from "./membershipStatusEmailDispatcher";
 
-const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
+const APP_BASE_URL = (() => {
+  const url = process.env.APP_BASE_URL || "http://localhost:5173";
+  try { new URL(url); } catch { throw new Error(`APP_BASE_URL is not a valid URL: "${url}"`); }
+  return url;
+})();
 
 /** Sends membership access email when the stored status value changes. */
 export function scheduleMembershipStatusEmailIfChanged(args: {

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -58,7 +58,18 @@ const stripeSecret = defineSecret("STRIPE_SECRET");
 const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
 const stripeWebhookPaymentsSecret = defineSecret("STRIPE_WEBHOOK_SECRET_PAYMENTS");
 const CHECKOUT_CURRENCY = "gbp";
-const APP_BASE_URL = process.env.APP_BASE_URL || "http://localhost:5173";
+const APP_BASE_URL = (() => {
+  const url = process.env.APP_BASE_URL || "http://localhost:5173";
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+      throw new Error(`APP_BASE_URL must use http or https, got: ${parsed.protocol}`);
+    }
+  } catch {
+    throw new Error(`APP_BASE_URL is not a valid URL: "${url}"`);
+  }
+  return url;
+})();
 
 /** Member payments route — must match frontend `ROUTES.MY_PAYMENTS` (`/payments`). */
 export const MEMBER_PAYMENTS_PATH = "/payments";

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -2,7 +2,7 @@ import { onCall } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
 import { listUsers as dcListUsers } from "@dataconnect/admin-generated";
-import { requireAuth, requireAdmin, requireString, validateStringLength, MAX_NAME_LENGTH, mapUserRecord, handleFunctionError } from "./helpers";
+import { requireAuth, requireAdmin, requireString, validateStringLength, MAX_NAME_LENGTH, mapUserRecord, handleFunctionError, listAllAuthUsers } from "./helpers";
 import { FUNCTIONS_REGION } from "./constants";
 import { isUserAwaitingProfile, isUserPendingApproval } from "./pendingUserApproval";
 
@@ -66,9 +66,9 @@ export const searchUsers = onCall(
 
   try {
     const searchLower = searchTerm.toLowerCase();
-    const listUsersResult = await admin.auth().listUsers();
+    const allUsers = await listAllAuthUsers();
     
-    const matchingUsers = listUsersResult.users
+    const matchingUsers = allUsers
       .map((userRecord) => {
         const email = (userRecord.email || "").toLowerCase();
         const displayName = (userRecord.displayName || "").toLowerCase();
@@ -116,14 +116,14 @@ export const listUsersWithoutDataConnectProfile = onCall(
     try {
       const [dcResult, authResult] = await Promise.all([
         dcListUsers(),
-        admin.auth().listUsers(),
+        listAllAuthUsers(),
       ]);
 
       const dcById = new Map(
         (dcResult.data?.users ?? []).map((user) => [user.id, user])
       );
 
-      const users = authResult.users
+      const users = authResult
         .map((authUser) => {
           const hasDataConnectProfile = dcById.has(authUser.uid);
           const authEnabled = authUser.customClaims?.enabled === true;
@@ -172,14 +172,14 @@ export const listUsersPendingApproval = onCall(
     try {
       const [dcResult, authResult] = await Promise.all([
         dcListUsers(),
-        admin.auth().listUsers(),
+        listAllAuthUsers(),
       ]);
 
       const dcById = new Map(
         (dcResult.data?.users ?? []).map((user) => [user.id, user])
       );
 
-      const users = authResult.users
+      const users = authResult
         .map((authUser) => {
           const profile = dcById.get(authUser.uid);
           if (!profile) {


### PR DESCRIPTION
Closes #199, #200, #201, #202, #203, #206, #283, #284, #285
Part of epic #282

## Changes

| Issue | Fix |
|-------|-----|
| #206 | `handleFunctionError` now returns `"Internal server error"` instead of leaking `error.message` to clients |
| #200 | `revokeAdmin` preserves existing custom claims (e.g. `enabled`) when clearing `admin`, preventing accidental claim wipe |
| #283 | `sitNextToUserIds` entries are now validated as UUIDs via `validateUUID()` before being stored |
| #284 | `guestDisplayName` capped at `MAX_NAME_LENGTH` (100) and `dietaryNote` capped at `MAX_DESCRIPTION_LENGTH` (500) in both `submitEventBooking` and `submitGuestTicketRequest` |
| #285 | `moderatorNote` capped at `MAX_DESCRIPTION_LENGTH` (500) in `reviewGuestTicketRequest` |
| #201 | `APP_BASE_URL` is validated as a parseable URL at module init across all four function files — misconfigured deployments fail fast rather than silently building bad redirect URLs |
| #203 | Firebase Auth scans now use a new `listAllAuthUsers()` helper that paginates in batches of 1000, replacing the single unbounded `listUsers()` call in `searchUsers`, `listUsersWithoutDataConnectProfile`, and `listUsersPendingApproval` |
| #199 | `.gitignore` now excludes `.env` and `.env.*` files (preserving `.env.example` variants) |

## Not in this PR

The following issues from epic #282 require more significant architectural changes and are tracked separately:
- #204 — lock down legacy client-callable booking mutations
- #205 — Firebase Auth as source of truth for profile email  
- #207 — prevent arbitrary user-group self-assignment
- #208 — minimum password length
- #286 — rate limiting on callable functions

## Test plan

- [x] `npm --prefix functions run build` — clean TypeScript build
- [x] `npm --prefix functions run test` — 181/181 tests pass
- [ ] CI: build-checks, functions tests, functions security tests, frontend tests, frontend coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)