### PR TITLE
fix: use timing-safe comparison for GOV Notify callback bearer token

### DIFF
--- a/functions/src/__tests__/notifyCallback.test.ts
+++ b/functions/src/__tests__/notifyCallback.test.ts
@@ -52,6 +52,14 @@ describe("handleNotifyDelivery", () => {
     expect((res.status as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(403);
   });
 
+  it("rejects a same-length wrong bearer token (exercises the timingSafeEqual path, not just the length check)", async () => {
+    const wrongSameLength = BEARER.slice(0, -1) + (BEARER.at(-1) === "x" ? "y" : "x");
+    expect(wrongSameLength.length).toBe(BEARER.length);
+    const res = makeRes();
+    await handleNotifyDelivery(makeReq({ headers: { authorization: `Bearer ${wrongSameLength}` } }), res, BEARER);
+    expect((res.status as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(403);
+  });
+
   it("rejects requests with no auth header", async () => {
     const res = makeRes();
     await handleNotifyDelivery(makeReq({ headers: {} }), res, BEARER);

--- a/functions/src/notifyCallback.ts
+++ b/functions/src/notifyCallback.ts
@@ -1,6 +1,7 @@
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import * as logger from "firebase-functions/logger";
+import { timingSafeEqual } from "node:crypto";
 import type { Response } from "express";
 import {
   getUserByEmail,
@@ -25,15 +26,21 @@ export interface NotifyReceipt {
   sent_at?: string;
 }
 
+function isValidBearerToken(token: string, expected: string): boolean {
+  const tokenBuf = Buffer.from(token);
+  const expectedBuf = Buffer.from(expected);
+  return tokenBuf.length === expectedBuf.length && timingSafeEqual(tokenBuf, expectedBuf);
+}
+
 export async function handleNotifyDelivery(
   req: Request,
   res: Response,
   bearerToken: string
 ): Promise<void> {
-  // Verify bearer token
+  // Verify bearer token (constant-time compare — this is a shared secret, not just a lookup key)
   const authHeader = (req.headers["authorization"] as string | undefined) ?? "";
   const token = authHeader.startsWith("Bearer ") ? authHeader.slice(7) : "";
-  if (!token || token !== bearerToken) {
+  if (!token || !isValidBearerToken(token, bearerToken)) {
     res.status(403).send("Forbidden");
     return;
   }


### PR DESCRIPTION
## Summary
- `handleNotifyDelivery` (functions/src/notifyCallback.ts) authenticated the GOV Notify delivery-receipt webhook with a plain `token !== bearerToken` string comparison, which short-circuits on the first mismatched character and is theoretically susceptible to a timing side-channel.
- The sibling webhook-style handler `unsubscribe.ts` already uses `crypto.timingSafeEqual` for its HMAC verification — brought this in line with that pattern.
- Added `isValidBearerToken`: compares buffer lengths first (required since `timingSafeEqual` throws on unequal-length inputs), then does the constant-time comparison.

## Test plan
- [x] Added a test exercising a same-length-but-wrong token (the previous tests only covered a different-length wrong token and no-header cases, which wouldn't have exercised the `timingSafeEqual` branch specifically)
- [x] `npx vitest run` in `functions/` — 324 tests pass
- [x] `npx tsc --noEmit` — clean

Part of #326. Fixes #332.