### PR TITLE
Notify admins when a new user enters the approval queue

### DIFF
--- a/docs/operations/govuk-notify-pending-approval-templates.md
+++ b/docs/operations/govuk-notify-pending-approval-templates.md
@@ -1,0 +1,50 @@
+# GOV.UK Notify: pending-approval admin alert
+
+This template sends an **internal** email to all admins when a new user enters the **Approve Users** queue. Implementation: [`functions/src/pendingApprovalAdminAlert.ts`](../../functions/src/pendingApprovalAdminAlert.ts), wired from [`functions/src/users.ts`](../../functions/src/users.ts) (`syncPendingUserClaims`).
+
+Recipients are **all current Firebase Auth admins** (`getAdminUsers()`, same pattern as guest-ticket moderator alerts) — no separate ops env var, unlike payment ops alerts.
+
+**Source of truth:** Personalisation **keys** in this document must match the object sent to Notify.
+
+**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+
+## Configuration
+
+| Logical key (code) | Firebase / runtime env var for template UUID |
+|---------------------|-----------------------------------------------|
+| `newUserPendingApprovalAlert` | `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT` |
+
+Env var name follows [`govNotifyTemplateEnvVarName`](../../functions/src/mailer.ts).
+
+Also required for sends: `GOV_NOTIFY_API_KEY` (secret), optional `GOV_NOTIFY_EMAIL_REPLY_TO_ID`, and **`APP_BASE_URL`** for the Approve Users deep link (see [environment-and-secrets.md](./environment-and-secrets.md)).
+
+## Trigger
+
+`syncPendingUserClaims` runs both at registration and again after profile submission (so the `enabled` claim is never left unset). On each call it checks `isUserPendingApproval` (verified email + `enabled` claim not true + membership status awaiting approval, from [`pendingUserApproval.ts`](../../functions/src/pendingUserApproval.ts)) — the alert only fires once that's actually true, i.e. in practice after profile submission (email verification is already required to reach profile completion).
+
+**No send:** user has no Data Connect profile yet (pre-profile-submission registration call); email not verified; membership status not awaiting approval (e.g. already enabled, or an admin-created account); no admin recipients.
+
+## Notify `reference` field
+
+`PENDING_APPROVAL:<userId>`.
+
+## Delivery key
+
+`pending-approval:<userId>:<adminEmail>` — deduped per admin, so adding a new admin later or `syncPendingUserClaims` firing again for the same still-pending user only emails admins who haven't already been notified about this user.
+
+## Template: `newUserPendingApprovalAlert`
+
+| Key | Semantics |
+|-----|-----------|
+| `firstName` | User's first name |
+| `lastName` | User's last name |
+| `email` | User's email |
+| `serviceNumber` | User's service number |
+| `serviceBackgroundSummary` | Comma-joined service background flags, e.g. `Regular, Reserve`, or `Not specified` |
+| `requestedMembershipStatus` | Requested membership status, falling back to current status or `—` |
+| `approveUsersUrl` | `APP_BASE_URL` (normalised) + `/admin/users/approvals` |
+
+## Related docs
+
+- [transactional-email-policy.md](./transactional-email-policy.md)
+- [govuk-notify-membership-templates.md](./govuk-notify-membership-templates.md) — membership status change emails to the member

--- a/docs/operations/govuk-notify-sample-personalisation.json
+++ b/docs/operations/govuk-notify-sample-personalisation.json
@@ -125,5 +125,14 @@
     "previousTotalFormatted": "35.00 GBP",
     "revisedTotalFormatted": "50.00 GBP",
     "deltaAmountFormatted": "+15.00 GBP"
+  },
+  "newUserPendingApprovalAlert": {
+    "firstName": "Ada",
+    "lastName": "Lovelace",
+    "email": "ada@example.com",
+    "serviceNumber": "S123456",
+    "serviceBackgroundSummary": "Regular, Reserve",
+    "requestedMembershipStatus": "Regular",
+    "approveUsersUrl": "https://app.example/admin/users/approvals"
   }
 }

--- a/docs/operations/govuk-notify-template-copy.md
+++ b/docs/operations/govuk-notify-template-copy.md
@@ -344,3 +344,30 @@ Payments: ((myPaymentsUrl))
 ```
 
 **Placeholders used:** all confirmation keys plus `previousRevisionNumber`, `revisedRevisionNumber`, `paymentAdjustmentStatus`, `previousTotalFormatted`, `revisedTotalFormatted`, `deltaAmountFormatted`
+
+---
+
+## Internal approval queue
+
+### `newUserPendingApprovalAlert`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT`
+
+**Subject:** [SODC] New member awaiting approval — ((firstName)) ((lastName))
+
+**Body:**
+
+```
+A new member has completed their profile and is awaiting approval.
+
+Name: ((firstName)) ((lastName))
+Email: ((email))
+Service number: ((serviceNumber))
+Service background: ((serviceBackgroundSummary))
+Requested status: ((requestedMembershipStatus))
+
+Review in Approve Users:
+((approveUsersUrl))
+```
+
+**Placeholders used:** `firstName`, `lastName`, `email`, `serviceNumber`, `serviceBackgroundSummary`, `requestedMembershipStatus`, `approveUsersUrl`

--- a/docs/operations/govuk-notify-template-registration.md
+++ b/docs/operations/govuk-notify-template-registration.md
@@ -39,10 +39,11 @@ Use this checklist when creating templates in Notify for **Dev**, **Beta**, and 
 | `guestTicketRequestRejected` | `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_REJECTED` | | | | [ ] |
 | `bookingConfirmation` | `GOV_NOTIFY_TEMPLATE_BOOKING_CONFIRMATION` | | | | [ ] |
 | `bookingRevision` | `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION` | | | | [ ] |
+| `newUserPendingApprovalAlert` | `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT` | | | | [ ] |
 
 ## Suggested order
 
-1. Dev — all 12 templates, then E2E smoke tests  
+1. Dev — all 13 templates, then E2E smoke tests  
 2. Beta — clone copy, new UUIDs, repeat smoke tests  
 3. Prod — final copy review, register UUIDs, enable sends  
 

--- a/docs/operations/transactional-email-policy.md
+++ b/docs/operations/transactional-email-policy.md
@@ -26,6 +26,7 @@ Sent because of a **user action or system state change** the user or operator mu
 | Membership access | Account activated, access restricted | No — tied to status change |
 | Guest ticket moderation | Moderator alert, approve/reject to booker | No — tied to request workflow |
 | Internal payment ops | Reconciliation exception, dispute alert | N/A (internal recipients only) |
+| Internal approval queue | New user entering Approve Users queue | N/A (internal recipients only) |
 
 **Rules**
 
@@ -59,6 +60,7 @@ Lower priority or bulk-style messages. **Do not implement** without explicit pro
 | Membership | `membershipActivated`, `membershipAccessRestricted` |
 | Guest tickets | `guestTicketRequestSubmittedModerator`, `guestTicketRequestApproved`, `guestTicketRequestRejected` |
 | Bookings | `bookingConfirmation`, `bookingRevision` |
+| Approval queue (internal) | `newUserPendingApprovalAlert` |
 
 Configuration: [environment-and-secrets.md](./environment-and-secrets.md). Registration: [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
 

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -83,6 +83,18 @@ flowchart LR
 | **Templates** | `bookingConfirmation` (new booking); `bookingRevision` (supersedes prior booking) |
 | **Deep dive** | [govuk-notify-booking-templates.md](./govuk-notify-booking-templates.md) |
 
+### Approval queue (internal)
+
+| | |
+|---|---|
+| **Trigger** | `syncPendingUserClaims` (runs at registration and again after profile submit) where the user is newly `isUserPendingApproval` (verified email + `enabled` claim not true + membership status awaiting approval) |
+| **Entrypoint** | [`users.ts`](../../functions/src/users.ts) → [`pendingApprovalAdminAlert.ts`](../../functions/src/pendingApprovalAdminAlert.ts) |
+| **Recipient** | All current admins (`getAdminUsers()`) |
+| **No send** | No Data Connect profile yet; email not verified; membership status not awaiting approval; no admin recipients |
+| **Delivery key** | `pending-approval:{userId}:{adminEmail}` |
+| **Templates** | `newUserPendingApprovalAlert` |
+| **Deep dive** | [govuk-notify-pending-approval-templates.md](./govuk-notify-pending-approval-templates.md) |
+
 ## Manual QA (Beta)
 
 After templates are provisioned per Firebase environment (see [govuk-notify-template-registration.md](./govuk-notify-template-registration.md)):
@@ -93,6 +105,7 @@ After templates are provisioned per Firebase environment (see [govuk-notify-temp
 - [ ] Admin activates member / restricts member → correct user email
 - [ ] Guest ticket submit → moderator inboxes; approve/reject → booker
 - [ ] New booking → confirmation; revision → revision email; same idempotency key replay → no second email
+- [ ] Register, verify email, complete profile → admin alert; repeat profile-submit call → no second email to the same admin
 
 ## Related issues
 

--- a/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
+++ b/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserRecord } from "firebase-admin/auth";
+import * as dc from "@dataconnect/admin-generated";
+import { MembershipStatus } from "@dataconnect/admin-generated";
+import * as helpers from "../helpers";
+import * as notificationDelivery from "../notificationDelivery";
+import {
+  notifyAdminsUserPendingApproval,
+  pendingApprovalDeliveryKey,
+  summarizeServiceBackground,
+} from "../pendingApprovalAdminAlert";
+
+const mockGetUserById = vi.spyOn(dc, "getUserById");
+const mockGetAdminUsers = vi.spyOn(helpers, "getAdminUsers");
+const mockSendOnce = vi.spyOn(notificationDelivery, "sendNotificationOnce");
+
+const userId = "00000000-0000-4000-8000-000000000001";
+
+function profile(overrides: Partial<{
+  firstName: string;
+  lastName: string;
+  email: string;
+  serviceNumber: string;
+  membershipStatus: string;
+  requestedMembershipStatus: string | null;
+  isRegular: boolean | null;
+  isReserve: boolean | null;
+  isCivilServant: boolean | null;
+  isIndustry: boolean | null;
+}> = {}) {
+  return {
+    id: userId,
+    firstName: "Ada",
+    lastName: "Lovelace",
+    email: "ada@example.com",
+    serviceNumber: "S123456",
+    membershipStatus: MembershipStatus.PENDING,
+    requestedMembershipStatus: MembershipStatus.REGULAR,
+    isRegular: true,
+    isReserve: false,
+    isCivilServant: false,
+    isIndustry: false,
+    ...overrides,
+  };
+}
+
+function mockAdminUser(email: string) {
+  return { uid: `admin-${email}`, email } as unknown as UserRecord & { email: string };
+}
+
+describe("summarizeServiceBackground", () => {
+  it("joins the set flags", () => {
+    expect(summarizeServiceBackground({ isRegular: true, isReserve: true })).toBe("Regular, Reserve");
+  });
+
+  it("returns a placeholder when nothing is set", () => {
+    expect(summarizeServiceBackground({})).toBe("Not specified");
+    expect(
+      summarizeServiceBackground({ isRegular: false, isReserve: null, isCivilServant: undefined })
+    ).toBe("Not specified");
+  });
+});
+
+describe("pendingApprovalDeliveryKey", () => {
+  it("builds a stable per-admin key", () => {
+    expect(pendingApprovalDeliveryKey(userId, "admin@example.com")).toBe(
+      `pending-approval:${userId}:admin@example.com`
+    );
+  });
+});
+
+describe("notifyAdminsUserPendingApproval", () => {
+  beforeEach(() => {
+    mockGetUserById.mockReset();
+    mockGetAdminUsers.mockReset();
+    mockSendOnce.mockReset();
+    mockSendOnce.mockResolvedValue({ outcome: "sent" });
+  });
+
+  it("does nothing when the user has no Data Connect profile yet", async () => {
+    mockGetUserById.mockResolvedValue({ data: { user: undefined } } as unknown as Awaited<
+      ReturnType<typeof dc.getUserById>
+    >);
+
+    await notifyAdminsUserPendingApproval({ userId, emailVerified: true, appBaseUrl: "https://app.example" });
+
+    expect(mockGetAdminUsers).not.toHaveBeenCalled();
+    expect(mockSendOnce).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the email isn't verified yet", async () => {
+    mockGetUserById.mockResolvedValue({ data: { user: profile() } } as unknown as Awaited<
+      ReturnType<typeof dc.getUserById>
+    >);
+
+    await notifyAdminsUserPendingApproval({ userId, emailVerified: false, appBaseUrl: "https://app.example" });
+
+    expect(mockSendOnce).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when membership status is not awaiting approval", async () => {
+    mockGetUserById.mockResolvedValue({
+      data: { user: profile({ membershipStatus: MembershipStatus.REGULAR }) },
+    } as unknown as Awaited<ReturnType<typeof dc.getUserById>>);
+
+    await notifyAdminsUserPendingApproval({ userId, emailVerified: true, appBaseUrl: "https://app.example" });
+
+    expect(mockSendOnce).not.toHaveBeenCalled();
+  });
+
+  it("sends one deduped email per admin when the user is pending approval", async () => {
+    mockGetUserById.mockResolvedValue({ data: { user: profile() } } as unknown as Awaited<
+      ReturnType<typeof dc.getUserById>
+    >);
+    mockGetAdminUsers.mockResolvedValue([
+      mockAdminUser("admin1@example.com"),
+      mockAdminUser("admin2@example.com"),
+    ] as unknown as UserRecord[]);
+
+    const sendEmail = vi.fn().mockResolvedValue({ provider: "govuk_notify", providerNotificationId: "n-1" });
+
+    await notifyAdminsUserPendingApproval({
+      userId,
+      emailVerified: true,
+      appBaseUrl: "https://app.example/",
+      getMailer: () => ({ sendEmail }),
+    });
+
+    expect(mockSendOnce).toHaveBeenCalledTimes(2);
+    expect(mockSendOnce.mock.calls.map((c) => c[0].deliveryKey)).toEqual([
+      pendingApprovalDeliveryKey(userId, "admin1@example.com"),
+      pendingApprovalDeliveryKey(userId, "admin2@example.com"),
+    ]);
+    expect(mockSendOnce.mock.calls[0][0].notificationType).toBe("USER_PENDING_APPROVAL");
+
+    await mockSendOnce.mock.calls[0][0].send();
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateName: "newUserPendingApprovalAlert",
+        to: "admin1@example.com",
+        personalisation: expect.objectContaining({
+          firstName: "Ada",
+          lastName: "Lovelace",
+          serviceBackgroundSummary: "Regular",
+          approveUsersUrl: "https://app.example/admin/users/approvals",
+        }),
+      })
+    );
+  });
+
+  it("skips sending (without throwing) when there are no admin recipients", async () => {
+    mockGetUserById.mockResolvedValue({ data: { user: profile() } } as unknown as Awaited<
+      ReturnType<typeof dc.getUserById>
+    >);
+    mockGetAdminUsers.mockResolvedValue([] as unknown as UserRecord[]);
+
+    await notifyAdminsUserPendingApproval({ userId, emailVerified: true, appBaseUrl: "https://app.example" });
+
+    expect(mockSendOnce).not.toHaveBeenCalled();
+  });
+});

--- a/functions/src/pendingApprovalAdminAlert.ts
+++ b/functions/src/pendingApprovalAdminAlert.ts
@@ -1,0 +1,140 @@
+import * as logger from "firebase-functions/logger";
+import { getUserById, NotificationChannel } from "@dataconnect/admin-generated";
+import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import { sanitizeMailerError } from "./mailerErrors";
+import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
+import { sendNotificationOnce } from "./notificationDelivery";
+import { getAdminUsers } from "./helpers";
+import { isUserPendingApproval } from "./pendingUserApproval";
+
+export const PENDING_APPROVAL_ALERT_TEMPLATE_KEYS = ["newUserPendingApprovalAlert"] as const;
+
+export type PendingApprovalAlertTemplates = {
+  newUserPendingApprovalAlert: {
+    firstName: string;
+    lastName: string;
+    email: string;
+    serviceNumber: string;
+    serviceBackgroundSummary: string;
+    requestedMembershipStatus: string;
+    approveUsersUrl: string;
+  };
+};
+
+export function createPendingApprovalAlertMailer(): ReturnType<
+  typeof createConfiguredGovNotifyMailer<PendingApprovalAlertTemplates>
+> {
+  return createConfiguredGovNotifyMailer([...PENDING_APPROVAL_ALERT_TEMPLATE_KEYS]);
+}
+
+export function pendingApprovalDeliveryKey(userId: string, adminEmail: string): string {
+  return `pending-approval:${userId}:${adminEmail}`;
+}
+
+/** e.g. "Regular, Reserve" or "Not specified" if none of the flags are set. */
+export function summarizeServiceBackground(profile: {
+  isRegular?: boolean | null;
+  isReserve?: boolean | null;
+  isCivilServant?: boolean | null;
+  isIndustry?: boolean | null;
+}): string {
+  const labels: string[] = [];
+  if (profile.isRegular) labels.push("Regular");
+  if (profile.isReserve) labels.push("Reserve");
+  if (profile.isCivilServant) labels.push("Civil Servant");
+  if (profile.isIndustry) labels.push("Industry");
+  return labels.length > 0 ? labels.join(", ") : "Not specified";
+}
+
+/**
+ * Notifies all admins when a user enters the Approve Users queue: verified email, profile
+ * submitted, membership awaiting approval, and not yet enabled (see isUserPendingApproval).
+ * Safe to call from any path that might put a user into this state — no-ops if the user isn't
+ * actually pending approval yet, and sendNotificationOnce dedupes per admin so retries or repeat
+ * calls (e.g. syncPendingUserClaims runs at both registration and post-profile-submit) never
+ * double-send. See #271.
+ */
+export async function notifyAdminsUserPendingApproval(args: {
+  userId: string;
+  emailVerified: boolean;
+  appBaseUrl: string;
+  getMailer?: () => ReturnType<typeof createPendingApprovalAlertMailer>;
+}): Promise<void> {
+  try {
+    const row = await getUserById({ id: args.userId });
+    const profile = row.data?.user;
+    if (!profile) {
+      return;
+    }
+    if (
+      !isUserPendingApproval({
+        emailVerified: args.emailVerified,
+        authEnabled: false,
+        membershipStatus: profile.membershipStatus,
+      })
+    ) {
+      return;
+    }
+
+    const admins = await getAdminUsers();
+    const recipients = Array.from(
+      new Set(
+        admins
+          .map((a) => a.email?.trim().toLowerCase())
+          .filter((email): email is string => !!email)
+      )
+    );
+    if (recipients.length === 0) {
+      logger.warn("pending approval admin alert skipped (no admin recipients)", { userId: args.userId });
+      return;
+    }
+
+    const mailer = (args.getMailer ?? createPendingApprovalAlertMailer)();
+    const base = normaliseAppBaseUrl(args.appBaseUrl);
+    const approveUsersUrl = `${base}/admin/users/approvals`;
+    const reference = `PENDING_APPROVAL:${args.userId}`;
+
+    const personalisation: PendingApprovalAlertTemplates["newUserPendingApprovalAlert"] = {
+      firstName: profile.firstName,
+      lastName: profile.lastName,
+      email: profile.email,
+      serviceNumber: profile.serviceNumber,
+      serviceBackgroundSummary: summarizeServiceBackground(profile),
+      requestedMembershipStatus: profile.requestedMembershipStatus ?? profile.membershipStatus ?? "—",
+      approveUsersUrl,
+    };
+
+    for (const to of recipients) {
+      const deliveryKey = pendingApprovalDeliveryKey(args.userId, to);
+      try {
+        await sendNotificationOnce({
+          channel: NotificationChannel.EMAIL,
+          notificationType: "USER_PENDING_APPROVAL",
+          deliveryKey,
+          userId: args.userId,
+          provider: GOV_NOTIFY_PROVIDER,
+          send: async () => {
+            const r = await mailer.sendEmail({
+              templateName: "newUserPendingApprovalAlert",
+              to,
+              personalisation,
+              reference,
+            });
+            return { providerMessageId: r.providerNotificationId ?? null };
+          },
+        });
+      } catch (error) {
+        logger.error("pending approval admin alert delivery failed", {
+          userId: args.userId,
+          to,
+          error: sanitizeMailerError(error),
+        });
+      }
+    }
+  } catch (error) {
+    logger.error("pending approval admin alert failed", {
+      userId: args.userId,
+      error: sanitizeMailerError(error),
+    });
+  }
+}

--- a/functions/src/users.ts
+++ b/functions/src/users.ts
@@ -6,6 +6,13 @@ import { requireAuth, requireAdmin, requireString, validateStringLength, MAX_NAM
 import { enforceRateLimit } from "./rateLimiter";
 import { FUNCTIONS_REGION } from "./constants";
 import { isUserAwaitingProfile, isUserPendingApproval } from "./pendingUserApproval";
+import { notifyAdminsUserPendingApproval } from "./pendingApprovalAdminAlert";
+
+const APP_BASE_URL = (() => {
+  const url = process.env.APP_BASE_URL || "http://localhost:5173";
+  try { new URL(url); } catch { throw new Error(`APP_BASE_URL is not a valid URL: "${url}"`); }
+  return url.replace(/\/$/, "");
+})();
 
 const DC_PROFILE_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 let dcProfileCache: { map: Map<string, MembershipStatus>; expiresAt: number } | null = null;
@@ -282,6 +289,15 @@ export const syncPendingUserClaims = onCall(
         enabled: false,
       });
       logger.info(`syncPendingUserClaims: enabled=false for uid=${uid}`);
+
+      // Non-blocking: no-ops unless this call is what actually put the user into the approval
+      // queue (verified email + profile submitted + awaiting approval) — see #271.
+      void notifyAdminsUserPendingApproval({
+        userId: uid,
+        emailVerified: userRecord.emailVerified,
+        appBaseUrl: APP_BASE_URL,
+      });
+
       return { success: true };
     } catch (e: unknown) {
       handleFunctionError(e, "syncing pending user claims");


### PR DESCRIPTION
## Summary
- Adds `functions/src/pendingApprovalAdminAlert.ts`, matching the existing shape of `paymentOpsInternalAlerts.ts`/`guestTicketRequestEmails.ts`: a new `newUserPendingApprovalAlert` GOV Notify template, `sendNotificationOnce` for idempotent per-admin delivery (`pending-approval:<userId>:<adminEmail>`), and `getAdminUsers()` to resolve recipients (all current admins — no separate ops env var needed, unlike payment ops alerts).
- Wired into `syncPendingUserClaims` (`functions/src/users.ts`), which already runs both at registration and again after profile submission (per its existing comment — "so the claim is never left unset"). The new call checks `isUserPendingApproval` itself and no-ops unless *this* invocation is what actually puts the user into the queue (verified email + profile submitted + awaiting approval), so it's safe to call unconditionally from both call sites rather than needing a separate trigger point.
- Fired with `void` (non-blocking), matching the existing convention for this kind of side-effect email (`guestTicketRequests.ts`, `payments.ts`).
- Content: user's name, email, service number, a joined service-background summary (e.g. "Regular, Reserve"), requested membership status, and a deep link to Approve Users (`/admin/users/approvals`).

Documents the new template across the existing `docs/operations/` conventions: a new `govuk-notify-pending-approval-templates.md` deep dive, plus entries in `transactional-email-policy.md`, `transactional-email-workflows.md`, `govuk-notify-template-registration.md`, `govuk-notify-template-copy.md`, and `govuk-notify-sample-personalisation.json`.

Fixes #271

## Test plan
- [x] `npx tsc --noEmit -p .` (functions) — clean
- [x] `npx vitest run` (functions) — 368 passed, including 8 new tests covering: no Data Connect profile yet → no-op, email not verified → no-op, membership status not awaiting approval → no-op, no admin recipients → no-op, and the happy path sending one deduped email per admin with correct personalisation/delivery key
- [x] Root `npx tsc -b` — clean (no client-side surface changed)
- Not covered: a full integration test of `syncPendingUserClaims` itself (mocking `firebase-admin`'s `auth()`) — this callable, like the rest of `users.ts`, has no existing test coverage at all; scoped this PR's tests to the new dispatcher/recipient-resolution logic per the issue's acceptance criteria, consistent with how the other alert dispatchers in this codebase (`paymentOpsInternalAlerts.ts`, `guestTicketRequestEmails.ts`) are tested

## Manual QA (documented in transactional-email-workflows.md)
- [ ] Register, verify email, complete profile → admin alert
- [ ] Repeat profile-submit call → no second email to the same admin
- [ ] New admin added later, user still pending → new admin gets the alert, existing admins don't get a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)