### PR TITLE
docs: user guides and README update for beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,57 @@
 # SODC Web
 
-SODC Web is a React + Firebase application for section membership, event booking, moderation, and payments.
+The SODC members' site — section membership, event booking, guest ticket management, and payments.
+
+**Beta site:** [https://sodc-web.web.app/](https://sodc-web.web.app/)
+
+---
+
+## For members
+
+- [Getting started](docs/user-guide/member-getting-started.md) — registering, completing your profile, and getting approved
+- [Booking an event](docs/user-guide/booking-an-event.md) — finding events, booking tickets, and guest ticket requests
+
+## For administrators
+
+- [Admin guide](docs/user-guide/admin-guide.md) — approving members, managing sections, events, and bookings
+
+---
+
+## Technical documentation
+
+Full documentation index: [docs/README.md](docs/README.md)
+
+---
 
 ## Repository layout
 
-- `src/`: frontend application code (features, shared components, hooks, utilities)
-- `functions/src/`: Firebase Functions backend (callables, webhooks, server-side rules)
-- `dataconnect/`: Data Connect schema and GraphQL operations
-- `docs/`: architecture and operational documentation
+| Path | Contents |
+|------|----------|
+| `src/` | Frontend application (React, features, shared components, hooks, utilities) |
+| `functions/src/` | Firebase Functions backend (callables, webhooks, server-side validation) |
+| `dataconnect/` | Data Connect schema and GraphQL operations |
+| `docs/` | Architecture, operations, and user documentation |
+| `src/dataconnect-generated/` | Generated — do not hand-edit |
+| `functions/src/dataconnect-admin-generated/` | Generated — do not hand-edit |
 
-Detailed structure conventions live in:
-- `docs/architecture/repo-structure.md`
-
-Documentation index:
-- `docs/README.md`
-
-## Generated code
-
-These folders are generated from Data Connect operations and should not be hand-edited in normal flow:
-
-- `src/dataconnect-generated/`
-- `functions/src/dataconnect-admin-generated/`
-
-After `.gql` changes, regenerate SDKs with:
+After changing `.gql` files, regenerate SDKs with:
 
 ```sh
 npx firebase dataconnect:sdk:generate
 ```
 
+---
+
 ## Local development
 
-Frontend:
+**Frontend:**
 
 ```sh
 npm install
 npm run dev
 ```
 
-Functions:
+**Functions:**
 
 ```sh
 cd functions
@@ -45,41 +59,42 @@ npm install
 npm run build
 ```
 
-## Test commands
+See [docs/operations/environments-dev-beta-prod.md](docs/operations/environments-dev-beta-prod.md) for environment setup (cloud-backed dev; no emulators required).
 
-Frontend tests:
+---
+
+## Tests
+
+**Frontend:**
 
 ```sh
 npm run test
 ```
 
-Functions tests:
+**Functions:**
 
 ```sh
 cd functions
 npm run test
 ```
 
-Focused security/permission regression suites (functions):
+**Security/permission regression suites:**
 
 ```sh
 cd functions
 npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts --run
 ```
 
-## Dev-only reset helper (emulator)
+---
 
-When running the Firebase emulators you can wipe auth users, soft-reset DataConnect user rows, and seed a verified/enabled admin account.
+## Dev-only reset helper
 
-- Callable: `devResetAndSeed`
-- Payload: `{ email: "<desired-admin-email>" }`
-- Password: `password`
-- Guard:
-  - `ENV_NAME` must be `dev` or `stage` (fails otherwise).
-  - Active `projectId` (from `FIREBASE_CONFIG`/`GCLOUD_PROJECT`) must be in `PERMITTED_PROJECT_IDS` (comma-separated). If not, it fails and instructs you to add it.
+When running against the `dev` Firebase project you can wipe auth users, reset Data Connect user rows, and seed a verified admin account via the `devResetAndSeed` callable:
 
-Example (with emulators running):
 ```sh
 firebase functions:shell
 firebase > devResetAndSeed({ email: "admin@example.com" })
+# password: password
 ```
+
+Guards: `ENV_NAME` must be `dev` or `stage`; the active project must be in `PERMITTED_PROJECT_IDS`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,12 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 - `operations/transactional-email-policy.md`: operational vs optional/marketing email policy (#191).
 
+## User Guides
+
+- `user-guide/member-getting-started.md`: registration, profile completion, and approval flow.
+- `user-guide/booking-an-event.md`: finding events, booking tickets, guest tickets, and payments.
+- `user-guide/admin-guide.md`: approving members, managing sections, events, bookings, and user groups.
+
 ## Domain Guides
 
 - `user-groups-architecture.md`: user group and section access architecture.

--- a/docs/user-guide/admin-guide.md
+++ b/docs/user-guide/admin-guide.md
@@ -1,0 +1,92 @@
+# Admin Guide
+
+This guide covers the administrative functions available to SODC administrators.
+
+Admin functions are accessible from the **Admin** menu, which is only visible to users with the admin role.
+
+---
+
+## Approving new members
+
+When a member submits their profile, they enter the approval queue.
+
+1. Go to **Admin → Manage Users**
+2. New registrations appear with a pending status
+3. Review the member's name, service number, and service background
+4. Click **Approve** to activate their account, or **Reject** to decline
+
+Once approved, the member's account is activated and they can access sections and book events. Their membership status (Regular, Reserve, Civil Servant, Industry) is set during approval.
+
+---
+
+## Managing users
+
+**Admin → Manage Users** lists all registered members. From here you can:
+
+- View a member's profile and membership status
+- Grant or revoke admin rights
+- Deactivate an account if needed
+
+---
+
+## Managing sections
+
+**Admin → Manage Sections** lets you create and configure sections.
+
+Each section has:
+- **Name and description**
+- **Members** — add or remove members; member access is controlled by user groups
+- **Events** — create and manage events for the section
+
+### Adding members to a section
+
+Sections use user groups to control access. To add a member:
+1. Open the section
+2. Go to the **Members** tab
+3. Add the member to the appropriate user group
+
+---
+
+## Managing events
+
+Within a section, go to the **Events** tab and click **Add Event** to create a new event.
+
+Each event has:
+- **Name**
+- **Start and end date/time**
+- **Ticket types** — define ticket options, prices, and quantities
+
+### Editing an event
+
+Click on an event to open it. You can edit the event details, manage ticket types, and view bookings.
+
+> **Note:** Date and time are entered in your local time zone and stored correctly — you do not need to adjust for BST/UTC.
+
+---
+
+## Managing bookings
+
+Within an event, the **Bookings** tab shows all bookings for that event. You can:
+
+- View booking details including dietary requirements and seating preferences
+- See the status of each booking (confirmed, pending, cancelled)
+
+---
+
+## Guest ticket requests
+
+When a member requests a guest ticket, it requires moderator approval.
+
+Guest ticket requests appear in the event's bookings view. Review the request and click **Approve** or **Reject**. The member will receive an email notification of your decision.
+
+---
+
+## User groups
+
+**Admin → Manage User Groups** lets you create and manage user groups. User groups are used to control which members have access to which sections.
+
+Each user group has a **purpose**:
+- **Access** — controls section membership (members in this group can see and join the section)
+- **Other purposes** — used for communication and organisation
+
+Members can only self-subscribe to user groups marked as **subscribable**. Access-purpose groups must be managed by an administrator.

--- a/docs/user-guide/booking-an-event.md
+++ b/docs/user-guide/booking-an-event.md
@@ -1,0 +1,63 @@
+# Member Guide: Booking an Event
+
+This guide covers how to find events, book tickets, and manage your booking.
+
+---
+
+## Finding events
+
+From the home page, select a section to view its events. Events are shown under two tabs:
+
+- **Upcoming events** — events that have not yet taken place
+- **Past events** — a record of previous events
+
+Click an event to see its details, including date, time, and ticket information.
+
+---
+
+## Booking a ticket
+
+On the event detail page, click **Book** to start the booking process. The booking wizard walks you through the following steps:
+
+### 1. Your ticket
+
+Confirm that you want a ticket for yourself. Your details are pre-filled from your profile.
+
+### 2. Guest tickets (if applicable)
+
+If the event allows guests, you can request additional guest tickets here. Enter the guest's name and any relevant details. Guest ticket requests are subject to moderator approval — you will be notified of the outcome.
+
+### 3. Dietary requirements
+
+If you have dietary requirements, enter them here. These are passed to the event organisers.
+
+### 4. Seating preferences
+
+You can optionally indicate seating preferences:
+
+- **Sit next to** — enter the names of other members you would like to be seated near
+- **Accessibility** — note any accessibility requirements
+
+### 5. Review and confirm
+
+Review your booking summary and click **Confirm** to submit.
+
+---
+
+## After booking
+
+Once confirmed, your booking will appear in the event detail page. You will receive a confirmation email.
+
+If your booking includes guest ticket requests, those are reviewed separately by a moderator. You will receive an email when a decision is made.
+
+---
+
+## Cancellations and changes
+
+Contact your section administrator if you need to cancel or amend a booking after it has been confirmed.
+
+---
+
+## Payments
+
+Some events require payment. Where payment is required, you will be directed to a secure checkout after confirming your booking. Payment is processed via Stripe — your card details are never stored on the SODC site.

--- a/docs/user-guide/member-getting-started.md
+++ b/docs/user-guide/member-getting-started.md
@@ -1,0 +1,67 @@
+# Member Guide: Getting Started
+
+Welcome to the SODC members' site at [https://sodc-web.web.app/](https://sodc-web.web.app/).
+
+## How membership works
+
+Access to the site follows a four-step process:
+
+1. **Create an account** — register with your email address and a password
+2. **Verify your email** — click the link sent to your inbox
+3. **Complete your profile** — provide your name, service number, and service background
+4. **Wait for approval** — an administrator reviews your profile and activates your account
+
+Once approved, you can view sections, book events, and manage your membership details.
+
+---
+
+## Step 1: Create an account
+
+Go to [https://sodc-web.web.app/](https://sodc-web.web.app/) and click **Register**.
+
+Enter your email address and choose a password. You will be sent a verification email — check your inbox (and spam folder) and click the link to verify your address before continuing.
+
+---
+
+## Step 2: Complete your profile
+
+After verifying your email, you will be prompted to complete your profile. You will need:
+
+- **First name and last name**
+- **Service number**
+- **Service background** — tick any that apply: Regular, Reserve, Civil Servant, Industry
+
+Your email address is pre-filled from your account and cannot be changed here.
+
+Once submitted, your profile enters the approval queue. You will not have full access to the site until an administrator approves your account.
+
+---
+
+## Step 3: Waiting for approval
+
+After submitting your profile you will see a confirmation message. You can sign out and return later — your account status will be updated once an administrator has reviewed your profile.
+
+When approved, your membership status (Regular, Reserve, Civil Servant, or Industry) will be set by the administrator based on your service background.
+
+---
+
+## Once you're approved
+
+After approval you have access to:
+
+- **Sections** — view sections you are a member of, see upcoming and past events
+- **Event booking** — book tickets for events, including guest tickets and dietary/seating preferences
+- **Profile** — update your name, service number, and service background at any time
+- **Account settings** — change your password or manage your account
+
+---
+
+## Sections and membership
+
+Sections are groups within SODC (for example, a particular sporting or social group). Membership of a section is managed by administrators. Once you are added to a section, it will appear on your home page.
+
+---
+
+## Getting help
+
+If you have not received a verification email, check your spam folder. If your account is not approved within a few days of submitting your profile, contact your section administrator.


### PR DESCRIPTION
## Summary

- New `docs/user-guide/` with three guides written for members and administrators (not developers):
  - **member-getting-started.md** — registration, profile completion, and the approval flow
  - **booking-an-event.md** — finding events, booking tickets, guest tickets, dietary/seating preferences, payments
  - **admin-guide.md** — approving members, managing sections/events/bookings, guest ticket moderation, user groups
- **README.md** rewritten — beta URL and member/admin links at the top, repo layout as a table, technical detail preserved but de-emphasised
- **docs/README.md** index updated to include the new User Guides section

## Test plan
- [ ] Links in README resolve to the correct doc files
- [ ] User guide content matches current app behaviour (registration flow, booking wizard steps, admin menu structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)