### PR TITLE
fix: event datetime timezone bug and empty sit-next-to crash

### DIFF
--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -129,7 +129,9 @@ function parseSitNextTo(raw: unknown, uid: string): string[] {
     if (typeof v !== "string") {
       throw new HttpsError("invalid-argument", "sitNextToUserIds must be an array of user ids");
     }
-    const id = validateUUID(v.trim(), "sitNextToUserIds");
+    const trimmed = v.trim();
+    if (!trimmed) continue;
+    const id = validateUUID(trimmed, "sitNextToUserIds");
     if (id === uid) {
       throw new HttpsError("invalid-argument", "You cannot select yourself in sit-next-to preferences");
     }

--- a/src/features/admin/utils/__tests__/eventDatetime.test.ts
+++ b/src/features/admin/utils/__tests__/eventDatetime.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { toDatetimeLocal, fromDatetimeLocal } from "../eventDatetime";
+
+describe("toDatetimeLocal", () => {
+  it("formats an ISO string as a datetime-local value in local time", () => {
+    // Use a fixed local date to avoid DST ambiguity in the test
+    const local = new Date(2026, 6, 27, 19, 30); // 27 Jul 2026 19:30 local
+    const result = toDatetimeLocal(local.toISOString());
+    expect(result).toBe("2026-07-27T19:30");
+  });
+});
+
+describe("fromDatetimeLocal", () => {
+  it("round-trips through toDatetimeLocal without shifting the time", () => {
+    const original = new Date(2026, 6, 27, 19, 30); // 27 Jul 2026 19:30 local
+    const localString = toDatetimeLocal(original.toISOString());
+    const roundTripped = new Date(fromDatetimeLocal(localString));
+    expect(roundTripped.getFullYear()).toBe(2026);
+    expect(roundTripped.getMonth()).toBe(6); // July (0-indexed)
+    expect(roundTripped.getDate()).toBe(27);
+    expect(roundTripped.getHours()).toBe(19);
+    expect(roundTripped.getMinutes()).toBe(30);
+  });
+
+  it("treats a date-only value as midnight local time, not midnight UTC", () => {
+    // "2026-07-28" with no time — new Date("2026-07-28") would give midnight UTC,
+    // which is 23:00 BST the night before. fromDatetimeLocal must avoid this.
+    const result = new Date(fromDatetimeLocal("2026-07-28"));
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(6);
+    expect(result.getDate()).toBe(28);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+  });
+
+  it("correctly converts a future datetime — event should not appear as past", () => {
+    const futureLocal = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000); // 30 days from now
+    const localString = toDatetimeLocal(futureLocal.toISOString());
+    const stored = fromDatetimeLocal(localString);
+    expect(new Date(stored).getTime()).toBeGreaterThan(Date.now());
+  });
+});

--- a/src/features/admin/utils/eventDatetime.ts
+++ b/src/features/admin/utils/eventDatetime.ts
@@ -5,5 +5,11 @@ export function toDatetimeLocal(iso: string): string {
 }
 
 export function fromDatetimeLocal(value: string): string {
-  return new Date(value).toISOString();
+  // datetime-local strings have no timezone — parse as local time explicitly.
+  // new Date("2026-07-28") would be treated as midnight UTC by spec, which is
+  // the previous evening in BST and causes future events to appear as past.
+  const [datePart, timePart = "00:00"] = value.split("T");
+  const [year, month, day] = datePart.split("-").map(Number);
+  const [hours, minutes] = timePart.split(":").map(Number);
+  return new Date(year, month - 1, day, hours, minutes).toISOString();
 }


### PR DESCRIPTION
Closes #291

## Changes

### Event datetime timezone (#291)
`fromDatetimeLocal()` in `src/features/admin/utils/eventDatetime.ts` was using `new Date(value).toISOString()` to convert datetime-local input strings. The ECMAScript spec treats date-only strings (e.g. `"2026-07-28"`) as midnight **UTC**, which in BST is 23:00 the previous evening — causing a newly created event to appear immediately in Past events despite being set in the future.

Fixed by splitting the string and constructing the date with `new Date(year, month-1, day, hours, minutes)`, which always uses local time.

Added tests covering: round-trip fidelity, the date-only midnight-UTC edge case, and a future-event smoke test.

### Empty sit-next-to crash (regression from #283)
The UUID validation fix in #283 accidentally dropped the blank-entry guard in `parseSitNextTo()`. An empty string in `sitNextToUserIds` (e.g. when the field is left blank) would hit `validateUUID()` and return `"Invalid sitNextToUserIds format"` to the user. Guard restored — empty entries are now silently skipped as before.

## Test plan
- [ ] Create a new event with a date one month in the future — confirm it appears under Upcoming events, not Past events
- [ ] Edit an existing event that was created with the old code, save without changes — confirm it moves to Upcoming events
- [ ] Submit a booking with the sit-next-to field left blank — confirm it submits successfully with no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)