### PR TITLE
fix: gate SectionAdminPage to admins and section moderators

### DIFF
--- a/src/features/admin/components/SectionAdminPage.tsx
+++ b/src/features/admin/components/SectionAdminPage.tsx
@@ -1,17 +1,19 @@
 import { useState } from "react";
 import { useParams, useLocation, useNavigate } from "react-router-dom";
 import {
+  Alert,
   Box,
+  Button,
   Card,
   CardActionArea,
   CardContent,
+  CircularProgress,
   Typography,
 } from "@mui/material";
 import { Campaign, Event, Settings } from "@mui/icons-material";
 import PageHeader from "../../../shared/components/PageHeader";
 import { ROUTES } from "../../../constants";
-import { useAdminClaim } from "../../users/hooks/useAdminClaim";
-import { auth } from "../../../config/firebase";
+import { useCanModerateSection } from "../../sections/hooks/useCanModerateSection";
 import SendAnnouncementPage from "./SendAnnouncementPage";
 import "../../../shared/components/PageContainer.css";
 
@@ -45,7 +47,7 @@ export default function SectionAdminPage() {
   const { sectionId } = useParams<{ sectionId: string }>();
   const location = useLocation();
   const navigate = useNavigate();
-  const isAdmin = useAdminClaim(auth.currentUser);
+  const { isResolved, isAdmin, canModerateSection } = useCanModerateSection(sectionId);
   const state = location.state as SectionAdminLocationState | null;
   const sectionName = state?.sectionName ?? "Section";
   const sectionType = state?.sectionType ?? "MEMBERS";
@@ -62,6 +64,28 @@ export default function SectionAdminPage() {
   };
 
   if (!sectionId) return null;
+
+  if (!isResolved) {
+    return (
+      <Box className="page-container" sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (!isAdmin && !canModerateSection) {
+    return (
+      <Box className="page-container">
+        <PageHeader title={`Administer — ${sectionName}`} onBack={() => navigate(-1)} />
+        <Alert severity="error" sx={{ mb: 2 }}>
+          Access denied. You must be an admin or a moderator of this section.
+        </Alert>
+        <Button variant="outlined" onClick={() => navigate(ROUTES.HOME)}>
+          Back to Home
+        </Button>
+      </Box>
+    );
+  }
 
   if (view === "announcement") {
     return (

--- a/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
+++ b/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../../../test-utils';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import SectionAdminPage from '../SectionAdminPage';
+import * as reactGenerated from '@dataconnect/generated/react';
+import { createMockUser } from '../../../../test-utils/mocks/firebase';
+import {
+  dataConnectQueryResult,
+  type DataConnectQueryResultOverrides,
+} from '../../../../test-utils/dataConnectMocks';
+
+vi.mock('@dataconnect/generated/react', () => ({
+  useGetSectionById: vi.fn(),
+  useGetUserAccessGroups: vi.fn(),
+}));
+
+const mockCurrentUser = createMockUser({ uid: 'user-1' });
+let mockIsAdmin = false;
+
+vi.mock('../../../users/hooks/useAdminClaim', () => ({
+  useAdminClaim: vi.fn(() => mockIsAdmin),
+}));
+
+vi.mock('../../../../config/firebase', () => ({
+  dataConnect: {},
+  auth: {
+    get currentUser() {
+      return mockCurrentUser;
+    },
+  },
+}));
+
+function mockGetSectionById(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetSectionById).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetSectionById>(overrides)
+  );
+}
+
+function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
+  vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue(
+    dataConnectQueryResult<typeof reactGenerated.useGetUserAccessGroups>(overrides)
+  );
+}
+
+const sectionId = 'section-1';
+const moderatorGroupId = 'group-moderator';
+
+function renderSectionAdminPage() {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: `/admin/section/${sectionId}`, state: { sectionName: 'Test Section', sectionType: 'MEMBERS' } }]}>
+      <Routes>
+        <Route path="/admin/section/:sectionId" element={<SectionAdminPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('SectionAdminPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAdmin = false;
+    mockGetSectionById({
+      data: {
+        section: {
+          id: sectionId,
+          purposeLinks: [
+            { purposes: ['MODERATOR'], userGroup: { id: moderatorGroupId } },
+          ],
+        },
+      },
+    });
+    mockGetUserAccessGroups({
+      data: { user: { userGroups: [] } },
+    });
+  });
+
+  it('shows access denied for a user who is neither admin nor a section moderator', async () => {
+    renderSectionAdminPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Access denied/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Send Announcement')).not.toBeInTheDocument();
+  });
+
+  it('shows the admin hub for a section moderator, without the admin-only Edit Section card', async () => {
+    mockGetUserAccessGroups({
+      data: { user: { userGroups: [{ userGroup: { id: moderatorGroupId } }] } },
+    });
+
+    renderSectionAdminPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Send Announcement')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Edit Section')).not.toBeInTheDocument();
+  });
+
+  it('shows the admin hub including Edit Section for a global admin', async () => {
+    mockIsAdmin = true;
+
+    renderSectionAdminPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Send Announcement')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Edit Section')).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
+++ b/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../../../test-utils';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import SectionAdminPage from '../SectionAdminPage';
 import * as reactGenerated from '@dataconnect/generated/react';
@@ -8,6 +9,7 @@ import {
   dataConnectQueryResult,
   type DataConnectQueryResultOverrides,
 } from '../../../../test-utils/dataConnectMocks';
+import { ROUTES } from '../../../../constants';
 
 vi.mock('@dataconnect/generated/react', () => ({
   useGetSectionById: vi.fn(),
@@ -30,6 +32,25 @@ vi.mock('../../../../config/firebase', () => ({
   },
 }));
 
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../SendAnnouncementPage', () => ({
+  default: ({ sectionName, onBack }: { sectionName: string; onBack: () => void }) => (
+    <div>
+      <div>Mock Send Announcement Page for {sectionName}</div>
+      <button onClick={onBack}>Back to hub</button>
+    </div>
+  ),
+}));
+
 function mockGetSectionById(overrides: DataConnectQueryResultOverrides) {
   vi.mocked(reactGenerated.useGetSectionById).mockReturnValue(
     dataConnectQueryResult<typeof reactGenerated.useGetSectionById>(overrides)
@@ -45,9 +66,13 @@ function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
 const sectionId = 'section-1';
 const moderatorGroupId = 'group-moderator';
 
-function renderSectionAdminPage() {
+function renderSectionAdminPage(sectionType: string = 'MEMBERS') {
   return render(
-    <MemoryRouter initialEntries={[{ pathname: `/admin/section/${sectionId}`, state: { sectionName: 'Test Section', sectionType: 'MEMBERS' } }]}>
+    <MemoryRouter
+      initialEntries={[
+        { pathname: `/admin/section/${sectionId}`, state: { sectionName: 'Test Section', sectionType } },
+      ]}
+    >
       <Routes>
         <Route path="/admin/section/:sectionId" element={<SectionAdminPage />} />
       </Routes>
@@ -83,6 +108,17 @@ describe('SectionAdminPage', () => {
     expect(screen.queryByText('Send Announcement')).not.toBeInTheDocument();
   });
 
+  it('navigates home from the access-denied state', async () => {
+    const user = userEvent.setup();
+    renderSectionAdminPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Access denied/i)).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Back to Home'));
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.HOME);
+  });
+
   it('shows the admin hub for a section moderator, without the admin-only Edit Section card', async () => {
     mockGetUserAccessGroups({
       data: { user: { userGroups: [{ userGroup: { id: moderatorGroupId } }] } },
@@ -96,14 +132,54 @@ describe('SectionAdminPage', () => {
     expect(screen.queryByText('Edit Section')).not.toBeInTheDocument();
   });
 
-  it('shows the admin hub including Edit Section for a global admin', async () => {
-    mockIsAdmin = true;
+  it('opens and returns from the Send Announcement view', async () => {
+    const user = userEvent.setup();
+    mockGetUserAccessGroups({
+      data: { user: { userGroups: [{ userGroup: { id: moderatorGroupId } }] } },
+    });
 
     renderSectionAdminPage();
 
     await waitFor(() => {
       expect(screen.getByText('Send Announcement')).toBeInTheDocument();
     });
-    expect(screen.getByText('Edit Section')).toBeInTheDocument();
+    await user.click(screen.getByText('Send Announcement'));
+
+    expect(screen.getByText('Mock Send Announcement Page for Test Section')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Back to hub'));
+    expect(screen.getByText('Send Announcement')).toBeInTheDocument();
+  });
+
+  it('navigates to Manage Sections with the managed section for an EVENTS section', async () => {
+    const user = userEvent.setup();
+    mockIsAdmin = true;
+
+    renderSectionAdminPage('EVENTS');
+
+    await waitFor(() => {
+      expect(screen.getByText('Manage Events')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Manage Events'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.MANAGE_SECTIONS, {
+      state: { managedSection: { id: sectionId, name: 'Test Section' } },
+    });
+  });
+
+  it('shows the admin hub including Edit Section for a global admin, and navigates to edit it', async () => {
+    const user = userEvent.setup();
+    mockIsAdmin = true;
+
+    renderSectionAdminPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Section')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Edit Section'));
+
+    expect(mockNavigate).toHaveBeenCalledWith(ROUTES.MANAGE_SECTIONS, {
+      state: { editSectionId: sectionId },
+    });
   });
 });

--- a/src/features/sections/hooks/useCanModerateSection.ts
+++ b/src/features/sections/hooks/useCanModerateSection.ts
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import { useGetSectionById, useGetUserAccessGroups } from "@dataconnect/generated/react";
+import { dataConnect } from "../../../config/firebase";
+import type { UUIDString } from "@dataconnect/generated";
+import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
+import { auth } from "../../../config/firebase";
+import { useAdminClaim } from "../../users/hooks/useAdminClaim";
+
+interface UseCanModerateSectionResult {
+  /** True once section/user-group data has loaded enough to know the answer. */
+  isResolved: boolean;
+  isAdmin: boolean;
+  canModerateSection: boolean;
+}
+
+/**
+ * Whether the current user can administer a section — either as a global admin or as a
+ * member of a user group with MODERATOR purpose on that section. Mirrors the check
+ * SectionDetail.tsx uses to show its "Admin" button; kept in one place since this is an
+ * authorization decision, not just UI copy.
+ */
+export function useCanModerateSection(sectionId: string | undefined): UseCanModerateSectionResult {
+  const currentUser = auth.currentUser;
+  const isAdmin = useAdminClaim(currentUser);
+
+  const { data: sectionData, isLoading: loadingSection } = useGetSectionById(
+    dataConnect,
+    { id: sectionId as UUIDString },
+    { enabled: Boolean(sectionId) }
+  );
+  const { data: userAccessGroupsData, isLoading: loadingUserGroups } = useGetUserAccessGroups(
+    dataConnect,
+    {}
+  );
+
+  const userUserGroupIds = useMemo(() => {
+    if (!userAccessGroupsData?.user?.userGroups) {
+      return [];
+    }
+    return userAccessGroupsData.user.userGroups.map((group) => group.userGroup.id);
+  }, [userAccessGroupsData]);
+
+  const canModerateSection = useMemo(() => {
+    const purposeLinks = sectionData?.section?.purposeLinks ?? [];
+    return purposeLinks.some(
+      (link) =>
+        (link.purposes?.includes(SectionPurpose.MODERATOR) ?? false) &&
+        userUserGroupIds.includes(link.userGroup.id)
+    );
+  }, [sectionData, userUserGroupIds]);
+
+  return {
+    isResolved: !loadingSection && !loadingUserGroups,
+    isAdmin,
+    canModerateSection,
+  };
+}


### PR DESCRIPTION
## Summary
- `/admin/section/:sectionId` was wrapped only in `protectedRoute` (logged in + enabled) — `SectionAdminPage` itself never checked `isAdmin`/moderator status before rendering the hub, only conditionally hiding the "Edit Section" card. Any enabled member could reach the Send Announcement / Manage Events hub for any section.
- Extracted the `isAdmin || canModerateSection` check that `SectionDetail.tsx` already computes into a shared `useCanModerateSection(sectionId)` hook (`src/features/sections/hooks/useCanModerateSection.ts`), so this authorization logic lives in one place rather than being reimplemented per component.
- `SectionAdminPage` now shows a loading state while section/user-group data resolves, then a proper "Access denied" state for anyone who isn't an admin or a moderator of that specific section, before rendering the hub.
- Didn't touch the route wrapper itself (`protectedRoute`) — moving it to `renderAdminOnly` would incorrectly lock out legitimate non-admin section moderators, which is exactly the bug #336 found on the sidebar nav side. The component-level check handles both cases correctly.

## Test plan
- [x] Added `SectionAdminPage.test.tsx` — non-admin/non-moderator sees access denied; moderator sees the hub without "Edit Section"; admin sees the hub with "Edit Section"
- [x] `npx vitest run` — 478 tests pass across the frontend suite
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean

Part of #326. Fixes #329.