### PR TITLE
fix: point sidebar 'Administer' links at the section admin hub

### DIFF
--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -239,6 +239,10 @@ vi.mock("../features/admin/components/ManageSections", () => ({
   default: () => <h1>Manage Sections Page</h1>,
 }));
 
+vi.mock("../features/admin/components/SectionAdminPage", () => ({
+  default: () => <h1>Section Admin Page</h1>,
+}));
+
 vi.mock("../features/users/components/AccountStatusMessage", () => ({
   default: () => <h1>Account Status Page</h1>,
 }));
@@ -506,13 +510,16 @@ describe("App routing", () => {
     renderApp([ROUTES.HOME]);
 
     expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Administer" })).toHaveAttribute("href", ROUTES.MANAGE_SECTIONS);
+    expect(screen.getByRole("link", { name: "Administer" })).toHaveAttribute(
+      "href",
+      ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1")
+    );
     expect(screen.getByRole("link", { name: "Manage Sections" })).toHaveAttribute("href", ROUTES.MANAGE_SECTIONS);
     expect(screen.queryByRole("link", { name: "Manage Users" })).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Audit Logs" })).not.toBeInTheDocument();
   });
 
-  it("navigates section admin links with managed section route state", async () => {
+  it("navigates section admin links to the section admin hub", async () => {
     signInEnabledUser({ admin: true });
     const user = userEvent.setup();
 
@@ -521,14 +528,16 @@ describe("App routing", () => {
     expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await user.click(screen.getByRole("link", { name: "Administer" }));
 
-    expect(await screen.findByRole("heading", { name: "Manage Sections Page" })).toBeInTheDocument();
-    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.MANAGE_SECTIONS);
+    expect(await screen.findByRole("heading", { name: "Section Admin Page" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1")
+    );
     expect(screen.getByTestId("location-state")).toHaveTextContent(
-      JSON.stringify({ managedSection: { id: "section-1", name: "Signals" } })
+      JSON.stringify({ sectionName: "Signals", sectionType: "MEMBERS" })
     );
   });
 
-  it("clears managed section route state from the root Manage Sections link", async () => {
+  it("clears route state when navigating from the section admin hub to the root Manage Sections link", async () => {
     signInEnabledUser({ admin: true });
     const user = userEvent.setup();
 
@@ -536,8 +545,8 @@ describe("App routing", () => {
 
     expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
     await user.click(screen.getByRole("link", { name: "Administer" }));
-    await screen.findByRole("heading", { name: "Manage Sections Page" });
-    expect(screen.getByTestId("location-state")).toHaveTextContent("section-1");
+    await screen.findByRole("heading", { name: "Section Admin Page" });
+    expect(screen.getByTestId("location-state")).toHaveTextContent("Signals");
 
     await user.click(screen.getByRole("link", { name: "Manage Sections" }));
 

--- a/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
+++ b/src/shared/navigation/__tests__/buildNavigationLinks.test.ts
@@ -99,8 +99,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Administer",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-1", name: "Signals" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+            state: { sectionName: "Signals", sectionType: "EVENTS" },
           },
         ],
       },
@@ -113,8 +113,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Signals",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-1", name: "Signals" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+            state: { sectionName: "Signals", sectionType: "EVENTS" },
           },
         ],
       },
@@ -145,8 +145,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Administer",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-2", name: "Events" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-2"),
+            state: { sectionName: "Events", sectionType: "EVENTS" },
           },
         ],
       },
@@ -159,8 +159,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Events",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-2", name: "Events" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-2"),
+            state: { sectionName: "Events", sectionType: "EVENTS" },
           },
         ],
       },
@@ -237,8 +237,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Administer",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-1", name: "Signals" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+            state: { sectionName: "Signals", sectionType: "EVENTS" },
           },
         ],
       },
@@ -253,8 +253,8 @@ describe("buildNavigationLinks", () => {
           children: [
             {
               label: "Signals",
-              to: ROUTES.MANAGE_SECTIONS,
-              state: { managedSection: { id: "section-1", name: "Signals" } },
+              to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+              state: { sectionName: "Signals", sectionType: "EVENTS" },
             },
           ],
         },
@@ -309,8 +309,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Administer",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-1", name: "Alpha" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+            state: { sectionName: "Alpha", sectionType: "EVENTS" },
           },
         ],
       },
@@ -321,8 +321,8 @@ describe("buildNavigationLinks", () => {
         children: [
           {
             label: "Administer",
-            to: ROUTES.MANAGE_SECTIONS,
-            state: { managedSection: { id: "section-2", name: "Zulu" } },
+            to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-2"),
+            state: { sectionName: "Zulu", sectionType: "EVENTS" },
           },
         ],
       },
@@ -334,13 +334,13 @@ describe("buildNavigationLinks", () => {
           children: [
             {
               label: "Alpha",
-              to: ROUTES.MANAGE_SECTIONS,
-              state: { managedSection: { id: "section-1", name: "Alpha" } },
+              to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-1"),
+              state: { sectionName: "Alpha", sectionType: "EVENTS" },
             },
             {
               label: "Zulu",
-              to: ROUTES.MANAGE_SECTIONS,
-              state: { managedSection: { id: "section-2", name: "Zulu" } },
+              to: ROUTES.SECTION_ADMIN.replace(":sectionId", "section-2"),
+              state: { sectionName: "Zulu", sectionType: "EVENTS" },
             },
           ],
         }),

--- a/src/shared/navigation/buildNavigationLinks.ts
+++ b/src/shared/navigation/buildNavigationLinks.ts
@@ -26,6 +26,7 @@ type SectionLinkSource = {
   section?: {
     id?: string | null;
     name?: string | null;
+    type?: string | null;
   } | null;
 };
 
@@ -33,9 +34,19 @@ function linkHasPurpose(link: SectionLinkSource, target: SectionUserGroupPurpose
   return link.purposes?.includes(target) ?? false;
 }
 
-function addSectionLink(map: Map<string, NavigationLink>, link: SectionLinkSource) {
+function addSectionLink(
+  map: Map<string, NavigationLink>,
+  typeMap: Map<string, string | null | undefined>,
+  link: SectionLinkSource
+) {
   const section = link.section;
-  if (!section?.id || map.has(section.id)) {
+  if (!section?.id) {
+    return;
+  }
+  if (!typeMap.has(section.id)) {
+    typeMap.set(section.id, section.type);
+  }
+  if (map.has(section.id)) {
     return;
   }
   const label = section.name || "Untitled section";
@@ -58,23 +69,25 @@ function sortLinks<T extends NavigationLink>(links: Iterable<T>): T[] {
   return Array.from(links).sort((a, b) => a.label.localeCompare(b.label));
 }
 
-function manageSectionLink({
+// Same destination as the "Admin" button on a section's own page (see getSectionAdminDestination) —
+// both entry points should open the same hub of options, not diverge into a narrower admin surface.
+function sectionAdminLink({
   label,
   sectionId,
   sectionName,
+  sectionType,
 }: {
   label: string;
   sectionId: string;
   sectionName: string;
+  sectionType?: string | null;
 }): NavigationLink {
   return {
     label,
-    to: ROUTES.MANAGE_SECTIONS,
+    to: ROUTES.SECTION_ADMIN.replace(":sectionId", sectionId),
     state: {
-      managedSection: {
-        id: sectionId,
-        name: sectionName,
-      },
+      sectionName,
+      sectionType: sectionType ?? "MEMBERS",
     },
   };
 }
@@ -83,11 +96,13 @@ function buildAdminLinks({
   isAdmin,
   sectionMap,
   administerableSectionIds,
+  sectionTypeMap,
   sectionsData,
 }: {
   isAdmin: boolean;
   sectionMap: Map<string, NavigationLink>;
   administerableSectionIds: Map<string, boolean>;
+  sectionTypeMap: Map<string, string | null | undefined>;
   sectionsData?: GetSectionsForUserData;
 }): NavigationLink[] {
   const sectionAdminChildren = sortLinks(
@@ -97,10 +112,11 @@ function buildAdminLinks({
         return [];
       }
       return [
-        manageSectionLink({
+        sectionAdminLink({
           label: section.label,
           sectionId,
           sectionName: section.label,
+          sectionType: sectionTypeMap.get(sectionId),
         }),
       ];
     })
@@ -159,6 +175,7 @@ export function buildNavigationLinks({
   }
 
   const sectionMap = new Map<string, NavigationLink>();
+  const sectionTypeMap = new Map<string, string | null | undefined>();
   const administerableSectionIds = new Map<string, boolean>();
   const explicitGroups = sectionsData?.user?.userGroups ?? [];
 
@@ -168,7 +185,7 @@ export function buildNavigationLinks({
         linkHasPurpose(purposeLink, SectionPurpose.ACCESS) ||
         linkHasPurpose(purposeLink, SectionPurpose.MODERATOR)
       ) {
-        addSectionLink(sectionMap, purposeLink);
+        addSectionLink(sectionMap, sectionTypeMap, purposeLink);
       }
       markSectionAdministerable(administerableSectionIds, purposeLink);
     }
@@ -185,7 +202,7 @@ export function buildNavigationLinks({
           linkHasPurpose(purposeLink, SectionPurpose.ACCESS) ||
           linkHasPurpose(purposeLink, SectionPurpose.MODERATOR)
         ) {
-          addSectionLink(sectionMap, purposeLink);
+          addSectionLink(sectionMap, sectionTypeMap, purposeLink);
         }
         markSectionAdministerable(administerableSectionIds, purposeLink);
       }
@@ -207,14 +224,15 @@ export function buildNavigationLinks({
         return {
           ...section,
           children: [
-            manageSectionLink({
+            sectionAdminLink({
               label: "Administer",
               sectionId,
               sectionName: section.label,
+              sectionType: sectionTypeMap.get(sectionId),
             }),
           ],
         };
       }),
-    admin: buildAdminLinks({ isAdmin, sectionMap, administerableSectionIds, sectionsData }),
+    admin: buildAdminLinks({ isAdmin, sectionMap, administerableSectionIds, sectionTypeMap, sectionsData }),
   };
 }


### PR DESCRIPTION
## Summary
- The sidebar's per-section "Administer" links (under both "Sections" and "Admin → Manage Sections") pointed at `ROUTES.MANAGE_SECTIONS`, dropping straight into event management — skipping the hub of options (Send Announcement / Manage Events / Edit Section) that the section detail page's own "Admin" button opens via `getSectionAdminDestination`. Same conceptual action, two different destinations depending on entry point.
- That link was also broken for non-admin section moderators: it's shown to anyone with MODERATOR purpose (`markSectionAdministerable` doesn't check `isAdmin`), but `MANAGE_SECTIONS` is admin-only, so a moderator clicking their own section's sidebar link got "Access denied" despite having legitimate rights. `SECTION_ADMIN` doesn't have that problem since #329 gates it on `isAdmin || canModerateSection`.
- Pointed both usages of the link-building helper at `ROUTES.SECTION_ADMIN` instead, threading the section's `type` through `buildNavigationLinks.ts` (needed so the hub can correctly show/hide the "Manage Events" card for EVENTS-type sections — the sidebar navigation data wasn't carrying section type at all before this).

## Test plan
- [x] Updated `buildNavigationLinks.test.ts` expectations for the new destination/state shape
- [x] Updated `App.routing.test.tsx` — added a mock for `SectionAdminPage` (previously unmocked and untested at this integration level), fixed the `href` assertion, and rewrote the two navigation tests that clicked "Administer" and expected to land on the old Manage Sections page
- [x] `npx vitest run` — 487 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npm run test:coverage` — 75.75% functions, healthy

Fixes #336. Part of #326.