### PR TITLE
ux: polish booking wizard, empty states, and account toast (#300)

### DIFF
--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   DialogContentText,
   DialogTitle,
   Divider,
+  Snackbar,
   Stack,
   TextField,
   Typography,
@@ -24,7 +25,7 @@ import {
 } from "firebase/auth";
 import { auth } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
-import { ROUTES, SUCCESS_MESSAGE_TIMEOUT } from "../../../constants";
+import { ROUTES } from "../../../constants";
 import type { UserData } from "../../../types";
 import { resignMembership } from "../../../shared/utils/firebaseFunctions";
 import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
@@ -113,7 +114,6 @@ export default function AccountSettingsPage({
       setNewPassword("");
       setConfirmPassword("");
       setPasswordSuccess(true);
-      window.setTimeout(() => setPasswordSuccess(false), SUCCESS_MESSAGE_TIMEOUT);
     } catch (error) {
       setPasswordError(getAuthErrorMessage(error));
     } finally {
@@ -173,11 +173,6 @@ export default function AccountSettingsPage({
             </Alert>
           ) : (
             <>
-              {passwordSuccess && (
-                <Alert severity="success" sx={{ mb: 2 }}>
-                  Password updated successfully.
-                </Alert>
-              )}
               {passwordError && (
                 <Alert severity="error" sx={{ mb: 2 }}>
                   {passwordError}
@@ -279,6 +274,14 @@ export default function AccountSettingsPage({
           Back
         </Button>
       )}
+
+      <Snackbar
+        open={passwordSuccess}
+        autoHideDuration={4000}
+        onClose={() => setPasswordSuccess(false)}
+        message="Password updated successfully"
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      />
 
       <Dialog open={resignDialogOpen} onClose={() => !resignSubmitting && setResignDialogOpen(false)}>
         <DialogTitle>Resign membership?</DialogTitle>

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -95,7 +95,7 @@ describe("AccountSettingsPage", () => {
       expect(reauthenticateWithCredential).toHaveBeenCalled();
       expect(updatePassword).toHaveBeenCalledWith(mockUser, "new-pass");
     });
-    expect(screen.getByText("Password updated successfully.")).toBeInTheDocument();
+    expect(screen.getByText("Password updated successfully")).toBeInTheDocument();
   });
 
   it("resigns membership and signs out", async () => {

--- a/src/features/sections/components/MyBookings.tsx
+++ b/src/features/sections/components/MyBookings.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -75,9 +74,9 @@ export default function MyBookings({ onBack }: MyBookingsProps) {
           {error instanceof Error ? error.message : "We could not load your bookings. Please try again."}
         </Alert>
       ) : bookings.length === 0 ? (
-        <Alert severity="info">
-          You do not have any bookings yet. Open a section&apos;s events tab to book an upcoming event.
-        </Alert>
+        <Typography variant="body1" color="text.secondary">
+          No bookings yet — head to a section to find an upcoming event.
+        </Typography>
       ) : (
         <Stack spacing={2}>
           {bookings.map((booking) => {

--- a/src/features/sections/components/MyBookings.tsx
+++ b/src/features/sections/components/MyBookings.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Box,
   Button,
   Card,

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -282,8 +282,8 @@ describe("EventBookingWizard", () => {
     expect(screen.getByText("Edit your booking")).toBeInTheDocument();
     expect(screen.getByText(/editing your submitted booking/i)).toBeInTheDocument();
     expect(screen.queryByText("Number of guests")).not.toBeInTheDocument();
-    expect(screen.getByText("Guest details")).toBeInTheDocument();
-    expect(screen.getByText("Payment")).toBeInTheDocument();
+    expect(screen.getByText("Guest")).toBeInTheDocument();
+    expect(screen.getByText("Pay")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Next" }));
     await user.click(screen.getByRole("button", { name: "Next" }));
@@ -568,7 +568,7 @@ describe("EventBookingWizard", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/Pay for all tickets in one checkout/i)).toBeInTheDocument();
+      expect(screen.getByText(/Pay now to secure your place/i)).toBeInTheDocument();
     });
 
     await user.click(screen.getByRole("button", { name: "Back" }));
@@ -579,7 +579,7 @@ describe("EventBookingWizard", () => {
 
     await user.click(screen.getByRole("button", { name: "Next" }));
 
-    expect(screen.getByText(/Pay for all tickets in one checkout/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pay now to secure your place/i)).toBeInTheDocument();
   });
 
   it("submits separate dietary notes for each guest", async () => {
@@ -786,7 +786,7 @@ describe("EventBookingWizard", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Complete your booking")).toBeInTheDocument();
-      expect(screen.getByText(/Pay for all tickets in one checkout/i)).toBeInTheDocument();
+      expect(screen.getByText(/Pay now to secure your place/i)).toBeInTheDocument();
     });
     expect(screen.queryByLabelText(/how many guest tickets in total/i)).not.toBeInTheDocument();
   });

--- a/src/features/sections/components/__tests__/MyBookings.test.tsx
+++ b/src/features/sections/components/__tests__/MyBookings.test.tsx
@@ -202,7 +202,7 @@ describe("MyBookings", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByRole("link", { name: "Continue booking" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Complete booking" })).toBeInTheDocument();
   });
 
   it("shows empty state when there are no bookings", () => {
@@ -220,6 +220,6 @@ describe("MyBookings", () => {
       </MemoryRouter>
     );
 
-    expect(screen.getByText(/you do not have any bookings yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/no bookings yet/i)).toBeInTheDocument();
   });
 });

--- a/src/features/sections/components/wizardSteps/PaymentStep.tsx
+++ b/src/features/sections/components/wizardSteps/PaymentStep.tsx
@@ -24,8 +24,8 @@ export default function PaymentStep({
   return (
     <Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Pay for all tickets in one checkout to secure your place. You can also finish later and return
-        from your booking summary.
+        Pay now to secure your place. If you'd rather come back to it, you'll find the payment link
+        in your booking summary.
       </Typography>
 
       {paymentTicketRows.length > 0 ? (

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -45,13 +45,13 @@ export const EMPTY_GUEST_DETAIL: GuestDetailFields = { guestDisplayName: "", die
 
 export const BOOKING_STEPS = [
   "Your ticket",
-  "Guest details",
+  "Guest",
   "Review",
-  "Payment",
+  "Pay",
   "Confirmation",
 ] as const;
 
-export const ADDITIONAL_GUEST_STEPS = ["Extra guests", "Guest details", "Review"] as const;
+export const ADDITIONAL_GUEST_STEPS = ["Extra guests", "Guest", "Review"] as const;
 
 function extractCallableErrorCode(err: unknown): string | undefined {
   const e = err as {

--- a/src/features/sections/utils/__tests__/myBookingsDisplay.test.ts
+++ b/src/features/sections/utils/__tests__/myBookingsDisplay.test.ts
@@ -4,7 +4,7 @@ import { bookingStatusChipColor, getMyBookingActionLabel } from "../myBookingsDi
 
 describe("myBookingsDisplay", () => {
   it("returns action labels by booking status", () => {
-    expect(getMyBookingActionLabel(BookingStatus.DRAFT)).toBe("Continue booking");
+    expect(getMyBookingActionLabel(BookingStatus.DRAFT)).toBe("Complete booking");
     expect(getMyBookingActionLabel(BookingStatus.SUBMITTED)).toBe("View booking");
   });
 

--- a/src/features/sections/utils/myBookingsDisplay.ts
+++ b/src/features/sections/utils/myBookingsDisplay.ts
@@ -2,7 +2,7 @@ import { BookingStatus } from "@dataconnect/generated";
 
 export function getMyBookingActionLabel(status: BookingStatus | string): string {
   if (status === BookingStatus.DRAFT) {
-    return "Continue booking";
+    return "Complete booking";
   }
   return "View booking";
 }


### PR DESCRIPTION
Closes #300

## Changes

- **Wizard step labels**: "Guest details" → "Guest", "Payment" → "Pay" — shorter and less jargon-y in the stepper
- **PaymentStep copy**: warmer, more direct — "Pay now to secure your place. If you'd rather come back to it, you'll find the payment link in your booking summary."
- **My Bookings empty state**: replaced `Alert severity="info"` with plain `Typography` matching the dashboard's tone — "No bookings yet — head to a section to find an upcoming event."
- **DRAFT booking CTA**: "Complete booking" (was "Continue booking") — clearer intent
- **Account settings**: password-changed feedback is now a `Snackbar` toast at the bottom of the screen instead of an inline Alert that pushes the form down

## Test plan
- [ ] All 368 tests pass
- [ ] Wizard stepper shows "Your ticket · Guest · Review · Pay · Confirmation"
- [ ] Payment step body copy updated
- [ ] My Bookings with no bookings shows plain text, not an alert box
- [ ] Draft booking card shows "Complete booking" CTA
- [ ] Changing password on Account page shows a toast, not an inline success message

🤖 Generated with [Claude Code](https://claude.com/claude-code)