### PR TITLE
feat: email template version control and drift detection (#304)

### DIFF
--- a/functions/email-templates/README.md
+++ b/functions/email-templates/README.md
@@ -25,16 +25,19 @@ Email body in GOV Notify Markdown.
 
 `template-registry.json` maps each `templateKey` to its GOV Notify template UUID per environment. UUIDs are not secrets — they are safe to commit.
 
+Environments match the Firebase project aliases in `.firebaserc`:
+
 ```json
 {
   "bookingConfirmation": {
-    "staging": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-    "production": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+    "dev": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "beta": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy",
+    "production": "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz"
   }
 }
 ```
 
-Fill in UUIDs after creating/locating each template in the GOV Notify dashboard.
+Fill in UUIDs after creating/locating each template in the GOV Notify dashboard for that environment.
 
 ## Workflow: updating a template
 

--- a/functions/email-templates/README.md
+++ b/functions/email-templates/README.md
@@ -1,0 +1,55 @@
+# Email Templates
+
+GOV Notify email templates for SODC, stored as Markdown for version control and review.
+
+## Files
+
+Each template is a `.md` file with YAML frontmatter:
+
+```markdown
+---
+subject: "Your subject line with ((variable)) support"
+templateKey: camelCaseKey
+variables:
+  - variableName
+  - anotherVariable
+---
+Email body in GOV Notify Markdown.
+```
+
+- **`subject`** — the email subject line, may include `((variable))` placeholders
+- **`templateKey`** — must match the key used in the dispatcher TypeScript file
+- **`variables`** — the full list of `((variable))` names used in this template; must match exactly what the dispatcher sends
+
+## Template registry
+
+`template-registry.json` maps each `templateKey` to its GOV Notify template UUID per environment. UUIDs are not secrets — they are safe to commit.
+
+```json
+{
+  "bookingConfirmation": {
+    "staging": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "production": "yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy"
+  }
+}
+```
+
+Fill in UUIDs after creating/locating each template in the GOV Notify dashboard.
+
+## Workflow: updating a template
+
+1. Edit the `.md` file and commit the change (PR review applies here)
+2. Log in to the GOV Notify dashboard and update the corresponding template manually
+3. Check the admin template drift page to confirm the live template matches the `.md` file
+
+> GOV Notify does not provide a template create/update API — all dashboard changes must be made manually.
+
+## Workflow: new environment setup
+
+1. Create each template in the GOV Notify dashboard by copying subject and body from the `.md` files
+2. Fill in the returned UUIDs in `template-registry.json`
+3. Commit the updated registry
+
+## Admin drift detection
+
+The admin panel includes a **Template sync** page that fetches each template from GOV Notify via the API and compares it against the `.md` file. This catches cases where the dashboard was updated without updating the codebase, or vice versa. A diff is shown for any template that has drifted.

--- a/functions/email-templates/bookingConfirmation.md
+++ b/functions/email-templates/bookingConfirmation.md
@@ -16,27 +16,27 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your booking for **((eventTitle))** has been confirmed.
+Your booking for ((eventTitle)) has been confirmed.
 
 ---
 
-^**Event details**
+# Event details
 
-**When:** ((eventDateTime))
+When: ((eventDateTime))
 
-**Where:** ((eventLocation))
+Where: ((eventLocation))
 
 ---
 
-^**Your booking (revision ((revisionNumber)))**
+# Your booking (revision ((revisionNumber)))
 
 ((ticketLinesSummary))
 
-**Your dietary note:** ((bookerDietaryNote))
+Your dietary note: ((bookerDietaryNote))
 
-**Accommodation:** ((accommodationSummary))
+Accommodation: ((accommodationSummary))
 
-**Total:** ((bookingTotalFormatted))
+Total: ((bookingTotalFormatted))
 
 ---
 

--- a/functions/email-templates/bookingConfirmation.md
+++ b/functions/email-templates/bookingConfirmation.md
@@ -1,0 +1,51 @@
+---
+subject: "Your SODC booking — ((eventTitle))"
+templateKey: bookingConfirmation
+variables:
+  - customerFirstName
+  - eventTitle
+  - eventDateTime
+  - eventLocation
+  - revisionNumber
+  - ticketLinesSummary
+  - bookerDietaryNote
+  - accommodationSummary
+  - bookingTotalFormatted
+  - sectionBookingsUrl
+  - myPaymentsUrl
+---
+Dear ((customerFirstName)),
+
+Your booking for **((eventTitle))** has been confirmed.
+
+---
+
+^**Event details**
+
+**When:** ((eventDateTime))
+
+**Where:** ((eventLocation))
+
+---
+
+^**Your booking (revision ((revisionNumber)))**
+
+((ticketLinesSummary))
+
+**Your dietary note:** ((bookerDietaryNote))
+
+**Accommodation:** ((accommodationSummary))
+
+**Total:** ((bookingTotalFormatted))
+
+---
+
+You can view your booking and payment status at any time:
+
+((sectionBookingsUrl))
+
+If payment is outstanding, visit My Payments:
+
+((myPaymentsUrl))
+
+SODC

--- a/functions/email-templates/bookingRevision.md
+++ b/functions/email-templates/bookingRevision.md
@@ -22,33 +22,33 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your booking for **((eventTitle))** has been updated (revision ((previousRevisionNumber)) → ((revisedRevisionNumber))).
+Your booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).
 
 ---
 
-^**Event details**
+# Event details
 
-**When:** ((eventDateTime))
+When: ((eventDateTime))
 
-**Where:** ((eventLocation))
+Where: ((eventLocation))
 
 ---
 
-^**Updated booking (revision ((revisedRevisionNumber)))**
+# Updated booking (revision ((revisedRevisionNumber)))
 
 ((ticketLinesSummary))
 
-**Your dietary note:** ((bookerDietaryNote))
+Your dietary note: ((bookerDietaryNote))
 
-**Accommodation:** ((accommodationSummary))
+Accommodation: ((accommodationSummary))
 
-**Previous total:** ((previousTotalFormatted))
+Previous total: ((previousTotalFormatted))
 
-**Revised total:** ((revisedTotalFormatted))
+Revised total: ((revisedTotalFormatted))
 
-**Difference:** ((deltaAmountFormatted))
+Difference: ((deltaAmountFormatted))
 
-**Payment status:** ((paymentAdjustmentStatus))
+Payment status: ((paymentAdjustmentStatus))
 
 ---
 

--- a/functions/email-templates/bookingRevision.md
+++ b/functions/email-templates/bookingRevision.md
@@ -1,0 +1,63 @@
+---
+subject: "Your SODC booking has been updated — ((eventTitle))"
+templateKey: bookingRevision
+variables:
+  - customerFirstName
+  - eventTitle
+  - eventDateTime
+  - eventLocation
+  - revisionNumber
+  - ticketLinesSummary
+  - bookerDietaryNote
+  - accommodationSummary
+  - bookingTotalFormatted
+  - sectionBookingsUrl
+  - myPaymentsUrl
+  - previousRevisionNumber
+  - revisedRevisionNumber
+  - paymentAdjustmentStatus
+  - previousTotalFormatted
+  - revisedTotalFormatted
+  - deltaAmountFormatted
+---
+Dear ((customerFirstName)),
+
+Your booking for **((eventTitle))** has been updated (revision ((previousRevisionNumber)) → ((revisedRevisionNumber))).
+
+---
+
+^**Event details**
+
+**When:** ((eventDateTime))
+
+**Where:** ((eventLocation))
+
+---
+
+^**Updated booking (revision ((revisedRevisionNumber)))**
+
+((ticketLinesSummary))
+
+**Your dietary note:** ((bookerDietaryNote))
+
+**Accommodation:** ((accommodationSummary))
+
+**Previous total:** ((previousTotalFormatted))
+
+**Revised total:** ((revisedTotalFormatted))
+
+**Difference:** ((deltaAmountFormatted))
+
+**Payment status:** ((paymentAdjustmentStatus))
+
+---
+
+View your booking:
+
+((sectionBookingsUrl))
+
+Manage payments:
+
+((myPaymentsUrl))
+
+SODC

--- a/functions/email-templates/guestTicketRequestApproved.md
+++ b/functions/email-templates/guestTicketRequestApproved.md
@@ -1,0 +1,27 @@
+---
+subject: "Guest ticket request approved — ((eventTitle))"
+templateKey: guestTicketRequestApproved
+variables:
+  - customerFirstName
+  - eventTitle
+  - guestDisplayName
+  - requestedGuestCount
+  - decisionLabel
+  - moderatorNote
+  - myBookingsUrl
+---
+Dear ((customerFirstName)),
+
+Your guest ticket request for **((eventTitle))** has been **((decisionLabel))**.
+
+**Guest:** ((guestDisplayName))
+
+**Guest tickets:** ((requestedGuestCount))
+
+**Note from organiser:** ((moderatorNote))
+
+You can now complete payment for your guest tickets. Visit your booking to continue:
+
+((myBookingsUrl))
+
+SODC

--- a/functions/email-templates/guestTicketRequestApproved.md
+++ b/functions/email-templates/guestTicketRequestApproved.md
@@ -12,13 +12,13 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your guest ticket request for **((eventTitle))** has been **((decisionLabel))**.
+Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
 
-**Guest:** ((guestDisplayName))
+Guest: ((guestDisplayName))
 
-**Guest tickets:** ((requestedGuestCount))
+Guest tickets: ((requestedGuestCount))
 
-**Note from organiser:** ((moderatorNote))
+Note from organiser: ((moderatorNote))
 
 You can now complete payment for your guest tickets. Visit your booking to continue:
 

--- a/functions/email-templates/guestTicketRequestRejected.md
+++ b/functions/email-templates/guestTicketRequestRejected.md
@@ -1,0 +1,27 @@
+---
+subject: "Guest ticket request update — ((eventTitle))"
+templateKey: guestTicketRequestRejected
+variables:
+  - customerFirstName
+  - eventTitle
+  - guestDisplayName
+  - requestedGuestCount
+  - decisionLabel
+  - moderatorNote
+  - myBookingsUrl
+---
+Dear ((customerFirstName)),
+
+Your guest ticket request for **((eventTitle))** has been **((decisionLabel))**.
+
+**Guest:** ((guestDisplayName))
+
+**Guest tickets requested:** ((requestedGuestCount))
+
+**Note from organiser:** ((moderatorNote))
+
+If you have any questions, please contact your section organiser. You can view your booking at:
+
+((myBookingsUrl))
+
+SODC

--- a/functions/email-templates/guestTicketRequestRejected.md
+++ b/functions/email-templates/guestTicketRequestRejected.md
@@ -12,13 +12,13 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your guest ticket request for **((eventTitle))** has been **((decisionLabel))**.
+Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
 
-**Guest:** ((guestDisplayName))
+Guest: ((guestDisplayName))
 
-**Guest tickets requested:** ((requestedGuestCount))
+Guest tickets requested: ((requestedGuestCount))
 
-**Note from organiser:** ((moderatorNote))
+Note from organiser: ((moderatorNote))
 
 If you have any questions, please contact your section organiser. You can view your booking at:
 

--- a/functions/email-templates/guestTicketRequestSubmittedModerator.md
+++ b/functions/email-templates/guestTicketRequestSubmittedModerator.md
@@ -13,19 +13,19 @@ variables:
 ---
 A guest ticket request has been submitted for your review.
 
-**Event:** ((eventTitle))
+Event: ((eventTitle))
 
-**Section:** ((sectionName))
+Section: ((sectionName))
 
-**Requested by:** ((bookerDisplay))
+Requested by: ((bookerDisplay))
 
-**Guest name:** ((guestDisplayName))
+Guest name: ((guestDisplayName))
 
-**Guest count:** ((requestedGuestCount))
+Guest count: ((requestedGuestCount))
 
-**Ticket type:** ((guestTicketTypeTitle))
+Ticket type: ((guestTicketTypeTitle))
 
-**Dietary note:** ((dietaryNote))
+Dietary note: ((dietaryNote))
 
 ---
 

--- a/functions/email-templates/guestTicketRequestSubmittedModerator.md
+++ b/functions/email-templates/guestTicketRequestSubmittedModerator.md
@@ -1,0 +1,36 @@
+---
+subject: "Guest ticket request — ((eventTitle))"
+templateKey: guestTicketRequestSubmittedModerator
+variables:
+  - eventTitle
+  - sectionName
+  - bookerDisplay
+  - guestDisplayName
+  - requestedGuestCount
+  - guestTicketTypeTitle
+  - dietaryNote
+  - moderationUrl
+---
+A guest ticket request has been submitted for your review.
+
+**Event:** ((eventTitle))
+
+**Section:** ((sectionName))
+
+**Requested by:** ((bookerDisplay))
+
+**Guest name:** ((guestDisplayName))
+
+**Guest count:** ((requestedGuestCount))
+
+**Ticket type:** ((guestTicketTypeTitle))
+
+**Dietary note:** ((dietaryNote))
+
+---
+
+Review and approve or decline this request in the admin panel:
+
+((moderationUrl))
+
+SODC

--- a/functions/email-templates/membershipAccessRestricted.md
+++ b/functions/email-templates/membershipAccessRestricted.md
@@ -1,0 +1,18 @@
+---
+subject: "Your SODC membership status has changed"
+templateKey: membershipAccessRestricted
+variables:
+  - customerFirstName
+  - membershipStatusLabel
+  - previousStatusLabel
+  - appUrl
+---
+Dear ((customerFirstName)),
+
+Your SODC membership status has changed from **((previousStatusLabel))** to **((membershipStatusLabel))**.
+
+Your access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.
+
+((appUrl))
+
+SODC

--- a/functions/email-templates/membershipAccessRestricted.md
+++ b/functions/email-templates/membershipAccessRestricted.md
@@ -9,7 +9,7 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your SODC membership status has changed from **((previousStatusLabel))** to **((membershipStatusLabel))**.
+Your SODC membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)).
 
 Your access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.
 

--- a/functions/email-templates/membershipActivated.md
+++ b/functions/email-templates/membershipActivated.md
@@ -1,0 +1,26 @@
+---
+subject: "Welcome to SODC — your membership is active"
+templateKey: membershipActivated
+variables:
+  - customerFirstName
+  - membershipStatusLabel
+  - appUrl
+  - profileUrl
+---
+Dear ((customerFirstName)),
+
+Your SODC membership is now active. Your membership status is **((membershipStatusLabel))**.
+
+You can now access sections, view upcoming events, and make bookings.
+
+Sign in to get started:
+
+((appUrl))
+
+We recommend completing your profile before making your first booking:
+
+((profileUrl))
+
+Welcome aboard.
+
+SODC

--- a/functions/email-templates/membershipActivated.md
+++ b/functions/email-templates/membershipActivated.md
@@ -9,7 +9,7 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your SODC membership is now active. Your membership status is **((membershipStatusLabel))**.
+Your SODC membership is now active. Your membership status is ((membershipStatusLabel)).
 
 You can now access sections, view upcoming events, and make bookings.
 

--- a/functions/email-templates/paymentDisputeOpsAlert.md
+++ b/functions/email-templates/paymentDisputeOpsAlert.md
@@ -1,0 +1,42 @@
+---
+subject: "[SODC OPS] Payment dispute — ((orderId))"
+templateKey: paymentDisputeOpsAlert
+variables:
+  - orderId
+  - eventTitle
+  - customerDisplay
+  - disputeStripeStatus
+  - disputeReason
+  - disputeLocalState
+  - stripeDisputeId
+  - stripeEventType
+  - reconciliationDashboardUrl
+  - stripeEventId
+---
+A payment dispute event has been received.
+
+**Order ID:** ((orderId))
+
+**Event:** ((eventTitle))
+
+**Customer:** ((customerDisplay))
+
+**Dispute ID:** ((stripeDisputeId))
+
+**Stripe status:** ((disputeStripeStatus))
+
+**Reason:** ((disputeReason))
+
+**Local state:** ((disputeLocalState))
+
+**Stripe event type:** ((stripeEventType))
+
+**Stripe event ID:** ((stripeEventId))
+
+---
+
+Review in the reconciliation dashboard:
+
+((reconciliationDashboardUrl))
+
+SODC Ops

--- a/functions/email-templates/paymentDisputeOpsAlert.md
+++ b/functions/email-templates/paymentDisputeOpsAlert.md
@@ -15,23 +15,23 @@ variables:
 ---
 A payment dispute event has been received.
 
-**Order ID:** ((orderId))
+Order ID: ((orderId))
 
-**Event:** ((eventTitle))
+Event: ((eventTitle))
 
-**Customer:** ((customerDisplay))
+Customer: ((customerDisplay))
 
-**Dispute ID:** ((stripeDisputeId))
+Dispute ID: ((stripeDisputeId))
 
-**Stripe status:** ((disputeStripeStatus))
+Stripe status: ((disputeStripeStatus))
 
-**Reason:** ((disputeReason))
+Reason: ((disputeReason))
 
-**Local state:** ((disputeLocalState))
+Local state: ((disputeLocalState))
 
-**Stripe event type:** ((stripeEventType))
+Stripe event type: ((stripeEventType))
 
-**Stripe event ID:** ((stripeEventId))
+Stripe event ID: ((stripeEventId))
 
 ---
 

--- a/functions/email-templates/paymentReconciliationExceptionAlert.md
+++ b/functions/email-templates/paymentReconciliationExceptionAlert.md
@@ -1,0 +1,33 @@
+---
+subject: "[SODC OPS] Reconciliation exception — ((orderId))"
+templateKey: paymentReconciliationExceptionAlert
+variables:
+  - orderId
+  - eventTitle
+  - customerDisplay
+  - exceptionType
+  - exceptionNote
+  - reconciliationDashboardUrl
+  - stripeEventId
+---
+A payment reconciliation exception requires your attention.
+
+**Order ID:** ((orderId))
+
+**Event:** ((eventTitle))
+
+**Customer:** ((customerDisplay))
+
+**Exception type:** ((exceptionType))
+
+**Note:** ((exceptionNote))
+
+**Stripe event ID:** ((stripeEventId))
+
+---
+
+Review in the reconciliation dashboard:
+
+((reconciliationDashboardUrl))
+
+SODC Ops

--- a/functions/email-templates/paymentReconciliationExceptionAlert.md
+++ b/functions/email-templates/paymentReconciliationExceptionAlert.md
@@ -12,17 +12,17 @@ variables:
 ---
 A payment reconciliation exception requires your attention.
 
-**Order ID:** ((orderId))
+Order ID: ((orderId))
 
-**Event:** ((eventTitle))
+Event: ((eventTitle))
 
-**Customer:** ((customerDisplay))
+Customer: ((customerDisplay))
 
-**Exception type:** ((exceptionType))
+Exception type: ((exceptionType))
 
-**Note:** ((exceptionNote))
+Note: ((exceptionNote))
 
-**Stripe event ID:** ((stripeEventId))
+Stripe event ID: ((stripeEventId))
 
 ---
 

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -1,50 +1,62 @@
 {
   "bookingConfirmation": {
-    "staging": "",
+    "dev": "7eba3d20-5ab1-4834-b8a9-9d72baffe76a",
+    "beta": "",
     "production": ""
   },
   "bookingRevision": {
-    "staging": "",
+    "dev": "8f8549ec-0945-4ad9-9200-f507ada226bb",
+    "beta": "",
     "production": ""
   },
   "membershipActivated": {
-    "staging": "",
+    "dev": "640e51e0-d4cf-413c-a829-07f0f7cdca7d",
+    "beta": "",
     "production": ""
   },
   "membershipAccessRestricted": {
-    "staging": "",
+    "dev": "30457d61-4809-41db-9ebe-94690462a18e",
+    "beta": "",
     "production": ""
   },
   "ticketOrderPaid": {
-    "staging": "",
+    "dev": "b6816c5c-d742-4852-ba6d-88035581c538",
+    "beta": "",
     "production": ""
   },
   "ticketOrderFailed": {
-    "staging": "",
+    "dev": "a6f07564-b669-42c6-8380-1d474c7269eb",
+    "beta": "",
     "production": ""
   },
   "ticketOrderRefunded": {
-    "staging": "",
+    "dev": "b431d092-934a-42cb-9c04-562f3b088d9b",
+    "beta": "",
     "production": ""
   },
   "guestTicketRequestSubmittedModerator": {
-    "staging": "",
+    "dev": "cf9a8a7c-860f-43da-98b4-718c93fe92e6",
+    "beta": "",
     "production": ""
   },
   "guestTicketRequestApproved": {
-    "staging": "",
+    "dev": "651a5577-11c7-48c7-a1aa-42193cb223c7",
+    "beta": "",
     "production": ""
   },
   "guestTicketRequestRejected": {
-    "staging": "",
+    "dev": "132479c9-d8df-4a93-aff7-bf290ae7f543",
+    "beta": "",
     "production": ""
   },
   "paymentReconciliationExceptionAlert": {
-    "staging": "",
+    "dev": "b62197b8-1416-4918-b0e6-5129844f869d",
+    "beta": "",
     "production": ""
   },
   "paymentDisputeOpsAlert": {
-    "staging": "",
+    "dev": "da2fccf1-d5e2-44c4-a730-dabaafc95d60",
+    "beta": "",
     "production": ""
   }
 }

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -1,0 +1,50 @@
+{
+  "bookingConfirmation": {
+    "staging": "",
+    "production": ""
+  },
+  "bookingRevision": {
+    "staging": "",
+    "production": ""
+  },
+  "membershipActivated": {
+    "staging": "",
+    "production": ""
+  },
+  "membershipAccessRestricted": {
+    "staging": "",
+    "production": ""
+  },
+  "ticketOrderPaid": {
+    "staging": "",
+    "production": ""
+  },
+  "ticketOrderFailed": {
+    "staging": "",
+    "production": ""
+  },
+  "ticketOrderRefunded": {
+    "staging": "",
+    "production": ""
+  },
+  "guestTicketRequestSubmittedModerator": {
+    "staging": "",
+    "production": ""
+  },
+  "guestTicketRequestApproved": {
+    "staging": "",
+    "production": ""
+  },
+  "guestTicketRequestRejected": {
+    "staging": "",
+    "production": ""
+  },
+  "paymentReconciliationExceptionAlert": {
+    "staging": "",
+    "production": ""
+  },
+  "paymentDisputeOpsAlert": {
+    "staging": "",
+    "production": ""
+  }
+}

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -1,4 +1,9 @@
 {
+  "_serviceIds": {
+    "dev": "d67fd89c-5cb0-4767-be1d-e745fc71dd36",
+    "beta": "",
+    "production": ""
+  },
   "bookingConfirmation": {
     "dev": "7eba3d20-5ab1-4834-b8a9-9d72baffe76a",
     "beta": "",

--- a/functions/email-templates/ticketOrderFailed.md
+++ b/functions/email-templates/ticketOrderFailed.md
@@ -15,17 +15,17 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Unfortunately your payment for **((eventTitle))** was unsuccessful.
+Unfortunately your payment for ((eventTitle)) was unsuccessful.
 
-**Ticket:** ((ticketTypeTitle))
+Ticket: ((ticketTypeTitle))
 
-**Quantity:** ((quantity))
+Quantity: ((quantity))
 
-**Amount:** ((totalFormatted)) ((currencyDisplay))
+Amount: ((totalFormatted)) ((currencyDisplay))
 
-**Status:** ((orderStatusLabel))
+Status: ((orderStatusLabel))
 
-**Order reference:** ((orderId))
+Order reference: ((orderId))
 
 Your booking is still in place. You can return to My Payments to try again:
 

--- a/functions/email-templates/ticketOrderFailed.md
+++ b/functions/email-templates/ticketOrderFailed.md
@@ -1,0 +1,36 @@
+---
+subject: "Payment unsuccessful — ((eventTitle))"
+templateKey: ticketOrderFailed
+variables:
+  - customerFirstName
+  - firstName
+  - eventTitle
+  - ticketTypeTitle
+  - quantity
+  - totalFormatted
+  - currencyDisplay
+  - orderStatusLabel
+  - orderId
+  - myPaymentsUrl
+---
+Dear ((customerFirstName)),
+
+Unfortunately your payment for **((eventTitle))** was unsuccessful.
+
+**Ticket:** ((ticketTypeTitle))
+
+**Quantity:** ((quantity))
+
+**Amount:** ((totalFormatted)) ((currencyDisplay))
+
+**Status:** ((orderStatusLabel))
+
+**Order reference:** ((orderId))
+
+Your booking is still in place. You can return to My Payments to try again:
+
+((myPaymentsUrl))
+
+If you continue to have problems, please reply to this email.
+
+SODC

--- a/functions/email-templates/ticketOrderPaid.md
+++ b/functions/email-templates/ticketOrderPaid.md
@@ -1,0 +1,34 @@
+---
+subject: "Payment confirmed — ((eventTitle))"
+templateKey: ticketOrderPaid
+variables:
+  - customerFirstName
+  - firstName
+  - eventTitle
+  - ticketTypeTitle
+  - quantity
+  - totalFormatted
+  - currencyDisplay
+  - orderStatusLabel
+  - orderId
+  - myPaymentsUrl
+---
+Dear ((customerFirstName)),
+
+Your payment for **((eventTitle))** has been confirmed.
+
+**Ticket:** ((ticketTypeTitle))
+
+**Quantity:** ((quantity))
+
+**Total paid:** ((totalFormatted)) ((currencyDisplay))
+
+**Status:** ((orderStatusLabel))
+
+**Order reference:** ((orderId))
+
+You can view your payment history at any time:
+
+((myPaymentsUrl))
+
+SODC

--- a/functions/email-templates/ticketOrderPaid.md
+++ b/functions/email-templates/ticketOrderPaid.md
@@ -15,17 +15,17 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-Your payment for **((eventTitle))** has been confirmed.
+Your payment for ((eventTitle)) has been confirmed.
 
-**Ticket:** ((ticketTypeTitle))
+Ticket: ((ticketTypeTitle))
 
-**Quantity:** ((quantity))
+Quantity: ((quantity))
 
-**Total paid:** ((totalFormatted)) ((currencyDisplay))
+Total paid: ((totalFormatted)) ((currencyDisplay))
 
-**Status:** ((orderStatusLabel))
+Status: ((orderStatusLabel))
 
-**Order reference:** ((orderId))
+Order reference: ((orderId))
 
 You can view your payment history at any time:
 

--- a/functions/email-templates/ticketOrderRefunded.md
+++ b/functions/email-templates/ticketOrderRefunded.md
@@ -1,0 +1,37 @@
+---
+subject: "Refund processed — ((eventTitle))"
+templateKey: ticketOrderRefunded
+variables:
+  - customerFirstName
+  - firstName
+  - eventTitle
+  - ticketTypeTitle
+  - quantity
+  - totalFormatted
+  - currencyDisplay
+  - orderStatusLabel
+  - orderId
+  - myPaymentsUrl
+  - refundFormatted
+---
+Dear ((customerFirstName)),
+
+A refund of **((refundFormatted))** has been processed for your payment on **((eventTitle))**.
+
+**Ticket:** ((ticketTypeTitle))
+
+**Quantity:** ((quantity))
+
+**Original total:** ((totalFormatted)) ((currencyDisplay))
+
+**Status:** ((orderStatusLabel))
+
+**Order reference:** ((orderId))
+
+Refunds typically appear in your account within 5–10 working days depending on your bank.
+
+You can view your payment history at:
+
+((myPaymentsUrl))
+
+SODC

--- a/functions/email-templates/ticketOrderRefunded.md
+++ b/functions/email-templates/ticketOrderRefunded.md
@@ -16,19 +16,19 @@ variables:
 ---
 Dear ((customerFirstName)),
 
-A refund of **((refundFormatted))** has been processed for your payment on **((eventTitle))**.
+A refund of ((refundFormatted)) has been processed for your payment on ((eventTitle)).
 
-**Ticket:** ((ticketTypeTitle))
+Ticket: ((ticketTypeTitle))
 
-**Quantity:** ((quantity))
+Quantity: ((quantity))
 
-**Original total:** ((totalFormatted)) ((currencyDisplay))
+Original total: ((totalFormatted)) ((currencyDisplay))
 
-**Status:** ((orderStatusLabel))
+Status: ((orderStatusLabel))
 
-**Order reference:** ((orderId))
+Order reference: ((orderId))
 
-Refunds typically appear in your account within 5–10 working days depending on your bank.
+Refunds typically appear in your account within 5 to 10 working days depending on your bank.
 
 You can view your payment history at:
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -45,6 +45,29 @@
       "resolved": "src/dataconnect-admin-generated",
       "link": true
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -1104,7 +1127,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1219,7 +1241,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1486,7 +1507,6 @@
       "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "fflate": "^0.8.2",
@@ -1550,7 +1570,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2671,7 +2690,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3329,7 +3347,6 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
       "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
@@ -3353,7 +3370,6 @@
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
       "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "^4.17.21",
@@ -6868,7 +6884,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7157,7 +7172,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7262,7 +7276,6 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7354,7 +7367,6 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-import": "^2.25.4",
         "firebase-functions-test": "^0.3.3",
+        "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
         "vitest": "^4.1.9"
       },
@@ -27,32 +28,22 @@
         "node": "24"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@dataconnect/admin-generated": {
       "resolved": "src/dataconnect-admin-generated",
       "link": true
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
@@ -448,12 +439,33 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -908,6 +920,34 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -1064,6 +1104,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1178,6 +1219,7 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1444,6 +1486,7 @@
       "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "fflate": "^0.8.2",
@@ -1507,6 +1550,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1522,6 +1566,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -1588,6 +1645,13 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2132,6 +2196,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2306,6 +2377,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -2590,6 +2671,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3247,6 +3329,7 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-13.10.0.tgz",
       "integrity": "sha512-rbuCrJvYRwqBqvbccMS8fj/x2zsaMisdf5RQbRzQzr14Rbq9r2UlpuBHqWAwrO6c9dIRF56xF/xoepXsD5yDuQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
@@ -3270,6 +3353,7 @@
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.2.5.tgz",
       "integrity": "sha512-K+pP0AknluAguLRbD96hibyXbnOgwnvd4hkExWdGrxnNCLoj8LBFj08uvJYxyvhsCgYzQumrUaHBW4lsXKSiRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "^4.17.21",
@@ -5109,6 +5193,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -6777,6 +6868,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6832,6 +6924,50 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -7021,6 +7157,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7103,6 +7240,13 @@
         "uuid": "dist/esm/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -7118,6 +7262,7 @@
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7209,6 +7354,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -7572,6 +7718,16 @@
       "optional": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,6 +2,8 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint .",
+    "generate:templates": "ts-node --project tsconfig.scripts.json scripts/generate-template-manifest.ts",
+    "prebuild": "npm run generate:templates",
     "build": "tsc",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
@@ -32,6 +34,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.25.4",
     "firebase-functions-test": "^0.3.3",
+    "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "vitest": "^4.1.9"
   },

--- a/functions/scripts/generate-template-manifest.ts
+++ b/functions/scripts/generate-template-manifest.ts
@@ -1,0 +1,100 @@
+/**
+ * Reads all .md files from email-templates/ and generates
+ * src/generatedEmailTemplateManifest.ts for use by the Cloud Function.
+ * Run automatically as part of `npm run build` via the `prebuild` script.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+const TEMPLATES_DIR = path.resolve(__dirname, "../email-templates");
+const OUT_FILE = path.resolve(__dirname, "../src/generatedEmailTemplateManifest.ts");
+
+interface ParsedTemplate {
+  templateKey: string;
+  subject: string;
+  variables: string[];
+  body: string;
+}
+
+function parseFrontmatter(content: string): { meta: Record<string, unknown>; body: string } {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) {
+    throw new Error("Missing or malformed YAML frontmatter");
+  }
+  const rawMeta = match[1];
+  const body = match[2].trim();
+
+  const meta: Record<string, unknown> = {};
+  let currentKey: string | null = null;
+  let inList = false;
+
+  for (const line of rawMeta.split("\n")) {
+    const listMatch = line.match(/^\s+-\s+(.+)$/);
+    const keyMatch = line.match(/^(\w+):\s*(.*)$/);
+
+    if (listMatch && inList && currentKey) {
+      (meta[currentKey] as string[]).push(listMatch[1].trim());
+    } else if (keyMatch) {
+      currentKey = keyMatch[1];
+      const value = keyMatch[2].trim();
+      if (value === "") {
+        meta[currentKey] = [];
+        inList = true;
+      } else {
+        meta[currentKey] = value.replace(/^["']|["']$/g, "");
+        inList = false;
+      }
+    }
+  }
+
+  return { meta, body };
+}
+
+function loadTemplates(): ParsedTemplate[] {
+  const files = fs.readdirSync(TEMPLATES_DIR).filter((f) => f.endsWith(".md") && f !== "README.md");
+  return files.map((file) => {
+    const content = fs.readFileSync(path.join(TEMPLATES_DIR, file), "utf-8");
+    const { meta, body } = parseFrontmatter(content);
+    const templateKey = meta.templateKey as string;
+    const subject = meta.subject as string;
+    const variables = (meta.variables as string[]) ?? [];
+    if (!templateKey) throw new Error(`${file}: missing templateKey in frontmatter`);
+    if (!subject) throw new Error(`${file}: missing subject in frontmatter`);
+    return { templateKey, subject, variables, body };
+  });
+}
+
+function generate(): void {
+  const templates = loadTemplates();
+
+  const entries = templates
+    .map(({ templateKey, subject, variables, body }) => {
+      const varsArray = variables.map((v) => `    "${v}"`).join(",\n");
+      return `  ${templateKey}: {
+    subject: ${JSON.stringify(subject)},
+    variables: [\n${varsArray}\n    ],
+    body: ${JSON.stringify(body)},
+  }`;
+    })
+    .join(",\n");
+
+  const output = `// AUTO-GENERATED — do not edit directly.
+// Source: functions/email-templates/*.md
+// Regenerate by running: npm run build (or npm run generate:templates)
+
+export interface EmailTemplateDefinition {
+  subject: string;
+  variables: string[];
+  body: string;
+}
+
+export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = {
+${entries},
+};
+`;
+
+  fs.writeFileSync(OUT_FILE, output, "utf-8");
+  console.log(`Generated ${OUT_FILE} (${templates.length} templates)`);
+}
+
+generate();

--- a/functions/src/__tests__/emailTemplateMarkdown.test.ts
+++ b/functions/src/__tests__/emailTemplateMarkdown.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+const TEMPLATES_DIR = path.resolve(__dirname, "../../email-templates");
+
+const UNSUPPORTED_PATTERNS: { name: string; pattern: RegExp }[] = [
+  { name: "bold (**text**)", pattern: /\*\*[^*]+\*\*/ },
+  { name: "bold (__text__)", pattern: /__[^_]+__/ },
+  { name: "italic (*text*) — single asterisk not used as a bullet", pattern: /(?<!\*)\*(?!\*)(?!\s)([^*\n]+)(?<!\s)\*(?!\*)/ },
+  { name: "italic (_text_)", pattern: /(?<!_)_(?!_)(?!\s)([^_\n]+)(?<!\s)_(?!_)/ },
+  { name: "strikethrough (~~text~~)", pattern: /~~[^~]+~~/ },
+  { name: "inline code (`code`)", pattern: /`[^`]+`/ },
+  { name: "fenced code block (```)", pattern: /^```/m },
+  { name: "blockquote (> text)", pattern: /^> /m },
+  { name: "image (![alt](url))", pattern: /!\[[^\]]*\]\([^)]+\)/ },
+  { name: "HTML tag (<tag>)", pattern: /<\/?[a-z][a-z0-9]*(\s[^>]*)?>/ },
+];
+
+function readTemplateBody(filePath: string): string {
+  const content = fs.readFileSync(filePath, "utf8");
+  // Strip YAML frontmatter
+  const match = content.match(/^---\n[\s\S]*?\n---\n([\s\S]*)$/);
+  return match ? match[1] : content;
+}
+
+describe("GOV Notify email templates", () => {
+  const templateFiles = fs
+    .readdirSync(TEMPLATES_DIR)
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .map((f) => ({ name: f, filePath: path.join(TEMPLATES_DIR, f) }));
+
+  it("should find template files to test", () => {
+    expect(templateFiles.length).toBeGreaterThan(0);
+  });
+
+  for (const { name, filePath } of templateFiles) {
+    describe(name, () => {
+      const body = readTemplateBody(filePath);
+
+      for (const { name: patternName, pattern } of UNSUPPORTED_PATTERNS) {
+        it(`must not use ${patternName}`, () => {
+          expect(body).not.toMatch(pattern);
+        });
+      }
+    });
+  }
+});

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -28,7 +28,6 @@ export interface TemplateSyncResult {
   templateUuid?: string;
   notifyEditUrl?: string;
   status: TemplateSyncStatus;
-  liveTemplateName?: string;
   liveSubject?: string;
   liveBody?: string;
   expectedSubject: string;
@@ -63,7 +62,6 @@ function buildEditUrl(serviceId: string, templateUuid: string): string {
 }
 
 interface NotifyTemplate {
-  name: string;
   subject: string;
   body: string;
 }
@@ -71,8 +69,8 @@ interface NotifyTemplate {
 async function fetchNotifyTemplate(apiKey: string, uuid: string): Promise<NotifyTemplate> {
   const client = new NotifyClient(apiKey);
   const response = await client.getTemplateById(uuid);
-  const data = response.data as { name: string; subject: string; body: string };
-  return { name: data.name ?? "", subject: data.subject ?? "", body: data.body ?? "" };
+  const data = response.data as { subject: string; body: string };
+  return { subject: data.subject ?? "", body: data.body ?? "" };
 }
 
 export const getTemplateSyncStatus = onCall(
@@ -108,7 +106,6 @@ export const getTemplateSyncStatus = onCall(
 
           try {
             const live = await fetchNotifyTemplate(apiKey, uuid);
-            const liveTemplateName = live.name;
             const liveSubject = live.subject;
             const liveBody = normaliseBody(live.body);
             const subjectMatch = liveSubject === expectedSubject;
@@ -118,7 +115,6 @@ export const getTemplateSyncStatus = onCall(
               templateUuid: uuid,
               notifyEditUrl,
               status: (subjectMatch && bodyMatch ? "in_sync" : "drift") as TemplateSyncStatus,
-              liveTemplateName,
               liveSubject,
               liveBody,
               expectedSubject,

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -9,7 +9,7 @@ import { FUNCTIONS_REGION } from "./constants";
 
 const REGISTRY_PATH = path.resolve(__dirname, "../../email-templates/template-registry.json");
 
-type TemplateRegistry = Record<string, { staging?: string; production?: string }>;
+type TemplateRegistry = Record<string, { dev?: string; beta?: string; production?: string }>;
 
 export type TemplateSyncStatus = "in_sync" | "drift" | "not_configured" | "fetch_error";
 
@@ -38,9 +38,11 @@ function loadRegistry(): TemplateRegistry {
   }
 }
 
-function resolveEnvironment(): "staging" | "production" {
-  const env = process.env.APP_ENV ?? process.env.GCLOUD_PROJECT ?? "";
-  return env.includes("prod") ? "production" : "staging";
+function resolveEnvironment(): "dev" | "beta" | "production" {
+  const project = process.env.GCLOUD_PROJECT ?? process.env.APP_ENV ?? "";
+  if (project.includes("production")) return "production";
+  if (project.includes("beta")) return "beta";
+  return "dev";
 }
 
 interface NotifyTemplate {

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -1,0 +1,120 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import * as fs from "fs";
+import * as path from "path";
+import { NotifyClient } from "notifications-node-client";
+import { requireAdmin, handleFunctionError } from "./helpers";
+import { govNotifyApiKey } from "./mailer";
+import { EMAIL_TEMPLATE_MANIFEST } from "./generatedEmailTemplateManifest";
+import { FUNCTIONS_REGION } from "./constants";
+
+const REGISTRY_PATH = path.resolve(__dirname, "../../email-templates/template-registry.json");
+
+type TemplateRegistry = Record<string, { staging?: string; production?: string }>;
+
+export type TemplateSyncStatus = "in_sync" | "drift" | "not_configured" | "fetch_error";
+
+export interface TemplateSyncResult {
+  templateKey: string;
+  status: TemplateSyncStatus;
+  liveSubject?: string;
+  liveBody?: string;
+  expectedSubject: string;
+  expectedBody: string;
+  subjectMatch?: boolean;
+  bodyMatch?: boolean;
+  errorMessage?: string;
+}
+
+function normaliseBody(body: string): string {
+  return body.trim().replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function loadRegistry(): TemplateRegistry {
+  try {
+    const raw = fs.readFileSync(REGISTRY_PATH, "utf-8");
+    return JSON.parse(raw) as TemplateRegistry;
+  } catch {
+    return {};
+  }
+}
+
+function resolveEnvironment(): "staging" | "production" {
+  const env = process.env.APP_ENV ?? process.env.GCLOUD_PROJECT ?? "";
+  return env.includes("prod") ? "production" : "staging";
+}
+
+interface NotifyTemplate {
+  subject: string;
+  body: string;
+}
+
+async function fetchNotifyTemplate(apiKey: string, uuid: string): Promise<NotifyTemplate> {
+  const client = new NotifyClient(apiKey);
+  const response = await client.getTemplateById(uuid);
+  const data = response.data as { subject: string; body: string };
+  return { subject: data.subject ?? "", body: data.body ?? "" };
+}
+
+export const getTemplateSyncStatus = onCall(
+  { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
+  async (request): Promise<{ results: TemplateSyncResult[] }> => {
+    requireAdmin(request);
+
+    const apiKey = govNotifyApiKey.value();
+    if (!apiKey) {
+      throw new HttpsError("failed-precondition", "GOV_NOTIFY_API_KEY is not configured");
+    }
+
+    const registry = loadRegistry();
+    const environment = resolveEnvironment();
+
+    try {
+      const results: TemplateSyncResult[] = await Promise.all(
+        Object.entries(EMAIL_TEMPLATE_MANIFEST).map(async ([templateKey, definition]) => {
+          const uuid = registry[templateKey]?.[environment]?.trim();
+          const expectedSubject = definition.subject;
+          const expectedBody = normaliseBody(definition.body);
+
+          if (!uuid) {
+            return {
+              templateKey,
+              status: "not_configured" as TemplateSyncStatus,
+              expectedSubject,
+              expectedBody,
+            };
+          }
+
+          try {
+            const live = await fetchNotifyTemplate(apiKey, uuid);
+            const liveSubject = live.subject;
+            const liveBody = normaliseBody(live.body);
+            const subjectMatch = liveSubject === expectedSubject;
+            const bodyMatch = liveBody === expectedBody;
+            return {
+              templateKey,
+              status: (subjectMatch && bodyMatch ? "in_sync" : "drift") as TemplateSyncStatus,
+              liveSubject,
+              liveBody,
+              expectedSubject,
+              expectedBody,
+              subjectMatch,
+              bodyMatch,
+            };
+          } catch (err) {
+            return {
+              templateKey,
+              status: "fetch_error" as TemplateSyncStatus,
+              expectedSubject,
+              expectedBody,
+              errorMessage: err instanceof Error ? err.message : String(err),
+            };
+          }
+        })
+      );
+
+      return { results };
+    } catch (e) {
+      handleFunctionError(e, "fetching template sync status");
+    }
+  }
+);

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -9,12 +9,24 @@ import { FUNCTIONS_REGION } from "./constants";
 
 const REGISTRY_PATH = path.resolve(__dirname, "../email-templates/template-registry.json");
 
-type TemplateRegistry = Record<string, { dev?: string; beta?: string; production?: string }>;
+type Environment = "dev" | "beta" | "production";
+
+interface RegistryEntry {
+  dev?: string;
+  beta?: string;
+  production?: string;
+}
+
+type TemplateRegistry = Record<string, RegistryEntry> & {
+  _serviceIds?: RegistryEntry;
+};
 
 export type TemplateSyncStatus = "in_sync" | "drift" | "not_configured" | "fetch_error";
 
 export interface TemplateSyncResult {
   templateKey: string;
+  templateUuid?: string;
+  notifyEditUrl?: string;
   status: TemplateSyncStatus;
   liveSubject?: string;
   liveBody?: string;
@@ -38,11 +50,15 @@ function loadRegistry(): TemplateRegistry {
   }
 }
 
-function resolveEnvironment(): "dev" | "beta" | "production" {
+function resolveEnvironment(): Environment {
   const project = process.env.GCLOUD_PROJECT ?? process.env.APP_ENV ?? "";
   if (project.includes("production")) return "production";
   if (project.includes("beta")) return "beta";
   return "dev";
+}
+
+function buildEditUrl(serviceId: string, templateUuid: string): string {
+  return `https://www.notifications.service.gov.uk/services/${serviceId}/templates/${templateUuid}/edit`;
 }
 
 interface NotifyTemplate {
@@ -69,6 +85,7 @@ export const getTemplateSyncStatus = onCall(
 
     const registry = loadRegistry();
     const environment = resolveEnvironment();
+    const serviceId = registry._serviceIds?.[environment]?.trim() ?? "";
 
     try {
       const results: TemplateSyncResult[] = await Promise.all(
@@ -76,6 +93,7 @@ export const getTemplateSyncStatus = onCall(
           const uuid = registry[templateKey]?.[environment]?.trim();
           const expectedSubject = definition.subject;
           const expectedBody = normaliseBody(definition.body);
+          const notifyEditUrl = uuid && serviceId ? buildEditUrl(serviceId, uuid) : undefined;
 
           if (!uuid) {
             return {
@@ -94,6 +112,8 @@ export const getTemplateSyncStatus = onCall(
             const bodyMatch = liveBody === expectedBody;
             return {
               templateKey,
+              templateUuid: uuid,
+              notifyEditUrl,
               status: (subjectMatch && bodyMatch ? "in_sync" : "drift") as TemplateSyncStatus,
               liveSubject,
               liveBody,
@@ -105,6 +125,8 @@ export const getTemplateSyncStatus = onCall(
           } catch (err) {
             return {
               templateKey,
+              templateUuid: uuid,
+              notifyEditUrl,
               status: "fetch_error" as TemplateSyncStatus,
               expectedSubject,
               expectedBody,

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -7,7 +7,7 @@ import { govNotifyApiKey } from "./mailer";
 import { EMAIL_TEMPLATE_MANIFEST } from "./generatedEmailTemplateManifest";
 import { FUNCTIONS_REGION } from "./constants";
 
-const REGISTRY_PATH = path.resolve(__dirname, "../../email-templates/template-registry.json");
+const REGISTRY_PATH = path.resolve(__dirname, "../email-templates/template-registry.json");
 
 type TemplateRegistry = Record<string, { dev?: string; beta?: string; production?: string }>;
 

--- a/functions/src/emailTemplateSync.ts
+++ b/functions/src/emailTemplateSync.ts
@@ -28,6 +28,7 @@ export interface TemplateSyncResult {
   templateUuid?: string;
   notifyEditUrl?: string;
   status: TemplateSyncStatus;
+  liveTemplateName?: string;
   liveSubject?: string;
   liveBody?: string;
   expectedSubject: string;
@@ -62,6 +63,7 @@ function buildEditUrl(serviceId: string, templateUuid: string): string {
 }
 
 interface NotifyTemplate {
+  name: string;
   subject: string;
   body: string;
 }
@@ -69,8 +71,8 @@ interface NotifyTemplate {
 async function fetchNotifyTemplate(apiKey: string, uuid: string): Promise<NotifyTemplate> {
   const client = new NotifyClient(apiKey);
   const response = await client.getTemplateById(uuid);
-  const data = response.data as { subject: string; body: string };
-  return { subject: data.subject ?? "", body: data.body ?? "" };
+  const data = response.data as { name: string; subject: string; body: string };
+  return { name: data.name ?? "", subject: data.subject ?? "", body: data.body ?? "" };
 }
 
 export const getTemplateSyncStatus = onCall(
@@ -106,6 +108,7 @@ export const getTemplateSyncStatus = onCall(
 
           try {
             const live = await fetchNotifyTemplate(apiKey, uuid);
+            const liveTemplateName = live.name;
             const liveSubject = live.subject;
             const liveBody = normaliseBody(live.body);
             const subjectMatch = liveSubject === expectedSubject;
@@ -115,6 +118,7 @@ export const getTemplateSyncStatus = onCall(
               templateUuid: uuid,
               notifyEditUrl,
               status: (subjectMatch && bodyMatch ? "in_sync" : "drift") as TemplateSyncStatus,
+              liveTemplateName,
               liveSubject,
               liveBody,
               expectedSubject,

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -24,7 +24,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "sectionBookingsUrl",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for **((eventTitle))** has been confirmed.\n\n---\n\n^**Event details**\n\n**When:** ((eventDateTime))\n\n**Where:** ((eventLocation))\n\n---\n\n^**Your booking (revision ((revisionNumber)))**\n\n((ticketLinesSummary))\n\n**Your dietary note:** ((bookerDietaryNote))\n\n**Accommodation:** ((accommodationSummary))\n\n**Total:** ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been confirmed.\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your booking (revision ((revisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nTotal: ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
   },
   bookingRevision: {
     subject: "Your SODC booking has been updated — ((eventTitle))",
@@ -47,7 +47,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "revisedTotalFormatted",
     "deltaAmountFormatted"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for **((eventTitle))** has been updated (revision ((previousRevisionNumber)) → ((revisedRevisionNumber))).\n\n---\n\n^**Event details**\n\n**When:** ((eventDateTime))\n\n**Where:** ((eventLocation))\n\n---\n\n^**Updated booking (revision ((revisedRevisionNumber)))**\n\n((ticketLinesSummary))\n\n**Your dietary note:** ((bookerDietaryNote))\n\n**Accommodation:** ((accommodationSummary))\n\n**Previous total:** ((previousTotalFormatted))\n\n**Revised total:** ((revisedTotalFormatted))\n\n**Difference:** ((deltaAmountFormatted))\n\n**Payment status:** ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Updated booking (revision ((revisedRevisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nDifference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
   },
   guestTicketRequestApproved: {
     subject: "Guest ticket request approved — ((eventTitle))",
@@ -60,7 +60,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "moderatorNote",
     "myBookingsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for **((eventTitle))** has been **((decisionLabel))**.\n\n**Guest:** ((guestDisplayName))\n\n**Guest tickets:** ((requestedGuestCount))\n\n**Note from organiser:** ((moderatorNote))\n\nYou can now complete payment for your guest tickets. Visit your booking to continue:\n\n((myBookingsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for ((eventTitle)) has been ((decisionLabel)).\n\nGuest: ((guestDisplayName))\n\nGuest tickets: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nYou can now complete payment for your guest tickets. Visit your booking to continue:\n\n((myBookingsUrl))\n\nSODC",
   },
   guestTicketRequestRejected: {
     subject: "Guest ticket request update — ((eventTitle))",
@@ -73,7 +73,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "moderatorNote",
     "myBookingsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for **((eventTitle))** has been **((decisionLabel))**.\n\n**Guest:** ((guestDisplayName))\n\n**Guest tickets requested:** ((requestedGuestCount))\n\n**Note from organiser:** ((moderatorNote))\n\nIf you have any questions, please contact your section organiser. You can view your booking at:\n\n((myBookingsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for ((eventTitle)) has been ((decisionLabel)).\n\nGuest: ((guestDisplayName))\n\nGuest tickets requested: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nIf you have any questions, please contact your section organiser. You can view your booking at:\n\n((myBookingsUrl))\n\nSODC",
   },
   guestTicketRequestSubmittedModerator: {
     subject: "Guest ticket request — ((eventTitle))",
@@ -87,7 +87,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "dietaryNote",
     "moderationUrl"
     ],
-    body: "A guest ticket request has been submitted for your review.\n\n**Event:** ((eventTitle))\n\n**Section:** ((sectionName))\n\n**Requested by:** ((bookerDisplay))\n\n**Guest name:** ((guestDisplayName))\n\n**Guest count:** ((requestedGuestCount))\n\n**Ticket type:** ((guestTicketTypeTitle))\n\n**Dietary note:** ((dietaryNote))\n\n---\n\nReview and approve or decline this request in the admin panel:\n\n((moderationUrl))\n\nSODC",
+    body: "A guest ticket request has been submitted for your review.\n\nEvent: ((eventTitle))\n\nSection: ((sectionName))\n\nRequested by: ((bookerDisplay))\n\nGuest name: ((guestDisplayName))\n\nGuest count: ((requestedGuestCount))\n\nTicket type: ((guestTicketTypeTitle))\n\nDietary note: ((dietaryNote))\n\n---\n\nReview and approve or decline this request in the admin panel:\n\n((moderationUrl))\n\nSODC",
   },
   membershipAccessRestricted: {
     subject: "Your SODC membership status has changed",
@@ -97,7 +97,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "previousStatusLabel",
     "appUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour SODC membership status has changed from **((previousStatusLabel))** to **((membershipStatusLabel))**.\n\nYour access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.\n\n((appUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour SODC membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)).\n\nYour access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.\n\n((appUrl))\n\nSODC",
   },
   membershipActivated: {
     subject: "Welcome to SODC — your membership is active",
@@ -107,7 +107,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "appUrl",
     "profileUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour SODC membership is now active. Your membership status is **((membershipStatusLabel))**.\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nWe recommend completing your profile before making your first booking:\n\n((profileUrl))\n\nWelcome aboard.\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour SODC membership is now active. Your membership status is ((membershipStatusLabel)).\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nWe recommend completing your profile before making your first booking:\n\n((profileUrl))\n\nWelcome aboard.\n\nSODC",
   },
   paymentDisputeOpsAlert: {
     subject: "[SODC OPS] Payment dispute — ((orderId))",
@@ -123,7 +123,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "reconciliationDashboardUrl",
     "stripeEventId"
     ],
-    body: "A payment dispute event has been received.\n\n**Order ID:** ((orderId))\n\n**Event:** ((eventTitle))\n\n**Customer:** ((customerDisplay))\n\n**Dispute ID:** ((stripeDisputeId))\n\n**Stripe status:** ((disputeStripeStatus))\n\n**Reason:** ((disputeReason))\n\n**Local state:** ((disputeLocalState))\n\n**Stripe event type:** ((stripeEventType))\n\n**Stripe event ID:** ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+    body: "A payment dispute event has been received.\n\nOrder ID: ((orderId))\n\nEvent: ((eventTitle))\n\nCustomer: ((customerDisplay))\n\nDispute ID: ((stripeDisputeId))\n\nStripe status: ((disputeStripeStatus))\n\nReason: ((disputeReason))\n\nLocal state: ((disputeLocalState))\n\nStripe event type: ((stripeEventType))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
   },
   paymentReconciliationExceptionAlert: {
     subject: "[SODC OPS] Reconciliation exception — ((orderId))",
@@ -136,7 +136,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "reconciliationDashboardUrl",
     "stripeEventId"
     ],
-    body: "A payment reconciliation exception requires your attention.\n\n**Order ID:** ((orderId))\n\n**Event:** ((eventTitle))\n\n**Customer:** ((customerDisplay))\n\n**Exception type:** ((exceptionType))\n\n**Note:** ((exceptionNote))\n\n**Stripe event ID:** ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+    body: "A payment reconciliation exception requires your attention.\n\nOrder ID: ((orderId))\n\nEvent: ((eventTitle))\n\nCustomer: ((customerDisplay))\n\nException type: ((exceptionType))\n\nNote: ((exceptionNote))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
   },
   ticketOrderFailed: {
     subject: "Payment unsuccessful — ((eventTitle))",
@@ -152,7 +152,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "orderId",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nUnfortunately your payment for **((eventTitle))** was unsuccessful.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Amount:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nYour booking is still in place. You can return to My Payments to try again:\n\n((myPaymentsUrl))\n\nIf you continue to have problems, please reply to this email.\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nUnfortunately your payment for ((eventTitle)) was unsuccessful.\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nAmount: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nYour booking is still in place. You can return to My Payments to try again:\n\n((myPaymentsUrl))\n\nIf you continue to have problems, please reply to this email.\n\nSODC",
   },
   ticketOrderPaid: {
     subject: "Payment confirmed — ((eventTitle))",
@@ -168,7 +168,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "orderId",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour payment for **((eventTitle))** has been confirmed.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Total paid:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nYou can view your payment history at any time:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour payment for ((eventTitle)) has been confirmed.\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nTotal paid: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nYou can view your payment history at any time:\n\n((myPaymentsUrl))\n\nSODC",
   },
   ticketOrderRefunded: {
     subject: "Refund processed — ((eventTitle))",
@@ -185,6 +185,6 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "myPaymentsUrl",
     "refundFormatted"
     ],
-    body: "Dear ((customerFirstName)),\n\nA refund of **((refundFormatted))** has been processed for your payment on **((eventTitle))**.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Original total:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nRefunds typically appear in your account within 5–10 working days depending on your bank.\n\nYou can view your payment history at:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nA refund of ((refundFormatted)) has been processed for your payment on ((eventTitle)).\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nOriginal total: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nRefunds typically appear in your account within 5 to 10 working days depending on your bank.\n\nYou can view your payment history at:\n\n((myPaymentsUrl))\n\nSODC",
   },
 };

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -1,0 +1,190 @@
+// AUTO-GENERATED — do not edit directly.
+// Source: functions/email-templates/*.md
+// Regenerate by running: npm run build (or npm run generate:templates)
+
+export interface EmailTemplateDefinition {
+  subject: string;
+  variables: string[];
+  body: string;
+}
+
+export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = {
+  bookingConfirmation: {
+    subject: "Your SODC booking — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "eventTitle",
+    "eventDateTime",
+    "eventLocation",
+    "revisionNumber",
+    "ticketLinesSummary",
+    "bookerDietaryNote",
+    "accommodationSummary",
+    "bookingTotalFormatted",
+    "sectionBookingsUrl",
+    "myPaymentsUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour booking for **((eventTitle))** has been confirmed.\n\n---\n\n^**Event details**\n\n**When:** ((eventDateTime))\n\n**Where:** ((eventLocation))\n\n---\n\n^**Your booking (revision ((revisionNumber)))**\n\n((ticketLinesSummary))\n\n**Your dietary note:** ((bookerDietaryNote))\n\n**Accommodation:** ((accommodationSummary))\n\n**Total:** ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
+  },
+  bookingRevision: {
+    subject: "Your SODC booking has been updated — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "eventTitle",
+    "eventDateTime",
+    "eventLocation",
+    "revisionNumber",
+    "ticketLinesSummary",
+    "bookerDietaryNote",
+    "accommodationSummary",
+    "bookingTotalFormatted",
+    "sectionBookingsUrl",
+    "myPaymentsUrl",
+    "previousRevisionNumber",
+    "revisedRevisionNumber",
+    "paymentAdjustmentStatus",
+    "previousTotalFormatted",
+    "revisedTotalFormatted",
+    "deltaAmountFormatted"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour booking for **((eventTitle))** has been updated (revision ((previousRevisionNumber)) → ((revisedRevisionNumber))).\n\n---\n\n^**Event details**\n\n**When:** ((eventDateTime))\n\n**Where:** ((eventLocation))\n\n---\n\n^**Updated booking (revision ((revisedRevisionNumber)))**\n\n((ticketLinesSummary))\n\n**Your dietary note:** ((bookerDietaryNote))\n\n**Accommodation:** ((accommodationSummary))\n\n**Previous total:** ((previousTotalFormatted))\n\n**Revised total:** ((revisedTotalFormatted))\n\n**Difference:** ((deltaAmountFormatted))\n\n**Payment status:** ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
+  },
+  guestTicketRequestApproved: {
+    subject: "Guest ticket request approved — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "eventTitle",
+    "guestDisplayName",
+    "requestedGuestCount",
+    "decisionLabel",
+    "moderatorNote",
+    "myBookingsUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for **((eventTitle))** has been **((decisionLabel))**.\n\n**Guest:** ((guestDisplayName))\n\n**Guest tickets:** ((requestedGuestCount))\n\n**Note from organiser:** ((moderatorNote))\n\nYou can now complete payment for your guest tickets. Visit your booking to continue:\n\n((myBookingsUrl))\n\nSODC",
+  },
+  guestTicketRequestRejected: {
+    subject: "Guest ticket request update — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "eventTitle",
+    "guestDisplayName",
+    "requestedGuestCount",
+    "decisionLabel",
+    "moderatorNote",
+    "myBookingsUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for **((eventTitle))** has been **((decisionLabel))**.\n\n**Guest:** ((guestDisplayName))\n\n**Guest tickets requested:** ((requestedGuestCount))\n\n**Note from organiser:** ((moderatorNote))\n\nIf you have any questions, please contact your section organiser. You can view your booking at:\n\n((myBookingsUrl))\n\nSODC",
+  },
+  guestTicketRequestSubmittedModerator: {
+    subject: "Guest ticket request — ((eventTitle))",
+    variables: [
+    "eventTitle",
+    "sectionName",
+    "bookerDisplay",
+    "guestDisplayName",
+    "requestedGuestCount",
+    "guestTicketTypeTitle",
+    "dietaryNote",
+    "moderationUrl"
+    ],
+    body: "A guest ticket request has been submitted for your review.\n\n**Event:** ((eventTitle))\n\n**Section:** ((sectionName))\n\n**Requested by:** ((bookerDisplay))\n\n**Guest name:** ((guestDisplayName))\n\n**Guest count:** ((requestedGuestCount))\n\n**Ticket type:** ((guestTicketTypeTitle))\n\n**Dietary note:** ((dietaryNote))\n\n---\n\nReview and approve or decline this request in the admin panel:\n\n((moderationUrl))\n\nSODC",
+  },
+  membershipAccessRestricted: {
+    subject: "Your SODC membership status has changed",
+    variables: [
+    "customerFirstName",
+    "membershipStatusLabel",
+    "previousStatusLabel",
+    "appUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour SODC membership status has changed from **((previousStatusLabel))** to **((membershipStatusLabel))**.\n\nYour access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.\n\n((appUrl))\n\nSODC",
+  },
+  membershipActivated: {
+    subject: "Welcome to SODC — your membership is active",
+    variables: [
+    "customerFirstName",
+    "membershipStatusLabel",
+    "appUrl",
+    "profileUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour SODC membership is now active. Your membership status is **((membershipStatusLabel))**.\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nWe recommend completing your profile before making your first booking:\n\n((profileUrl))\n\nWelcome aboard.\n\nSODC",
+  },
+  paymentDisputeOpsAlert: {
+    subject: "[SODC OPS] Payment dispute — ((orderId))",
+    variables: [
+    "orderId",
+    "eventTitle",
+    "customerDisplay",
+    "disputeStripeStatus",
+    "disputeReason",
+    "disputeLocalState",
+    "stripeDisputeId",
+    "stripeEventType",
+    "reconciliationDashboardUrl",
+    "stripeEventId"
+    ],
+    body: "A payment dispute event has been received.\n\n**Order ID:** ((orderId))\n\n**Event:** ((eventTitle))\n\n**Customer:** ((customerDisplay))\n\n**Dispute ID:** ((stripeDisputeId))\n\n**Stripe status:** ((disputeStripeStatus))\n\n**Reason:** ((disputeReason))\n\n**Local state:** ((disputeLocalState))\n\n**Stripe event type:** ((stripeEventType))\n\n**Stripe event ID:** ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+  },
+  paymentReconciliationExceptionAlert: {
+    subject: "[SODC OPS] Reconciliation exception — ((orderId))",
+    variables: [
+    "orderId",
+    "eventTitle",
+    "customerDisplay",
+    "exceptionType",
+    "exceptionNote",
+    "reconciliationDashboardUrl",
+    "stripeEventId"
+    ],
+    body: "A payment reconciliation exception requires your attention.\n\n**Order ID:** ((orderId))\n\n**Event:** ((eventTitle))\n\n**Customer:** ((customerDisplay))\n\n**Exception type:** ((exceptionType))\n\n**Note:** ((exceptionNote))\n\n**Stripe event ID:** ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+  },
+  ticketOrderFailed: {
+    subject: "Payment unsuccessful — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "firstName",
+    "eventTitle",
+    "ticketTypeTitle",
+    "quantity",
+    "totalFormatted",
+    "currencyDisplay",
+    "orderStatusLabel",
+    "orderId",
+    "myPaymentsUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nUnfortunately your payment for **((eventTitle))** was unsuccessful.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Amount:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nYour booking is still in place. You can return to My Payments to try again:\n\n((myPaymentsUrl))\n\nIf you continue to have problems, please reply to this email.\n\nSODC",
+  },
+  ticketOrderPaid: {
+    subject: "Payment confirmed — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "firstName",
+    "eventTitle",
+    "ticketTypeTitle",
+    "quantity",
+    "totalFormatted",
+    "currencyDisplay",
+    "orderStatusLabel",
+    "orderId",
+    "myPaymentsUrl"
+    ],
+    body: "Dear ((customerFirstName)),\n\nYour payment for **((eventTitle))** has been confirmed.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Total paid:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nYou can view your payment history at any time:\n\n((myPaymentsUrl))\n\nSODC",
+  },
+  ticketOrderRefunded: {
+    subject: "Refund processed — ((eventTitle))",
+    variables: [
+    "customerFirstName",
+    "firstName",
+    "eventTitle",
+    "ticketTypeTitle",
+    "quantity",
+    "totalFormatted",
+    "currencyDisplay",
+    "orderStatusLabel",
+    "orderId",
+    "myPaymentsUrl",
+    "refundFormatted"
+    ],
+    body: "Dear ((customerFirstName)),\n\nA refund of **((refundFormatted))** has been processed for your payment on **((eventTitle))**.\n\n**Ticket:** ((ticketTypeTitle))\n\n**Quantity:** ((quantity))\n\n**Original total:** ((totalFormatted)) ((currencyDisplay))\n\n**Status:** ((orderStatusLabel))\n\n**Order reference:** ((orderId))\n\nRefunds typically appear in your account within 5–10 working days depending on your bank.\n\nYou can view your payment history at:\n\n((myPaymentsUrl))\n\nSODC",
+  },
+};

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,7 @@ export * from "./guestTicketRequests";
 export * from "./payments";
 export * from "./stagedExpiry";
 export * from "./userGroups";
+export * from "./emailTemplateSync";
 
 // Initialize Firebase Admin
 if (!admin.apps.length) {

--- a/functions/tsconfig.scripts.json
+++ b/functions/tsconfig.scripts.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "outDir": "lib-scripts",
+    "noUnusedLocals": false
+  },
+  "include": ["scripts"]
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const UserGroups = lazy(() => import("./features/admin/components/UserGroups"));
 const AuditLogs = lazy(() => import("./features/admin/components/AuditLogs"));
 const ManageSections = lazy(() => import("./features/admin/components/ManageSections"));
 const PaymentReconciliationDashboard = lazy(() => import("./features/admin/components/PaymentReconciliationDashboard"));
+const EmailTemplateSyncPage = lazy(() => import("./features/admin/components/EmailTemplateSyncPage"));
 const SectionsList = lazy(() => import("./features/sections/components/SectionsList"));
 const SectionDetail = lazy(() => import("./features/sections/components/SectionDetail"));
 const MyPayments = lazy(() => import("./features/sections/components/MyPayments"));
@@ -538,6 +539,15 @@ function AppContent() {
                         <PaymentReconciliationDashboard onBack={() => navigateBackOr(ROUTES.HOME)} />
                       </Suspense>
                     </ErrorBoundary>
+                  )}
+                />
+                <Route
+                  path={ROUTES.EMAIL_TEMPLATES}
+                  element={renderAdminOnly(
+                    "Email Templates",
+                    <Suspense fallback={<LoadingFallback />}>
+                      <EmailTemplateSyncPage onBack={() => navigateBackOr(ROUTES.HOME)} />
+                    </Suspense>
                   )}
                 />
                 <Route

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
   SECTIONS: "/sections",
   SECTION_DETAIL: "/sections/:sectionId",
   MANAGE_SECTIONS: "/admin/sections",
+  EMAIL_TEMPLATES: "/admin/email-templates",
   REGISTER: "/register",
   PROFILE_COMPLETION: "/profile-completion",
 } as const;

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -140,16 +140,14 @@ function UpdateInstructions({ result }: { result: TemplateSyncResult }) {
       </Typography>
 
       <Stack spacing={1}>
-        {result.liveTemplateName && (
-          <Stack direction="row" alignItems="center" gap={1}>
-            <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Template name</Typography>
-            <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, bgcolor: "grey.100", px: 1, py: 0.5, borderRadius: 1 }}>
-              {result.liveTemplateName}
-            </Typography>
-            <CopyButton value={result.liveTemplateName} label="template name" />
-            <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>no change needed</Typography>
-          </Stack>
-        )}
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Template name</Typography>
+          <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, bgcolor: "grey.100", px: 1, py: 0.5, borderRadius: 1 }}>
+            {result.templateKey}
+          </Typography>
+          <CopyButton value={result.templateKey} label="template name" />
+          <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>no change needed</Typography>
+        </Stack>
 
         <Stack direction="row" alignItems="center" gap={1}>
           <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Subject</Typography>

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -1,0 +1,274 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Collapse,
+  Divider,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { CheckCircle, Error, Warning, ExpandMore, ExpandLess } from "@mui/icons-material";
+import PageHeader from "../../../shared/components/PageHeader";
+import {
+  getTemplateSyncStatus,
+  type TemplateSyncResult,
+  type TemplateSyncStatus,
+} from "../../../shared/utils/firebaseFunctions";
+
+interface EmailTemplateSyncPageProps {
+  onBack: () => void;
+}
+
+function statusChipColor(status: TemplateSyncStatus): "success" | "error" | "warning" | "default" {
+  if (status === "in_sync") return "success";
+  if (status === "drift") return "error";
+  if (status === "not_configured") return "warning";
+  return "default";
+}
+
+function statusLabel(status: TemplateSyncStatus): string {
+  if (status === "in_sync") return "In sync";
+  if (status === "drift") return "Drift detected";
+  if (status === "not_configured") return "UUID not configured";
+  return "Fetch error";
+}
+
+function statusIcon(status: TemplateSyncStatus) {
+  if (status === "in_sync") return <CheckCircle fontSize="small" color="success" />;
+  if (status === "drift") return <Error fontSize="small" color="error" />;
+  if (status === "not_configured") return <Warning fontSize="small" color="warning" />;
+  return <Error fontSize="small" color="disabled" />;
+}
+
+function lineDiff(expected: string, live: string): { line: string; kind: "same" | "added" | "removed" }[] {
+  const expectedLines = expected.split("\n");
+  const liveLines = live.split("\n");
+  const result: { line: string; kind: "same" | "added" | "removed" }[] = [];
+  const maxLen = Math.max(expectedLines.length, liveLines.length);
+  for (let i = 0; i < maxLen; i++) {
+    const e = expectedLines[i];
+    const l = liveLines[i];
+    if (e === l) {
+      result.push({ line: e ?? "", kind: "same" });
+    } else {
+      if (e !== undefined) result.push({ line: e, kind: "removed" });
+      if (l !== undefined) result.push({ line: l, kind: "added" });
+    }
+  }
+  return result;
+}
+
+function DiffBlock({ label, expected, live }: { label: string; expected: string; live: string }) {
+  const lines = lineDiff(expected, live);
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="caption" fontWeight={600} color="text.secondary" sx={{ display: "block", mb: 0.5 }}>
+        {label}
+      </Typography>
+      <Paper
+        variant="outlined"
+        sx={{
+          p: 1.5,
+          fontFamily: "monospace",
+          fontSize: "0.75rem",
+          lineHeight: 1.6,
+          overflowX: "auto",
+          bgcolor: "grey.50",
+        }}
+      >
+        {lines.map((l, i) => (
+          <Box
+            key={i}
+            sx={{
+              bgcolor:
+                l.kind === "removed"
+                  ? "error.light"
+                  : l.kind === "added"
+                    ? "success.light"
+                    : "transparent",
+              px: 0.5,
+              borderRadius: 0.5,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+            }}
+          >
+            {l.kind === "removed" ? "− " : l.kind === "added" ? "+ " : "  "}
+            {l.line}
+          </Box>
+        ))}
+      </Paper>
+    </Box>
+  );
+}
+
+function TemplateRow({ result }: { result: TemplateSyncResult }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasDiff = result.status === "drift";
+  const showToggle = hasDiff || result.status === "fetch_error";
+
+  return (
+    <>
+      <TableRow
+        sx={{
+          cursor: showToggle ? "pointer" : "default",
+          "&:hover": showToggle ? { bgcolor: "action.hover" } : undefined,
+        }}
+        onClick={showToggle ? () => setExpanded((v) => !v) : undefined}
+      >
+        <TableCell>
+          <Stack direction="row" alignItems="center" gap={1}>
+            {statusIcon(result.status)}
+            <Typography variant="body2" fontFamily="monospace">
+              {result.templateKey}
+            </Typography>
+          </Stack>
+        </TableCell>
+        <TableCell>
+          <Chip
+            size="small"
+            label={statusLabel(result.status)}
+            color={statusChipColor(result.status)}
+          />
+        </TableCell>
+        <TableCell>
+          <Typography variant="body2" color="text.secondary" noWrap sx={{ maxWidth: 300 }}>
+            {result.expectedSubject}
+          </Typography>
+        </TableCell>
+        <TableCell align="right">
+          {showToggle ? (
+            expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />
+          ) : null}
+        </TableCell>
+      </TableRow>
+      {showToggle && (
+        <TableRow>
+          <TableCell colSpan={4} sx={{ py: 0 }}>
+            <Collapse in={expanded} unmountOnExit>
+              <Box sx={{ py: 2, px: 1 }}>
+                {result.status === "fetch_error" ? (
+                  <Alert severity="error">{result.errorMessage ?? "Unknown error fetching template from GOV Notify."}</Alert>
+                ) : (
+                  <>
+                    {!result.subjectMatch && (
+                      <DiffBlock
+                        label="Subject"
+                        expected={result.expectedSubject}
+                        live={result.liveSubject ?? ""}
+                      />
+                    )}
+                    {!result.bodyMatch && (
+                      <DiffBlock
+                        label="Body"
+                        expected={result.expectedBody}
+                        live={result.liveBody ?? ""}
+                      />
+                    )}
+                  </>
+                )}
+              </Box>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+}
+
+export default function EmailTemplateSyncPage({ onBack }: EmailTemplateSyncPageProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<TemplateSyncResult[] | null>(null);
+
+  const runCheck = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getTemplateSyncStatus();
+      setResults(data.results);
+    } catch {
+      setError("Failed to fetch template sync status");
+
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const driftCount = results?.filter((r) => r.status === "drift").length ?? 0;
+  const unconfiguredCount = results?.filter((r) => r.status === "not_configured").length ?? 0;
+  const errorCount = results?.filter((r) => r.status === "fetch_error").length ?? 0;
+
+  return (
+    <Box className="page-container">
+      <PageHeader title="Email Template Sync" onBack={onBack} />
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Compares the GOV Notify templates (fetched live) against the{" "}
+        <Typography component="span" variant="body2" fontFamily="monospace">
+          functions/email-templates/
+        </Typography>{" "}
+        files in the codebase. Drift means the dashboard was updated without updating the code, or
+        vice versa. Update the GOV Notify dashboard manually to resolve.
+      </Typography>
+
+      <Button variant="contained" onClick={runCheck} disabled={loading} sx={{ mb: 3 }}>
+        {loading ? <CircularProgress size={20} color="inherit" sx={{ mr: 1 }} /> : null}
+        {loading ? "Checking…" : results ? "Re-check" : "Check sync status"}
+      </Button>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      {results && (
+        <>
+          {driftCount + unconfiguredCount + errorCount === 0 ? (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              All {results.length} templates are in sync.
+            </Alert>
+          ) : (
+            <Stack direction="row" gap={1} flexWrap="wrap" sx={{ mb: 2 }}>
+              {driftCount > 0 && (
+                <Chip label={`${driftCount} drift detected`} color="error" size="small" />
+              )}
+              {unconfiguredCount > 0 && (
+                <Chip label={`${unconfiguredCount} UUID not configured`} color="warning" size="small" />
+              )}
+              {errorCount > 0 && (
+                <Chip label={`${errorCount} fetch error`} color="default" size="small" />
+              )}
+            </Stack>
+          )}
+
+          <Divider sx={{ mb: 2 }} />
+
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Template</TableCell>
+                <TableCell>Status</TableCell>
+                <TableCell>Expected subject</TableCell>
+                <TableCell />
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {results.map((result) => (
+                <TemplateRow key={result.templateKey} result={result} />
+              ))}
+            </TableBody>
+          </Table>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -91,9 +91,9 @@ function DiffBlock({ label, expected, live }: { label: string; expected: string;
             sx={{
               bgcolor:
                 l.kind === "removed"
-                  ? "error.light"
+                  ? "#fde8e8"
                   : l.kind === "added"
-                    ? "success.light"
+                    ? "#e8f5e9"
                     : "transparent",
               px: 0.5,
               borderRadius: 0.5,

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -7,6 +7,7 @@ import {
   CircularProgress,
   Collapse,
   Divider,
+  IconButton,
   Paper,
   Stack,
   Table,
@@ -14,9 +15,10 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from "@mui/material";
-import { CheckCircle, Error, Warning, ExpandMore, ExpandLess } from "@mui/icons-material";
+import { CheckCircle, ContentCopy, Error, ExpandLess, ExpandMore, OpenInNew, Warning } from "@mui/icons-material";
 import PageHeader from "../../../shared/components/PageHeader";
 import {
   getTemplateSyncStatus,
@@ -67,6 +69,23 @@ function lineDiff(expected: string, live: string): { line: string; kind: "same" 
   return result;
 }
 
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    });
+  };
+  return (
+    <Tooltip title={copied ? "Copied!" : `Copy ${label}`}>
+      <IconButton size="small" onClick={handleCopy} aria-label={`Copy ${label}`}>
+        <ContentCopy fontSize="inherit" color={copied ? "success" : "inherit"} />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
 function DiffBlock({ label, expected, live }: { label: string; expected: string; live: string }) {
   const lines = lineDiff(expected, live);
   return (
@@ -110,10 +129,69 @@ function DiffBlock({ label, expected, live }: { label: string; expected: string;
   );
 }
 
+function UpdateInstructions({ result }: { result: TemplateSyncResult }) {
+  return (
+    <Box sx={{ mb: 2 }}>
+      <Typography variant="subtitle2" gutterBottom>
+        How to update
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+        Open the template in GOV Notify and update the fields below. The{" "}
+        <strong>Template name</strong> field does not need to change.
+      </Typography>
+
+      <Stack spacing={1}>
+        <Stack direction="row" alignItems="center" gap={1}>
+          <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Subject</Typography>
+          <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, bgcolor: "grey.100", px: 1, py: 0.5, borderRadius: 1 }}>
+            {result.expectedSubject}
+          </Typography>
+          <CopyButton value={result.expectedSubject} label="subject" />
+        </Stack>
+
+        <Stack direction="row" alignItems="flex-start" gap={1}>
+          <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600, pt: 0.5 }}>Message</Typography>
+          <Typography
+            variant="body2"
+            fontFamily="monospace"
+            sx={{
+              flex: 1,
+              bgcolor: "grey.100",
+              px: 1,
+              py: 0.5,
+              borderRadius: 1,
+              whiteSpace: "pre-wrap",
+              maxHeight: 120,
+              overflow: "hidden",
+              WebkitMaskImage: "linear-gradient(to bottom, black 60%, transparent 100%)",
+            }}
+          >
+            {result.expectedBody}
+          </Typography>
+          <CopyButton value={result.expectedBody} label="message body" />
+        </Stack>
+      </Stack>
+
+      {result.notifyEditUrl && (
+        <Button
+          href={result.notifyEditUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="outlined"
+          size="small"
+          endIcon={<OpenInNew fontSize="small" />}
+          sx={{ mt: 2 }}
+        >
+          Edit in GOV Notify
+        </Button>
+      )}
+    </Box>
+  );
+}
+
 function TemplateRow({ result }: { result: TemplateSyncResult }) {
   const [expanded, setExpanded] = useState(false);
-  const hasDiff = result.status === "drift";
-  const showToggle = hasDiff || result.status === "fetch_error";
+  const showToggle = result.status === "drift" || result.status === "fetch_error";
 
   return (
     <>
@@ -147,6 +225,19 @@ function TemplateRow({ result }: { result: TemplateSyncResult }) {
         <TableCell align="right">
           {showToggle ? (
             expanded ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />
+          ) : result.notifyEditUrl ? (
+            <Tooltip title="Edit in GOV Notify">
+              <IconButton
+                size="small"
+                href={result.notifyEditUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Edit in GOV Notify"
+              >
+                <OpenInNew fontSize="small" />
+              </IconButton>
+            </Tooltip>
           ) : null}
         </TableCell>
       </TableRow>
@@ -156,9 +247,14 @@ function TemplateRow({ result }: { result: TemplateSyncResult }) {
             <Collapse in={expanded} unmountOnExit>
               <Box sx={{ py: 2, px: 1 }}>
                 {result.status === "fetch_error" ? (
-                  <Alert severity="error">{result.errorMessage ?? "Unknown error fetching template from GOV Notify."}</Alert>
+                  <Alert severity="error" sx={{ mb: 2 }}>
+                    {result.errorMessage ?? "Unknown error fetching template from GOV Notify."}
+                  </Alert>
                 ) : (
                   <>
+                    <UpdateInstructions result={result} />
+                    <Divider sx={{ my: 2 }} />
+                    <Typography variant="subtitle2" gutterBottom>Diff</Typography>
                     {!result.subjectMatch && (
                       <DiffBlock
                         label="Subject"
@@ -197,7 +293,6 @@ export default function EmailTemplateSyncPage({ onBack }: EmailTemplateSyncPageP
       setResults(data.results);
     } catch {
       setError("Failed to fetch template sync status");
-
     } finally {
       setLoading(false);
     }
@@ -216,7 +311,7 @@ export default function EmailTemplateSyncPage({ onBack }: EmailTemplateSyncPageP
           functions/email-templates/
         </Typography>{" "}
         files in the codebase. Drift means the dashboard was updated without updating the code, or
-        vice versa. Update the GOV Notify dashboard manually to resolve.
+        vice versa. Click a drifted template to see the diff and copy the correct values.
       </Typography>
 
       <Button variant="contained" onClick={runCheck} disabled={loading} sx={{ mb: 3 }}>

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -136,11 +136,21 @@ function UpdateInstructions({ result }: { result: TemplateSyncResult }) {
         How to update
       </Typography>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
-        Open the template in GOV Notify and update the fields below. The{" "}
-        <strong>Template name</strong> field does not need to change.
+        Open the template in GOV Notify and update the fields below.
       </Typography>
 
       <Stack spacing={1}>
+        {result.liveTemplateName && (
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Template name</Typography>
+            <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, bgcolor: "grey.100", px: 1, py: 0.5, borderRadius: 1 }}>
+              {result.liveTemplateName}
+            </Typography>
+            <CopyButton value={result.liveTemplateName} label="template name" />
+            <Typography variant="caption" color="text.secondary" sx={{ whiteSpace: "nowrap" }}>no change needed</Typography>
+          </Stack>
+        )}
+
         <Stack direction="row" alignItems="center" gap={1}>
           <Typography variant="body2" sx={{ minWidth: 80, fontWeight: 600 }}>Subject</Typography>
           <Typography variant="body2" fontFamily="monospace" sx={{ flex: 1, bgcolor: "grey.100", px: 1, py: 0.5, borderRadius: 1 }}>

--- a/src/shared/navigation/buildNavigationLinks.ts
+++ b/src/shared/navigation/buildNavigationLinks.ts
@@ -142,6 +142,7 @@ function buildAdminLinks({
       children: userGroupChildren,
     });
     links.push({ label: "Payment Reconciliation", to: ROUTES.PAYMENT_RECONCILIATION });
+    links.push({ label: "Email Templates", to: ROUTES.EMAIL_TEMPLATES });
     links.push({ label: "Audit Logs", to: ROUTES.AUDIT_LOGS });
   }
 

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -590,3 +590,30 @@ export async function registerForSectionCallable(userGroupId: string): Promise<{
   return result.data;
 }
 
+// ============================================================================
+// Email Template Sync
+// ============================================================================
+
+export type TemplateSyncStatus = "in_sync" | "drift" | "not_configured" | "fetch_error";
+
+export interface TemplateSyncResult {
+  templateKey: string;
+  status: TemplateSyncStatus;
+  liveSubject?: string;
+  liveBody?: string;
+  expectedSubject: string;
+  expectedBody: string;
+  subjectMatch?: boolean;
+  bodyMatch?: boolean;
+  errorMessage?: string;
+}
+
+export async function getTemplateSyncStatus(): Promise<{ results: TemplateSyncResult[] }> {
+  const callable = httpsCallable<void, { results: TemplateSyncResult[] }>(
+    functions,
+    "getTemplateSyncStatus"
+  );
+  const result = await callable();
+  return result.data;
+}
+

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -598,6 +598,8 @@ export type TemplateSyncStatus = "in_sync" | "drift" | "not_configured" | "fetch
 
 export interface TemplateSyncResult {
   templateKey: string;
+  templateUuid?: string;
+  notifyEditUrl?: string;
   status: TemplateSyncStatus;
   liveSubject?: string;
   liveBody?: string;

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -601,6 +601,7 @@ export interface TemplateSyncResult {
   templateUuid?: string;
   notifyEditUrl?: string;
   status: TemplateSyncStatus;
+  liveTemplateName?: string;
   liveSubject?: string;
   liveBody?: string;
   expectedSubject: string;

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -601,7 +601,6 @@ export interface TemplateSyncResult {
   templateUuid?: string;
   notifyEditUrl?: string;
   status: TemplateSyncStatus;
-  liveTemplateName?: string;
   liveSubject?: string;
   liveBody?: string;
   expectedSubject: string;


### PR DESCRIPTION
Closes #304

## Summary

- All 12 GOV Notify email templates stored as `.md` files in `functions/email-templates/` — subject, variables, and body in one reviewable file per template
- `template-registry.json` maps each template key to its GOV Notify UUID per environment (UUIDs left blank, to be filled in from the dashboard)
- `generate-template-manifest.ts` script runs automatically on `prebuild`, parsing the `.md` files into a typed TypeScript manifest used by the Cloud Function
- `getTemplateSyncStatus` Cloud Function (admin-only) fetches each live template from GOV Notify and compares against the manifest, returning per-template status
- **Email Templates** admin page shows `in_sync` / `drift` / `not_configured` / `fetch_error` per template, with an expandable inline line diff for any drift

## Workflow going forward

1. Edit the `.md` file and raise a PR — body content is reviewable in GitHub
2. After merge, manually update the template in the GOV Notify dashboard
3. Open the Email Templates admin page and run Check to confirm sync

## Test plan
- [ ] `npm run build` in `functions/` regenerates the manifest from the `.md` files
- [ ] All 549 tests pass (368 frontend, 181 functions)
- [ ] Email Templates appears in the admin side nav
- [ ] Admin page renders and the Check button calls the function
- [ ] Drift row expands to show a line diff
- [ ] Not-configured rows show a warning chip (expected with empty registry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)