### PR TITLE
fix: close remaining security issues #204 #205 #207

### DIFF
--- a/dataconnect/api/booking-mutations.gql
+++ b/dataconnect/api/booking-mutations.gql
@@ -1,7 +1,9 @@
 # Booking mutations (member flow and admin cascade deletes).
-# Booking rules / audience validation live in issue #46; keep mutations permissive until then.
+# CreateBookingDraft, AddBookingLine, UpdateBookingStatus, and CreateGuestTicketRequest
+# are server-only: all client paths go through the submitEventBooking / submitGuestTicketRequest
+# callables which enforce ownership and booking rules before writing.
 
-mutation CreateBookingDraft($eventId: UUID!) @auth(expr: "auth.token.enabled == true") {
+mutation CreateBookingDraft($eventId: UUID!) @auth(level: NO_ACCESS) {
   booking_insert(
     data: {
       eventId: $eventId
@@ -18,7 +20,7 @@ mutation AddBookingLine(
   $guestDisplayName: String
   $dietaryNote: String
   $sortOrder: Int!
-) @auth(expr: "auth.token.enabled == true") {
+) @auth(level: NO_ACCESS) {
   bookingLine_insert(
     data: {
       bookingId: $bookingId
@@ -31,7 +33,7 @@ mutation AddBookingLine(
   )
 }
 
-mutation UpdateBookingStatus($id: UUID!, $status: BookingStatus!) @auth(expr: "auth.token.enabled == true") {
+mutation UpdateBookingStatus($id: UUID!, $status: BookingStatus!) @auth(level: NO_ACCESS) {
   booking_update(
     id: $id
     data: {
@@ -48,7 +50,7 @@ mutation CreateGuestTicketRequest(
   $guestTicketTypeId: UUID!
   $guestDisplayName: String!
   $dietaryNote: String
-) @auth(expr: "auth.token.enabled == true") {
+) @auth(level: NO_ACCESS) {
   guestTicketRequest_insert(
     data: {
       bookingId: $bookingId

--- a/dataconnect/api/user-mutations.gql
+++ b/dataconnect/api/user-mutations.gql
@@ -15,7 +15,6 @@
 mutation CreateUserProfile(
   $firstName: String!
   $lastName: String!
-  $email: String!
   $serviceNumber: String!
   $requestedMembershipStatus: MembershipStatus!
   $isRegular: Boolean
@@ -28,7 +27,7 @@ mutation CreateUserProfile(
       id_expr: "auth.uid"
       firstName: $firstName
       lastName: $lastName
-      email: $email
+      email_expr: "auth.token.email"
       serviceNumber: $serviceNumber
       requestedMembershipStatus: $requestedMembershipStatus
       membershipStatus: PENDING
@@ -50,7 +49,6 @@ mutation CreateUserProfile(
 mutation UpsertUser(
   $firstName: String!
   $lastName: String!
-  $email: String!
   $serviceNumber: String!
   $isRegular: Boolean
   $isReserve: Boolean
@@ -62,7 +60,7 @@ mutation UpsertUser(
       id_expr: "auth.uid"
       firstName: $firstName
       lastName: $lastName
-      email: $email
+      email_expr: "auth.token.email"
       serviceNumber: $serviceNumber
       isRegular: $isRegular
       isReserve: $isReserve
@@ -113,7 +111,7 @@ mutation UpdateUser(
 # Requires enabled claim (admins must also be enabled)
 mutation RegisterForSection(
   $userGroupId: UUID!
-) @auth(expr: "auth.token.enabled == true") {
+) @auth(level: NO_ACCESS) {
   userUserGroup_upsert(
     data: {
       userId_expr: "auth.uid"
@@ -136,12 +134,11 @@ mutation UnregisterFromSection(
 }
 
 # Subscribe to a subscribable user group (self-subscription)
-# Requires enabled claim (admins must also be enabled)
-# Note: The user group must be marked as subscribable. This should be validated
-# in the frontend before calling this mutation (by checking the user group's subscribable field).
+# Server-only: client must call the subscribeToUserGroup Firebase callable which
+# verifies UserGroup.subscribable == true before writing.
 mutation SubscribeToUserGroup(
   $userGroupId: UUID!
-) @auth(expr: "auth.token.enabled == true") {
+) @auth(level: NO_ACCESS) {
   userUserGroup_upsert(
     data: {
       userId_expr: "auth.uid"

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -50,7 +50,7 @@ describe("Data Connect auth contracts", () => {
     ]);
 
     assertAuth(bookingMutations, [
-      { op: "mutation CreateGuestTicketRequest", mustInclude: USER_EXPR },
+      { op: "mutation CreateGuestTicketRequest", mustInclude: NO_ACCESS },
       { op: "mutation AdminReviewGuestTicketRequest", mustInclude: ADMIN_EXPR },
     ]);
 
@@ -244,16 +244,12 @@ describe("Data Connect auth contracts", () => {
   it("Phase F: all booking-mutations.gql operations have correct auth level", () => {
     const bookingMutations = readApiFile("booking-mutations.gql");
 
-    // Member-facing booking operations (enabled user)
-    // NOTE: CreateBookingDraft, AddBookingLine, and UpdateBookingStatus operate on
-    // booking IDs supplied by the client without row-level ownership enforcement at
-    // the Data Connect layer. Business-logic ownership is enforced in the
-    // submitEventBooking callable; these direct mutations exist for the draft flow.
-    // Tracked for row-level auth hardening in issue #46.
+    // Legacy booking operations now server-only — all client paths go through
+    // submitEventBooking callable which enforces ownership and rules.
     assertAuth(bookingMutations, [
-      { op: "mutation CreateBookingDraft", mustInclude: USER_EXPR },
-      { op: "mutation AddBookingLine", mustInclude: USER_EXPR },
-      { op: "mutation UpdateBookingStatus", mustInclude: USER_EXPR },
+      { op: "mutation CreateBookingDraft", mustInclude: NO_ACCESS },
+      { op: "mutation AddBookingLine", mustInclude: NO_ACCESS },
+      { op: "mutation UpdateBookingStatus", mustInclude: NO_ACCESS },
     ]);
 
     // Admin-only booking operations
@@ -268,12 +264,17 @@ describe("Data Connect auth contracts", () => {
   it("Phase G: all user-mutations.gql operations have correct auth level", () => {
     const userMutations = readApiFile("user-mutations.gql");
 
-    // Self-service section/group operations (enabled user)
+    // Self-removal operations remain client-callable (no privilege escalation risk)
     assertAuth(userMutations, [
-      { op: "mutation RegisterForSection", mustInclude: USER_EXPR },
       { op: "mutation UnregisterFromSection", mustInclude: USER_EXPR },
-      { op: "mutation SubscribeToUserGroup", mustInclude: USER_EXPR },
       { op: "mutation UnsubscribeFromUserGroup", mustInclude: USER_EXPR },
+    ]);
+
+    // Server-only: RegisterForSection and SubscribeToUserGroup now go through
+    // Firebase callables that verify UserGroup.subscribable == true.
+    assertAuth(userMutations, [
+      { op: "mutation RegisterForSection", mustInclude: NO_ACCESS },
+      { op: "mutation SubscribeToUserGroup", mustInclude: NO_ACCESS },
     ]);
   });
 });

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -25,9 +25,20 @@ function extractAllOperationHeaders(source: string): Array<{ name: string; heade
 }
 
 describe("GQL schema integrity", () => {
-  it("user-facing mutation files must not use NO_ACCESS", () => {
-    // These files are callable from the client SDK. NO_ACCESS would make them
-    // unreachable from the frontend while silently appearing in the generated SDK.
+  it("user-facing mutation files only use NO_ACCESS for explicitly server-migrated operations", () => {
+    // Operations listed here have been deliberately moved to server-only callable
+    // paths and must NOT appear as client-callable in future.
+    const serverOnlyOps = new Set([
+      // booking-mutations.gql: all now routed through submitEventBooking callable
+      "CreateBookingDraft",
+      "AddBookingLine",
+      "UpdateBookingStatus",
+      "CreateGuestTicketRequest",
+      // user-mutations.gql: routed through subscribeToUserGroup / registerForSectionCallable
+      "RegisterForSection",
+      "SubscribeToUserGroup",
+    ]);
+
     const userFacingFiles = [
       "user-mutations.gql",
       "user-group-mutations.gql",
@@ -38,10 +49,17 @@ describe("GQL schema integrity", () => {
       const source = readApiFile(fileName);
       const ops = extractAllOperationHeaders(source);
       for (const { name, header } of ops) {
-        expect(
-          header,
-          `${fileName}: ${name} must not use NO_ACCESS — it is client-callable`,
-        ).not.toContain("NO_ACCESS");
+        if (serverOnlyOps.has(name)) {
+          expect(
+            header,
+            `${fileName}: ${name} was migrated to server-only and must use NO_ACCESS`,
+          ).toContain("NO_ACCESS");
+        } else {
+          expect(
+            header,
+            `${fileName}: ${name} must not use NO_ACCESS — it is client-callable`,
+          ).not.toContain("NO_ACCESS");
+        }
       }
     }
   });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,7 @@ export * from "./bookings";
 export * from "./guestTicketRequests";
 export * from "./payments";
 export * from "./stagedExpiry";
+export * from "./userGroups";
 
 // Initialize Firebase Admin
 if (!admin.apps.length) {

--- a/functions/src/userGroups.ts
+++ b/functions/src/userGroups.ts
@@ -1,0 +1,73 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import * as logger from "firebase-functions/logger";
+import {
+  getUserGroupById,
+  registerForSection,
+  subscribeToUserGroup as subscribeToUserGroupMutation,
+} from "@dataconnect/admin-generated";
+import type { UUIDString } from "@dataconnect/admin-generated";
+import { requireEnabled, validateUUID, handleFunctionError } from "./helpers";
+import { FUNCTIONS_REGION } from "./constants";
+
+/**
+ * Subscribes the caller to a user group, enforcing that the group has subscribable: true.
+ * Replaces the legacy client-callable SubscribeToUserGroup mutation.
+ */
+export const subscribeToUserGroup = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    requireEnabled(request);
+    const uid = request.auth!.uid;
+    const userGroupId = validateUUID(request.data?.userGroupId, "userGroupId") as UUIDString;
+
+    try {
+      const result = await getUserGroupById({ id: userGroupId });
+      const group = result.data?.userGroup;
+      if (!group) {
+        throw new HttpsError("not-found", "User group not found");
+      }
+      if (group.subscribable !== true) {
+        throw new HttpsError("permission-denied", "This group does not allow self-subscription");
+      }
+
+      await subscribeToUserGroupMutation({ userGroupId });
+      logger.info(`subscribeToUserGroup: uid=${uid} groupId=${userGroupId}`);
+      return { success: true };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e, "subscribing to user group");
+    }
+  }
+);
+
+/**
+ * Registers the caller for a section by joining the specified user group,
+ * enforcing that the group has subscribable: true.
+ * Replaces the legacy client-callable RegisterForSection mutation.
+ */
+export const registerForSectionCallable = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    requireEnabled(request);
+    const uid = request.auth!.uid;
+    const userGroupId = validateUUID(request.data?.userGroupId, "userGroupId") as UUIDString;
+
+    try {
+      const result = await getUserGroupById({ id: userGroupId });
+      const group = result.data?.userGroup;
+      if (!group) {
+        throw new HttpsError("not-found", "User group not found");
+      }
+      if (group.subscribable !== true) {
+        throw new HttpsError("permission-denied", "This group does not allow self-registration");
+      }
+
+      await registerForSection({ userGroupId });
+      logger.info(`registerForSection: uid=${uid} groupId=${userGroupId}`);
+      return { success: true };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e, "registering for section");
+    }
+  }
+);

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -82,7 +82,6 @@ export default function Profile({ userData, userEmail, onBack, onUpdate }: Profi
       const vars: UpsertUserVariables = {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
-        email: email.trim(),
         serviceNumber: serviceNumber.trim(),
         isRegular,
         isReserve,

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -413,7 +413,6 @@ export interface CreateUserProfileData {
 export interface CreateUserProfileVariables {
   firstName: string;
   lastName: string;
-  email: string;
   serviceNumber: string;
   requestedMembershipStatus: MembershipStatus;
   isRegular?: boolean | null;
@@ -2059,7 +2058,6 @@ export interface UpsertUserData {
 export interface UpsertUserVariables {
   firstName: string;
   lastName: string;
-  email: string;
   serviceNumber: string;
   isRegular?: boolean | null;
   isReserve?: boolean | null;

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -71,7 +71,6 @@ export default function ProfileCompletion({
       const mutation = mutationRef(dataConnect, "CreateUserProfile", {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
-        email: email.trim(),
         serviceNumber: serviceNumber.trim(),
         requestedMembershipStatus: MembershipStatus.REGULAR,
         isRegular,

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -83,7 +83,6 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
       const vars: UpsertUserVariables = {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
-        email: email.trim(),
         serviceNumber: serviceNumber.trim(),
         isRegular,
         isReserve,

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -23,7 +23,7 @@ import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { useNavigate, useLocation } from "react-router-dom";
-import { getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
+import { getSectionMembersMerged, subscribeToUserGroup } from "../../../shared/utils/firebaseFunctions";
 import type { SectionUserGroupPurpose, UUIDString } from "@dataconnect/generated";
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
 import { ITEMS_PER_PAGE, ROUTES } from "../../../constants";
@@ -226,10 +226,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
 
     setSubscribing(true);
     try {
-      const { subscribeToUserGroupRef } = await import("@dataconnect/generated");
-      await executeMutation(subscribeToUserGroupRef(dataConnect, {
-        userGroupId: subscribableGroup.id as UUIDString,
-      }));
+      await subscribeToUserGroup(subscribableGroup.id);
 
       setSnackbar({
         open: true,

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -572,3 +572,21 @@ export async function reviewGuestTicketRequest(
   return result.data;
 }
 
+export async function subscribeToUserGroup(userGroupId: string): Promise<{ success: boolean }> {
+  const callable = httpsCallable<{ userGroupId: string }, { success: boolean }>(
+    functions,
+    "subscribeToUserGroup"
+  );
+  const result = await callable({ userGroupId: toCanonicalUuid(userGroupId) });
+  return result.data;
+}
+
+export async function registerForSectionCallable(userGroupId: string): Promise<{ success: boolean }> {
+  const callable = httpsCallable<{ userGroupId: string }, { success: boolean }>(
+    functions,
+    "registerForSectionCallable"
+  );
+  const result = await callable({ userGroupId: toCanonicalUuid(userGroupId) });
+  return result.data;
+}
+


### PR DESCRIPTION
Closes #204, #205, #207
Part of epic #282

## Changes

### #204 — Legacy client-callable booking mutations locked down
`CreateBookingDraft`, `AddBookingLine`, `UpdateBookingStatus`, and `CreateGuestTicketRequest` in `booking-mutations.gql` are now `@auth(level: NO_ACCESS)`. All client paths have always routed through the `submitEventBooking` and `submitGuestTicketRequest` callables which enforce ownership and booking rules server-side. No frontend code called these mutations directly.

### #205 — Profile email sourced from Firebase Auth token
`CreateUserProfile` and `UpsertUser` in `user-mutations.gql` now use `email_expr: "auth.token.email"` instead of accepting a client-supplied `$email` parameter. The `email` stored in Data Connect is now always the verified Firebase Auth email — a user can no longer register or update their profile with an arbitrary email address.

Frontend changes: removed `email` from the `mutationRef` call in `ProfileCompletion.tsx` and from `upsertUser` calls in both `Profile.tsx` files. Updated generated SDK `index.d.ts` to drop `email` from `CreateUserProfileVariables` and `UpsertUserVariables`.

### #207 — User group self-assignment requires server-side subscribable check
`RegisterForSection` and `SubscribeToUserGroup` in `user-mutations.gql` are now `@auth(level: NO_ACCESS)`. Replaced by two new Firebase callable functions in `functions/src/userGroups.ts`:

- **`subscribeToUserGroup`** — fetches the `UserGroup` via admin SDK, verifies `subscribable: true`, then writes via `SubscribeToUserGroup` mutation
- **`registerForSectionCallable`** — same check for section registration

`SectionDetail.tsx` updated to call the `subscribeToUserGroup` callable instead of the direct mutation. `UnregisterFromSection` and `UnsubscribeFromUserGroup` remain client-callable (self-removal cannot escalate privileges).

## Test coverage
- `dataconnectAuthContracts.test.ts` assertions updated to expect `NO_ACCESS` for all migrated mutations
- `gqlSchemaIntegrity.test.ts` updated: the "no NO_ACCESS in user-facing files" invariant is now a precise allowlist check — it asserts that known server-only ops have `NO_ACCESS` and all others do not
- All 181 functions tests pass; frontend builds clean

## Deployment note
The GQL changes take effect on next Firebase Data Connect deployment (`firebase deploy --only dataconnect`). The generated client SDK (`src/dataconnect-generated/`) will be fully regenerated at that point; the manual `index.d.ts` edit is a forward-compatibility shim until then.

## Test plan
- [ ] Register a new user — verify email in Data Connect profile matches Firebase Auth email, not anything typed into the form
- [ ] Edit profile — verify email in DB is not updated by the form submit (Auth email is used)
- [ ] On a section page, click Subscribe — verify the callable is called and the subscription succeeds for a `subscribable: true` group
- [ ] Attempt to subscribe to a non-subscribable group directly (e.g. via Postman / browser console calling `subscribeToUserGroup` with a non-subscribable group ID) — expect `permission-denied` error
- [ ] Complete a booking end-to-end — verify nothing broke in the booking submission flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)