### PR TITLE
Add dark mode with system/light/dark toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,7 +296,7 @@ function AppContent() {
     }
     return (
       <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
-        <Typography variant="h4" sx={{ color: "primary.main", mb: 3 }}>
+        <Typography variant="h4" sx={{ color: "primary.light", mb: 3 }}>
           {title}
         </Typography>
         {!user ? (

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,14 +1,33 @@
-import { alpha, createTheme } from "@mui/material/styles";
+import { alpha, createTheme, lighten, type Theme } from "@mui/material/styles";
 
 const PRIMARY = "#1A2F5A";
 const SECONDARY = "#770800";
-const BACKGROUND_DEFAULT = "#F9FAFB";
+const LIGHT_BACKGROUND_DEFAULT = "#F9FAFB";
 
-export const theme = createTheme({
-  palette: {
-    primary: { main: PRIMARY },
-    secondary: { main: SECONDARY },
-    background: { default: BACKGROUND_DEFAULT },
-    text: { secondary: alpha(PRIMARY, 0.75) },
-  },
-});
+export type AppColorMode = "light" | "dark";
+
+/**
+ * primary.main stays the fixed brand navy in both modes — across the app it's only ever used as
+ * a background (AppBar, avatars) or paired with an explicit white foreground, so it never needs
+ * to contrast against the page's own background. primary.light is used for heading/link text
+ * color rendered directly on the page background, which must lighten in dark mode to stay legible
+ * against a dark background.
+ */
+export function createAppTheme(mode: AppColorMode): Theme {
+  return createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: PRIMARY,
+        light: mode === "dark" ? lighten(PRIMARY, 0.55) : PRIMARY,
+      },
+      secondary: { main: SECONDARY },
+      ...(mode === "light"
+        ? {
+            background: { default: LIGHT_BACKGROUND_DEFAULT },
+            text: { secondary: alpha(PRIMARY, 0.75) },
+          }
+        : {}),
+    },
+  });
+}

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -302,7 +302,7 @@ export default function AccountSettingsPage({
 
   return (
     <Box sx={{ maxWidth: "600px", mx: "auto", py: 2 }}>
-      <Typography variant="h4" gutterBottom sx={{ color: "primary.main", mb: 3 }}>
+      <Typography variant="h4" gutterBottom sx={{ color: "primary.light", mb: 3 }}>
         Account
       </Typography>
 

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -15,8 +15,11 @@ import {
   Stack,
   Switch,
   TextField,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
 } from "@mui/material";
+import { DarkMode, LightMode, SettingsBrightness } from "@mui/icons-material";
 import {
   useGetMyAnnouncementPreferences,
   useOptOutSectionAnnouncement,
@@ -38,6 +41,7 @@ import type { UserData } from "../../../types";
 import { resignMembership } from "../../../shared/utils/firebaseFunctions";
 import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatusLabels";
 import { canUserResignMembership } from "../../users/utils/membershipStatusValidation";
+import { useColorMode, type ColorModePreference } from "../../../shared/appShell/ColorModeContext";
 
 export interface AccountSettingsPageProps {
   user: User;
@@ -208,6 +212,8 @@ export default function AccountSettingsPage({
   const [shareContactInfoError, setShareContactInfoError] = useState<string | null>(null);
   const [shareContactInfoOverride, setShareContactInfoOverride] = useState<boolean | null>(null);
 
+  const { preference: colorModePreference, setPreference: setColorModePreference } = useColorMode();
+
   const canChangePassword = usesEmailPassword(user);
   const membershipStatus = userData?.membershipStatus ?? null;
   const membershipLabel = userDataLoading && !userData
@@ -320,6 +326,39 @@ export default function AccountSettingsPage({
           <Button component={RouterLink} to={ROUTES.PROFILE} variant="outlined">
             Edit profile details
           </Button>
+        </Box>
+
+        <Divider />
+
+        <Box component="section" aria-labelledby="appearance-heading">
+          <Typography id="appearance-heading" variant="h6" component="h2" sx={{ mb: 1 }}>
+            Appearance
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Choose whether the site follows your device's light/dark setting, or always uses a
+            specific one.
+          </Typography>
+          <ToggleButtonGroup
+            value={colorModePreference}
+            exclusive
+            onChange={(_, value: ColorModePreference | null) => {
+              if (value) setColorModePreference(value);
+            }}
+            aria-label="Appearance"
+          >
+            <ToggleButton value="system" aria-label="System">
+              <SettingsBrightness fontSize="small" sx={{ mr: 1 }} />
+              System
+            </ToggleButton>
+            <ToggleButton value="light" aria-label="Light">
+              <LightMode fontSize="small" sx={{ mr: 1 }} />
+              Light
+            </ToggleButton>
+            <ToggleButton value="dark" aria-label="Dark">
+              <DarkMode fontSize="small" sx={{ mr: 1 }} />
+              Dark
+            </ToggleButton>
+          </ToggleButtonGroup>
         </Box>
 
         <Divider />

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -86,9 +86,19 @@ function renderAccountSettings(props: ComponentProps<typeof AccountSettingsPage>
   );
 }
 
+function clearCookies() {
+  document.cookie.split(";").forEach((cookie) => {
+    const name = cookie.split("=")[0]?.trim();
+    if (name) {
+      document.cookie = `${name}=; max-age=0; path=/`;
+    }
+  });
+}
+
 describe("AccountSettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearCookies();
   });
 
   it("shows read-only membership status and profile link", () => {
@@ -101,6 +111,32 @@ describe("AccountSettingsPage", () => {
       "href",
       "/profile"
     );
+  });
+
+  it("defaults the Appearance selector to System", () => {
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    expect(screen.getByRole("button", { name: "System" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("selecting Dark in Appearance persists the choice", async () => {
+    const user = userEvent.setup();
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    await user.click(screen.getByRole("button", { name: "Dark" }));
+
+    expect(screen.getByRole("button", { name: "Dark" })).toHaveAttribute("aria-pressed", "true");
+    expect(document.cookie).toContain("sodc-color-mode-preference=dark");
+  });
+
+  it("selecting Light in Appearance persists the choice", async () => {
+    const user = userEvent.setup();
+    renderAccountSettings({ user: mockUser, userData, isAdmin: false });
+
+    await user.click(screen.getByRole("button", { name: "Light" }));
+
+    expect(screen.getByRole("button", { name: "Light" })).toHaveAttribute("aria-pressed", "true");
+    expect(document.cookie).toContain("sodc-color-mode-preference=light");
   });
 
   it("shows the privacy toggle on by default", () => {

--- a/src/features/admin/components/ApproveUsers.tsx
+++ b/src/features/admin/components/ApproveUsers.tsx
@@ -190,7 +190,7 @@ export default function ApproveUsers({ onBack }: ApproveUsersProps) {
         <Alert severity="error">{error}</Alert>
       ) : (
         <>
-          <Typography variant="h6" sx={{ mb: 1, color: "primary.main" }}>
+          <Typography variant="h6" sx={{ mb: 1, color: "primary.light" }}>
             Not enabled, no Data Connect profile ({usersWithoutProfile.length})
           </Typography>
           <Typography variant="body2" sx={{ mb: 2, color: "text.secondary" }}>
@@ -263,7 +263,7 @@ export default function ApproveUsers({ onBack }: ApproveUsersProps) {
             </Table>
           </TableContainer>
 
-          <Typography variant="h6" sx={{ mb: 1, color: "primary.main" }}>
+          <Typography variant="h6" sx={{ mb: 1, color: "primary.light" }}>
             Pending membership approval ({pendingUsers.length})
           </Typography>
           <Typography variant="body2" sx={{ mb: 2, color: "text.secondary" }}>

--- a/src/features/admin/components/SectionAdminPage.tsx
+++ b/src/features/admin/components/SectionAdminPage.tsx
@@ -34,7 +34,7 @@ function ActionCard({ icon, title, description, onClick }: ActionCardProps) {
     <Card variant="outlined">
       <CardActionArea onClick={onClick} sx={{ height: "100%" }}>
         <CardContent sx={{ display: "flex", flexDirection: "column", gap: 1, p: 3 }}>
-          <Box sx={{ color: "primary.main" }}>{icon}</Box>
+          <Box sx={{ color: "primary.light" }}>{icon}</Box>
           <Typography variant="subtitle1" fontWeight={600}>{title}</Typography>
           <Typography variant="body2" color="text.secondary">{description}</Typography>
         </CardContent>

--- a/src/features/admin/components/TemplateEditor.tsx
+++ b/src/features/admin/components/TemplateEditor.tsx
@@ -479,7 +479,7 @@ export default function TemplateEditor({ sectionName }: TemplateEditorProps) {
                   fontSize: "0.875rem",
                   lineHeight: 1.6,
                   fontFamily: "Arial, sans-serif",
-                  "& a": { color: "primary.main" },
+                  "& a": { color: "primary.light" },
                   "& h1,h2": { fontFamily: "inherit" },
                 }}
                 dangerouslySetInnerHTML={{ __html: previewHtml }}

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -111,7 +111,7 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
 
   return (
     <Stack spacing={2} sx={{ mt: 2 }}>
-      <Typography variant="h5" sx={{ color: "primary.main" }}>
+      <Typography variant="h5" sx={{ color: "primary.light" }}>
         Sign in
       </Typography>
       <Typography variant="body2" sx={{ color: "text.secondary" }}>

--- a/src/features/auth/components/EmailVerificationMessage.tsx
+++ b/src/features/auth/components/EmailVerificationMessage.tsx
@@ -82,7 +82,7 @@ export default function EmailVerificationMessage({
 
   return (
     <Box sx={{ textAlign: "left" }}>
-      <Typography variant="h5" sx={{ color: "primary.main", mb: 1 }}>
+      <Typography variant="h5" sx={{ color: "primary.light", mb: 1 }}>
         Verify your email
       </Typography>
       <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>

--- a/src/features/auth/components/OnboardingShell.tsx
+++ b/src/features/auth/components/OnboardingShell.tsx
@@ -25,7 +25,7 @@ export default function OnboardingShell({ activeStep, children }: OnboardingShel
           </Step>
         ))}
       </Stepper>
-      <Box sx={{ color: "primary.main" }}>{children}</Box>
+      <Box sx={{ color: "primary.light" }}>{children}</Box>
     </Box>
   );
 }

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -136,7 +136,7 @@ export default function ProfileCompletion({
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ color: "primary.main", mb: 1 }}>
+      <Typography variant="h5" gutterBottom sx={{ color: "primary.light", mb: 1 }}>
         Complete your profile
       </Typography>
 
@@ -200,7 +200,7 @@ export default function ProfileCompletion({
 
           <Divider sx={{ my: 2 }} />
 
-          <Typography variant="h6" sx={{ color: "primary.main", mb: 1 }}>
+          <Typography variant="h6" sx={{ color: "primary.light", mb: 1 }}>
             Service background
           </Typography>
 

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -122,7 +122,7 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
 
   return (
     <Stack spacing={2}>
-      <Typography variant="h5" sx={{ color: "primary.main", mb: 1 }}>
+      <Typography variant="h5" sx={{ color: "primary.light", mb: 1 }}>
         Create account
       </Typography>
       <Typography variant="body2" sx={{ color: "text.secondary" }}>

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -316,7 +316,7 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
 
               <Divider sx={{ my: 2 }} />
 
-              <Typography variant="h6" sx={{ color: "primary.main", mb: 1 }}>
+              <Typography variant="h6" sx={{ color: "primary.light", mb: 1 }}>
                 Service Background
               </Typography>
 

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -140,7 +140,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
 
   return (
     <Box sx={{ maxWidth: "600px", mx: "auto" }}>
-      <Typography variant="h4" gutterBottom sx={{ color: "primary.main", mb: 3 }}>
+      <Typography variant="h4" gutterBottom sx={{ color: "primary.light", mb: 3 }}>
         Profile
       </Typography>
 
@@ -252,7 +252,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
 
           <Divider sx={{ my: 2 }} />
 
-          <Typography variant="h6" sx={{ color: "primary.main", mb: 1 }}>
+          <Typography variant="h6" sx={{ color: "primary.light", mb: 1 }}>
             Service Background
           </Typography>
 

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -40,7 +40,7 @@ export default function MemberWelcomePage({
       <Typography
         variant="h4"
         component="h1"
-        sx={{ color: "primary.main", fontWeight: 500, mb: 1 }}
+        sx={{ color: "primary.light", fontWeight: 500, mb: 1 }}
       >
         Welcome, {displayName}
       </Typography>

--- a/src/features/welcome/components/PublicHomePage.tsx
+++ b/src/features/welcome/components/PublicHomePage.tsx
@@ -12,7 +12,7 @@ export default function PublicHomePage({ onJoinClick, onLogInClick }: PublicHome
         variant="h3"
         component="h1"
         sx={{
-          color: "primary.main",
+          color: "primary.light",
           fontWeight: 400,
           fontSize: { xs: "2rem", sm: "2.75rem" },
           mb: 1,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
-import { ThemeProvider } from '@mui/material/styles'
-import CssBaseline from '@mui/material/CssBaseline'
-import { theme } from './config/theme'
+import { ColorModeProvider } from './shared/appShell/ColorModeProvider'
 import './index.css'
 import App from './App.tsx'
 
@@ -20,13 +18,12 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
+    <ColorModeProvider>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
           <App />
         </BrowserRouter>
       </QueryClientProvider>
-    </ThemeProvider>
+    </ColorModeProvider>
   </StrictMode>,
 )

--- a/src/shared/appShell/ColorModeContext.ts
+++ b/src/shared/appShell/ColorModeContext.ts
@@ -1,17 +1,17 @@
 import { createContext, useContext } from "react";
 import type { AppColorMode } from "../../config/theme";
+import { getCookie, removeCookie, setCookie } from "../utils/cookies";
 
 export type ColorModePreference = "system" | AppColorMode;
 
-export const STORAGE_KEY = "sodc-color-mode-preference";
+export const PREFERENCE_COOKIE = "sodc-color-mode-preference";
 
 export function readStoredPreference(): ColorModePreference {
   try {
-    const stored = window.localStorage.getItem(STORAGE_KEY);
+    const stored = getCookie(PREFERENCE_COOKIE);
     return stored === "light" || stored === "dark" ? stored : "system";
   } catch {
-    // localStorage can throw (e.g. private browsing, or unavailable in some environments) —
-    // fall back to following the system preference.
+    // Cookie access can throw in some environments — fall back to following the system preference.
     return "system";
   }
 }
@@ -19,9 +19,9 @@ export function readStoredPreference(): ColorModePreference {
 export function writeStoredPreference(preference: ColorModePreference): void {
   try {
     if (preference === "system") {
-      window.localStorage.removeItem(STORAGE_KEY);
+      removeCookie(PREFERENCE_COOKIE);
     } else {
-      window.localStorage.setItem(STORAGE_KEY, preference);
+      setCookie(PREFERENCE_COOKIE, preference);
     }
   } catch {
     // Ignore — the preference just won't persist across sessions.
@@ -29,9 +29,18 @@ export function writeStoredPreference(preference: ColorModePreference): void {
 }
 
 export interface ColorModeContextValue {
+  /** The persisted System/Light/Dark choice, set from Account Settings. Defaults to "system". */
   preference: ColorModePreference;
+  /**
+   * The mode actually applied to the app right now. Starts each page load from `preference`
+   * (system preference, or the persisted explicit choice) — toggleSessionMode can flip it for
+   * the current session only, without touching the persisted preference.
+   */
   resolvedMode: AppColorMode;
+  /** Persists an explicit System/Light/Dark choice (Account Settings). Clears any session override. */
   setPreference: (preference: ColorModePreference) => void;
+  /** Flips resolvedMode for the current session only (Header toggle) — never persisted. */
+  toggleSessionMode: () => void;
 }
 
 export const ColorModeContext = createContext<ColorModeContextValue | null>(null);

--- a/src/shared/appShell/ColorModeContext.ts
+++ b/src/shared/appShell/ColorModeContext.ts
@@ -1,0 +1,45 @@
+import { createContext, useContext } from "react";
+import type { AppColorMode } from "../../config/theme";
+
+export type ColorModePreference = "system" | AppColorMode;
+
+export const STORAGE_KEY = "sodc-color-mode-preference";
+
+export function readStoredPreference(): ColorModePreference {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === "light" || stored === "dark" ? stored : "system";
+  } catch {
+    // localStorage can throw (e.g. private browsing, or unavailable in some environments) —
+    // fall back to following the system preference.
+    return "system";
+  }
+}
+
+export function writeStoredPreference(preference: ColorModePreference): void {
+  try {
+    if (preference === "system") {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, preference);
+    }
+  } catch {
+    // Ignore — the preference just won't persist across sessions.
+  }
+}
+
+export interface ColorModeContextValue {
+  preference: ColorModePreference;
+  resolvedMode: AppColorMode;
+  setPreference: (preference: ColorModePreference) => void;
+}
+
+export const ColorModeContext = createContext<ColorModeContextValue | null>(null);
+
+export function useColorMode(): ColorModeContextValue {
+  const context = useContext(ColorModeContext);
+  if (!context) {
+    throw new Error("useColorMode must be used within a ColorModeProvider");
+  }
+  return context;
+}

--- a/src/shared/appShell/ColorModeProvider.tsx
+++ b/src/shared/appShell/ColorModeProvider.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { ThemeProvider } from "@mui/material/styles";
+import CssBaseline from "@mui/material/CssBaseline";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { createAppTheme, type AppColorMode } from "../../config/theme";
+import {
+  ColorModeContext,
+  readStoredPreference,
+  writeStoredPreference,
+  type ColorModePreference,
+} from "./ColorModeContext";
+
+export function ColorModeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreferenceState] = useState<ColorModePreference>(readStoredPreference);
+  const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+
+  const setPreference = useCallback((next: ColorModePreference) => {
+    setPreferenceState(next);
+    writeStoredPreference(next);
+  }, []);
+
+  const resolvedMode: AppColorMode = preference === "system" ? (prefersDark ? "dark" : "light") : preference;
+
+  const theme = useMemo(() => createAppTheme(resolvedMode), [resolvedMode]);
+
+  const contextValue = useMemo(
+    () => ({ preference, resolvedMode, setPreference }),
+    [preference, resolvedMode, setPreference]
+  );
+
+  return (
+    <ColorModeContext.Provider value={contextValue}>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </ColorModeContext.Provider>
+  );
+}

--- a/src/shared/appShell/ColorModeProvider.tsx
+++ b/src/shared/appShell/ColorModeProvider.tsx
@@ -12,20 +12,31 @@ import {
 
 export function ColorModeProvider({ children }: { children: ReactNode }) {
   const [preference, setPreferenceState] = useState<ColorModePreference>(readStoredPreference);
+  // Session-only override from the Header's quick toggle — never persisted, always starts null
+  // (i.e. "no override") on a fresh page load, so the effective mode falls back to `preference`.
+  const [sessionOverride, setSessionOverride] = useState<AppColorMode | null>(null);
   const prefersDark = useMediaQuery("(prefers-color-scheme: dark)");
+
+  const persistedResolvedMode: AppColorMode = preference === "system" ? (prefersDark ? "dark" : "light") : preference;
+  const resolvedMode: AppColorMode = sessionOverride ?? persistedResolvedMode;
 
   const setPreference = useCallback((next: ColorModePreference) => {
     setPreferenceState(next);
     writeStoredPreference(next);
+    // A deliberate persistent choice should take effect immediately, not be masked by a
+    // leftover session-only override from the Header toggle.
+    setSessionOverride(null);
   }, []);
 
-  const resolvedMode: AppColorMode = preference === "system" ? (prefersDark ? "dark" : "light") : preference;
+  const toggleSessionMode = useCallback(() => {
+    setSessionOverride((current) => (current ?? persistedResolvedMode) === "dark" ? "light" : "dark");
+  }, [persistedResolvedMode]);
 
   const theme = useMemo(() => createAppTheme(resolvedMode), [resolvedMode]);
 
   const contextValue = useMemo(
-    () => ({ preference, resolvedMode, setPreference }),
-    [preference, resolvedMode, setPreference]
+    () => ({ preference, resolvedMode, setPreference, toggleSessionMode }),
+    [preference, resolvedMode, setPreference, toggleSessionMode]
   );
 
   return (

--- a/src/shared/appShell/__tests__/ColorModeProvider.test.tsx
+++ b/src/shared/appShell/__tests__/ColorModeProvider.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { ColorModeProvider } from "../ColorModeProvider";
+import { useColorMode } from "../ColorModeContext";
+
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}
+
+function createMockStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => store.clear(),
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+describe("ColorModeProvider / useColorMode", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: createMockStorage(),
+      writable: true,
+    });
+  });
+
+  it("defaults to system preference resolving to light when the OS prefers light", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolvedMode).toBe("light");
+  });
+
+  it("defaults to system preference resolving to dark when the OS prefers dark", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolvedMode).toBe("dark");
+  });
+
+  it("setPreference overrides the system preference", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    act(() => result.current.setPreference("dark"));
+
+    expect(result.current.preference).toBe("dark");
+    expect(result.current.resolvedMode).toBe("dark");
+  });
+
+  it("persists an explicit preference and restores it on the next mount", () => {
+    mockMatchMedia(false);
+    const first = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+    act(() => first.result.current.setPreference("dark"));
+
+    const second = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+    expect(second.result.current.preference).toBe("dark");
+    expect(second.result.current.resolvedMode).toBe("dark");
+  });
+
+  it("setPreference('system') clears the stored preference and follows the OS again", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    act(() => result.current.setPreference("light"));
+    expect(result.current.resolvedMode).toBe("light");
+
+    act(() => result.current.setPreference("system"));
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolvedMode).toBe("dark");
+    expect(window.localStorage.getItem("sodc-color-mode-preference")).toBeNull();
+  });
+
+  it("throws when useColorMode is used outside a ColorModeProvider", () => {
+    const { result } = renderHook(() => {
+      try {
+        return useColorMode();
+      } catch (error) {
+        return error;
+      }
+    });
+    expect(result.current).toBeInstanceOf(Error);
+  });
+});

--- a/src/shared/appShell/__tests__/ColorModeProvider.test.tsx
+++ b/src/shared/appShell/__tests__/ColorModeProvider.test.tsx
@@ -16,30 +16,18 @@ function mockMatchMedia(matches: boolean) {
   })) as unknown as typeof window.matchMedia;
 }
 
-function createMockStorage(): Storage {
-  const store = new Map<string, string>();
-  return {
-    getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => {
-      store.set(key, value);
-    },
-    removeItem: (key: string) => {
-      store.delete(key);
-    },
-    clear: () => store.clear(),
-    key: (index: number) => Array.from(store.keys())[index] ?? null,
-    get length() {
-      return store.size;
-    },
-  };
+function clearCookies() {
+  document.cookie.split(";").forEach((cookie) => {
+    const name = cookie.split("=")[0]?.trim();
+    if (name) {
+      document.cookie = `${name}=; max-age=0; path=/`;
+    }
+  });
 }
 
 describe("ColorModeProvider / useColorMode", () => {
   beforeEach(() => {
-    Object.defineProperty(window, "localStorage", {
-      value: createMockStorage(),
-      writable: true,
-    });
+    clearCookies();
   });
 
   it("defaults to system preference resolving to light when the OS prefers light", () => {
@@ -68,17 +56,19 @@ describe("ColorModeProvider / useColorMode", () => {
     expect(result.current.resolvedMode).toBe("dark");
   });
 
-  it("persists an explicit preference and restores it on the next mount", () => {
+  it("persists an explicit preference in a cookie and restores it on the next mount", () => {
     mockMatchMedia(false);
     const first = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
     act(() => first.result.current.setPreference("dark"));
+
+    expect(document.cookie).toContain("sodc-color-mode-preference=dark");
 
     const second = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
     expect(second.result.current.preference).toBe("dark");
     expect(second.result.current.resolvedMode).toBe("dark");
   });
 
-  it("setPreference('system') clears the stored preference and follows the OS again", () => {
+  it("setPreference('system') clears the cookie and follows the OS again", () => {
     mockMatchMedia(true);
     const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
 
@@ -88,7 +78,41 @@ describe("ColorModeProvider / useColorMode", () => {
     act(() => result.current.setPreference("system"));
     expect(result.current.preference).toBe("system");
     expect(result.current.resolvedMode).toBe("dark");
-    expect(window.localStorage.getItem("sodc-color-mode-preference")).toBeNull();
+    expect(document.cookie).not.toContain("sodc-color-mode-preference=");
+  });
+
+  it("toggleSessionMode flips resolvedMode without changing the persisted preference", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    expect(result.current.resolvedMode).toBe("light");
+
+    act(() => result.current.toggleSessionMode());
+
+    expect(result.current.resolvedMode).toBe("dark");
+    expect(result.current.preference).toBe("system");
+    expect(document.cookie).not.toContain("sodc-color-mode-preference=");
+  });
+
+  it("a fresh mount ignores a previous session's toggleSessionMode override", () => {
+    mockMatchMedia(false);
+    const first = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+    act(() => first.result.current.toggleSessionMode());
+    expect(first.result.current.resolvedMode).toBe("dark");
+
+    const second = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+    expect(second.result.current.resolvedMode).toBe("light");
+  });
+
+  it("setPreference clears any active session override", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useColorMode(), { wrapper: ColorModeProvider });
+
+    act(() => result.current.toggleSessionMode());
+    expect(result.current.resolvedMode).toBe("dark");
+
+    act(() => result.current.setPreference("light"));
+    expect(result.current.resolvedMode).toBe("light");
   });
 
   it("throws when useColorMode is used outside a ColorModeProvider", () => {

--- a/src/shared/components/ColorModeToggle.tsx
+++ b/src/shared/components/ColorModeToggle.tsx
@@ -1,0 +1,64 @@
+import { useState, type ReactNode } from "react";
+import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from "@mui/material";
+import { DarkMode, LightMode, SettingsBrightness } from "@mui/icons-material";
+import { useColorMode, type ColorModePreference } from "../appShell/ColorModeContext";
+
+const OPTIONS: Array<{ value: ColorModePreference; label: string; icon: ReactNode }> = [
+  { value: "system", label: "System", icon: <SettingsBrightness fontSize="small" /> },
+  { value: "light", label: "Light", icon: <LightMode fontSize="small" /> },
+  { value: "dark", label: "Dark", icon: <DarkMode fontSize="small" /> },
+];
+
+export default function ColorModeToggle() {
+  const { preference, resolvedMode, setPreference } = useColorMode();
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const currentIcon =
+    preference === "system" ? (
+      <SettingsBrightness />
+    ) : resolvedMode === "dark" ? (
+      <DarkMode />
+    ) : (
+      <LightMode />
+    );
+
+  return (
+    <>
+      <Tooltip title="Appearance">
+        <IconButton
+          color="inherit"
+          aria-label="Appearance"
+          aria-haspopup="true"
+          aria-expanded={open ? "true" : "false"}
+          aria-controls={open ? "color-mode-menu" : undefined}
+          onClick={(event) => setAnchorEl(event.currentTarget)}
+        >
+          {currentIcon}
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id="color-mode-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        {OPTIONS.map((option) => (
+          <MenuItem
+            key={option.value}
+            selected={preference === option.value}
+            onClick={() => {
+              setPreference(option.value);
+              setAnchorEl(null);
+            }}
+          >
+            <ListItemIcon>{option.icon}</ListItemIcon>
+            <ListItemText>{option.label}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/src/shared/components/ColorModeToggle.tsx
+++ b/src/shared/components/ColorModeToggle.tsx
@@ -1,64 +1,22 @@
-import { useState, type ReactNode } from "react";
-import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from "@mui/material";
-import { DarkMode, LightMode, SettingsBrightness } from "@mui/icons-material";
-import { useColorMode, type ColorModePreference } from "../appShell/ColorModeContext";
-
-const OPTIONS: Array<{ value: ColorModePreference; label: string; icon: ReactNode }> = [
-  { value: "system", label: "System", icon: <SettingsBrightness fontSize="small" /> },
-  { value: "light", label: "Light", icon: <LightMode fontSize="small" /> },
-  { value: "dark", label: "Dark", icon: <DarkMode fontSize="small" /> },
-];
+import { Switch, Tooltip } from "@mui/material";
+import { DarkMode, LightMode } from "@mui/icons-material";
+import { useColorMode } from "../appShell/ColorModeContext";
 
 export default function ColorModeToggle() {
-  const { preference, resolvedMode, setPreference } = useColorMode();
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-
-  const currentIcon =
-    preference === "system" ? (
-      <SettingsBrightness />
-    ) : resolvedMode === "dark" ? (
-      <DarkMode />
-    ) : (
-      <LightMode />
-    );
+  const { resolvedMode, toggleSessionMode } = useColorMode();
+  const isDark = resolvedMode === "dark";
 
   return (
-    <>
-      <Tooltip title="Appearance">
-        <IconButton
-          color="inherit"
-          aria-label="Appearance"
-          aria-haspopup="true"
-          aria-expanded={open ? "true" : "false"}
-          aria-controls={open ? "color-mode-menu" : undefined}
-          onClick={(event) => setAnchorEl(event.currentTarget)}
-        >
-          {currentIcon}
-        </IconButton>
-      </Tooltip>
-      <Menu
-        id="color-mode-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={() => setAnchorEl(null)}
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        transformOrigin={{ vertical: "top", horizontal: "right" }}
-      >
-        {OPTIONS.map((option) => (
-          <MenuItem
-            key={option.value}
-            selected={preference === option.value}
-            onClick={() => {
-              setPreference(option.value);
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemIcon>{option.icon}</ListItemIcon>
-            <ListItemText>{option.label}</ListItemText>
-          </MenuItem>
-        ))}
-      </Menu>
-    </>
+    <Tooltip title={isDark ? "Switch to light mode" : "Switch to dark mode"}>
+      <Switch
+        checked={isDark}
+        onChange={toggleSessionMode}
+        icon={<LightMode fontSize="small" sx={{ p: "1px", color: "warning.main" }} />}
+        checkedIcon={<DarkMode fontSize="small" sx={{ p: "1px", color: "primary.dark" }} />}
+        slotProps={{
+          input: { role: "switch", "aria-label": isDark ? "Switch to light mode" : "Switch to dark mode" },
+        }}
+      />
+    </Tooltip>
   );
 }

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -5,6 +5,7 @@ import { signOut, type User } from "firebase/auth";
 import { auth } from "../../config/firebase";
 import type { UserData } from "../../types";
 import { useEnabledClaim } from "../../features/users/hooks/useEnabledClaim";
+import ColorModeToggle from "./ColorModeToggle";
 
 interface HeaderProps {
   user: User | null;
@@ -118,6 +119,7 @@ export default function Header({
           SODC
         </Typography>
         <Box sx={{ flexGrow: 1 }} />
+        <ColorModeToggle />
         {user ? (
           <>
             <Button

--- a/src/shared/components/PageHeader.tsx
+++ b/src/shared/components/PageHeader.tsx
@@ -41,7 +41,7 @@ export default function PageHeader({ title, onBack, adminAction: adminActionOver
     <Box sx={{ mb: 3 }}>
       {breadcrumbs}
       <Box className="page-header" sx={{ mb: 0 }}>
-        <Typography variant="h4" sx={{ color: "primary.main" }}>
+        <Typography variant="h4" sx={{ color: "primary.light" }}>
           {title}
         </Typography>
         <Box className="page-header-actions">

--- a/src/shared/components/__tests__/ColorModeToggle.test.tsx
+++ b/src/shared/components/__tests__/ColorModeToggle.test.tsx
@@ -4,47 +4,30 @@ import { render, screen } from "../../../test-utils";
 import ColorModeToggle from "../ColorModeToggle";
 
 describe("ColorModeToggle", () => {
-  it("shows the appearance menu with System, Light, and Dark options", async () => {
-    const user = userEvent.setup();
+  it("shows a switch reflecting the current resolved mode", () => {
     render(<ColorModeToggle />);
 
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
-
-    expect(screen.getByRole("menuitem", { name: "System" })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "Light" })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "Dark" })).toBeInTheDocument();
+    expect(screen.getByRole("switch")).toBeInTheDocument();
   });
 
-  it("defaults to System selected", async () => {
+  it("toggling the switch flips resolved mode", async () => {
     const user = userEvent.setup();
     render(<ColorModeToggle />);
 
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    const initiallyChecked = (screen.getByRole("switch") as HTMLInputElement).checked;
+    await user.click(screen.getByRole("switch"));
 
-    expect(screen.getByRole("menuitem", { name: "System" })).toHaveClass("Mui-selected");
+    expect((screen.getByRole("switch") as HTMLInputElement).checked).toBe(!initiallyChecked);
   });
 
-  it("selecting Dark closes the menu and marks Dark as selected next time it's opened", async () => {
+  it("toggling twice returns to the original resolved mode", async () => {
     const user = userEvent.setup();
     render(<ColorModeToggle />);
 
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
-    await user.click(screen.getByRole("menuitem", { name: "Dark" }));
+    const initiallyChecked = (screen.getByRole("switch") as HTMLInputElement).checked;
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("switch"));
 
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
-    expect(screen.getByRole("menuitem", { name: "Dark" })).toHaveClass("Mui-selected");
-  });
-
-  it("selecting Light marks Light as selected next time it's opened", async () => {
-    const user = userEvent.setup();
-    render(<ColorModeToggle />);
-
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
-    await user.click(screen.getByRole("menuitem", { name: "Light" }));
-
-    await user.click(screen.getByRole("button", { name: "Appearance" }));
-    expect(screen.getByRole("menuitem", { name: "Light" })).toHaveClass("Mui-selected");
+    expect((screen.getByRole("switch") as HTMLInputElement).checked).toBe(initiallyChecked);
   });
 });

--- a/src/shared/components/__tests__/ColorModeToggle.test.tsx
+++ b/src/shared/components/__tests__/ColorModeToggle.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "../../../test-utils";
+import ColorModeToggle from "../ColorModeToggle";
+
+describe("ColorModeToggle", () => {
+  it("shows the appearance menu with System, Light, and Dark options", async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+
+    expect(screen.getByRole("menuitem", { name: "System" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Light" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Dark" })).toBeInTheDocument();
+  });
+
+  it("defaults to System selected", async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+
+    expect(screen.getByRole("menuitem", { name: "System" })).toHaveClass("Mui-selected");
+  });
+
+  it("selecting Dark closes the menu and marks Dark as selected next time it's opened", async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    await user.click(screen.getByRole("menuitem", { name: "Dark" }));
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    expect(screen.getByRole("menuitem", { name: "Dark" })).toHaveClass("Mui-selected");
+  });
+
+  it("selecting Light marks Light as selected next time it's opened", async () => {
+    const user = userEvent.setup();
+    render(<ColorModeToggle />);
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    await user.click(screen.getByRole("menuitem", { name: "Light" }));
+
+    await user.click(screen.getByRole("button", { name: "Appearance" }));
+    expect(screen.getByRole("menuitem", { name: "Light" })).toHaveClass("Mui-selected");
+  });
+});

--- a/src/shared/utils/__tests__/cookies.test.ts
+++ b/src/shared/utils/__tests__/cookies.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getCookie, setCookie, removeCookie } from "../cookies";
+
+function clearCookies() {
+  document.cookie.split(";").forEach((cookie) => {
+    const name = cookie.split("=")[0]?.trim();
+    if (name) {
+      document.cookie = `${name}=; max-age=0; path=/`;
+    }
+  });
+}
+
+describe("cookies", () => {
+  beforeEach(() => {
+    clearCookies();
+  });
+
+  it("returns null for a cookie that isn't set", () => {
+    expect(getCookie("missing")).toBeNull();
+  });
+
+  it("sets and reads back a cookie value", () => {
+    setCookie("test-cookie", "dark");
+    expect(getCookie("test-cookie")).toBe("dark");
+  });
+
+  it("URL-encodes and decodes values", () => {
+    setCookie("test-cookie", "a b=c;d");
+    expect(getCookie("test-cookie")).toBe("a b=c;d");
+  });
+
+  it("removeCookie clears a previously set value", () => {
+    setCookie("test-cookie", "dark");
+    removeCookie("test-cookie");
+    expect(getCookie("test-cookie")).toBeNull();
+  });
+
+  it("does not confuse cookies with similar name prefixes", () => {
+    setCookie("theme", "dark");
+    setCookie("theme-extra", "light");
+    expect(getCookie("theme")).toBe("dark");
+    expect(getCookie("theme-extra")).toBe("light");
+  });
+});

--- a/src/shared/utils/cookies.ts
+++ b/src/shared/utils/cookies.ts
@@ -1,0 +1,16 @@
+const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+export function getCookie(name: string): string | null {
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith(`${name}=`));
+  return match ? decodeURIComponent(match.slice(name.length + 1)) : null;
+}
+
+export function setCookie(name: string, value: string): void {
+  document.cookie = `${name}=${encodeURIComponent(value)}; max-age=${ONE_YEAR_SECONDS}; path=/; SameSite=Lax`;
+}
+
+export function removeCookie(name: string): void {
+  document.cookie = `${name}=; max-age=0; path=/; SameSite=Lax`;
+}

--- a/src/test-utils/index.tsx
+++ b/src/test-utils/index.tsx
@@ -1,9 +1,7 @@
 import type { ReactElement } from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
-import { ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { theme } from '../config/theme';
+import { ColorModeProvider } from '../shared/appShell/ColorModeProvider';
 
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient({
@@ -12,10 +10,7 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <CssBaseline />
-        {children}
-      </ThemeProvider>
+      <ColorModeProvider>{children}</ColorModeProvider>
     </QueryClientProvider>
   );
 };
@@ -27,4 +22,3 @@ const customRender = (
 
 export * from '@testing-library/react';
 export { customRender as render };
-

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -1,6 +1,22 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+// JSDOM doesn't implement matchMedia; MUI's useMediaQuery (used by ColorModeProvider to detect
+// the system color-scheme preference) needs it on every render.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
 // Mock Firebase Auth
 vi.mock('../config/firebase', () => ({
   auth: {


### PR DESCRIPTION
## Summary
- Adds `ColorModeProvider`/`useColorMode` (`src/shared/appShell/ColorModeContext.ts` + `ColorModeProvider.tsx`) which resolves the effective theme mode from a persisted System/Light/Dark preference (cookie), or `useMediaQuery('(prefers-color-scheme: dark)')` when the preference is "system".
- **Header**: a simple binary light/dark switch (`ColorModeToggle.tsx`). It always starts from the persisted preference/system resolution on every fresh page load, and toggling it only flips the mode for the current session — it never persists anything. This is a quick override, not the durable setting.
- **Account Settings**: a new "Appearance" section with the durable System/Light/Dark choice (segmented `ToggleButtonGroup`), persisted via a cookie (`src/shared/utils/cookies.ts` — a small dependency-free get/set/remove helper). Choosing an explicit value here takes effect immediately and clears any active session-only override from the Header switch.
- Extends `src/config/theme.ts` with `createAppTheme(mode)`:
  - `primary.main` stays the fixed brand navy in both modes — every usage is either a background (AppBar, avatars) or paired with an explicit white foreground, so it never needs to contrast against the page's own background.
  - A new `primary.light` token lightens in dark mode specifically for heading/link text rendered directly on the page background (~18 call sites moved from `primary.main` to `primary.light`); in light mode it equals the same navy, so no light-mode visual change.
  - `background.default`/`text.secondary` are only overridden for light mode; dark mode uses MUI's own sensible defaults.
- Cookie access is wrapped defensively (try/catch), matching the same defensive pattern used for the local-storage attempt this went through first.
- Filed #359 for a separate site footer (appearance toggle placement reconsideration, legal links, cookie settings) — kept out of scope here.

Fixes #355

## Test plan
- [x] `npx tsc -b` (root) — clean
- [x] `npx vitest run` — 531 passed
- [x] `npx eslint` on all changed files — clean
- [x] Manually verified in browser: Header switch flips light/dark instantly and resets to system on reload without touching the cookie; Account Settings' Appearance selector persists System/Light/Dark via cookie and survives reload; switching Account Settings while a session override is active immediately takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)