### PR TITLE
fix: add success confirmation to admin CRUD screens

### DIFF
--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -21,6 +21,8 @@ import {
 import SectionEventsManager from "./SectionEventsManager";
 import { colors } from "../../../config/colors";
 import PageHeader from "../../../shared/components/PageHeader";
+import SnackbarAlert from "../../../shared/components/SnackbarAlert";
+import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import { useLocation } from "react-router-dom";
@@ -52,7 +54,8 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
   const [sections, setSections] = useState<SectionWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  
+  const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
+
   // Create/Edit dialog state
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingSection, setEditingSection] = useState<SectionWithDetails | null>(null);
@@ -220,6 +223,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       const ref = deleteSectionRef(dataConnect, { id: section.id });
       await executeMutation(ref);
       await fetchSections();
+      showSuccess(`Section "${section.name}" deleted`);
     } catch (err: any) {
       setError(err?.message || "Failed to delete section");
     }
@@ -253,6 +257,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       }
       setDialogOpen(false);
       await fetchSections();
+      showSuccess(`Section ${editingSection ? "updated" : "created"}`);
     } catch (err: any) {
       setError(err?.message || `Failed to ${editingSection ? "update" : "create"} section`);
     } finally {
@@ -281,12 +286,13 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
         ),
       });
       await executeMutation(ref);
-      
+
       await fetchSectionUserGroups(editingSection.id);
-      
+
       setSelectedUserGroup(null);
       setSelectedPurpose(SectionUserGroupPurpose.ACCESS);
       setAddUserGroupDialogOpen(false);
+      showSuccess("User group added to section");
     } catch (err: any) {
       setError(err?.message || "Failed to add user group");
     } finally {
@@ -329,6 +335,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       
       // Refresh section user groups
       await fetchSectionUserGroups(editingSection.id);
+      showSuccess("User group removed from section");
     } catch (err: any) {
       setError(err?.message || "Failed to remove user group");
     } finally {
@@ -437,6 +444,8 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
         onPurposeChange={handlePurposeChange}
         onUserGroupChange={setSelectedUserGroup}
       />
+
+      <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>
   );
 }

--- a/src/features/admin/components/PaymentReconciliationDashboard.tsx
+++ b/src/features/admin/components/PaymentReconciliationDashboard.tsx
@@ -27,6 +27,8 @@ import {
 import { useListOpenPaymentReconciliationExceptions } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import PageHeader from "../../../shared/components/PageHeader";
+import SnackbarAlert from "../../../shared/components/SnackbarAlert";
+import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import "../../../shared/components/PageContainer.css";
 
 interface PaymentReconciliationDashboardProps {
@@ -39,6 +41,7 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
   const [eventSearch, setEventSearch] = useState("");
   const [resolvingId, setResolvingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
 
   const filteredRows = useMemo(() => {
     const rows = data?.paymentReconciliationExceptions ?? [];
@@ -61,6 +64,7 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
     try {
       await executeMutation(resolvePaymentReconciliationExceptionRef(dataConnect, { id, note: "Reviewed in dashboard" }));
       await refetch();
+      showSuccess("Exception marked reviewed");
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to mark exception reviewed");
     } finally {
@@ -157,6 +161,8 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
           </Table>
         </TableContainer>
       )}
+
+      <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>
   );
 }

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -45,6 +45,8 @@ import {
   TicketTypeDialogSurface,
 } from "./SectionEventsManagerSurfaces";
 import SendAnnouncementPage from "./SendAnnouncementPage";
+import SnackbarAlert from "../../../shared/components/SnackbarAlert";
+import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import "../../../shared/components/PageContainer.css";
 
 interface SectionEventsManagerProps {
@@ -71,6 +73,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
   const [maxGuestsStr, setMaxGuestsStr] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
   const [deletingEventId, setDeletingEventId] = useState<string | null>(null);
 
   // Ticket types: which event we're managing ticket types for
@@ -213,6 +216,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       }
       refetchEvents();
       setEventDialogOpen(false);
+      showSuccess(`Event ${editingEvent ? "updated" : "created"}`);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to save event");
     } finally {
@@ -244,6 +248,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       await executeMutation(deleteEventRef(dataConnect, { id: event.id }));
       refetchEvents();
       if (ticketTypesEventId === event.id) setTicketTypesEventId(null);
+      showSuccess(`Event "${event.title}" deleted`);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to delete event");
     } finally {
@@ -315,6 +320,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       refetchEventDetail();
       refetchEvents();
       setTicketTypeDialogOpen(false);
+      showSuccess(`Ticket type ${editingTicketType ? "updated" : "created"}`);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to save ticket type");
     } finally {
@@ -330,6 +336,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       await executeMutation(deleteTicketTypeRef(dataConnect, { id }));
       refetchEventDetail();
       refetchEvents();
+      showSuccess("Ticket type deleted");
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to delete ticket type");
     } finally {
@@ -365,6 +372,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       });
       setModeratorNoteDraft((prev) => ({ ...prev, [request.id]: "" }));
       refetchGuestRequests();
+      showSuccess(`Guest ticket request ${status === GuestTicketRequestStatus.APPROVED ? "approved" : "rejected"}`);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Failed to review guest ticket request");
     } finally {
@@ -476,6 +484,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           onBookingEndDateTimeChange={setBookingEndDateTime}
           onMaxGuestsChange={setMaxGuestsStr}
         />
+
+        <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
       </Box>
     );
   }
@@ -520,6 +530,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
         onBookingEndDateTimeChange={setBookingEndDateTime}
         onMaxGuestsChange={setMaxGuestsStr}
       />
+
+      <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>
   );
 }

--- a/src/features/admin/components/UserGroupMemberships.tsx
+++ b/src/features/admin/components/UserGroupMemberships.tsx
@@ -37,6 +37,8 @@ import {
   type ListUserGroupsData,
 } from "@dataconnect/generated";
 import { MembershipStatus } from "@dataconnect/generated";
+import SnackbarAlert from "../../../shared/components/SnackbarAlert";
+import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 
 interface UserGroupMembershipsProps {
   userId: string;
@@ -54,6 +56,7 @@ export default function UserGroupMemberships({
   const [allGroups, setAllGroups] = useState<ListUserGroupsData["userGroups"]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [removingGroupId, setRemovingGroupId] = useState<string | null>(null);
   const [addingGroupId, setAddingGroupId] = useState<string | null>(null);
@@ -105,6 +108,7 @@ export default function UserGroupMemberships({
         onUpdate();
       }
       setAddDialogOpen(false);
+      showSuccess(`Added to "${allGroups.find((g) => g.id === groupId)?.name ?? "group"}"`);
     } catch (err: any) {
       setError(err?.message || "Failed to add user to user group");
     } finally {
@@ -117,6 +121,7 @@ export default function UserGroupMemberships({
       return;
     }
 
+    const groupName = userData?.userGroups?.find((ug) => ug.userGroup.id === groupId)?.userGroup.name ?? "group";
     setRemovingGroupId(groupId);
     setError(null);
     try {
@@ -129,6 +134,7 @@ export default function UserGroupMemberships({
       if (onUpdate) {
         onUpdate();
       }
+      showSuccess(`Removed from "${groupName}"`);
     } catch (err: any) {
       setError(err?.message || "Failed to remove user from user group");
     } finally {
@@ -315,6 +321,8 @@ export default function UserGroupMemberships({
           </Button>
         </DialogActions>
       </Dialog>
+
+      <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>
   );
 }

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -19,6 +19,8 @@ import {
 import { MembershipStatus } from "@dataconnect/generated";
 import { colors } from "../../../config/colors";
 import PageHeader from "../../../shared/components/PageHeader";
+import SnackbarAlert from "../../../shared/components/SnackbarAlert";
+import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import { searchUsers } from "../../users/utils/searchUsers";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
@@ -53,6 +55,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const [userGroups, setUserGroups] = useState<UserGroupWithDetails[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
   const [groupDetails, setGroupDetails] = useState<Record<string, UserGroupDetails>>({});
   const [loadingDetails, setLoadingDetails] = useState<Record<string, boolean>>({});
@@ -280,16 +283,17 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         userGroupId: addingToGroupId,
       });
       await executeMutation(ref);
-      
+
       // Refresh group details
       delete groupDetails[addingToGroupId];
       setGroupDetails({ ...groupDetails });
       await fetchGroupDetails(addingToGroupId);
-      
+
       setAddUserDialogOpen(false);
       setAddingToGroupId(null);
       setUserSearchTerm("");
       setSearchResults([]);
+      showSuccess("User added to group");
     } catch (err: any) {
       setError(err?.message || "Failed to add user to group");
     } finally {
@@ -308,11 +312,12 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         userGroupId: groupId,
       });
       await executeMutation(ref);
-      
+
       // Refresh group details
       delete groupDetails[groupId];
       setGroupDetails({ ...groupDetails });
       await fetchGroupDetails(groupId);
+      showSuccess("User removed from group");
     } catch (err: any) {
       setError(err?.message || "Failed to remove user from group");
     }
@@ -348,6 +353,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       }
       delete groupDetails[group.id];
       setGroupDetails({ ...groupDetails });
+      showSuccess(`User group "${group.name}" deleted`);
     } catch (err: any) {
       setError(err?.message || "Failed to delete user group");
     }
@@ -382,6 +388,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       }
       setDialogOpen(false);
       await fetchUserGroupsList();
+      showSuccess(`User group ${editingGroup ? "updated" : "created"}`);
     } catch (err: any) {
       setError(err?.message || `Failed to ${editingGroup ? "update" : "create"} user group`);
     } finally {
@@ -498,6 +505,8 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       />
 
       <UserDetailDialogSurface user={selectedUserDetail} onClose={() => setSelectedUserDetail(null)} />
+
+      <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>
   );
 }

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -338,6 +338,7 @@ describe("SectionEventsManager", () => {
         status: "APPROVED",
       })
     );
+    expect(await screen.findByText("Guest ticket request approved")).toBeInTheDocument();
   });
 
   it("opens event edit dialog from the event admin details section", async () => {

--- a/src/shared/components/SnackbarAlert.tsx
+++ b/src/shared/components/SnackbarAlert.tsx
@@ -1,0 +1,23 @@
+import { Alert, Snackbar } from "@mui/material";
+import type { SnackbarState } from "../hooks/useSnackbar";
+
+interface SnackbarAlertProps {
+  snackbar: SnackbarState;
+  onClose: () => void;
+}
+
+export default function SnackbarAlert({ snackbar, onClose }: SnackbarAlertProps) {
+  return (
+    <Snackbar
+      open={snackbar.open}
+      autoHideDuration={6000}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      sx={{ mt: 10 }}
+    >
+      <Alert onClose={onClose} severity={snackbar.severity} sx={{ width: "100%" }}>
+        {snackbar.message}
+      </Alert>
+    </Snackbar>
+  );
+}

--- a/src/shared/hooks/__tests__/useSnackbar.test.ts
+++ b/src/shared/hooks/__tests__/useSnackbar.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useSnackbar } from "../useSnackbar";
+
+describe("useSnackbar", () => {
+  it("starts closed", () => {
+    const { result } = renderHook(() => useSnackbar());
+    expect(result.current.snackbar).toEqual({ open: false, message: "", severity: "success" });
+  });
+
+  it("showSuccess opens with success severity", () => {
+    const { result } = renderHook(() => useSnackbar());
+    act(() => result.current.showSuccess("Saved"));
+    expect(result.current.snackbar).toEqual({ open: true, message: "Saved", severity: "success" });
+  });
+
+  it("showError opens with error severity", () => {
+    const { result } = renderHook(() => useSnackbar());
+    act(() => result.current.showError("Failed"));
+    expect(result.current.snackbar).toEqual({ open: true, message: "Failed", severity: "error" });
+  });
+
+  it("close sets open to false without clearing the message", () => {
+    const { result } = renderHook(() => useSnackbar());
+    act(() => result.current.showSuccess("Saved"));
+    act(() => result.current.close());
+    expect(result.current.snackbar).toEqual({ open: false, message: "Saved", severity: "success" });
+  });
+
+  it("a later call replaces the previous message and severity", () => {
+    const { result } = renderHook(() => useSnackbar());
+    act(() => result.current.showSuccess("Saved"));
+    act(() => result.current.showError("Now failed"));
+    expect(result.current.snackbar).toEqual({ open: true, message: "Now failed", severity: "error" });
+  });
+});

--- a/src/shared/hooks/useSnackbar.ts
+++ b/src/shared/hooks/useSnackbar.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from "react";
+
+export interface SnackbarState {
+  open: boolean;
+  message: string;
+  severity: "success" | "error";
+}
+
+export interface UseSnackbarResult {
+  snackbar: SnackbarState;
+  showSuccess: (message: string) => void;
+  showError: (message: string) => void;
+  close: () => void;
+}
+
+const initialState: SnackbarState = { open: false, message: "", severity: "success" };
+
+/** Shared success/error snackbar state, extracted from the pattern SectionDetail.tsx and
+ * ManageUsers.tsx already used independently. See #320. */
+export function useSnackbar(): UseSnackbarResult {
+  const [snackbar, setSnackbar] = useState<SnackbarState>(initialState);
+
+  const showSuccess = useCallback((message: string) => {
+    setSnackbar({ open: true, message, severity: "success" });
+  }, []);
+
+  const showError = useCallback((message: string) => {
+    setSnackbar({ open: true, message, severity: "error" });
+  }, []);
+
+  const close = useCallback(() => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  }, []);
+
+  return { snackbar, showSuccess, showError, close };
+}


### PR DESCRIPTION
## Summary
- `UserGroups.tsx`, `ManageSections.tsx`, `UserGroupMemberships.tsx`, `SectionEventsManager.tsx`, and `PaymentReconciliationDashboard.tsx` all call `executeMutation` for create/update/delete/add/remove actions with no positive feedback on success — the dialog just closed, and the only visible feedback was an `Alert` that appeared *if something went wrong*.
- Extracted the snackbar pattern `SectionDetail.tsx` and `ManageUsers.tsx` each already had independently into a shared `useSnackbar` hook (`src/shared/hooks/useSnackbar.ts`) + `SnackbarAlert` component (`src/shared/components/SnackbarAlert.tsx`), rather than inventing a third variant.
- Wired a success message into every mutation handler across the five components: group/section create/update/delete, add/remove user to/from group, add/remove user group to/from section, event/ticket-type create/update/delete, guest ticket request approve/reject, and payment reconciliation exception resolution.
- `SectionEventsManager.tsx` has two separate return branches (event list vs. the per-event ticket-types/admin view) — the snackbar is rendered in both, since handlers used from each branch are different.

## Test plan
- [x] Added `useSnackbar.test.ts` — 5 tests covering open/close state transitions and severity
- [x] Extended the existing `SectionEventsManager.test.tsx` "approves a pending request" test with a snackbar assertion
- [x] `npx vitest run` — 492 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on all changed files — clean
- [x] `npm run test:coverage` — 75.93% functions (up from 75.56%)

Fixes #320. Part of #319.