### PR TITLE
fix: gate section/event lookup by id behind an access check

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -212,8 +212,10 @@ query GetUserAccessGroupsById($userId: String!) @auth(expr: "auth.token.admin ==
   }
 }
 
-# Get events for a section (user must have access to section via GetSectionsForUser). Order by startDateTime.
-query GetEventsForSection($sectionId: UUID!) @auth(expr: "auth.token.enabled == true") {
+# Admin only — accepts an arbitrary sectionId with no relationship check. Non-admin members
+# go through the getSectionEventsForUser callable, which checks their actual section access
+# server-side before calling this same query with admin SDK credentials.
+query GetEventsForSection($sectionId: UUID!) @auth(expr: "auth.token.admin == true && auth.token.enabled == true") {
   section(id: $sectionId) {
     id
     events: events_on_section(orderBy: { startDateTime: ASC }) {
@@ -230,8 +232,8 @@ query GetEventsForSection($sectionId: UUID!) @auth(expr: "auth.token.enabled == 
   }
 }
 
-# Get event by ID with ticket types (user must have access to event's section). Ticket types ordered by sortOrder.
-query GetEventById($id: UUID!) @auth(expr: "auth.token.enabled == true") {
+# Admin only — see GetEventsForSection. Non-admin members go through getEventForUser.
+query GetEventById($id: UUID!) @auth(expr: "auth.token.admin == true && auth.token.enabled == true") {
   event(id: $id) {
     id
     section {
@@ -261,8 +263,8 @@ query GetEventById($id: UUID!) @auth(expr: "auth.token.enabled == true") {
   }
 }
 
-# Get section by ID with user groups and registration info
-query GetSectionById($id: UUID!) @auth(expr: "auth.token.enabled == true") {
+# Admin only — see GetEventsForSection. Non-admin members go through getSectionForUser.
+query GetSectionById($id: UUID!) @auth(expr: "auth.token.admin == true && auth.token.enabled == true") {
   section(id: $id) {
     id
     name

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -181,9 +181,6 @@ describe("Data Connect auth contracts", () => {
       { op: "query GetCurrentUser", mustInclude: USER_EXPR },
       { op: "query GetSectionsForUser", mustInclude: USER_EXPR },
       { op: "query GetUserAccessGroups", mustInclude: USER_EXPR },
-      { op: "query GetEventsForSection", mustInclude: USER_EXPR },
-      { op: "query GetEventById", mustInclude: USER_EXPR },
-      { op: "query GetSectionById", mustInclude: USER_EXPR },
       { op: "query GetMyBookingsForEvent", mustInclude: USER_EXPR },
       { op: "query GetMyTicketOrders", mustInclude: USER_EXPR },
       { op: "query GetMyBookingPaymentAdjustments", mustInclude: USER_EXPR },
@@ -200,6 +197,13 @@ describe("Data Connect auth contracts", () => {
       { op: "query GetUserGroupById", mustInclude: ADMIN_EXPR },
       { op: "query ListBookingPaymentAdjustmentsForAdmin", mustInclude: ADMIN_EXPR },
       { op: "query ListOpenPaymentReconciliationExceptions", mustInclude: ADMIN_EXPR },
+      // GetEventsForSection/GetEventById/GetSectionById accept an arbitrary id with no
+      // relationship check — must stay admin-only. Non-admin members go through the
+      // getSectionEventsForUser/getEventForUser/getSectionForUser callables
+      // (functions/src/sections.ts), which verify the caller's own section access first.
+      { op: "query GetEventsForSection", mustInclude: ADMIN_EXPR },
+      { op: "query GetEventById", mustInclude: ADMIN_EXPR },
+      { op: "query GetSectionById", mustInclude: ADMIN_EXPR },
     ]);
 
     // System-only queries (NO_ACCESS — callable from Firebase Functions only)

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -35,6 +35,9 @@ describe("function entry guard contracts", () => {
 
     const sections = readSource("sections.ts");
     assertOnCallGuard(sections, "getSectionMembersMerged", "requireAuth(request);");
+    assertOnCallGuard(sections, "getSectionForUser", "requireEnabled(request);");
+    assertOnCallGuard(sections, "getSectionEventsForUser", "requireEnabled(request);");
+    assertOnCallGuard(sections, "getEventForUser", "requireEnabled(request);");
 
     const bookings = readSource("bookings.ts");
     assertOnCallGuard(bookings, "submitEventBooking", "requireEnabled(request);");

--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as admin from "@dataconnect/admin-generated";
+import { MembershipStatus } from "@dataconnect/admin-generated";
+import { getSectionForUser, getSectionEventsForUser, getEventForUser } from "../sections";
+
+const mockGetSectionById = vi.spyOn(admin, "getSectionById");
+const mockGetUserAccessGroupsById = vi.spyOn(admin, "getUserAccessGroupsById");
+const mockGetUserMembershipStatus = vi.spyOn(admin, "getUserMembershipStatus");
+const mockGetEventsForSection = vi.spyOn(admin, "getEventsForSection");
+const mockGetEventById = vi.spyOn(admin, "getEventById");
+
+const sectionId = "00000000-0000-4000-8000-000000000001";
+const accessGroupId = "00000000-0000-4000-8000-0000000000a1";
+const moderatorGroupId = "00000000-0000-4000-8000-0000000000a2";
+
+function callAs<T>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fn: { run: (request: any) => Promise<T> },
+  uid: string,
+  isAdmin: boolean,
+  data: Record<string, unknown>
+): Promise<T> {
+  return fn.run({
+    auth: { uid, token: { admin: isAdmin, enabled: true } },
+    data,
+  });
+}
+
+function mockSection(purposeLinks: Array<{ purposes: string[]; userGroupId: string }>) {
+  mockGetSectionById.mockResolvedValue({
+    data: {
+      section: {
+        id: sectionId,
+        name: "Test Section",
+        type: "MEMBERS",
+        description: null,
+        isOpenForRegistration: false,
+        allowedUserGroups: null,
+        purposeLinks: purposeLinks.map((pl) => ({
+          purposes: pl.purposes,
+          userGroup: { id: pl.userGroupId, name: "Group", description: null, subscribable: false, membershipStatuses: null },
+        })),
+      },
+    },
+  } as unknown as Awaited<ReturnType<typeof admin.getSectionById>>);
+}
+
+describe("getSectionForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: MembershipStatus.REGULAR, firstName: "A", lastName: "B", email: "a@b.com" } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+  });
+
+  it("returns the full section for an admin caller with no group relationship at all", async () => {
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "admin-1", userGroups: [] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    const result = await callAs(getSectionForUser, "admin-1", true, { sectionId });
+
+    expect(result.hasAccess).toBe(true);
+    expect(result.section?.id).toBe(sectionId);
+  });
+
+  it("returns hasAccess and canModerate for a non-admin with a MODERATOR group", async () => {
+    mockSection([{ purposes: ["MODERATOR"], userGroupId: moderatorGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "mod-1", userGroups: [{ userGroup: { id: moderatorGroupId, name: "Mods", description: null } }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    const result = await callAs(getSectionForUser, "mod-1", false, { sectionId });
+
+    expect(result.hasAccess).toBe(true);
+    expect(result.canModerate).toBe(true);
+    expect(result.section?.id).toBe(sectionId);
+  });
+
+  it("does not throw, and withholds the section, for a non-admin with no relationship to the section", async () => {
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "stranger-1", userGroups: [] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    const result = await callAs(getSectionForUser, "stranger-1", false, { sectionId });
+
+    expect(result).toEqual({ section: null, hasAccess: false, canModerate: false });
+  });
+});
+
+describe("getSectionEventsForUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: MembershipStatus.REGULAR, firstName: "A", lastName: "B", email: "a@b.com" } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+  });
+
+  it("rejects a non-admin with no access to the section", async () => {
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "stranger-1", userGroups: [] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    await expect(
+      callAs(getSectionEventsForUser, "stranger-1", false, { sectionId })
+    ).rejects.toMatchObject({ code: "permission-denied" });
+    expect(mockGetEventsForSection).not.toHaveBeenCalled();
+  });
+
+  it("returns events for a user with ACCESS", async () => {
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "member-1", userGroups: [{ userGroup: { id: accessGroupId, name: "Access", description: null } }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+    mockGetEventsForSection.mockResolvedValue({
+      data: { section: { id: sectionId, events: [{ id: "event-1", title: "Event One" }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getEventsForSection>>);
+
+    const result = await callAs(getSectionEventsForUser, "member-1", false, { sectionId });
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].title).toBe("Event One");
+  });
+});
+
+describe("getEventForUser", () => {
+  const eventId = "00000000-0000-4000-8000-000000000099";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: MembershipStatus.REGULAR, firstName: "A", lastName: "B", email: "a@b.com" } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+  });
+
+  it("rejects when the event does not exist", async () => {
+    mockGetEventById.mockResolvedValue({ data: { event: undefined } } as unknown as Awaited<
+      ReturnType<typeof admin.getEventById>
+    >);
+
+    await expect(
+      callAs(getEventForUser, "member-1", false, { eventId })
+    ).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("rejects a non-admin with no access to the event's section", async () => {
+    mockGetEventById.mockResolvedValue({
+      data: { event: { id: eventId, section: { id: sectionId }, title: "Event" } },
+    } as unknown as Awaited<ReturnType<typeof admin.getEventById>>);
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "stranger-1", userGroups: [] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    await expect(
+      callAs(getEventForUser, "stranger-1", false, { eventId })
+    ).rejects.toMatchObject({ code: "permission-denied" });
+  });
+
+  it("returns the event for a user with access to its section", async () => {
+    mockGetEventById.mockResolvedValue({
+      data: { event: { id: eventId, section: { id: sectionId }, title: "Event" } },
+    } as unknown as Awaited<ReturnType<typeof admin.getEventById>>);
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "member-1", userGroups: [{ userGroup: { id: accessGroupId, name: "Access", description: null } }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+
+    const result = await callAs(getEventForUser, "member-1", false, { eventId });
+
+    expect(result.event?.id).toBe(eventId);
+  });
+});

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -1,12 +1,15 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
-import { requireAuth, requireString, handleFunctionError } from "./helpers";
+import { requireAuth, requireEnabled, requireString, handleFunctionError } from "./helpers";
 import {
   getSectionById,
   getSectionMembers,
+  getEventsForSection,
+  getEventById,
   getUserAccessGroupsById,
   getUserMembershipStatus,
   listUsers,
+  type GetSectionByIdData,
 } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
 
@@ -20,6 +23,53 @@ export interface SectionMemberResponse {
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
   return link.purpose === target || (link.purposes?.includes(target) ?? false);
+}
+
+interface SectionAccess {
+  section: NonNullable<GetSectionByIdData["section"]>;
+  hasAccess: boolean;
+  canModerate: boolean;
+}
+
+/**
+ * Fetches a section and determines whether callerUid has ACCESS/MODERATOR purpose on it
+ * (explicit group membership or membership-status-derived), independent of callerIsAdmin.
+ * Used by every section/event lookup a non-admin member is allowed to make, since the
+ * underlying GetSectionById/GetEventsForSection/GetEventById Data Connect queries are
+ * admin-only — this is the only path a regular member has to that data, and it's gated
+ * on their actual relationship to the section rather than an arbitrary client-supplied id.
+ */
+async function resolveSectionAccess(sectionId: string, callerUid: string): Promise<SectionAccess> {
+  const [sectionResult, callerGroupsResult, userStatusResult] = await Promise.all([
+    getSectionById({ id: sectionId }),
+    getUserAccessGroupsById({ userId: callerUid }),
+    getUserMembershipStatus({ id: callerUid }),
+  ]);
+
+  const section = sectionResult.data?.section;
+  if (!section) {
+    throw new HttpsError("not-found", "Section not found");
+  }
+
+  const purposeLinks = section.purposeLinks ?? [];
+  const callerGroupIds = new Set(
+    (callerGroupsResult.data?.user?.userGroups ?? []).map(
+      (ug: { userGroup: { id: string } }) => ug.userGroup.id
+    )
+  );
+  const userStatus = userStatusResult.data?.user?.membershipStatus;
+
+  const matchesPurpose = (target: string) =>
+    purposeLinks.some((pl) => {
+      if (!linkHasPurpose(pl, target)) return false;
+      if (callerGroupIds.has(pl.userGroup.id)) return true;
+      return userStatus ? (pl.userGroup.membershipStatuses?.includes(userStatus) ?? false) : false;
+    });
+
+  const canModerate = matchesPurpose("MODERATOR");
+  const hasAccess = canModerate || matchesPurpose("ACCESS");
+
+  return { section, hasAccess, canModerate };
 }
 
 /**
@@ -131,6 +181,98 @@ export const getSectionMembersMerged = onCall(
     } catch (e: unknown) {
       if (e instanceof HttpsError) throw e;
       handleFunctionError(e as Error, "getSectionMembersMerged");
+    }
+  }
+);
+
+export interface SectionForUserResponse {
+  section: NonNullable<GetSectionByIdData["section"]> | null;
+  hasAccess: boolean;
+  canModerate: boolean;
+}
+
+/**
+ * Section lookup for a regular member (or admin). GetSectionById itself is admin-only in
+ * Data Connect, since it accepts an arbitrary id with no relationship check — this is the
+ * only path a non-admin has to a section's details, and it's scoped to their actual access.
+ * Does not throw for an unauthorized caller: returns hasAccess/canModerate: false so the
+ * client can render an access-denied state rather than an error boundary.
+ */
+export const getSectionForUser = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<SectionForUserResponse> => {
+    requireEnabled(request);
+    const sectionId = requireString(request.data?.sectionId, "sectionId");
+    const callerUid = request.auth!.uid;
+    const callerIsAdmin = request.auth!.token?.admin === true;
+
+    try {
+      const { section, hasAccess, canModerate } = await resolveSectionAccess(sectionId, callerUid);
+      if (!callerIsAdmin && !hasAccess) {
+        return { section: null, hasAccess: false, canModerate: false };
+      }
+      return { section, hasAccess: true, canModerate };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e as Error, "getSectionForUser");
+    }
+  }
+);
+
+export interface SectionEventsForUserResponse {
+  events: NonNullable<Awaited<ReturnType<typeof getEventsForSection>>["data"]["section"]>["events"];
+}
+
+/** Events for a section, gated the same way as getSectionForUser. */
+export const getSectionEventsForUser = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<SectionEventsForUserResponse> => {
+    requireEnabled(request);
+    const sectionId = requireString(request.data?.sectionId, "sectionId");
+    const callerUid = request.auth!.uid;
+    const callerIsAdmin = request.auth!.token?.admin === true;
+
+    try {
+      const { hasAccess } = await resolveSectionAccess(sectionId, callerUid);
+      if (!callerIsAdmin && !hasAccess) {
+        throw new HttpsError("permission-denied", "You do not have permission to view this section");
+      }
+      const result = await getEventsForSection({ sectionId });
+      return { events: result.data?.section?.events ?? [] };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e as Error, "getSectionEventsForUser");
+    }
+  }
+);
+
+export interface EventForUserResponse {
+  event: NonNullable<Awaited<ReturnType<typeof getEventById>>["data"]["event"]> | null;
+}
+
+/** Single event lookup, gated on access to the event's own section. */
+export const getEventForUser = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request): Promise<EventForUserResponse> => {
+    requireEnabled(request);
+    const eventId = requireString(request.data?.eventId, "eventId");
+    const callerUid = request.auth!.uid;
+    const callerIsAdmin = request.auth!.token?.admin === true;
+
+    try {
+      const eventResult = await getEventById({ id: eventId });
+      const event = eventResult.data?.event;
+      if (!event) {
+        throw new HttpsError("not-found", "Event not found");
+      }
+      const { hasAccess } = await resolveSectionAccess(event.section.id, callerUid);
+      if (!callerIsAdmin && !hasAccess) {
+        throw new HttpsError("permission-denied", "You do not have permission to view this event");
+      }
+      return { event };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e as Error, "getEventForUser");
     }
   }
 );

--- a/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
+++ b/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
@@ -3,17 +3,12 @@ import { render, screen, waitFor } from '../../../../test-utils';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import SectionAdminPage from '../SectionAdminPage';
-import * as reactGenerated from '@dataconnect/generated/react';
 import { createMockUser } from '../../../../test-utils/mocks/firebase';
-import {
-  dataConnectQueryResult,
-  type DataConnectQueryResultOverrides,
-} from '../../../../test-utils/dataConnectMocks';
 import { ROUTES } from '../../../../constants';
+import { getSectionForUser } from '../../../../shared/utils/firebaseFunctions';
 
-vi.mock('@dataconnect/generated/react', () => ({
-  useGetSectionById: vi.fn(),
-  useGetUserAccessGroups: vi.fn(),
+vi.mock('../../../../shared/utils/firebaseFunctions', () => ({
+  getSectionForUser: vi.fn(),
 }));
 
 const mockCurrentUser = createMockUser({ uid: 'user-1' });
@@ -51,20 +46,15 @@ vi.mock('../SendAnnouncementPage', () => ({
   ),
 }));
 
-function mockGetSectionById(overrides: DataConnectQueryResultOverrides) {
-  vi.mocked(reactGenerated.useGetSectionById).mockReturnValue(
-    dataConnectQueryResult<typeof reactGenerated.useGetSectionById>(overrides)
-  );
-}
-
-function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
-  vi.mocked(reactGenerated.useGetUserAccessGroups).mockReturnValue(
-    dataConnectQueryResult<typeof reactGenerated.useGetUserAccessGroups>(overrides)
-  );
-}
-
 const sectionId = 'section-1';
-const moderatorGroupId = 'group-moderator';
+
+function mockCanModerate(canModerate: boolean) {
+  vi.mocked(getSectionForUser).mockResolvedValue({
+    section: { id: sectionId },
+    hasAccess: canModerate,
+    canModerate,
+  } as unknown as Awaited<ReturnType<typeof getSectionForUser>>);
+}
 
 function renderSectionAdminPage(sectionType: string = 'MEMBERS') {
   return render(
@@ -84,19 +74,7 @@ describe('SectionAdminPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsAdmin = false;
-    mockGetSectionById({
-      data: {
-        section: {
-          id: sectionId,
-          purposeLinks: [
-            { purposes: ['MODERATOR'], userGroup: { id: moderatorGroupId } },
-          ],
-        },
-      },
-    });
-    mockGetUserAccessGroups({
-      data: { user: { userGroups: [] } },
-    });
+    mockCanModerate(false);
   });
 
   it('shows access denied for a user who is neither admin nor a section moderator', async () => {
@@ -120,9 +98,7 @@ describe('SectionAdminPage', () => {
   });
 
   it('shows the admin hub for a section moderator, without the admin-only Edit Section card', async () => {
-    mockGetUserAccessGroups({
-      data: { user: { userGroups: [{ userGroup: { id: moderatorGroupId } }] } },
-    });
+    mockCanModerate(true);
 
     renderSectionAdminPage();
 
@@ -134,9 +110,7 @@ describe('SectionAdminPage', () => {
 
   it('opens and returns from the Send Announcement view', async () => {
     const user = userEvent.setup();
-    mockGetUserAccessGroups({
-      data: { user: { userGroups: [{ userGroup: { id: moderatorGroupId } }] } },
-    });
+    mockCanModerate(true);
 
     renderSectionAdminPage();
 
@@ -154,6 +128,7 @@ describe('SectionAdminPage', () => {
   it('navigates to Manage Sections with the managed section for an EVENTS section', async () => {
     const user = userEvent.setup();
     mockIsAdmin = true;
+    mockCanModerate(false);
 
     renderSectionAdminPage('EVENTS');
 
@@ -170,6 +145,7 @@ describe('SectionAdminPage', () => {
   it('shows the admin hub including Edit Section for a global admin, and navigates to edit it', async () => {
     const user = userEvent.setup();
     mockIsAdmin = true;
+    mockCanModerate(false);
 
     renderSectionAdminPage();
 

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   Snackbar,
 } from "@mui/material";
-import { useGetSectionById, useGetUserAccessGroups, useGetSectionsForUser, useGetEventsForSection, useGetEventById } from "@dataconnect/generated/react";
+import { useGetUserAccessGroups, useGetSectionsForUser } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import { executeMutation } from "firebase/data-connect";
 import { colors } from "../../../config/colors";
@@ -21,7 +21,18 @@ import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { useNavigate, useLocation } from "react-router-dom";
-import { getSectionMembersMerged, subscribeToUserGroup } from "../../../shared/utils/firebaseFunctions";
+import {
+  getSectionMembersMerged,
+  subscribeToUserGroup,
+  getSectionForUser,
+  getSectionEventsForUser,
+  getEventForUser,
+} from "../../../shared/utils/firebaseFunctions";
+import type {
+  SectionForUserResponse,
+  SectionEventsForUserResponse,
+  EventForUserResponse,
+} from "../../../shared/utils/firebaseFunctions";
 import type { SectionUserGroupPurpose, UUIDString } from "@dataconnect/generated";
 import { MembershipStatus, SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
 import { ITEMS_PER_PAGE, ROUTES } from "../../../constants";
@@ -61,13 +72,31 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const currentUser = auth.currentUser;
   const isAdmin = useAdminClaim(currentUser);
 
-  // Get section details (for user group info and subscribability)
-  const {
-    data: sectionData,
-    isLoading: loadingSection,
-    isError: errorSection,
-    refetch: refetchSection,
-  } = useGetSectionById(dataConnect, { id: sectionId as UUIDString });
+  // Get section details (for user group info and subscribability). GetSectionById itself is
+  // admin-only in Data Connect (see #328) — this callable checks the caller's actual section
+  // access server-side before returning anything.
+  const [sectionData, setSectionData] = useState<{ section: SectionForUserResponse["section"] } | undefined>(undefined);
+  const [loadingSection, setLoadingSection] = useState(true);
+  const [errorSection, setErrorSection] = useState(false);
+
+  const refetchSection = useCallback(async () => {
+    if (!sectionId) return;
+    setLoadingSection(true);
+    setErrorSection(false);
+    try {
+      const result = await getSectionForUser(sectionId);
+      setSectionData({ section: result.section });
+    } catch {
+      setSectionData(undefined);
+      setErrorSection(true);
+    } finally {
+      setLoadingSection(false);
+    }
+  }, [sectionId]);
+
+  useEffect(() => {
+    void refetchSection();
+  }, [refetchSection]);
 
   const fetchMembers = useCallback(async () => {
     setLoadingMembers(true);
@@ -107,25 +136,60 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   // Used to check access including status-based group memberships (result is cached from App.tsx)
   const { data: userSectionsData } = useGetSectionsForUser(dataConnect, {});
 
-  // Get events for this section (used when section.type === EVENTS)
-  const {
-    data: eventsData,
-    isLoading: loadingEvents,
-    isError: errorEvents,
-    refetch: refetchEvents,
-  } = useGetEventsForSection(dataConnect, { sectionId: sectionId as UUIDString });
+  // Get events for this section (used when section.type === EVENTS). GetEventsForSection is
+  // admin-only in Data Connect (see #328); this callable is access-checked the same way as
+  // getSectionForUser above.
+  const [eventsData, setEventsData] = useState<{ section: { events: SectionEventsForUserResponse["events"] } } | undefined>(undefined);
+  const [loadingEvents, setLoadingEvents] = useState(false);
+  const [errorEvents, setErrorEvents] = useState(false);
 
-  // Get single event for detail view (only runs when selectedEventId is set)
-  const {
-    data: eventDetailData,
-    isLoading: loadingEventDetail,
-    isError: errorEventDetail,
-    refetch: refetchEventDetail,
-  } = useGetEventById(
-    dataConnect,
-    { id: (selectedEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
-    { enabled: !!selectedEventId }
-  );
+  const refetchEvents = useCallback(async () => {
+    if (!sectionId) return;
+    setLoadingEvents(true);
+    setErrorEvents(false);
+    try {
+      const result = await getSectionEventsForUser(sectionId);
+      setEventsData({ section: { events: result.events } });
+    } catch {
+      setEventsData(undefined);
+      setErrorEvents(true);
+    } finally {
+      setLoadingEvents(false);
+    }
+  }, [sectionId]);
+
+  useEffect(() => {
+    void refetchEvents();
+  }, [refetchEvents]);
+
+  // Get single event for detail view (only runs when selectedEventId is set). GetEventById is
+  // admin-only in Data Connect (see #328); this callable checks access to the event's section.
+  const [eventDetailData, setEventDetailData] = useState<{ event: EventForUserResponse["event"] } | undefined>(undefined);
+  const [loadingEventDetail, setLoadingEventDetail] = useState(false);
+  const [errorEventDetail, setErrorEventDetail] = useState(false);
+
+  const refetchEventDetail = useCallback(async () => {
+    if (!selectedEventId) return;
+    setLoadingEventDetail(true);
+    setErrorEventDetail(false);
+    try {
+      const result = await getEventForUser(selectedEventId);
+      setEventDetailData({ event: result.event });
+    } catch {
+      setEventDetailData(undefined);
+      setErrorEventDetail(true);
+    } finally {
+      setLoadingEventDetail(false);
+    }
+  }, [selectedEventId]);
+
+  useEffect(() => {
+    if (!selectedEventId) {
+      setEventDetailData(undefined);
+      return;
+    }
+    void refetchEventDetail();
+  }, [selectedEventId, refetchEventDetail]);
 
   // Extract user's user group IDs
   const userUserGroupIds = useMemo(() => {

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -4,7 +4,12 @@ import { MemoryRouter } from 'react-router-dom';
 import SectionDetail from '../SectionDetail';
 import * as reactGenerated from '@dataconnect/generated/react';
 import { createMockUser } from '../../../../test-utils/mocks/firebase';
-import { getSectionMembersMerged } from '../../../../shared/utils/firebaseFunctions';
+import {
+  getSectionMembersMerged,
+  getSectionForUser,
+  getSectionEventsForUser,
+  getEventForUser,
+} from '../../../../shared/utils/firebaseFunctions';
 import {
   dataConnectQueryResult,
   type DataConnectQueryResultOverrides,
@@ -12,14 +17,11 @@ import {
 
 // Mock the DataConnect hooks (SectionDetail uses getSectionMembersMerged callable, not useGetSectionMembers)
 vi.mock('@dataconnect/generated/react', () => ({
-  useGetSectionById: vi.fn(),
   useGetUserAccessGroups: vi.fn(),
   useGetSectionsForUser: vi.fn(() => ({
     data: { user: { membershipStatus: null, userGroups: [] }, allUserGroups: [] },
     isLoading: false,
   })),
-  useGetEventsForSection: vi.fn(),
-  useGetEventById: vi.fn(),
   useGetCurrentUser: vi.fn(),
   useGetMyBookingsForEvent: vi.fn(),
   useGetMyTicketOrders: vi.fn(),
@@ -45,6 +47,9 @@ vi.mock('../../../../shared/utils/firebaseFunctions', () => ({
   getSectionMembersMerged: vi.fn().mockResolvedValue({ members: [] }),
   subscribeToUserGroup: vi.fn().mockResolvedValue(undefined),
   submitEventBooking: vi.fn(),
+  getSectionForUser: vi.fn(),
+  getSectionEventsForUser: vi.fn(),
+  getEventForUser: vi.fn(),
 }));
 
 vi.mock('../../../users/hooks/useAdminClaim', () => ({
@@ -82,10 +87,26 @@ vi.mock('@dataconnect/generated', async () => {
   };
 });
 
+// SectionDetail.tsx fetches section/events/event-detail via callables (getSectionForUser etc.,
+// see #328) rather than the react-query hooks these tests used to mock directly. These helpers
+// keep the old { data, isLoading, isError } call shape used throughout this file (so none of the
+// dozens of call sites below need to change) and translate it into a promise-based mock: a
+// never-resolving promise for isLoading, a rejection for isError, otherwise a resolved value
+// built from the same `data` shape the old react-query mock would have returned.
 function mockGetSectionById(overrides: DataConnectQueryResultOverrides) {
-  vi.mocked(reactGenerated.useGetSectionById).mockReturnValue(
-    dataConnectQueryResult<typeof reactGenerated.useGetSectionById>(overrides)
-  );
+  const mocked = vi.mocked(getSectionForUser);
+  if (overrides.isLoading) {
+    mocked.mockReturnValue(new Promise(() => undefined));
+    return;
+  }
+  if (overrides.isError) {
+    mocked.mockRejectedValue(new Error('Failed to load section'));
+    return;
+  }
+  const section = (overrides.data as { section?: unknown } | undefined)?.section ?? null;
+  mocked.mockResolvedValue({ section, hasAccess: true, canModerate: false } as Awaited<
+    ReturnType<typeof getSectionForUser>
+  >);
 }
 
 function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
@@ -95,15 +116,31 @@ function mockGetUserAccessGroups(overrides: DataConnectQueryResultOverrides) {
 }
 
 function mockGetEventsForSection(overrides: DataConnectQueryResultOverrides) {
-  vi.mocked(reactGenerated.useGetEventsForSection).mockReturnValue(
-    dataConnectQueryResult<typeof reactGenerated.useGetEventsForSection>(overrides)
-  );
+  const mocked = vi.mocked(getSectionEventsForUser);
+  if (overrides.isLoading) {
+    mocked.mockReturnValue(new Promise(() => undefined));
+    return;
+  }
+  if (overrides.isError) {
+    mocked.mockRejectedValue(new Error('Failed to load events'));
+    return;
+  }
+  const events = (overrides.data as { section?: { events?: unknown[] } } | undefined)?.section?.events ?? [];
+  mocked.mockResolvedValue({ events } as Awaited<ReturnType<typeof getSectionEventsForUser>>);
 }
 
 function mockGetEventById(overrides: DataConnectQueryResultOverrides) {
-  vi.mocked(reactGenerated.useGetEventById).mockReturnValue(
-    dataConnectQueryResult<typeof reactGenerated.useGetEventById>(overrides)
-  );
+  const mocked = vi.mocked(getEventForUser);
+  if (overrides.isLoading) {
+    mocked.mockReturnValue(new Promise(() => undefined));
+    return;
+  }
+  if (overrides.isError) {
+    mocked.mockRejectedValue(new Error('Failed to load event'));
+    return;
+  }
+  const event = (overrides.data as { event?: unknown } | undefined)?.event ?? null;
+  mocked.mockResolvedValue({ event } as Awaited<ReturnType<typeof getEventForUser>>);
 }
 
 function mockGetCurrentUser(overrides: DataConnectQueryResultOverrides) {

--- a/src/features/sections/hooks/useCanModerateSection.ts
+++ b/src/features/sections/hooks/useCanModerateSection.ts
@@ -1,13 +1,10 @@
-import { useMemo } from "react";
-import { useGetSectionById, useGetUserAccessGroups } from "@dataconnect/generated/react";
-import { dataConnect } from "../../../config/firebase";
-import type { UUIDString } from "@dataconnect/generated";
-import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
+import { useEffect, useState } from "react";
+import { getSectionForUser } from "../../../shared/utils/firebaseFunctions";
 import { auth } from "../../../config/firebase";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 
 interface UseCanModerateSectionResult {
-  /** True once section/user-group data has loaded enough to know the answer. */
+  /** True once the section access check has resolved (or failed). */
   isResolved: boolean;
   isAdmin: boolean;
   canModerateSection: boolean;
@@ -15,42 +12,45 @@ interface UseCanModerateSectionResult {
 
 /**
  * Whether the current user can administer a section — either as a global admin or as a
- * member of a user group with MODERATOR purpose on that section. Mirrors the check
- * SectionDetail.tsx uses to show its "Admin" button; kept in one place since this is an
- * authorization decision, not just UI copy.
+ * member of a user group with MODERATOR purpose on that section. Backed by the
+ * getSectionForUser callable, which is the only path a non-admin has to a section's
+ * purpose links (the underlying GetSectionById query is admin-only — see #328) and
+ * computes canModerate server-side against the caller's own group memberships.
  */
 export function useCanModerateSection(sectionId: string | undefined): UseCanModerateSectionResult {
   const currentUser = auth.currentUser;
   const isAdmin = useAdminClaim(currentUser);
+  const [canModerateSection, setCanModerateSection] = useState(false);
+  const [isResolved, setIsResolved] = useState(false);
 
-  const { data: sectionData, isLoading: loadingSection } = useGetSectionById(
-    dataConnect,
-    { id: sectionId as UUIDString },
-    { enabled: Boolean(sectionId) }
-  );
-  const { data: userAccessGroupsData, isLoading: loadingUserGroups } = useGetUserAccessGroups(
-    dataConnect,
-    {}
-  );
-
-  const userUserGroupIds = useMemo(() => {
-    if (!userAccessGroupsData?.user?.userGroups) {
-      return [];
+  useEffect(() => {
+    if (!sectionId) {
+      setCanModerateSection(false);
+      setIsResolved(true);
+      return;
     }
-    return userAccessGroupsData.user.userGroups.map((group) => group.userGroup.id);
-  }, [userAccessGroupsData]);
-
-  const canModerateSection = useMemo(() => {
-    const purposeLinks = sectionData?.section?.purposeLinks ?? [];
-    return purposeLinks.some(
-      (link) =>
-        (link.purposes?.includes(SectionPurpose.MODERATOR) ?? false) &&
-        userUserGroupIds.includes(link.userGroup.id)
-    );
-  }, [sectionData, userUserGroupIds]);
+    let cancelled = false;
+    setIsResolved(false);
+    getSectionForUser(sectionId)
+      .then((result) => {
+        if (cancelled) return;
+        setCanModerateSection(result.canModerate);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCanModerateSection(false);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsResolved(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sectionId]);
 
   return {
-    isResolved: !loadingSection && !loadingUserGroups,
+    isResolved,
     isAdmin,
     canModerateSection,
   };

--- a/src/shared/utils/__tests__/firebaseFunctions.test.ts
+++ b/src/shared/utils/__tests__/firebaseFunctions.test.ts
@@ -25,6 +25,9 @@ import {
   updateMembershipStatus,
   resignMembership,
   getSectionMembersMerged,
+  getSectionForUser,
+  getSectionEventsForUser,
+  getEventForUser,
   submitEventBooking,
   createTicketCheckoutSession,
   createEventBookingCheckoutSession,
@@ -261,6 +264,65 @@ describe("getSectionMembersMerged", () => {
     makeFailingCallable("Section not found");
 
     await expect(getSectionMembersMerged("bad-id")).rejects.toThrow("Section not found");
+  });
+});
+
+describe("getSectionForUser", () => {
+  it("calls getSectionForUser with sectionId and returns the access result", async () => {
+    const response = { section: { id: "section-abc", name: "Test" }, hasAccess: true, canModerate: false };
+    const callable = makeCallable({ data: response });
+
+    const result = await getSectionForUser("section-abc");
+
+    expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), "getSectionForUser");
+    expect(callable).toHaveBeenCalledWith({ sectionId: "section-abc" });
+    expect(result).toEqual(response);
+  });
+
+  it("propagates errors (no try/catch)", async () => {
+    makeFailingCallable("Section not found");
+
+    await expect(getSectionForUser("bad-id")).rejects.toThrow("Section not found");
+  });
+});
+
+describe("getSectionEventsForUser", () => {
+  it("calls getSectionEventsForUser with sectionId and returns events", async () => {
+    const events = [{ id: "event-1", title: "Dinner" }];
+    const callable = makeCallable({ data: { events } });
+
+    const result = await getSectionEventsForUser("section-abc");
+
+    expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), "getSectionEventsForUser");
+    expect(callable).toHaveBeenCalledWith({ sectionId: "section-abc" });
+    expect(result).toEqual({ events });
+  });
+
+  it("propagates errors (no try/catch)", async () => {
+    makeFailingCallable("You do not have permission to view this section");
+
+    await expect(getSectionEventsForUser("bad-id")).rejects.toThrow(
+      "You do not have permission to view this section"
+    );
+  });
+});
+
+describe("getEventForUser", () => {
+  it("calls getEventForUser with eventId and returns the event", async () => {
+    const event = { id: "event-1", title: "Dinner" };
+    const callable = makeCallable({ data: { event } });
+
+    const result = await getEventForUser("event-1");
+
+    expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), "getEventForUser");
+    expect(callable).toHaveBeenCalledWith({ eventId: "event-1" });
+    expect(result).toEqual({ event });
+  });
+
+  it("propagates errors (no try/catch)", async () => {
+    makeFailingCallable("Event not found");
+
+    await expect(getEventForUser("bad-id")).rejects.toThrow("Event not found");
   });
 });
 

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -1,6 +1,6 @@
 import { httpsCallable } from "firebase/functions";
 import { functions } from "../../config/firebase";
-import type { MembershipStatus } from "@dataconnect/generated";
+import type { GetEventByIdData, GetEventsForSectionData, GetSectionByIdData, MembershipStatus } from "@dataconnect/generated";
 import { toCanonicalUuid } from "./uuid";
 
 /**
@@ -357,6 +357,54 @@ export async function getSectionMembersMerged(
     GetSectionMembersMergedResponse
   >(functions, "getSectionMembersMerged");
   const result = await callable({ sectionId });
+  return result.data;
+}
+
+// ============================================================================
+// Section/event lookup (callable — GetSectionById/GetEventsForSection/GetEventById
+// are admin-only in Data Connect since they accept an arbitrary id with no relationship
+// check; these callables are the only path a non-admin member has to that data, and they
+// verify the caller's actual section access server-side first)
+// ============================================================================
+
+export interface SectionForUserResponse {
+  section: NonNullable<GetSectionByIdData["section"]> | null;
+  hasAccess: boolean;
+  canModerate: boolean;
+}
+
+export async function getSectionForUser(sectionId: string): Promise<SectionForUserResponse> {
+  const callable = httpsCallable<{ sectionId: string }, SectionForUserResponse>(
+    functions,
+    "getSectionForUser"
+  );
+  const result = await callable({ sectionId });
+  return result.data;
+}
+
+export interface SectionEventsForUserResponse {
+  events: NonNullable<GetEventsForSectionData["section"]>["events"];
+}
+
+export async function getSectionEventsForUser(sectionId: string): Promise<SectionEventsForUserResponse> {
+  const callable = httpsCallable<{ sectionId: string }, SectionEventsForUserResponse>(
+    functions,
+    "getSectionEventsForUser"
+  );
+  const result = await callable({ sectionId });
+  return result.data;
+}
+
+export interface EventForUserResponse {
+  event: NonNullable<GetEventByIdData["event"]> | null;
+}
+
+export async function getEventForUser(eventId: string): Promise<EventForUserResponse> {
+  const callable = httpsCallable<{ eventId: string }, EventForUserResponse>(
+    functions,
+    "getEventForUser"
+  );
+  const result = await callable({ eventId });
   return result.data;
 }
 


### PR DESCRIPTION
## Summary
- `GetSectionById`, `GetEventsForSection`, and `GetEventById` accepted an arbitrary id with only `auth.token.enabled == true` — any enabled member could view any section's name/description/purpose-links, or any event's details/ticket prices, regardless of whether they had ACCESS to that section — by navigating to `/sections/<any-id>` or calling the query directly.
- Tightened all three to admin-only in Data Connect. They're already only used elsewhere by the admin-gated `ManageSections`/`SectionEventsManager` components (route-gated via `renderAdminOnly`), which are unaffected.
- Added three callables in `functions/src/sections.ts` (`getSectionForUser`, `getSectionEventsForUser`, `getEventForUser`) that check the caller's actual section access (explicit group membership or membership-status-derived — mirroring the existing `getSectionMembersMerged` pattern) before returning data, reusing the same admin-generated queries server-side (which bypass `@auth` entirely, so no new `.gql` operations were needed for the callables themselves).
- `SectionDetail.tsx` (the member-facing page) and `useCanModerateSection` (built for #329) now go through these callables instead of the raw react-query hooks. `useCanModerateSection` in particular gets simpler — `canModerate` is now computed server-side rather than cross-referencing the section's purposeLinks against the caller's own groups client-side.
- `SectionDetail.tsx`'s existing error-handling already produces a safe, reasonable outcome for the no-access case without any special-casing: `getSectionMembersMerged` (already fixed in #327) throws a "you do not have permission" error for unauthorized section access, and that's what the page already surfaces via its generic error state.

## Test plan
- [x] Added `functions/src/__tests__/sections.test.ts` — covers `getSectionForUser` (admin bypass, moderator access, and the no-access case returning `{section: null, hasAccess: false, canModerate: false}` without throwing), `getSectionEventsForUser` and `getEventForUser` (both reject with `permission-denied`/`not-found` as appropriate)
- [x] Extended `functionEntryGuardContracts.test.ts` and `dataconnectAuthContracts.test.ts` for the new callables and the tightened `@auth` levels
- [x] Updated `SectionAdminPage.test.tsx` and `SectionDetail.test.tsx` mocks to match the new callable-based data fetching (kept the same helper function signatures in `SectionDetail.test.tsx` so none of the ~20 call sites throughout that 1477-line file needed to change)
- [x] Added tests for the three new client wrapper functions in `firebaseFunctions.test.ts` (the coverage gate flagged these as undertested, same lesson as #338)
- [x] `npx vitest run` at root — 487 tests pass; in `functions/` — 332 tests pass
- [x] `npm run test:coverage` — 75.63% functions, passes the 75% gate
- [x] `npx tsc --noEmit` (both root and functions/) — clean
- [x] `npm run build` — succeeds
- [x] `npx eslint` on all changed frontend files — clean

Part of #326. Fixes #328.