### PR TITLE
Member directory: rank, photo placeholder, and contact-sharing privacy

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -23,6 +23,8 @@ query GetCurrentUser @auth(expr: "auth.token.enabled == true") {
     isReserve
     isCivilServant
     isIndustry
+    rank
+    shareContactInfo
     createdAt
     updatedAt
   }
@@ -63,6 +65,8 @@ query ListUsers @auth(expr: "auth.token.admin == true && auth.token.enabled == t
     isReserve
     isCivilServant
     isIndustry
+    rank
+    shareContactInfo
     createdAt
     updatedAt
     createdBy
@@ -352,6 +356,8 @@ query GetSectionMembers($sectionId: UUID!) @auth(level: NO_ACCESS) {
             email
             serviceNumber
             membershipStatus
+            rank
+            shareContactInfo
           }
         }
       }

--- a/dataconnect/api/user-mutations.gql
+++ b/dataconnect/api/user-mutations.gql
@@ -21,6 +21,8 @@ mutation CreateUserProfile(
   $isReserve: Boolean
   $isCivilServant: Boolean
   $isIndustry: Boolean
+  $rank: String
+  $shareContactInfo: Boolean
 ) @auth(expr: "auth.token.email_verified == true") {
   user_upsert(
     data: {
@@ -35,6 +37,8 @@ mutation CreateUserProfile(
       isReserve: $isReserve
       isCivilServant: $isCivilServant
       isIndustry: $isIndustry
+      rank: $rank
+      shareContactInfo: $shareContactInfo
       # createdAt, updatedAt, createdBy, and updatedBy are set automatically via defaults
     }
   )
@@ -54,6 +58,8 @@ mutation UpsertUser(
   $isReserve: Boolean
   $isCivilServant: Boolean
   $isIndustry: Boolean
+  $rank: String
+  $shareContactInfo: Boolean
 ) @auth(expr: "auth.token.enabled == true") {
   user_upsert(
     data: {
@@ -66,6 +72,8 @@ mutation UpsertUser(
       isReserve: $isReserve
       isCivilServant: $isCivilServant
       isIndustry: $isIndustry
+      rank: $rank
+      shareContactInfo: $shareContactInfo
       updatedAt_expr: "request.time"
       updatedBy_expr: "auth.uid"
       # createdAt and createdBy are set automatically via defaults on insert only

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -96,6 +96,13 @@ type User @table {
   isReserve: Boolean @default(value: false)
   isCivilServant: Boolean @default(value: false)
   isIndustry: Boolean @default(value: false)
+  # Free-text rank/title (e.g. "Wing Commander", "Mr") — the client constrains input to a fixed
+  # dropdown, but this stays a plain string so the list can change without a schema migration.
+  rank: String
+  # Site-wide (not per-section) preference: whether other members can see this user's contact
+  # details (currently just email) on section member lists. Enforced server-side in
+  # getSectionMembersMerged, not just hidden client-side. See #273.
+  shareContactInfo: Boolean @default(value: true)
   stripeCustomerId: String
   emailBounceCount: Int! @default(value: 0)
   emailLastBounceAt: Timestamp

--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as admin from "@dataconnect/admin-generated";
 import { MembershipStatus } from "@dataconnect/admin-generated";
-import { getSectionForUser, getSectionEventsForUser, getEventForUser } from "../sections";
+import { getSectionForUser, getSectionEventsForUser, getEventForUser, getSectionMembersMerged } from "../sections";
 
 const mockGetSectionById = vi.spyOn(admin, "getSectionById");
 const mockGetUserAccessGroupsById = vi.spyOn(admin, "getUserAccessGroupsById");
 const mockGetUserMembershipStatus = vi.spyOn(admin, "getUserMembershipStatus");
 const mockGetEventsForSection = vi.spyOn(admin, "getEventsForSection");
 const mockGetEventById = vi.spyOn(admin, "getEventById");
+const mockGetSectionMembers = vi.spyOn(admin, "getSectionMembers");
+const mockListUsers = vi.spyOn(admin, "listUsers");
 
 const sectionId = "00000000-0000-4000-8000-000000000001";
 const accessGroupId = "00000000-0000-4000-8000-0000000000a1";
@@ -172,5 +174,131 @@ describe("getEventForUser", () => {
     const result = await callAs(getEventForUser, "member-1", false, { eventId });
 
     expect(result.event?.id).toBe(eventId);
+  });
+});
+
+describe("getSectionMembersMerged", () => {
+  function member(overrides: Partial<{
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    membershipStatus: string;
+    rank: string | null;
+    shareContactInfo: boolean | null;
+  }> = {}) {
+    return {
+      id: "user-1",
+      firstName: "Ada",
+      lastName: "Lovelace",
+      email: "ada@example.com",
+      membershipStatus: MembershipStatus.REGULAR,
+      rank: null,
+      shareContactInfo: true,
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "member-1", userGroups: [{ userGroup: { id: accessGroupId, name: "Access", description: null } }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: MembershipStatus.REGULAR } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+  });
+
+  function mockMembers(users: ReturnType<typeof member>[]) {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "MEMBERS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["MEMBER"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: null,
+                users: users.map((u) => ({ user: u })),
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+  }
+
+  it("includes email and rank for a member who shares contact info", async () => {
+    mockMembers([member({ rank: "Wing Commander", shareContactInfo: true })]);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toEqual([
+      {
+        id: "user-1",
+        firstName: "Ada",
+        lastName: "Lovelace",
+        membershipStatus: MembershipStatus.REGULAR,
+        rank: "Wing Commander",
+        sharesContactInfo: true,
+        email: "ada@example.com",
+      },
+    ]);
+  });
+
+  it("still lists an opted-out member but returns email: null", async () => {
+    mockMembers([member({ shareContactInfo: false })]);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toHaveLength(1);
+    expect(result.members[0]).toMatchObject({ id: "user-1", sharesContactInfo: false, email: null });
+  });
+
+  it("defaults to sharing when shareContactInfo is null/undefined (legacy rows)", async () => {
+    mockMembers([member({ shareContactInfo: null })]);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members[0]).toMatchObject({ sharesContactInfo: true, email: "ada@example.com" });
+  });
+
+  it("redacts status-derived members (resolved via listUsers) the same way as explicit members", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "MEMBERS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["MEMBER"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: [MembershipStatus.REGULAR],
+                users: [],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+    mockListUsers.mockResolvedValue({
+      data: { users: [member({ id: "user-2", shareContactInfo: false })] },
+    } as unknown as Awaited<ReturnType<typeof admin.listUsers>>);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toEqual([
+      expect.objectContaining({ id: "user-2", sharesContactInfo: false, email: null }),
+    ]);
   });
 });

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -469,6 +469,8 @@ export interface CreateUserProfileVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 
 export interface CreateUserVariables {
@@ -788,6 +790,8 @@ export interface GetCurrentUserData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
   } & User_Key;
@@ -1277,6 +1281,8 @@ export interface GetSectionMembersData {
             email: string;
             serviceNumber: string;
             membershipStatus: MembershipStatus;
+            rank?: string | null;
+            shareContactInfo?: boolean | null;
           } & User_Key;
         })[];
       } & UserGroup_Key;
@@ -1913,6 +1919,8 @@ export interface ListUsersData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
     createdBy?: string | null;
@@ -2313,6 +2321,8 @@ export interface UpsertUserVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 
 export interface UserGroup_Key {

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -17,8 +17,32 @@ export interface SectionMemberResponse {
   id: string;
   firstName: string;
   lastName: string;
+  membershipStatus: string;
+  rank: string | null;
+  sharesContactInfo: boolean;
+  /** Null whenever sharesContactInfo is false — the client never receives it, this isn't just hidden client-side. See #273. */
+  email: string | null;
+}
+
+function toSectionMemberResponse(u: {
+  id: string;
+  firstName: string;
+  lastName: string;
   email: string;
   membershipStatus: string;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
+}): SectionMemberResponse {
+  const sharesContactInfo = u.shareContactInfo !== false;
+  return {
+    id: u.id,
+    firstName: u.firstName,
+    lastName: u.lastName,
+    membershipStatus: u.membershipStatus,
+    rank: u.rank ?? null,
+    sharesContactInfo,
+    email: sharesContactInfo ? u.email : null,
+  };
 }
 
 function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
@@ -137,8 +161,18 @@ export const getSectionMembersMerged = onCall(
       const statuses = new Set<string>();
       const explicitMap = new Map<string, SectionMemberResponse>();
 
+      interface RawSectionMemberUser {
+        id: string;
+        firstName: string;
+        lastName: string;
+        email: string;
+        membershipStatus: string;
+        rank?: string | null;
+        shareContactInfo?: boolean | null;
+      }
+
       for (const rel of sourceLinks) {
-        const group = (rel as { userGroup: { membershipStatuses?: string[]; users: Array<{ user: SectionMemberResponse }> } })
+        const group = (rel as { userGroup: { membershipStatuses?: string[]; users: Array<{ user: RawSectionMemberUser }> } })
           .userGroup;
         if (group.membershipStatuses) {
           group.membershipStatuses.forEach((s: string) => statuses.add(s));
@@ -146,13 +180,7 @@ export const getSectionMembersMerged = onCall(
         for (const uag of group.users || []) {
           const u = uag.user;
           if (!explicitMap.has(u.id)) {
-            explicitMap.set(u.id, {
-              id: u.id,
-              firstName: u.firstName,
-              lastName: u.lastName,
-              email: u.email,
-              membershipStatus: u.membershipStatus,
-            });
+            explicitMap.set(u.id, toSectionMemberResponse(u));
           }
         }
       }
@@ -162,16 +190,10 @@ export const getSectionMembersMerged = onCall(
       }
 
       const listResult = await listUsers();
-      const users = listResult.data?.users || [];
+      const users = (listResult.data?.users || []) as RawSectionMemberUser[];
       for (const u of users) {
         if (statuses.has(u.membershipStatus) && !explicitMap.has(u.id)) {
-          explicitMap.set(u.id, {
-            id: u.id,
-            firstName: u.firstName,
-            lastName: u.lastName,
-            email: u.email,
-            membershipStatus: u.membershipStatus,
-          });
+          explicitMap.set(u.id, toSectionMemberResponse(u));
         }
       }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -30,6 +30,10 @@ import { MembershipStatus } from "../dataconnect-generated";
 // Re-export validation constants
 export { NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES } from "../features/users/utils/membershipStatusValidation";
 
+// Re-export rank/title dropdown options
+export { RANK_OPTION_GROUPS } from "./rankOptions";
+export type { RankOptionGroup } from "./rankOptions";
+
 export const MEMBERSHIP_STATUS_OPTIONS = [
   { value: MembershipStatus.PENDING, label: "Pending" },
   { value: MembershipStatus.REGULAR, label: "Regular" },

--- a/src/constants/rankOptions.ts
+++ b/src/constants/rankOptions.ts
@@ -1,0 +1,64 @@
+/**
+ * Rank/title options for the member profile dropdown (see #273). Stored as free text on
+ * User.rank so the list can change without a schema migration — this just constrains input.
+ * Grouped for display, RAF first (this is an RAF club).
+ */
+export interface RankOptionGroup {
+  label: string;
+  options: readonly string[];
+}
+
+export const RANK_OPTION_GROUPS: readonly RankOptionGroup[] = [
+  {
+    label: "Titles",
+    options: ["Mr", "Mrs", "Ms", "Miss", "Dr"],
+  },
+  {
+    label: "RAF",
+    options: [
+      "Pilot Officer",
+      "Flying Officer",
+      "Flight Lieutenant",
+      "Squadron Leader",
+      "Wing Commander",
+      "Group Captain",
+      "Air Commodore",
+      "Air Vice-Marshal",
+      "Air Marshal",
+      "Air Chief Marshal",
+      "Marshal of the Royal Air Force",
+    ],
+  },
+  {
+    label: "Army",
+    options: [
+      "Second Lieutenant",
+      "Lieutenant",
+      "Captain",
+      "Major",
+      "Lieutenant Colonel",
+      "Colonel",
+      "Brigadier",
+      "Major General",
+      "Lieutenant General",
+      "General",
+      "Field Marshal",
+    ],
+  },
+  {
+    label: "Royal Navy",
+    options: [
+      "Midshipman",
+      "Sub-Lieutenant",
+      "Lieutenant",
+      "Lieutenant Commander",
+      "Commander",
+      "Captain",
+      "Commodore",
+      "Rear Admiral",
+      "Vice Admiral",
+      "Admiral",
+      "Admiral of the Fleet",
+    ],
+  },
+] as const;

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -3452,6 +3452,8 @@ export interface GetCurrentUserData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
   } & User_Key;
@@ -3682,6 +3684,8 @@ export interface ListUsersData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
     createdBy?: string | null;
@@ -5297,6 +5301,8 @@ export interface GetSectionMembersData {
             email: string;
             serviceNumber: string;
             membershipStatus: MembershipStatus;
+            rank?: string | null;
+            shareContactInfo?: boolean | null;
           } & User_Key;
         })[];
       } & UserGroup_Key;
@@ -14240,6 +14246,8 @@ export interface CreateUserProfileVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 ```
 ### Return Type
@@ -14267,13 +14275,15 @@ const createUserProfileVars: CreateUserProfileVariables = {
   isReserve: ..., // optional
   isCivilServant: ..., // optional
   isIndustry: ..., // optional
+  rank: ..., // optional
+  shareContactInfo: ..., // optional
 };
 
 // Call the `createUserProfile()` function to execute the mutation.
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await createUserProfile(createUserProfileVars);
 // Variables can be defined inline as well.
-const { data } = await createUserProfile({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+const { data } = await createUserProfile({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -14304,12 +14314,14 @@ const createUserProfileVars: CreateUserProfileVariables = {
   isReserve: ..., // optional
   isCivilServant: ..., // optional
   isIndustry: ..., // optional
+  rank: ..., // optional
+  shareContactInfo: ..., // optional
 };
 
 // Call the `createUserProfileRef()` function to get a reference to the mutation.
 const ref = createUserProfileRef(createUserProfileVars);
 // Variables can be defined inline as well.
-const ref = createUserProfileRef({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+const ref = createUserProfileRef({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -14369,6 +14381,8 @@ export interface UpsertUserVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 ```
 ### Return Type
@@ -14395,13 +14409,15 @@ const upsertUserVars: UpsertUserVariables = {
   isReserve: ..., // optional
   isCivilServant: ..., // optional
   isIndustry: ..., // optional
+  rank: ..., // optional
+  shareContactInfo: ..., // optional
 };
 
 // Call the `upsertUser()` function to execute the mutation.
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await upsertUser(upsertUserVars);
 // Variables can be defined inline as well.
-const { data } = await upsertUser({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+const { data } = await upsertUser({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -14431,12 +14447,14 @@ const upsertUserVars: UpsertUserVariables = {
   isReserve: ..., // optional
   isCivilServant: ..., // optional
   isIndustry: ..., // optional
+  rank: ..., // optional
+  shareContactInfo: ..., // optional
 };
 
 // Call the `upsertUserRef()` function to get a reference to the mutation.
 const ref = upsertUserRef(upsertUserVars);
 // Variables can be defined inline as well.
-const ref = upsertUserRef({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+const ref = upsertUserRef({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -484,6 +484,8 @@ export interface CreateUserProfileVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 
 export interface CreateUserVariables {
@@ -803,6 +805,8 @@ export interface GetCurrentUserData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
   } & User_Key;
@@ -1292,6 +1296,8 @@ export interface GetSectionMembersData {
             email: string;
             serviceNumber: string;
             membershipStatus: MembershipStatus;
+            rank?: string | null;
+            shareContactInfo?: boolean | null;
           } & User_Key;
         })[];
       } & UserGroup_Key;
@@ -1928,6 +1934,8 @@ export interface ListUsersData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
     createdBy?: string | null;
@@ -2328,6 +2336,8 @@ export interface UpsertUserVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 
 export interface UserGroup_Key {

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2778,6 +2778,8 @@ export interface GetCurrentUserData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
   } & User_Key;
@@ -2959,6 +2961,8 @@ export interface ListUsersData {
     isReserve?: boolean | null;
     isCivilServant?: boolean | null;
     isIndustry?: boolean | null;
+    rank?: string | null;
+    shareContactInfo?: boolean | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
     createdBy?: string | null;
@@ -4228,6 +4232,8 @@ export interface GetSectionMembersData {
             email: string;
             serviceNumber: string;
             membershipStatus: MembershipStatus;
+            rank?: string | null;
+            shareContactInfo?: boolean | null;
           } & User_Key;
         })[];
       } & UserGroup_Key;
@@ -11741,6 +11747,8 @@ export interface CreateUserProfileVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 ```
 ### Return Type
@@ -11798,10 +11806,12 @@ export default function CreateUserProfileComponent() {
     isReserve: ..., // optional
     isCivilServant: ..., // optional
     isIndustry: ..., // optional
+    rank: ..., // optional
+    shareContactInfo: ..., // optional
   };
   mutation.mutate(createUserProfileVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., requestedMembershipStatus: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {
@@ -11848,6 +11858,8 @@ export interface UpsertUserVariables {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
 }
 ```
 ### Return Type
@@ -11904,10 +11916,12 @@ export default function UpsertUserComponent() {
     isReserve: ..., // optional
     isCivilServant: ..., // optional
     isIndustry: ..., // optional
+    rank: ..., // optional
+    shareContactInfo: ..., // optional
   };
   mutation.mutate(upsertUserVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
+  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., rank: ..., shareContactInfo: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -22,7 +22,7 @@ import {
   useOptOutSectionAnnouncement,
   useOptInSectionAnnouncement,
 } from "@dataconnect/generated/react";
-import { MembershipStatus, SectionUserGroupPurpose } from "@dataconnect/generated";
+import { MembershipStatus, SectionUserGroupPurpose, upsertUser, type UpsertUserVariables } from "@dataconnect/generated";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link as RouterLink } from "react-router-dom";
 import {
@@ -32,7 +32,7 @@ import {
   updatePassword,
   type User,
 } from "firebase/auth";
-import { auth } from "../../../config/firebase";
+import { auth, dataConnect } from "../../../config/firebase";
 import { colors } from "../../../config/colors";
 import { ROUTES } from "../../../constants";
 import type { UserData } from "../../../types";
@@ -205,6 +205,10 @@ export default function AccountSettingsPage({
   const [resignSubmitting, setResignSubmitting] = useState(false);
   const [resignError, setResignError] = useState<string | null>(null);
 
+  const [shareContactInfoSubmitting, setShareContactInfoSubmitting] = useState(false);
+  const [shareContactInfoError, setShareContactInfoError] = useState<string | null>(null);
+  const [shareContactInfoOverride, setShareContactInfoOverride] = useState<boolean | null>(null);
+
   const canChangePassword = usesEmailPassword(user);
   const membershipStatus = userData?.membershipStatus ?? null;
   const membershipLabel = userDataLoading && !userData
@@ -250,6 +254,35 @@ export default function AccountSettingsPage({
     }
   };
 
+  const shareContactInfo = shareContactInfoOverride ?? userData?.shareContactInfo ?? true;
+
+  const handleShareContactInfoToggle = async () => {
+    if (!userData) return;
+    const newValue = !shareContactInfo;
+    setShareContactInfoError(null);
+    setShareContactInfoOverride(newValue);
+    setShareContactInfoSubmitting(true);
+    try {
+      const vars: UpsertUserVariables = {
+        firstName: userData.firstName,
+        lastName: userData.lastName,
+        serviceNumber: userData.serviceNumber,
+        isRegular: userData.isRegular,
+        isReserve: userData.isReserve,
+        isCivilServant: userData.isCivilServant,
+        isIndustry: userData.isIndustry,
+        rank: userData.rank,
+        shareContactInfo: newValue,
+      };
+      await upsertUser(dataConnect, vars);
+    } catch (error) {
+      setShareContactInfoOverride(null);
+      setShareContactInfoError((error as Error)?.message ?? "Failed to update privacy setting");
+    } finally {
+      setShareContactInfoSubmitting(false);
+    }
+  };
+
   const handleResignConfirm = async () => {
     setResignError(null);
     setResignSubmitting(true);
@@ -288,6 +321,33 @@ export default function AccountSettingsPage({
           <Button component={RouterLink} to={ROUTES.PROFILE} variant="outlined">
             Edit profile details
           </Button>
+        </Box>
+
+        <Divider />
+
+        <Box component="section" aria-labelledby="privacy-heading">
+          <Typography id="privacy-heading" variant="h6" component="h2" sx={{ mb: 1 }}>
+            Privacy
+          </Typography>
+          {shareContactInfoError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {shareContactInfoError}
+            </Alert>
+          )}
+          <FormControlLabel
+            control={
+              <Switch
+                checked={shareContactInfo}
+                onChange={() => void handleShareContactInfoToggle()}
+                disabled={!userData || shareContactInfoSubmitting}
+              />
+            }
+            label="Share my contact details with other section members"
+          />
+          <Typography variant="body2" color="text.secondary">
+            When off, other members will see you listed but won't be able to view your contact
+            details.
+          </Typography>
         </Box>
 
         <Divider />

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -19,6 +19,16 @@ vi.mock("firebase/auth", () => ({
   signOut: vi.fn().mockResolvedValue(undefined),
 }));
 
+const mockUpsertUser = vi.fn().mockResolvedValue({ data: {} });
+
+vi.mock("@dataconnect/generated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+  return {
+    ...actual,
+    upsertUser: (...args: unknown[]) => mockUpsertUser(...args),
+  };
+});
+
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   resignMembership: vi.fn(),
 }));
@@ -62,6 +72,8 @@ const userData: UserData = {
   isReserve: false,
   isCivilServant: false,
   isIndustry: false,
+  rank: null,
+  shareContactInfo: true,
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-01-01T00:00:00Z",
 };
@@ -89,6 +101,67 @@ describe("AccountSettingsPage", () => {
       "href",
       "/profile"
     );
+  });
+
+  it("shows the privacy toggle on by default", () => {
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Share my contact details with other section members",
+    });
+    expect(toggle).toBeChecked();
+  });
+
+  it("shows the privacy toggle off when the user has opted out", () => {
+    renderAccountSettings({
+      user: mockUser,
+      userData: { ...userData, shareContactInfo: false },
+      isAdmin: false,
+    });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Share my contact details with other section members",
+    });
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("upserts the user with shareContactInfo flipped, preserving other fields", async () => {
+    const user = userEvent.setup();
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Share my contact details with other section members",
+    });
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(mockUpsertUser).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          firstName: "Alex",
+          lastName: "Member",
+          serviceNumber: "12345",
+          shareContactInfo: false,
+        })
+      );
+    });
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("reverts the toggle and shows an error if the upsert fails", async () => {
+    const user = userEvent.setup();
+    mockUpsertUser.mockRejectedValueOnce(new Error("Network error"));
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    const toggle = screen.getByRole("switch", {
+      name: "Share my contact details with other section members",
+    });
+    await user.click(toggle);
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+    expect(toggle).toBeChecked();
   });
 
   it("updates password after re-authentication", async () => {
@@ -353,7 +426,7 @@ describe("AnnouncementPreferencesList", () => {
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
     expect(screen.getByText("Alpha Section")).toBeInTheDocument();
-    const toggle = screen.getByRole("switch");
+    const toggle = screen.getByRole("switch", { name: "Alpha Section" });
     expect(toggle).toBeChecked();
   });
 
@@ -372,7 +445,7 @@ describe("AnnouncementPreferencesList", () => {
 
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
-    const toggle = screen.getByRole("switch");
+    const toggle = screen.getByRole("switch", { name: "Alpha Section" });
     expect(toggle).not.toBeChecked();
   });
 
@@ -392,7 +465,7 @@ describe("AnnouncementPreferencesList", () => {
 
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
-    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("switch", { name: "Alpha Section" }));
 
     await waitFor(() => {
       expect(mockOptOutAsync).toHaveBeenCalledWith({ sectionId: "s1" });
@@ -416,7 +489,7 @@ describe("AnnouncementPreferencesList", () => {
 
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
-    const toggle = screen.getByRole("switch");
+    const toggle = screen.getByRole("switch", { name: "Alpha Section" });
     expect(toggle).not.toBeChecked();
 
     await user.click(toggle);

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -19,6 +19,7 @@ import { validateUserForm } from "../../users/utils/userHelpers";
 import { MAX_NAME_LENGTH, MAX_SERVICE_NUMBER_LENGTH } from "../../../constants";
 import { auth } from "../../../config/firebase";
 import { syncPendingUserClaims, updateDisplayName } from "../../../shared/utils/firebaseFunctions";
+import RankSelect from "../../../shared/components/RankSelect";
 
 interface ProfileCompletionProps {
   userEmail: string;
@@ -37,6 +38,7 @@ export default function ProfileCompletion({
   const [isReserve, setIsReserve] = useState(false);
   const [isCivilServant, setIsCivilServant] = useState(false);
   const [isIndustry, setIsIndustry] = useState(false);
+  const [rank, setRank] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -77,6 +79,7 @@ export default function ProfileCompletion({
         isReserve,
         isCivilServant,
         isIndustry,
+        rank: rank || null,
       });
 
       const result = await executeMutation(mutation);
@@ -193,6 +196,8 @@ export default function ProfileCompletion({
             inputProps={{ maxLength: MAX_SERVICE_NUMBER_LENGTH }}
             helperText={`${serviceNumber.length}/${MAX_SERVICE_NUMBER_LENGTH} characters`}
           />
+
+          <RankSelect value={rank} onChange={setRank} disabled={submitting} />
 
           <Divider sx={{ my: 2 }} />
 

--- a/src/features/auth/components/__tests__/ProfileCompletion.test.tsx
+++ b/src/features/auth/components/__tests__/ProfileCompletion.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "../../../../test-utils";
+import { render, screen, waitFor, fireEvent } from "../../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import ProfileCompletion from "../ProfileCompletion";
 import { MembershipStatus } from "@dataconnect/generated";
@@ -60,7 +60,32 @@ describe("ProfileCompletion", () => {
           requestedMembershipStatus: MembershipStatus.REGULAR,
           firstName: "New",
           lastName: "Member",
+          rank: null,
         })
+      );
+    });
+  });
+
+  it("includes the selected rank when submitting", async () => {
+    const user = userEvent.setup();
+    render(<ProfileCompletion userEmail="new@example.com" />);
+
+    const textboxes = screen.getAllByRole("textbox");
+    await user.type(textboxes[0], "New");
+    await user.type(textboxes[1], "Member");
+    const serviceNumberInput = document.querySelector('input[maxlength="50"]') as HTMLInputElement;
+    await user.type(serviceNumberInput, "99999");
+
+    const rankSelect = screen.getByLabelText("Rank / Title");
+    fireEvent.mouseDown(rankSelect);
+    await user.click(await screen.findByRole("option", { name: "Flight Lieutenant" }));
+    await user.click(screen.getByRole("button", { name: /submit profile/i }));
+
+    await waitFor(() => {
+      expect(mutationRef).toHaveBeenCalledWith(
+        {},
+        "CreateUserProfile",
+        expect.objectContaining({ rank: "Flight Lieutenant" })
       );
     });
   });

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -22,6 +22,7 @@ import { upsertUser, type UpsertUserVariables, MembershipStatus } from "@datacon
 import type { UserData } from "../../../types";
 import { updateDisplayName, updateMembershipStatus } from "../../../shared/utils/firebaseFunctions";
 import { MAX_NAME_LENGTH, MAX_EMAIL_LENGTH, MAX_SERVICE_NUMBER_LENGTH, ROUTES, MEMBERSHIP_STATUS_OPTIONS } from "../../../constants";
+import RankSelect from "../../../shared/components/RankSelect";
 import { NON_RESTRICTED_STATUSES, isRestrictedStatus } from "../../users/utils/membershipStatusValidation";
 import { auth } from "../../../config/firebase";
 
@@ -42,6 +43,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
   const [isReserve, setIsReserve] = useState(false);
   const [isCivilServant, setIsCivilServant] = useState(false);
   const [isIndustry, setIsIndustry] = useState(false);
+  const [rank, setRank] = useState("");
   const [membershipStatus, setMembershipStatus] = useState<MembershipStatus | "">(
     () => userData?.membershipStatus ?? ""
   );
@@ -59,9 +61,11 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
       setIsReserve(userData.isReserve ?? false);
       setIsCivilServant(userData.isCivilServant ?? false);
       setIsIndustry(userData.isIndustry ?? false);
+      setRank(userData.rank || "");
       setMembershipStatus(userData.membershipStatus || "");
     } else {
       setEmail(userEmail);
+      setRank("");
       setMembershipStatus("");
     }
   }, [userData, userEmail]);
@@ -88,6 +92,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
         isReserve,
         isCivilServant,
         isIndustry,
+        rank: rank || null,
       };
       await upsertUser(dataConnect, vars);
 
@@ -243,6 +248,8 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
               </Typography>
             )}
           </FormControl>
+
+          <RankSelect value={rank} onChange={setRank} disabled={submitting} />
 
           <Divider sx={{ my: 2 }} />
 

--- a/src/features/profile/components/__tests__/Profile.test.tsx
+++ b/src/features/profile/components/__tests__/Profile.test.tsx
@@ -45,6 +45,8 @@ const userData: UserData = {
   isReserve: false,
   isCivilServant: false,
   isIndustry: false,
+  rank: null,
+  shareContactInfo: true,
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-01-01T00:00:00Z",
 };
@@ -114,6 +116,32 @@ describe("Profile", () => {
         MembershipStatus.RESERVE
       );
     });
+  });
+
+  it("includes the selected rank when saving", async () => {
+    const user = userEvent.setup();
+    renderProfile({ userData, userEmail: userData.email });
+
+    const rankSelect = screen.getByLabelText("Rank / Title");
+    fireEvent.mouseDown(rankSelect);
+    await user.click(await screen.findByRole("option", { name: "Wing Commander" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(dataconnect.upsertUser).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({ rank: "Wing Commander" })
+      );
+    });
+  });
+
+  it("pre-fills the rank field from existing user data", () => {
+    renderProfile({
+      userData: { ...userData, rank: "Squadron Leader" },
+      userEmail: userData.email,
+    });
+
+    expect(screen.getByText("Squadron Leader")).toBeInTheDocument();
   });
 
   it("locks membership status when current status is restricted", () => {

--- a/src/features/sections/components/ContactDetailsDialog.tsx
+++ b/src/features/sections/components/ContactDetailsDialog.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Chip, Dialog, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
+import type { SectionMember } from "../utils/sectionHelpers";
+
+interface ContactDetailsDialogProps {
+  member: SectionMember | null;
+  onClose: () => void;
+}
+
+/** Shown when a member card is clicked. Only ever rendered for members with sharesContactInfo
+ * true — SectionMemberCard doesn't wire up onSelect for opted-out members at all. See #273. */
+export default function ContactDetailsDialog({ member, onClose }: ContactDetailsDialogProps) {
+  const fullName = member ? `${member.firstName} ${member.lastName}`.trim() : "";
+  const displayName = member?.rank ? `${member.rank} ${fullName}` : fullName;
+
+  return (
+    <Dialog open={!!member} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle>Contact details</DialogTitle>
+      <DialogContent>
+        {member && (
+          <Box sx={{ pt: 0.5 }}>
+            <Typography variant="subtitle1" fontWeight={600}>
+              {displayName}
+            </Typography>
+            <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" sx={{ mt: 1, mb: 1.5 }} />
+            <Typography variant="body2" color="text.secondary" sx={{ wordBreak: "break-word" }}>
+              {member.email}
+            </Typography>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -16,6 +16,7 @@ import {
   canUserSubscribe,
   isUserMember,
   isMembersSection,
+  sortMembersBySurname,
 } from "../utils/sectionHelpers";
 import type { SectionMember } from "../utils/sectionHelpers";
 import { auth } from "../../../config/firebase";
@@ -108,6 +109,8 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
         firstName: m.firstName,
         lastName: m.lastName,
         email: m.email,
+        rank: m.rank,
+        sharesContactInfo: m.sharesContactInfo,
         membershipStatus: m.membershipStatus as SectionMember["membershipStatus"],
       }));
       setSectionMembers(members);
@@ -262,18 +265,18 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const allMembers = sectionMembers;
   const refetchMembers = fetchMembers;
 
-  // Filter members by search term
+  // Filter members by search term, then sort by surname
   const filteredMembers = useMemo(() => {
-    if (!searchTerm.trim()) {
-      return allMembers;
-    }
-    const lowerSearch = searchTerm.toLowerCase();
-    return allMembers.filter(
-      (member) =>
-        member.firstName.toLowerCase().includes(lowerSearch) ||
-        member.lastName.toLowerCase().includes(lowerSearch) ||
-        member.email.toLowerCase().includes(lowerSearch)
-    );
+    const lowerSearch = searchTerm.trim().toLowerCase();
+    const matching = lowerSearch
+      ? allMembers.filter(
+          (member) =>
+            member.firstName.toLowerCase().includes(lowerSearch) ||
+            member.lastName.toLowerCase().includes(lowerSearch) ||
+            (member.email?.toLowerCase().includes(lowerSearch) ?? false)
+        )
+      : allMembers;
+    return sortMembersBySurname(matching);
   }, [allMembers, searchTerm]);
 
   // Reset page to 1 when search term changes

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -5,10 +5,20 @@ import {
   Button,
   Chip,
   CircularProgress,
+  Paper,
   Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
   Tabs,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
+import { ViewList as ViewListIcon, ViewModule as ViewModuleIcon } from "@mui/icons-material";
 import { type GetEventByIdData, type GetEventsForSectionData, type GetSectionByIdData } from "@dataconnect/generated";
 import { colors } from "../../../config/colors";
 import PaginationDisplay from "../../../shared/components/PaginationDisplay";
@@ -18,10 +28,14 @@ import type { SectionMember } from "../utils/sectionHelpers";
 import { partitionSectionEventsByTiming } from "../../../shared/utils/sectionEventDisplay";
 import { eventDetailTabLabel, type EventDetailTab } from "../utils/sectionDetailTabs";
 import AnnouncementOptOutToggle from "./AnnouncementOptOutToggle";
+import ContactDetailsDialog from "./ContactDetailsDialog";
 import EventBookingWizard from "./EventBookingWizard";
 import EventDetailHero from "./EventDetailHero";
 import SectionEventCard from "./SectionEventCard";
 import SectionMemberCard from "./SectionMemberCard";
+import SectionMemberListItem from "./SectionMemberListItem";
+
+type MemberViewMode = "card" | "list";
 
 type SectionDetailSection = NonNullable<GetSectionByIdData["section"]>;
 type SectionEventRow = NonNullable<NonNullable<GetEventsForSectionData["section"]>["events"]>[number];
@@ -130,13 +144,32 @@ export function SectionMembersView({
   onRefresh,
   onPageChange,
 }: SectionMembersViewProps) {
+  const [selectedMember, setSelectedMember] = useState<SectionMember | null>(null);
+  const [viewMode, setViewMode] = useState<MemberViewMode>("card");
+
   return (
     <Box sx={{ mt: 1 }}>
-      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 600 }}>
-        Members ({allMembersCount})
-      </Typography>
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 2, mb: 1 }}>
+        <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+          Members ({allMembersCount})
+        </Typography>
+        <ToggleButtonGroup
+          value={viewMode}
+          exclusive
+          onChange={(_, value: MemberViewMode | null) => value && setViewMode(value)}
+          size="small"
+          aria-label="Member display style"
+        >
+          <ToggleButton value="card" aria-label="Card view">
+            <ViewModuleIcon fontSize="small" />
+          </ToggleButton>
+          <ToggleButton value="list" aria-label="List view">
+            <ViewListIcon fontSize="small" />
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Box>
       <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-        Names and membership type are shown by default. Email addresses stay hidden until you choose to show them for a member.
+        Tap a member to see their contact details. Members who've chosen not to share theirs are marked "Private".
       </Typography>
       <SearchBar
         value={searchTerm}
@@ -156,24 +189,45 @@ export function SectionMembersView({
             Showing {paginatedMembers.length} of {filteredMembers.length} {searchTerm ? "filtered " : ""}members
             {totalPages > 1 && ` (page ${page} of ${totalPages})`}
           </Typography>
-          <Box
-            component="ul"
-            sx={{
-              listStyle: "none",
-              m: 0,
-              p: 0,
-              display: "grid",
-              gap: 2,
-              gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" },
-            }}
-          >
-            {paginatedMembers.map((member) => (
-              <SectionMemberCard key={member.userId} member={member} />
-            ))}
-          </Box>
+          {viewMode === "card" ? (
+            <Box
+              component="ul"
+              sx={{
+                listStyle: "none",
+                m: 0,
+                p: 0,
+                display: "grid",
+                gap: 2,
+                gridTemplateColumns: { xs: "1fr", sm: "1fr 1fr", lg: "1fr 1fr 1fr" },
+              }}
+            >
+              {paginatedMembers.map((member) => (
+                <SectionMemberCard key={member.userId} member={member} onSelect={setSelectedMember} />
+              ))}
+            </Box>
+          ) : (
+            <TableContainer component={Paper} variant="outlined">
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Rank</TableCell>
+                    <TableCell>Membership</TableCell>
+                    <TableCell align="center">Privacy</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {paginatedMembers.map((member) => (
+                    <SectionMemberListItem key={member.userId} member={member} onSelect={setSelectedMember} />
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
           <PaginationDisplay page={page} totalPages={totalPages} onChange={onPageChange} />
         </>
       )}
+      <ContactDetailsDialog member={selectedMember} onClose={() => setSelectedMember(null)} />
     </Box>
   );
 }

--- a/src/features/sections/components/SectionMemberCard.tsx
+++ b/src/features/sections/components/SectionMemberCard.tsx
@@ -1,40 +1,62 @@
-import { useState } from "react";
-import { Button, Card, CardContent, Chip, Stack, Typography } from "@mui/material";
+import { Avatar, Card, CardActionArea, CardContent, Stack, Tooltip, Typography } from "@mui/material";
+import { Lock as LockIcon } from "@mui/icons-material";
 import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import type { SectionMember } from "../utils/sectionHelpers";
 
 export interface SectionMemberCardProps {
   member: SectionMember;
+  onSelect: (member: SectionMember) => void;
 }
 
-export default function SectionMemberCard({ member }: SectionMemberCardProps) {
-  const [showEmail, setShowEmail] = useState(false);
+function initials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+export default function SectionMemberCard({ member, onSelect }: SectionMemberCardProps) {
   const fullName = `${member.firstName} ${member.lastName}`.trim();
+
+  const header = (
+    <Stack direction="row" spacing={1.5} alignItems="center">
+      <Avatar sx={{ bgcolor: "primary.main" }}>{initials(member.firstName, member.lastName)}</Avatar>
+      <Stack sx={{ minWidth: 0, flex: 1 }}>
+        <Typography variant="subtitle1" component="h3" fontWeight={600} sx={{ wordBreak: "break-word" }}>
+          {fullName}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ wordBreak: "break-word" }}>
+          {member.rank || " "}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5 }}>
+          Membership: {getMembershipStatusLabel(member.membershipStatus)}
+        </Typography>
+      </Stack>
+    </Stack>
+  );
+
+  // CardContent's bottom padding depends on it being the last child, which differs between the
+  // two branches below (the padlock is a trailing sibling in the private case) — pin it explicitly
+  // so both variants render at the same height.
+  const cardContentSx = { "&:last-child": { pb: 2 } };
+
+  if (!member.sharesContactInfo) {
+    return (
+      <Card variant="outlined" component="li" sx={{ height: "100%", position: "relative" }}>
+        <CardContent sx={cardContentSx}>{header}</CardContent>
+        <Tooltip title="This member has chosen not to share their contact details">
+          <LockIcon
+            titleAccess="Private"
+            fontSize="small"
+            sx={{ position: "absolute", top: 12, right: 12, color: "text.secondary" }}
+          />
+        </Tooltip>
+      </Card>
+    );
+  }
 
   return (
     <Card variant="outlined" component="li" sx={{ height: "100%" }}>
-      <CardContent>
-        <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap={1} flexWrap="wrap">
-          <Typography variant="subtitle1" component="h3" fontWeight={600}>
-            {fullName}
-          </Typography>
-          <Chip label={getMembershipStatusLabel(member.membershipStatus)} size="small" />
-        </Stack>
-        {showEmail ? (
-          <Typography variant="body2" color="text.secondary" sx={{ mt: 1, wordBreak: "break-word" }}>
-            {member.email}
-          </Typography>
-        ) : null}
-        <Button
-          size="small"
-          variant="text"
-          onClick={() => setShowEmail((visible) => !visible)}
-          aria-expanded={showEmail}
-          sx={{ mt: 0.5, px: 0, minWidth: 0 }}
-        >
-          {showEmail ? "Hide email" : "Show email"}
-        </Button>
-      </CardContent>
+      <CardActionArea onClick={() => onSelect(member)} sx={{ height: "100%" }}>
+        <CardContent sx={cardContentSx}>{header}</CardContent>
+      </CardActionArea>
     </Card>
   );
 }

--- a/src/features/sections/components/SectionMemberListItem.tsx
+++ b/src/features/sections/components/SectionMemberListItem.tsx
@@ -1,0 +1,58 @@
+import { Avatar, Stack, TableCell, TableRow, Tooltip, Typography } from "@mui/material";
+import { Lock as LockIcon } from "@mui/icons-material";
+import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
+import type { SectionMember } from "../utils/sectionHelpers";
+
+export interface SectionMemberListItemProps {
+  member: SectionMember;
+  onSelect: (member: SectionMember) => void;
+}
+
+function initials(firstName: string, lastName: string): string {
+  return `${firstName.charAt(0)}${lastName.charAt(0)}`.toUpperCase();
+}
+
+export default function SectionMemberListItem({ member, onSelect }: SectionMemberListItemProps) {
+  const fullName = `${member.firstName} ${member.lastName}`.trim();
+  const clickable = member.sharesContactInfo;
+
+  return (
+    <TableRow
+      hover={clickable}
+      onClick={clickable ? () => onSelect(member) : undefined}
+      role={clickable ? "button" : undefined}
+      tabIndex={clickable ? 0 : undefined}
+      onKeyDown={
+        clickable
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                onSelect(member);
+              }
+            }
+          : undefined
+      }
+      sx={{ cursor: clickable ? "pointer" : "default" }}
+    >
+      <TableCell>
+        <Stack direction="row" spacing={1.5} alignItems="center">
+          <Avatar sx={{ bgcolor: "primary.main", width: 32, height: 32, fontSize: "0.875rem" }}>
+            {initials(member.firstName, member.lastName)}
+          </Avatar>
+          <Typography variant="body2" fontWeight={600}>
+            {fullName}
+          </Typography>
+        </Stack>
+      </TableCell>
+      <TableCell>{member.rank || "—"}</TableCell>
+      <TableCell>{getMembershipStatusLabel(member.membershipStatus)}</TableCell>
+      <TableCell align="center">
+        {!clickable && (
+          <Tooltip title="This member has chosen not to share their contact details">
+            <LockIcon titleAccess="Private" fontSize="small" sx={{ color: "text.secondary" }} />
+          </Tooltip>
+        )}
+      </TableCell>
+    </TableRow>
+  );
+}

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -336,8 +336,8 @@ describe('SectionDetail', () => {
 
     vi.mocked(getSectionMembersMerged).mockResolvedValue({
       members: [
-        { id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', membershipStatus: 'REGULAR' },
-        { id: 'user-2', firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', membershipStatus: 'RESERVE' },
+        { id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', membershipStatus: 'REGULAR', rank: null, sharesContactInfo: true },
+        { id: 'user-2', firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', membershipStatus: 'RESERVE', rank: null, sharesContactInfo: true },
       ],
     });
 
@@ -368,9 +368,96 @@ describe('SectionDetail', () => {
     expect(screen.getByText('Jane Smith')).toBeInTheDocument();
     expect(screen.queryByText('john@example.com')).not.toBeInTheDocument();
     expect(screen.queryByText('jane@example.com')).not.toBeInTheDocument();
-    expect(screen.getByText('Regular')).toBeInTheDocument();
-    expect(screen.getByText('Reserve')).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Show email' })).toHaveLength(2);
+    expect(screen.getByText('Membership: Regular')).toBeInTheDocument();
+    expect(screen.getByText('Membership: Reserve')).toBeInTheDocument();
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+    await user.click(screen.getByText('John Doe'));
+    expect(await screen.findByText('john@example.com')).toBeInTheDocument();
+  });
+
+  it('should sort members by surname', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Test Section',
+        type: 'MEMBERS',
+        purposeLinks: [],
+      },
+    };
+
+    vi.mocked(getSectionMembersMerged).mockResolvedValue({
+      members: [
+        { id: 'user-1', firstName: 'John', lastName: 'Zeta', email: 'john@example.com', membershipStatus: 'REGULAR', rank: null, sharesContactInfo: true },
+        { id: 'user-2', firstName: 'Jane', lastName: 'Alpha', email: 'jane@example.com', membershipStatus: 'RESERVE', rank: null, sharesContactInfo: true },
+      ],
+    });
+
+    mockGetSectionById({ data: mockSectionData, isLoading: false, isError: false });
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Members (2)')).toBeInTheDocument();
+    });
+
+    const headings = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
+    expect(headings).toEqual(['Jane Alpha', 'John Zeta']);
+  });
+
+  it('should switch between card and list view for members', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Test Section',
+        type: 'MEMBERS',
+        purposeLinks: [],
+      },
+    };
+
+    vi.mocked(getSectionMembersMerged).mockResolvedValue({
+      members: [
+        { id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', membershipStatus: 'REGULAR', rank: null, sharesContactInfo: true },
+      ],
+    });
+
+    mockGetSectionById({ data: mockSectionData, isLoading: false, isError: false });
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+
+    renderSectionDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    // Card view is the default — renders as a heading inside a card
+    expect(screen.getByRole('heading', { name: 'John Doe', level: 3 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'List view' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('heading', { name: 'John Doe' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Card view' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'John Doe', level: 3 })).toBeInTheDocument();
+    });
   });
 
   it('should show subscribe button when user can subscribe', async () => {
@@ -492,8 +579,8 @@ describe('SectionDetail', () => {
 
     vi.mocked(getSectionMembersMerged).mockResolvedValue({
       members: [
-        { id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', membershipStatus: 'REGULAR' },
-        { id: 'user-2', firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', membershipStatus: 'RESERVE' },
+        { id: 'user-1', firstName: 'John', lastName: 'Doe', email: 'john@example.com', membershipStatus: 'REGULAR', rank: null, sharesContactInfo: true },
+        { id: 'user-2', firstName: 'Jane', lastName: 'Smith', email: 'jane@example.com', membershipStatus: 'RESERVE', rank: null, sharesContactInfo: true },
       ],
     });
 

--- a/src/features/sections/components/__tests__/SectionMemberCard.test.tsx
+++ b/src/features/sections/components/__tests__/SectionMemberCard.test.tsx
@@ -1,34 +1,63 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import SectionMemberCard from "../SectionMemberCard";
 import { MembershipStatus } from "@dataconnect/generated";
+import type { SectionMember } from "../../utils/sectionHelpers";
 
 describe("SectionMemberCard", () => {
-  const member = {
+  const sharedMember: SectionMember = {
     userId: "user-1",
     firstName: "John",
     lastName: "Doe",
     email: "john@example.com",
     membershipStatus: MembershipStatus.REGULAR,
+    rank: null,
+    sharesContactInfo: true,
   };
 
-  it("shows name and membership label without email by default", () => {
-    render(<SectionMemberCard member={member} />);
+  it("shows name, initials, and membership label, with no email visible by default", () => {
+    render(<SectionMemberCard member={sharedMember} onSelect={vi.fn()} />);
 
     expect(screen.getByRole("heading", { name: "John Doe" })).toBeInTheDocument();
-    expect(screen.getByText("Regular")).toBeInTheDocument();
+    expect(screen.getByText("JD")).toBeInTheDocument();
+    expect(screen.getByText("Membership: Regular")).toBeInTheDocument();
     expect(screen.queryByText("john@example.com")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Show email" })).toHaveAttribute("aria-expanded", "false");
   });
 
-  it("reveals email when Show email is clicked", async () => {
+  it("shows rank below the name when set", () => {
+    render(<SectionMemberCard member={{ ...sharedMember, rank: "Wing Commander" }} onSelect={vi.fn()} />);
+
+    expect(screen.getByRole("heading", { name: "John Doe" })).toBeInTheDocument();
+    expect(screen.getByText("Wing Commander")).toBeInTheDocument();
+  });
+
+  it("does not show a rank line when rank is not set", () => {
+    render(<SectionMemberCard member={sharedMember} onSelect={vi.fn()} />);
+
+    expect(screen.queryByText("Wing Commander")).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect with the member when a shared-info card is clicked", async () => {
     const user = userEvent.setup();
-    render(<SectionMemberCard member={member} />);
+    const onSelect = vi.fn();
+    render(<SectionMemberCard member={sharedMember} onSelect={onSelect} />);
 
-    await user.click(screen.getByRole("button", { name: "Show email" }));
+    await user.click(screen.getByRole("heading", { name: "John Doe" }));
 
-    expect(screen.getByText("john@example.com")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Hide email" })).toHaveAttribute("aria-expanded", "true");
+    expect(onSelect).toHaveBeenCalledWith(sharedMember);
+  });
+
+  it("shows a Private indicator and is not clickable when the member has not shared contact info", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const privateMember: SectionMember = { ...sharedMember, sharesContactInfo: false, email: null };
+    render(<SectionMemberCard member={privateMember} onSelect={onSelect} />);
+
+    expect(screen.getByTitle("Private")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("heading", { name: "John Doe" }));
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });

--- a/src/features/sections/components/__tests__/SectionMemberListItem.test.tsx
+++ b/src/features/sections/components/__tests__/SectionMemberListItem.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Table, TableBody } from "@mui/material";
+import SectionMemberListItem from "../SectionMemberListItem";
+import { MembershipStatus } from "@dataconnect/generated";
+import type { SectionMember } from "../../utils/sectionHelpers";
+
+function renderRow(member: SectionMember, onSelect: (member: SectionMember) => void) {
+  return render(
+    <Table>
+      <TableBody>
+        <SectionMemberListItem member={member} onSelect={onSelect} />
+      </TableBody>
+    </Table>
+  );
+}
+
+describe("SectionMemberListItem", () => {
+  const sharedMember: SectionMember = {
+    userId: "user-1",
+    firstName: "John",
+    lastName: "Doe",
+    email: "john@example.com",
+    membershipStatus: MembershipStatus.REGULAR,
+    rank: null,
+    sharesContactInfo: true,
+  };
+
+  it("shows name, initials, rank, and membership status in separate cells", () => {
+    renderRow(sharedMember, vi.fn());
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("JD")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("Regular")).toBeInTheDocument();
+  });
+
+  it("shows the rank cell when set", () => {
+    renderRow({ ...sharedMember, rank: "Wing Commander" }, vi.fn());
+
+    expect(screen.getByText("Wing Commander")).toBeInTheDocument();
+    expect(screen.getByText("Regular")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with the member when a shared-info row is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    renderRow(sharedMember, onSelect);
+
+    await user.click(screen.getByText("John Doe"));
+
+    expect(onSelect).toHaveBeenCalledWith(sharedMember);
+  });
+
+  it("shows a Private indicator and is not clickable when the member has not shared contact info", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    const privateMember: SectionMember = { ...sharedMember, sharesContactInfo: false, email: null };
+    renderRow(privateMember, onSelect);
+
+    expect(screen.getByTitle("Private")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("John Doe"));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/sections/utils/__tests__/sectionHelpers.test.ts
+++ b/src/features/sections/utils/__tests__/sectionHelpers.test.ts
@@ -6,10 +6,53 @@ import {
   canUserAccessSection,
   canUserSubscribe,
   isUserMember,
+  sortMembersBySurname,
 } from '../sectionHelpers';
 import type { SectionType, MembershipStatus } from '@dataconnect/generated';
+import type { SectionMember } from '../sectionHelpers';
+
+function member(overrides: Partial<SectionMember>): SectionMember {
+  return {
+    userId: 'user-1',
+    firstName: 'First',
+    lastName: 'Last',
+    email: 'user@example.com',
+    membershipStatus: 'REGULAR' as MembershipStatus,
+    rank: null,
+    sharesContactInfo: true,
+    ...overrides,
+  };
+}
 
 describe('sectionHelpers', () => {
+  describe('sortMembersBySurname', () => {
+    it('sorts by last name', () => {
+      const result = sortMembersBySurname([
+        member({ userId: '1', firstName: 'John', lastName: 'Zeta' }),
+        member({ userId: '2', firstName: 'Jane', lastName: 'Alpha' }),
+      ]);
+      expect(result.map((m) => m.userId)).toEqual(['2', '1']);
+    });
+
+    it('breaks ties on last name using first name', () => {
+      const result = sortMembersBySurname([
+        member({ userId: '1', firstName: 'Zoe', lastName: 'Smith' }),
+        member({ userId: '2', firstName: 'Amy', lastName: 'Smith' }),
+      ]);
+      expect(result.map((m) => m.userId)).toEqual(['2', '1']);
+    });
+
+    it('does not mutate the input array', () => {
+      const input = [
+        member({ userId: '1', lastName: 'Zeta' }),
+        member({ userId: '2', lastName: 'Alpha' }),
+      ];
+      const result = sortMembersBySurname(input);
+      expect(result).not.toBe(input);
+      expect(input.map((m) => m.userId)).toEqual(['1', '2']);
+    });
+  });
+
   describe('isMembersSection', () => {
     it('should return true for MEMBERS section', () => {
       expect(isMembersSection({ type: 'MEMBERS' as SectionType })).toBe(true);

--- a/src/features/sections/utils/sectionHelpers.ts
+++ b/src/features/sections/utils/sectionHelpers.ts
@@ -7,8 +7,19 @@ export interface SectionMember {
   userId: string;
   firstName: string;
   lastName: string;
-  email: string;
   membershipStatus: MembershipStatus;
+  rank: string | null;
+  sharesContactInfo: boolean;
+  /** Null whenever sharesContactInfo is false — withheld server-side, not just hidden client-side. */
+  email: string | null;
+}
+
+/** Sorts by surname, then first name to break ties. Does not mutate the input array. */
+export function sortMembersBySurname(members: SectionMember[]): SectionMember[] {
+  return [...members].sort((a, b) => {
+    const lastNameCompare = a.lastName.localeCompare(b.lastName);
+    return lastNameCompare !== 0 ? lastNameCompare : a.firstName.localeCompare(b.firstName);
+  });
 }
 
 /** Purposes that allow opening / seeing a section. MODERATOR implies this for authorization. */
@@ -93,6 +104,11 @@ export function getAllUsersFromSection(
           lastName: user.lastName,
           email: user.email,
           membershipStatus: user.membershipStatus,
+          // This raw purposeLinks shape predates rank/shareContactInfo and isn't used by any
+          // production call site (only getSectionMembersMerged is, which does carry them) —
+          // default rather than plumb the fields through a function nothing calls.
+          rank: null,
+          sharesContactInfo: true,
         });
       }
     }

--- a/src/shared/components/RankSelect.tsx
+++ b/src/shared/components/RankSelect.tsx
@@ -1,0 +1,35 @@
+import { FormControl, InputLabel, ListSubheader, MenuItem, Select, type SelectChangeEvent } from "@mui/material";
+import { RANK_OPTION_GROUPS } from "../../constants";
+
+interface RankSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+}
+
+/** Grouped rank/title dropdown shared between ProfileCompletion.tsx and Profile.tsx. See #273. */
+export default function RankSelect({ value, onChange, disabled }: RankSelectProps) {
+  return (
+    <FormControl fullWidth disabled={disabled}>
+      <InputLabel id="rank-select-label">Rank / Title</InputLabel>
+      <Select
+        labelId="rank-select-label"
+        value={value}
+        label="Rank / Title"
+        onChange={(e: SelectChangeEvent) => onChange(e.target.value)}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        {RANK_OPTION_GROUPS.flatMap((group) => [
+          <ListSubheader key={`header-${group.label}`}>{group.label}</ListSubheader>,
+          ...group.options.map((option) => (
+            <MenuItem key={`${group.label}-${option}`} value={option}>
+              {option}
+            </MenuItem>
+          )),
+        ])}
+      </Select>
+    </FormControl>
+  );
+}

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -338,8 +338,11 @@ export interface GetSectionMembersMergedMember {
   id: string;
   firstName: string;
   lastName: string;
-  email: string;
   membershipStatus: string;
+  rank: string | null;
+  sharesContactInfo: boolean;
+  /** Null whenever sharesContactInfo is false — withheld server-side, not just hidden client-side. */
+  email: string | null;
 }
 
 export interface GetSectionMembersMergedResponse {

--- a/src/test-utils/factories/userData.ts
+++ b/src/test-utils/factories/userData.ts
@@ -17,6 +17,8 @@ export const createUserData = (overrides?: Partial<UserData>): UserData => ({
   isReserve: false,
   isCivilServant: false,
   isIndustry: false,
+  rank: null,
+  shareContactInfo: true,
   createdAt: '2024-01-01T00:00:00Z',
   updatedAt: '2024-01-01T00:00:00Z',
   ...overrides,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -15,6 +15,8 @@ export interface UserData {
   isReserve?: boolean | null;
   isCivilServant?: boolean | null;
   isIndustry?: boolean | null;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Members can set a rank/title (tri-service dropdown, RAF first, plus Mr/Mrs/Ms/Miss/Dr) on their profile, shown on section member cards/rows alongside an initials-avatar placeholder.
- New site-wide "Share my contact details with other section members" privacy toggle in Account Settings (default on). When off, a member is still listed but their contact details are withheld — enforced **server-side** in `getSectionMembersMerged` (the email is never sent to the client), not just hidden client-side. A padlock icon with a tooltip marks members who've opted out, so it reads as intentional rather than a bug.
- Clicking a member (card or table row) opens a contact-details dialog.
- Section member lists are now sorted by surname, and can be toggled between a card grid and a compact table view (Name / Rank / Membership / Privacy columns).
- Includes a real schema migration (`rank`, `shareContactInfo` columns on `User`) — flagging for review same as prior schema-change PRs this cycle.

Fixes #273

## Test plan
- [x] `npx tsc -b` (root) and `npx tsc --noEmit -p .` (functions) — clean
- [x] `npx vitest run` — 511 passed (root), 350 passed (functions)
- [x] `npx eslint` on all changed files — clean
- [x] Manually verified in browser: rank dropdown on Profile, privacy toggle in Account Settings, member card/table views, click-to-reveal contact dialog, and padlock indicator for opted-out members

🤖 Generated with [Claude Code](https://claude.com/claude-code)