### PR TITLE
fix: lock down GetSectionMembers to SDK-only access

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -327,7 +327,10 @@ query GetAllUserGroupsWithStatuses @auth(level: NO_ACCESS) {
 
 # Section member rollup uses MEMBER-purpose links; if none, ACCESS-purpose links (same as legacy fallback).
 # Includes both directly added users and users whose membership status matches the group's membershipStatuses
-query GetSectionMembers($sectionId: UUID!) @auth(expr: "auth.token.enabled == true") {
+# SDK-only: exposes member PII (email, serviceNumber) for an arbitrary sectionId with no relationship check.
+# The client must go through the getSectionMembersMerged callable, which verifies the caller's own section
+# access before returning data (see functions/src/sections.ts).
+query GetSectionMembers($sectionId: UUID!) @auth(level: NO_ACCESS) {
   section(id: $sectionId) {
     id
     name

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -184,7 +184,6 @@ describe("Data Connect auth contracts", () => {
       { op: "query GetEventsForSection", mustInclude: USER_EXPR },
       { op: "query GetEventById", mustInclude: USER_EXPR },
       { op: "query GetSectionById", mustInclude: USER_EXPR },
-      { op: "query GetSectionMembers", mustInclude: USER_EXPR },
       { op: "query GetMyBookingsForEvent", mustInclude: USER_EXPR },
       { op: "query GetMyTicketOrders", mustInclude: USER_EXPR },
       { op: "query GetMyBookingPaymentAdjustments", mustInclude: USER_EXPR },
@@ -207,6 +206,10 @@ describe("Data Connect auth contracts", () => {
     assertAuth(queries, [
       { op: "query GetUserMembershipStatus", mustInclude: NO_ACCESS },
       { op: "query GetAllUserGroupsWithStatuses", mustInclude: NO_ACCESS },
+      // GetSectionMembers exposes member PII (email, serviceNumber) for an arbitrary sectionId with
+      // no relationship check — must stay SDK-only. Clients go through the getSectionMembersMerged
+      // callable (functions/src/sections.ts), which verifies the caller's own section access first.
+      { op: "query GetSectionMembers", mustInclude: NO_ACCESS },
     ]);
   });
 


### PR DESCRIPTION
## Summary
- `GetSectionMembers` (dataconnect/api/queries.gql) was reachable directly from the client with only `auth.token.enabled == true`, letting any enabled user fetch the full member roster (name, email, service number, membership status) of any section by id, regardless of their actual access to it.
- The properly-guarded path already exists: `getSectionMembersMerged` (functions/src/sections.ts) checks the caller's real ACCESS/MODERATOR/status-derived access before returning data, and `SectionDetail.tsx` already uses that callable exclusively — nothing in the client calls the raw query directly (verified via grep).
- Changed `GetSectionMembers`'s `@auth` to `NO_ACCESS`, making it SDK-only (reachable only from the admin-generated SDK inside Cloud Functions).
- Updated the existing `dataconnectAuthContracts.test.ts` security-test contract to expect `NO_ACCESS` for this operation instead of the old `auth.token.enabled == true`.

## Test plan
- [x] `npx vitest run` in `functions/` — 319 tests pass, including the updated auth-contract test and schema-integrity test
- [x] Confirmed via grep that no client code calls `getSectionMembersRef`/`useGetSectionMembers` directly (only the generated SDK internals and a test comment reference it)

Part of #326. Fixes #327.