### PR TITLE
Only send announcement personalisation fields the template actually uses

### DIFF
--- a/functions/src/__tests__/announcements.test.ts
+++ b/functions/src/__tests__/announcements.test.ts
@@ -91,6 +91,23 @@ describe("extractTemplateVariables", () => {
   it("returns an empty array for a template with no placeholders", () => {
     expect(extractTemplateVariables("Just plain text.", "A subject")).toEqual([]);
   });
+
+  it("ignores an unclosed placeholder", () => {
+    expect(extractTemplateVariables("Hi ((firstName, no closing", "")).toEqual([]);
+  });
+
+  it("runs in linear time on adversarial input (no regex backtracking blowup)", () => {
+    // A long run of unmatched "(" is the classic trigger for catastrophic/polynomial regex
+    // backtracking on patterns like /\(\(([^)]+)\)\)/g. Template body/subject comes from GOV
+    // Notify, not something this app controls the shape of, so this must stay fast regardless.
+    const adversarial = "(".repeat(200_000);
+    const start = performance.now();
+    const result = extractTemplateVariables(adversarial, "");
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toEqual([]);
+    expect(elapsedMs).toBeLessThan(200);
+  });
 });
 
 describe("buildRecipientPersonalisation (#362)", () => {

--- a/functions/src/__tests__/announcements.test.ts
+++ b/functions/src/__tests__/announcements.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as admin from "@dataconnect/admin-generated";
-import { getAnnouncementSendRecipients } from "../announcements";
+import {
+  getAnnouncementSendRecipients,
+  extractTemplateVariables,
+  buildRecipientPersonalisation,
+} from "../announcements";
 
 const mockGetAnnouncementSendById = vi.spyOn(admin, "getAnnouncementSendById");
 const mockGetAnnouncementSendRecipients = vi.spyOn(admin, "getAnnouncementSendRecipients");
@@ -70,5 +74,74 @@ describe("getAnnouncementSendRecipients", () => {
     await expect(
       callAsAdmin({ sectionId: sectionAId, sendId: "00000000-0000-4000-8000-000000000000" })
     ).rejects.toMatchObject({ code: "not-found" });
+  });
+});
+
+describe("extractTemplateVariables", () => {
+  it("extracts placeholders from body and subject", () => {
+    expect(extractTemplateVariables("Hi ((firstName)), see ((section)) news", "((section)) update")).toEqual(
+      expect.arrayContaining(["firstName", "section"])
+    );
+  });
+
+  it("deduplicates repeated placeholders", () => {
+    expect(extractTemplateVariables("((firstName)) ((firstName))", "")).toEqual(["firstName"]);
+  });
+
+  it("returns an empty array for a template with no placeholders", () => {
+    expect(extractTemplateVariables("Just plain text.", "A subject")).toEqual([]);
+  });
+});
+
+describe("buildRecipientPersonalisation (#362)", () => {
+  const recipient = {
+    firstName: "Ada",
+    lastName: "Lovelace",
+    email: "ada@example.com",
+    serviceNumber: "S123456",
+    membershipStatus: "REGULAR",
+  };
+
+  it("includes only the fields the template actually references", () => {
+    const result = buildRecipientPersonalisation(
+      recipient,
+      "Signals",
+      "https://example.com/unsubscribe?token=abc",
+      ["firstName", "section"]
+    );
+
+    expect(result).toEqual({ firstName: "Ada", section: "Signals" });
+  });
+
+  it("returns an empty object for a template with no placeholders", () => {
+    const result = buildRecipientPersonalisation(
+      recipient,
+      "Signals",
+      "https://example.com/unsubscribe?token=abc",
+      []
+    );
+
+    expect(result).toEqual({});
+  });
+
+  it("never includes fields the template doesn't reference, even PII fields like serviceNumber/membershipStatus", () => {
+    const result = buildRecipientPersonalisation(
+      recipient,
+      "Signals",
+      "https://example.com/unsubscribe?token=abc",
+      ["firstName"]
+    );
+
+    expect(result).not.toHaveProperty("serviceNumber");
+    expect(result).not.toHaveProperty("membershipStatus");
+    expect(result).not.toHaveProperty("email");
+  });
+
+  it("includes unsubscribeUrl in personalisation only when the template references it", () => {
+    const withRef = buildRecipientPersonalisation(recipient, "Signals", "https://x/unsub", ["unsubscribeUrl"]);
+    const withoutRef = buildRecipientPersonalisation(recipient, "Signals", "https://x/unsub", ["firstName"]);
+
+    expect(withRef.unsubscribeUrl).toBe("https://x/unsub");
+    expect(withoutRef).not.toHaveProperty("unsubscribeUrl");
   });
 });

--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -165,10 +165,26 @@ async function resolveRecipients(sectionId: string, callerUid: string): Promise<
 
 // ── Personalisation helpers ───────────────────────────────────────────────────
 
+/**
+ * Extracts GOV Notify ((placeholder)) tokens from template content. A manual scan rather than a
+ * regex — `/\(\(([^)]+)\)\)/g` is vulnerable to polynomial-time backtracking on adversarial input
+ * (e.g. a long run of unmatched "(" characters), and template body/subject comes from GOV Notify,
+ * not something we control the format of.
+ */
 export function extractTemplateVariables(body: string, subject: string): string[] {
   const text = `${body} ${subject}`;
-  const matches = [...text.matchAll(/\(\(([^)]+)\)\)/g)];
-  return [...new Set(matches.map((m) => m[1].trim()))];
+  const found = new Set<string>();
+  let index = 0;
+  while (index < text.length) {
+    const start = text.indexOf("((", index);
+    if (start === -1) break;
+    const end = text.indexOf("))", start + 2);
+    if (end === -1) break;
+    const name = text.slice(start + 2, end).trim();
+    if (name) found.add(name);
+    index = end + 2;
+  }
+  return [...found];
 }
 
 /**

--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -165,10 +165,41 @@ async function resolveRecipients(sectionId: string, callerUid: string): Promise<
 
 // ── Personalisation helpers ───────────────────────────────────────────────────
 
-function extractTemplateVariables(body: string, subject: string): string[] {
+export function extractTemplateVariables(body: string, subject: string): string[] {
   const text = `${body} ${subject}`;
   const matches = [...text.matchAll(/\(\(([^)]+)\)\)/g)];
   return [...new Set(matches.map((m) => m[1].trim()))];
+}
+
+/**
+ * Filters a recipient's full candidate personalisation down to only the keys the selected
+ * template actually references. GOV Notify ignores extra personalisation keys at render time,
+ * but that doesn't stop the data being sent — every field here is member PII, so we only
+ * transmit what the template will actually display. See #362.
+ */
+export function buildRecipientPersonalisation(
+  recipient: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    serviceNumber: string;
+    membershipStatus: string;
+  },
+  sectionName: string,
+  unsubscribeUrl: string,
+  requiredPersonalisation: string[]
+): Record<string, string> {
+  const candidate: Record<string, string> = {
+    firstName: recipient.firstName,
+    lastName: recipient.lastName,
+    email: recipient.email,
+    serviceNumber: recipient.serviceNumber,
+    membershipStatus: recipient.membershipStatus,
+    section: sectionName,
+    unsubscribeUrl,
+  };
+  const required = new Set(requiredPersonalisation);
+  return Object.fromEntries(Object.entries(candidate).filter(([key]) => required.has(key)));
 }
 
 const PREVIEW_PLACEHOLDERS: Record<string, string> = {
@@ -288,11 +319,19 @@ interface AnnouncementEmailTask {
   lastName: string;
   email: string;
   personalisation: Record<string, string>;
+  /**
+   * Always present regardless of whether the template's visible text references
+   * ((unsubscribeUrl)) — GOV Notify requires a one-click-unsubscribe URL for bulk email
+   * independent of what the template body displays. Kept separate from `personalisation`
+   * (which is filtered down to only what the template references) so filtering can never
+   * silently disable this.
+   */
+  unsubscribeUrl: string;
   templateUuid: string;
 }
 
 export const sendSectionAnnouncement = onCall(
-  { region: FUNCTIONS_REGION, secrets: [unsubscribeSecret] },
+  { region: FUNCTIONS_REGION, secrets: [unsubscribeSecret, govNotifyApiKey] },
   async (request): Promise<SendAnnouncementResult> => {
     requireAuth(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
@@ -303,6 +342,13 @@ export const sendSectionAnnouncement = onCall(
     const callerUid = request.auth!.uid;
 
     await requireSectionModerator(callerUid, sectionId, request.auth!.token?.admin === true);
+
+    const apiKey = govNotifyApiKey.value();
+    if (!apiKey) throw new HttpsError("failed-precondition", "GOV_NOTIFY_API_KEY not configured");
+    const client = new NotifyClient(apiKey);
+    const templateResponse = await client.getTemplateById(templateUuid);
+    const template = templateResponse.data as { body?: string; subject?: string };
+    const requiredPersonalisation = extractTemplateVariables(template.body ?? "", template.subject ?? "");
 
     const [{ recipients, sectionName }, optOutResult] = await Promise.all([
       resolveRecipients(sectionId, callerUid),
@@ -330,23 +376,22 @@ export const sendSectionAnnouncement = onCall(
         continue;
       }
 
-      const personalisation: Record<string, string> = {
-        firstName: recipient.firstName,
-        lastName: recipient.lastName,
-        email: recipient.email,
-        serviceNumber: recipient.serviceNumber,
-        membershipStatus: recipient.membershipStatus,
-        section: sectionName,
-        unsubscribeUrl: `${APP_BASE_URL}/unsubscribe?token=${signUnsubscribeToken(
-          {
-            userId: recipient.id,
-            sectionId,
-            sectionName,
-            exp: Date.now() + 90 * 24 * 60 * 60 * 1000,
-          },
-          secret
-        )}`,
-      };
+      const unsubscribeUrl = `${APP_BASE_URL}/unsubscribe?token=${signUnsubscribeToken(
+        {
+          userId: recipient.id,
+          sectionId,
+          sectionName,
+          exp: Date.now() + 90 * 24 * 60 * 60 * 1000,
+        },
+        secret
+      )}`;
+
+      const personalisation = buildRecipientPersonalisation(
+        recipient,
+        sectionName,
+        unsubscribeUrl,
+        requiredPersonalisation
+      );
 
       tasks.push({
         sendId: "",  // filled in after createAnnouncementSend
@@ -355,6 +400,7 @@ export const sendSectionAnnouncement = onCall(
         lastName: recipient.lastName,
         email: recipient.email,
         personalisation,
+        unsubscribeUrl,
         templateUuid,
       });
     }
@@ -418,7 +464,7 @@ export const processAnnouncementEmail = onTaskDispatched<AnnouncementEmailTask>(
     retryConfig: { maxAttempts: 3, minBackoffSeconds: 10, maxBackoffSeconds: 60 },
   },
   async (req) => {
-    const { sendId, recipientId, firstName, lastName, email, personalisation, templateUuid } = req.data;
+    const { sendId, recipientId, firstName, lastName, email, personalisation, unsubscribeUrl, templateUuid } = req.data;
 
     const client = new NotifyClient(govNotifyApiKey.value());
     let status: "sent" | "failed" = "sent";
@@ -428,7 +474,7 @@ export const processAnnouncementEmail = onTaskDispatched<AnnouncementEmailTask>(
       await client.sendEmail(templateUuid, email, {
         personalisation,
         reference: buildAnnouncementReference(sendId, recipientId),
-        oneClickUnsubscribeURL: personalisation.unsubscribeUrl,
+        oneClickUnsubscribeURL: unsubscribeUrl,
       } as Parameters<typeof client.sendEmail>[2]);
     } catch (err) {
       status = "failed";


### PR DESCRIPTION
## Summary
- **The gap**: `sendSectionAnnouncement` (`functions/src/announcements.ts`) built the same fixed personalisation payload — `firstName`, `lastName`, `email`, `serviceNumber`, `membershipStatus`, `section`, `unsubscribeUrl` — for every recipient on every send, regardless of which of those fields the selected GOV Notify template actually references. GOV Notify ignores extra personalisation keys when *rendering*, but that doesn't stop the data being *sent* — every announcement transmitted full member PII (service number, membership status) to a third-party processor even for a plain-text template that displays none of it. A real data-minimization gap given this is a UK club and UK GDPR applies.
- **Fix**: fetches the selected template's body/subject once via `client.getTemplateById` (a `notifications-node-client` method not previously used in this file), reuses the existing `extractTemplateVariables` helper (already used for a read-only template listing, `requiredPersonalisation`, but never to filter what's actually sent) to compute which `((placeholder))` keys the template references, and filters each recipient's personalisation down to just those fields via a new `buildRecipientPersonalisation`.
- **Important nuance handled carefully**: GOV Notify's one-click-unsubscribe header (`oneClickUnsubscribeURL`) is a compliance requirement for bulk mail, independent of whether the template's *visible text* references `((unsubscribeUrl))`. Previously it was read straight off `personalisation.unsubscribeUrl` — if that key got filtered out for a template that doesn't display an unsubscribe link, one-click unsubscribe would have silently broken. Fixed by threading `unsubscribeUrl` through as its own dedicated task field, decoupled from the (now-filtered) `personalisation` object.
- `previewAnnouncementTemplate` (admin template preview, uses fake sample data) is unaffected — no real PII involved, no need to filter.

Fixes #362

## Test plan
- [x] `npx tsc --noEmit -p .` (functions) — clean
- [x] `npx vitest run` (functions) — 358 passed, including 6 new tests covering: template-with-some-fields gets only those fields, template-with-no-fields gets an empty object, PII fields (serviceNumber/membershipStatus/email) never leak when unreferenced, and unsubscribeUrl inclusion in *personalisation* correctly depends on whether the template references it (independent of the always-present dedicated `unsubscribeUrl` task field used for one-click unsubscribe)
- [x] Root `npx tsc -b` — clean (no client-side surface changed)
- Not covered: a full end-to-end integration test of `sendSectionAnnouncement`/`processAnnouncementEmail` — this function had no test coverage at all before this PR (would require mocking `NotifyClient`, Cloud Tasks, and several Data Connect admin queries together); scoped this fix's tests to the new filtering logic itself via focused, easily-verified pure-function tests rather than taking on that pre-existing gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)