### PR TITLE
fix: invalidate the DC profile cache when membershipStatus changes

### DIFF
--- a/functions/src/__tests__/notifyCallback.test.ts
+++ b/functions/src/__tests__/notifyCallback.test.ts
@@ -4,10 +4,12 @@ import * as admin from "@dataconnect/admin-generated";
 import type { Request } from "firebase-functions/v2/https";
 import type { Response } from "express";
 import { handleNotifyDelivery, BOUNCE_THRESHOLD } from "../notifyCallback.js";
+import * as users from "../users.js";
 
 const mockGetUserByEmail = vi.spyOn(admin, "getUserByEmail");
 const mockUpdateEmailBounceStats = vi.spyOn(admin, "updateEmailBounceStats");
 const mockUpdateUserMembershipStatus = vi.spyOn(admin, "updateUserMembershipStatus");
+const mockInvalidateDcProfileCache = vi.spyOn(users, "invalidateDcProfileCache");
 
 const BEARER = "test-bearer-token";
 
@@ -143,6 +145,7 @@ describe("handleNotifyDelivery", () => {
       userId: "user-abc",
       membershipStatus: MembershipStatus.LOST,
     });
+    expect(mockInvalidateDcProfileCache).toHaveBeenCalled();
     expect((res.status as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(200);
   });
 

--- a/functions/src/__tests__/searchUsers.test.ts
+++ b/functions/src/__tests__/searchUsers.test.ts
@@ -21,7 +21,7 @@ const mockListAllAuthUsers = vi.spyOn(helpers, "listAllAuthUsers");
 const mockGetCallableInvocation = vi.spyOn(admin, "getCallableInvocation");
 const mockUpsertCallableInvocation = vi.spyOn(admin, "upsertCallableInvocation");
 
-import { searchUsers } from "../users.js";
+import { searchUsers, invalidateDcProfileCache } from "../users.js";
 
 type Handler = (req: {
   auth: { uid: string; token?: Record<string, unknown> };
@@ -48,12 +48,10 @@ function makeAuthUser(uid: string, email: string) {
   } as unknown as import("firebase-admin").auth.UserRecord;
 }
 
-import { clearDcProfileCacheForTesting } from "../users.js";
-
 describe("searchUsers — membership status enrichment", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    clearDcProfileCacheForTesting();
+    invalidateDcProfileCache();
     mockGetCallableInvocation.mockResolvedValue({ data: { callableInvocation: undefined } } as never);
     mockUpsertCallableInvocation.mockResolvedValue({
       data: { callableInvocation_upsert: { userId: "admin-uid", functionName: "searchUsers" } },
@@ -102,6 +100,17 @@ describe("searchUsers — membership status enrichment", () => {
     await handler(adminRequest());
 
     expect(mockDcListUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches DC profiles after invalidateDcProfileCache, even within the TTL (see #321)", async () => {
+    mockListAllAuthUsers.mockResolvedValue([makeAuthUser("user-1", "alice@example.com")]);
+    mockDcListUsers.mockResolvedValue({ data: { users: [] } } as never);
+
+    await handler(adminRequest());
+    invalidateDcProfileCache();
+    await handler(adminRequest());
+
+    expect(mockDcListUsers).toHaveBeenCalledTimes(2);
   });
 
   it("only includes users matching the search term", async () => {

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -11,6 +11,7 @@ import {
 } from "@dataconnect/admin-generated";
 import { govNotifyApiKey } from "./mailer";
 import { notifyMembershipStatusEmailIfNeeded } from "./membershipStatusEmailDispatcher";
+import { invalidateDcProfileCache } from "./users";
 
 const APP_BASE_URL = (() => {
   const url = process.env.APP_BASE_URL || "http://localhost:5173";
@@ -168,6 +169,7 @@ async function updateMembershipStatusInDataConnect(
       userId,
       membershipStatus: membershipStatus as AdminMembershipStatus
     });
+    invalidateDcProfileCache();
     logger.info(`Successfully updated membership status for userId=${userId} to ${membershipStatus}`);
   } catch (error: any) {
     logger.error(`Could not update membership status in Data Connect for userId=${userId}:`, error);

--- a/functions/src/notifyCallback.ts
+++ b/functions/src/notifyCallback.ts
@@ -10,6 +10,7 @@ import {
   MembershipStatus,
 } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants.js";
+import { invalidateDcProfileCache } from "./users.js";
 
 export const notifyCallbackSecret = defineSecret("NOTIFY_CALLBACK_BEARER_TOKEN");
 
@@ -98,6 +99,7 @@ export async function handleNotifyDelivery(
 
     if (newCount >= BOUNCE_THRESHOLD && user.membershipStatus !== MembershipStatus.LOST) {
       await updateUserMembershipStatus({ userId: user.id, membershipStatus: MembershipStatus.LOST });
+      invalidateDcProfileCache();
       logger.info("Set membership status to LOST due to repeated email bounces", {
         userId: user.id,
         bounceCount: newCount,

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -10,7 +10,13 @@ import { isUserAwaitingProfile, isUserPendingApproval } from "./pendingUserAppro
 const DC_PROFILE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 let dcProfileCache: { map: Map<string, MembershipStatus>; expiresAt: number } | null = null;
 
-export function clearDcProfileCacheForTesting(): void { dcProfileCache = null; }
+/**
+ * Drops the cached membershipStatus map so the next searchUsers call re-fetches from Data
+ * Connect. Call this after any write that changes User.membershipStatus (see #321) — otherwise
+ * searchUsers can keep serving a stale status for up to DC_PROFILE_CACHE_TTL_MS regardless of
+ * which admin screen or code path made the change.
+ */
+export function invalidateDcProfileCache(): void { dcProfileCache = null; }
 
 async function getDcProfileMap(): Promise<Map<string, MembershipStatus>> {
   const now = Date.now();


### PR DESCRIPTION
## Summary
- `searchUsers`'s `dcProfileCache` (5-minute TTL, `functions/src/users.ts`) caches `User.membershipStatus`, which `UsersTable.tsx`'s "Membership" column displays. Nothing ever invalidated this cache when `membershipStatus` actually changed.
- Traced every write path that changes `membershipStatus`: `updateMembershipStatus`/`resignMembership` (both go through the shared `updateMembershipStatusInDataConnect` helper in `membershipStatus.ts`, triggered from `ApproveUsers.tsx`, `EditUserDialog.tsx` via `ManageUsers.tsx`, and self-service resignation in `Profile.tsx`), and the bounce-count-triggered LOST transition in `notifyCallback.ts`.
- None of these invalidated the cache, so any admin's next `searchUsers` call — regardless of which screen or code path made the change — could keep showing a stale membership status for up to 5 minutes.
- Renamed `clearDcProfileCacheForTesting` to `invalidateDcProfileCache` (identical implementation — it was always just "clear the cache", but it's a real production concern now, not test-only cleanup) and called it from the two invalidation points identified above.

Note: the original #321 wording focused on user-group membership changes specifically, but tracing the actual cached data (`membershipStatus`, not group membership) showed the real staleness risk is in the `membershipStatus` write paths above — group add/remove doesn't touch this cache at all since it's a different underlying field. Fixed the actual gap rather than the one the issue happened to be worded around.

## Test plan
- [x] Added a `searchUsers.test.ts` case proving `invalidateDcProfileCache()` forces a re-fetch even within the TTL (contrasted against the existing "does not re-fetch within TTL" test)
- [x] Added an assertion to the existing `notifyCallback.test.ts` LOST-transition test that `invalidateDcProfileCache` is actually called, not just that nothing crashed
- [x] `npx vitest run` in `functions/` — 338 tests pass
- [x] `npx tsc --noEmit` — clean

Fixes #321. Part of #319.