### PR TITLE
Fix: ACCESS-only purpose no longer counts as section membership

### DIFF
--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -301,4 +301,32 @@ describe("getSectionMembersMerged", () => {
       expect.objectContaining({ id: "user-2", sharesContactInfo: false, email: null }),
     ]);
   });
+
+  it("returns no members for a section with only an ACCESS-purpose group and no MEMBER group (#322)", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "MEMBERS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: null,
+                users: [{ user: member() }],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toEqual([]);
+  });
 });

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -154,9 +154,10 @@ export const getSectionMembersMerged = onCall(
         return { members: [] };
       }
 
+      // A section only has members if it has an explicit MEMBER-purpose group — ACCESS/MODERATOR
+      // only grant seeing the section, not membership. See #322.
       const links = sectionData.purposeLinks ?? [];
-      const memberLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
-      const sourceLinks = memberLinks.length > 0 ? memberLinks : links.filter((p) => linkHasPurpose(p, "ACCESS"));
+      const sourceLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
 
       const statuses = new Set<string>();
       const explicitMap = new Map<string, SectionMemberResponse>();

--- a/src/features/admin/components/ManageSectionsSurfaces.tsx
+++ b/src/features/admin/components/ManageSectionsSurfaces.tsx
@@ -270,7 +270,16 @@ export function SectionEditorDialogSurface({
                 No user groups assigned to this section.
               </Alert>
             ) : (
-              <TableContainer component={Paper} sx={{ mb: 2 }}>
+              <>
+                {sectionType === "MEMBERS" &&
+                  !sectionUserGroups.some((group) => group.purpose === SectionUserGroupPurpose.MEMBER) && (
+                    <Alert severity="warning" sx={{ mb: 2 }}>
+                      This section has no MEMBER-purpose group, so it has no members — ACCESS/MODERATOR only
+                      grant seeing the section, not membership. Add a MEMBER-purpose group below if this
+                      section should have a member list.
+                    </Alert>
+                  )}
+                <TableContainer component={Paper} sx={{ mb: 2 }}>
                 <Table size="small">
                   <TableHead>
                     <TableRow>
@@ -321,7 +330,8 @@ export function SectionEditorDialogSurface({
                     ))}
                   </TableBody>
                 </Table>
-              </TableContainer>
+                </TableContainer>
+              </>
             )}
 
             <Button

--- a/src/features/admin/components/__tests__/ManageSectionsSurfaces.test.tsx
+++ b/src/features/admin/components/__tests__/ManageSectionsSurfaces.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "../../../../test-utils";
+import { SectionUserGroupPurpose } from "@dataconnect/generated";
+import { SectionEditorDialogSurface } from "../ManageSectionsSurfaces";
+import type { SectionUserGroupRow, SectionWithDetails } from "../manageSectionsTypes";
+
+const editingSection: SectionWithDetails = {
+  id: "section-1",
+  name: "Test Section",
+  type: "MEMBERS" as SectionWithDetails["type"],
+  description: null,
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+function renderDialog(overrides: {
+  sectionUserGroups: SectionUserGroupRow[];
+  sectionType?: SectionWithDetails["type"];
+}) {
+  return render(
+    <SectionEditorDialogSurface
+      open
+      editingSection={editingSection}
+      sectionName="Test Section"
+      sectionType={overrides.sectionType ?? editingSection.type}
+      sectionDescription=""
+      submitting={false}
+      loadingUserGroups={false}
+      sectionUserGroups={overrides.sectionUserGroups}
+      removingUserGroupId={null}
+      onClose={vi.fn()}
+      onSubmit={vi.fn()}
+      onSectionNameChange={vi.fn()}
+      onSectionTypeChange={vi.fn()}
+      onSectionDescriptionChange={vi.fn()}
+      onOpenAddUserGroup={vi.fn()}
+      onRemoveUserGroup={vi.fn()}
+    />
+  );
+}
+
+const WARNING_TEXT = /no members/i;
+
+describe("SectionEditorDialogSurface — MEMBER-purpose warning (#322)", () => {
+  it("warns when a MEMBERS section has ACCESS-only groups and no MEMBER group", () => {
+    renderDialog({
+      sectionUserGroups: [
+        { id: "group-1", name: "Access Group", description: null, purpose: SectionUserGroupPurpose.ACCESS },
+      ],
+    });
+
+    expect(screen.getByText(WARNING_TEXT)).toBeInTheDocument();
+  });
+
+  it("does not warn when the section has a MEMBER-purpose group", () => {
+    renderDialog({
+      sectionUserGroups: [
+        { id: "group-1", name: "Access Group", description: null, purpose: SectionUserGroupPurpose.ACCESS },
+        { id: "group-2", name: "Member Group", description: null, purpose: SectionUserGroupPurpose.MEMBER },
+      ],
+    });
+
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("does not warn when the section has no user groups at all", () => {
+    renderDialog({ sectionUserGroups: [] });
+
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("does not warn for an EVENTS section without a MEMBER group", () => {
+    renderDialog({
+      sectionType: "EVENTS" as SectionWithDetails["type"],
+      sectionUserGroups: [
+        { id: "group-1", name: "Access Group", description: null, purpose: SectionUserGroupPurpose.ACCESS },
+      ],
+    });
+
+    expect(screen.queryByText(WARNING_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/sections/utils/__tests__/sectionHelpers.test.ts
+++ b/src/features/sections/utils/__tests__/sectionHelpers.test.ts
@@ -139,7 +139,7 @@ describe('sectionHelpers', () => {
       expect(result.map((u) => u.userId)).toEqual(['user-1', 'user-2', 'user-3']);
     });
 
-    it('should use ACCESS purpose when no MEMBER links exist', () => {
+    it('should return no members when the section only has ACCESS purpose links (no MEMBER group configured)', () => {
       const sectionData = {
         purposeLinks: [
           {
@@ -164,7 +164,7 @@ describe('sectionHelpers', () => {
       };
 
       const result = getAllUsersFromSection(sectionData as any);
-      expect(result).toHaveLength(1);
+      expect(result).toHaveLength(0);
     });
 
     it('should prefer MEMBER links over ACCESS for rollup', () => {
@@ -255,7 +255,7 @@ describe('sectionHelpers', () => {
       });
     });
 
-    it('should fall back to ACCESS groups when no MEMBER links', () => {
+    it('should return no member groups when the section only has ACCESS purpose links (no MEMBER group configured)', () => {
       const sectionData = {
         purposeLinks: [
           {
@@ -271,8 +271,7 @@ describe('sectionHelpers', () => {
       };
 
       const result = getMemberGroups(sectionData as any);
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('view-group-1');
+      expect(result).toHaveLength(0);
     });
   });
 

--- a/src/features/sections/utils/bookingEligibility.ts
+++ b/src/features/sections/utils/bookingEligibility.ts
@@ -1,4 +1,5 @@
 import type { MembershipStatus } from "@dataconnect/generated";
+import { linkHasPurpose } from "./purposeLinks";
 
 /** Mirrors server `bookingRules.userMatchesUserGroup` for client-side previews. */
 export function userMatchesUserGroup(
@@ -14,10 +15,6 @@ export function userMatchesUserGroup(
 
 export function purposeGrantsSectionAccess(purpose: string): boolean {
   return purpose === "ACCESS" || purpose === "MODERATOR";
-}
-
-function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  return link.purpose === target || (link.purposes?.includes(target) ?? false);
 }
 
 export function userHasSectionAccess(

--- a/src/features/sections/utils/purposeLinks.ts
+++ b/src/features/sections/utils/purposeLinks.ts
@@ -1,0 +1,8 @@
+export interface PurposeBearingLink {
+  purpose?: string;
+  purposes?: string[] | null;
+}
+
+export function linkHasPurpose(link: PurposeBearingLink, target: string): boolean {
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
+}

--- a/src/features/sections/utils/sectionHelpers.ts
+++ b/src/features/sections/utils/sectionHelpers.ts
@@ -1,4 +1,5 @@
 import type { SectionType, MembershipStatus, SectionUserGroupPurpose } from "@dataconnect/generated";
+import { linkHasPurpose, type PurposeBearingLink } from "./purposeLinks";
 
 /**
  * Flattened user data from section member list
@@ -36,11 +37,6 @@ export function isMembersSection(section: { type: SectionType }): boolean {
   return section.type === "MEMBERS";
 }
 
-type PurposeBearingLink = {
-  purpose?: string;
-  purposes?: string[] | null;
-};
-
 type PurposeLinkWithUsers = PurposeBearingLink & {
   userGroup: {
     id: string;
@@ -58,22 +54,19 @@ type PurposeLinkWithUsers = PurposeBearingLink & {
   };
 };
 
-// TODO: Extract to a shared utility module and reuse across bookingEligibility, sections, and bookingRules.
-function linkHasPurpose(link: PurposeBearingLink, target: string): boolean {
-  return link.purpose === target || (link.purposes?.includes(target) ?? false);
-}
-
 type SectionDataWithPurposeLinks = {
   purposeLinks?: PurposeLinkWithUsers[];
 };
 
-/** MEMBER-purpose groups for rollup; if none, ACCESS-purpose groups (legacy fallback). */
+/**
+ * MEMBER-purpose groups for rollup. A section only has members if it has an explicit
+ * MEMBER-purpose group — ACCESS/MODERATOR only grant seeing the section, not membership. See #322.
+ */
 function getRollupPurposeLinks(
   sectionData: SectionDataWithPurposeLinks | null | undefined
 ): PurposeLinkWithUsers[] {
   const links = sectionData?.purposeLinks ?? [];
-  const memberLinks = links.filter((l) => linkHasPurpose(l, "MEMBER"));
-  return memberLinks.length > 0 ? memberLinks : links.filter((l) => linkHasPurpose(l, "ACCESS"));
+  return links.filter((l) => linkHasPurpose(l, "MEMBER"));
 }
 
 /**
@@ -143,7 +136,7 @@ type SectionMemberGroupData = {
 };
 
 /**
- * Member-list / subscription groups: MEMBER purpose, or ACCESS if no MEMBER rows (legacy fallback).
+ * Member-list / subscription groups: only groups with an explicit MEMBER-purpose link. See #322.
  */
 export function getMemberGroups(
   sectionData: SectionMemberGroupData | null | undefined,
@@ -157,9 +150,9 @@ export function getMemberGroups(
   if (!sectionData?.purposeLinks?.length) {
     return [];
   }
-  const member = sectionData.purposeLinks.filter((l) => linkHasPurpose(l, "MEMBER"));
-  const source = member.length > 0 ? member : sectionData.purposeLinks.filter((l) => linkHasPurpose(l, "ACCESS"));
-  return source.map((groupRelation) => groupRelation.userGroup);
+  return sectionData.purposeLinks
+    .filter((l) => linkHasPurpose(l, "MEMBER"))
+    .map((groupRelation) => groupRelation.userGroup);
 }
 
 /**


### PR DESCRIPTION
## Summary
- **The bug**: a section with only ACCESS/MODERATOR-purpose user groups (no MEMBER-purpose group configured) silently showed all of those users as section "members" — a fallback presumably added for sections predating the MEMBER purpose. Fixed both:
  - **Server-side** (`functions/src/sections.ts`, `getSectionMembersMerged`) — the actual data behind a section's member list/count. This is the real-world-impacting half of the bug.
  - **Client-side** (`sectionHelpers.ts`'s `getRollupPurposeLinks`/`getMemberGroups`) — used for subscribe/unsubscribe eligibility (`SectionDetail.tsx`).
- A section's member list is now empty unless it has an explicit MEMBER-purpose group. No more silent ACCESS→member leakage, and no way for a newly-misconfigured section to hit the same bug going forward.
- Extracted the duplicated `linkHasPurpose` helper (`sectionHelpers.ts`, `bookingEligibility.ts`) into a shared `src/features/sections/utils/purposeLinks.ts`, per the pre-existing `// TODO` in `sectionHelpers.ts`.
- Added a warning in `ManageSections.tsx`'s section editor: editing a MEMBERS section with ACCESS/MODERATOR groups but no MEMBER group now visibly flags it, so admins can add one where the old fallback used to silently paper over it.

Fixes #322

## Test plan
- [x] `npx tsc -b` (root) and `npx tsc --noEmit -p .` (functions) — clean
- [x] `npx vitest run` — 535 passed (root), 351 passed (functions, includes a new regression test for the exact bug scenario)
- [x] `npx eslint` on all changed root files — clean (functions/ eslint has a pre-existing, unrelated local tooling issue that reproduces even on untouched files — not part of CI's gate)
- [x] Added new tests: server-side regression test asserting empty members for an ACCESS-only section; updated the two client-side tests that previously asserted the old fallback behavior; new `ManageSectionsSurfaces.test.tsx` covering the new admin warning (shown/not shown across MEMBERS-with-MEMBER-group, MEMBERS-without, no-groups, and EVENTS-section cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)