### PR TITLE
[#368] Enforce enabled-account access boundary

### DIFF
--- a/docs/architecture/security-and-permissions.md
+++ b/docs/architecture/security-and-permissions.md
@@ -55,13 +55,22 @@ Guard helpers in `functions/src/helpers.ts`:
 - `requireEnabled(request)`:
   - requires authenticated caller with `enabled: true`.
 - `requireAdmin(request)`:
-  - requires authenticated caller with `admin: true`.
+  - requires authenticated caller with both `admin: true` and `enabled: true`.
+  - an admin claim never bypasses account revocation.
 
 Typical usage:
 
-- Member flows (`submitEventBooking`, checkout start): `requireEnabled`.
-- Admin-only operations: `requireAdmin`.
-- Mixed/self-service operations (`updateMembershipStatus`, section member rollups): `requireAuth` + in-function ownership checks.
+- Member flows (`submitEventBooking`, checkout start, membership self-service): `requireEnabled`.
+- PII-bearing member directories and all announcement template, preview, send, history, and recipient callables: `requireEnabled` before section/group checks.
+- Admin-only operations: `requireAdmin`, which also enforces `enabled: true`.
+- A caller with `admin: true` but `enabled !== true` is rejected; admin status is not an access-revocation bypass.
+
+The only callable entry points intentionally using authentication without an enabled claim are pre-approval setup flows:
+
+- `updateDisplayName`, used while establishing the account profile.
+- `syncPendingUserClaims`, used to reconcile the pre-approval Auth/profile state.
+
+These exceptions must not return member-directory data, announcement data, or other enabled-member content. Adding another authentication-only callable requires an explicit security review and a contract-test update.
 
 ## Webhook security
 

--- a/functions/src/__tests__/announcements.test.ts
+++ b/functions/src/__tests__/announcements.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as admin from "@dataconnect/admin-generated";
 import {
+  getAnnouncementTemplates,
+  previewAnnouncementTemplate,
+  sendSectionAnnouncement,
+  getAnnouncementSendHistory,
   getAnnouncementSendRecipients,
   extractTemplateVariables,
   buildRecipientPersonalisation,
@@ -8,6 +12,7 @@ import {
 
 const mockGetAnnouncementSendById = vi.spyOn(admin, "getAnnouncementSendById");
 const mockGetAnnouncementSendRecipients = vi.spyOn(admin, "getAnnouncementSendRecipients");
+const mockGetSectionById = vi.spyOn(admin, "getSectionById");
 
 const sectionAId = "00000000-0000-4000-8000-00000000000a";
 const sectionBId = "00000000-0000-4000-8000-00000000000b";
@@ -15,10 +20,40 @@ const sendIdForSectionB = "00000000-0000-4000-8000-0000000000b1";
 
 function callAsAdmin(data: Record<string, unknown>) {
   return getAnnouncementSendRecipients.run({
-    auth: { uid: "admin-1", token: { admin: true } },
+    auth: { uid: "admin-1", token: { admin: true, enabled: true } },
     data,
   } as unknown as Parameters<typeof getAnnouncementSendRecipients.run>[0]);
 }
+
+const announcementCallables = [
+  getAnnouncementTemplates,
+  previewAnnouncementTemplate,
+  sendSectionAnnouncement,
+  getAnnouncementSendHistory,
+  getAnnouncementSendRecipients,
+] as const;
+
+describe("announcement callable enabled-account boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { role: "moderator", admin: false },
+    { role: "admin", admin: true },
+  ])("rejects a disabled $role before section-role checks", async ({ admin: isAdmin }) => {
+    for (const callable of announcementCallables) {
+      await expect(
+        callable.run({
+          auth: { uid: "disabled-user", token: { admin: isAdmin, enabled: false } },
+          data: {},
+        } as never)
+      ).rejects.toMatchObject({ code: "permission-denied", message: "Account must be enabled" });
+    }
+
+    expect(mockGetSectionById).not.toHaveBeenCalled();
+  });
+});
 
 describe("getAnnouncementSendRecipients", () => {
   beforeEach(() => {

--- a/functions/src/__tests__/authGuards.test.ts
+++ b/functions/src/__tests__/authGuards.test.ts
@@ -30,8 +30,18 @@ describe("auth guard helpers", () => {
   });
 
   it("requireAdmin rejects non-admin calls", () => {
-    const req: RequestLike = { auth: { uid: "u1", token: { admin: false } } };
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: false, enabled: true } } };
     expect(() => requireAdmin(req as unknown as never)).toThrow("Admins only");
+  });
+
+  it("requireAdmin rejects a disabled caller even when the admin claim is true", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: true, enabled: false } } };
+    expect(() => requireAdmin(req as unknown as never)).toThrow("Account must be enabled");
+  });
+
+  it("requireAdmin rejects an admin whose enabled claim is absent", () => {
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: true } } };
+    expect(() => requireAdmin(req as unknown as never)).toThrow("Account must be enabled");
   });
 
   it("requireAdmin rejects unauthenticated calls", () => {
@@ -39,7 +49,7 @@ describe("auth guard helpers", () => {
   });
 
   it("requireAdmin accepts admin calls", () => {
-    const req: RequestLike = { auth: { uid: "u1", token: { admin: true } } };
+    const req: RequestLike = { auth: { uid: "u1", token: { admin: true, enabled: true } } };
     expect(() => requireAdmin(req as unknown as never)).not.toThrow();
   });
 });

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -30,11 +30,11 @@ describe("function entry guard contracts", () => {
     assertOnCallGuard(users, "syncPendingUserClaims", "requireAuth(request);");
 
     const membership = readSource("membershipStatus.ts");
-    assertOnCallGuard(membership, "updateMembershipStatus", "requireAuth(request);");
-    assertOnCallGuard(membership, "resignMembership", "requireAuth(request);");
+    assertOnCallGuard(membership, "updateMembershipStatus", "requireEnabled(request);");
+    assertOnCallGuard(membership, "resignMembership", "requireEnabled(request);");
 
     const sections = readSource("sections.ts");
-    assertOnCallGuard(sections, "getSectionMembersMerged", "requireAuth(request);");
+    assertOnCallGuard(sections, "getSectionMembersMerged", "requireEnabled(request);");
     assertOnCallGuard(sections, "getSectionForUser", "requireEnabled(request);");
     assertOnCallGuard(sections, "getSectionEventsForUser", "requireEnabled(request);");
     assertOnCallGuard(sections, "getEventForUser", "requireEnabled(request);");
@@ -62,9 +62,23 @@ describe("function entry guard contracts", () => {
       "getAnnouncementSendHistory",
       "getAnnouncementSendRecipients",
     ]) {
-      assertOnCallGuard(announcements, fn, "requireAuth(request);");
+      assertOnCallGuard(announcements, fn, "requireEnabled(request);");
       assertOnCallGuard(announcements, fn, "requireSectionModerator(", 600);
     }
+  });
+
+  it("keeps only intentional pre-approval entry points authentication-only", () => {
+    const users = readSource("users.ts");
+    for (const fn of ["updateDisplayName", "syncPendingUserClaims"]) {
+      assertOnCallGuard(users, fn, "requireAuth(request);");
+    }
+
+    const guardedSources = [
+      readSource("sections.ts"),
+      readSource("announcements.ts"),
+      readSource("membershipStatus.ts"),
+    ].join("\n");
+    expect(guardedSources).not.toContain("requireAuth(request);");
   });
 
   it("applies enforceRateLimit to the high-risk callables named in #344", () => {

--- a/functions/src/__tests__/searchUsers.test.ts
+++ b/functions/src/__tests__/searchUsers.test.ts
@@ -31,7 +31,7 @@ const handler = searchUsers as unknown as Handler;
 
 function adminRequest(data: Record<string, unknown> = {}) {
   return {
-    auth: { uid: "admin-uid", token: { admin: true } },
+    auth: { uid: "admin-uid", token: { admin: true, enabled: true } },
     data: { searchTerm: "alice", ...data },
   };
 }

--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -19,10 +19,11 @@ function callAs<T>(
   fn: { run: (request: any) => Promise<T> },
   uid: string,
   isAdmin: boolean,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  enabled = true
 ): Promise<T> {
   return fn.run({
-    auth: { uid, token: { admin: isAdmin, enabled: true } },
+    auth: { uid, token: { admin: isAdmin, enabled } },
     data,
   });
 }
@@ -64,6 +65,13 @@ describe("getSectionForUser", () => {
 
     expect(result.hasAccess).toBe(true);
     expect(result.section?.id).toBe(sectionId);
+  });
+
+  it("rejects a disabled admin before the admin bypass or section lookup", async () => {
+    await expect(
+      callAs(getSectionForUser, "admin-1", true, { sectionId }, false)
+    ).rejects.toMatchObject({ code: "permission-denied", message: "Account must be enabled" });
+    expect(mockGetSectionById).not.toHaveBeenCalled();
   });
 
   it("returns hasAccess and canModerate for a non-admin with a MODERATOR group", async () => {
@@ -232,6 +240,16 @@ describe("getSectionMembersMerged", () => {
       },
     } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
   }
+
+  it("rejects a disabled caller before retained group membership can grant directory access", async () => {
+    await expect(
+      callAs(getSectionMembersMerged, "member-1", false, { sectionId }, false)
+    ).rejects.toMatchObject({ code: "permission-denied", message: "Account must be enabled" });
+
+    expect(mockGetSectionById).not.toHaveBeenCalled();
+    expect(mockGetSectionMembers).not.toHaveBeenCalled();
+    expect(mockGetUserAccessGroupsById).not.toHaveBeenCalled();
+  });
 
   it("includes email and rank for a member who shares contact info", async () => {
     mockMembers([member({ rank: "Wing Commander", shareContactInfo: true })]);

--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -17,7 +17,7 @@ import {
   getAnnouncementSendHistory as dcGetAnnouncementSendHistory,
   getAnnouncementSendRecipients as dcGetAnnouncementSendRecipients,
 } from "@dataconnect/admin-generated";
-import { requireAuth, requireString } from "./helpers";
+import { requireEnabled, requireString } from "./helpers";
 import { govNotifyApiKey } from "./mailer";
 import { FUNCTIONS_REGION } from "./constants";
 import { signUnsubscribeToken, unsubscribeSecret } from "./unsubscribe";
@@ -240,7 +240,7 @@ export interface AnnouncementTemplate {
 export const getAnnouncementTemplates = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request): Promise<{ templates: AnnouncementTemplate[] }> => {
-    requireAuth(request);
+    requireEnabled(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     await requireSectionModerator(request.auth!.uid, sectionId, request.auth!.token?.admin === true);
 
@@ -281,7 +281,7 @@ export const getAnnouncementTemplates = onCall(
 export const previewAnnouncementTemplate = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request): Promise<{ html: string; subject: string }> => {
-    requireAuth(request);
+    requireEnabled(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     const templateUuid = requireString(request.data?.templateUuid, "templateUuid");
     await requireSectionModerator(request.auth!.uid, sectionId, request.auth!.token?.admin === true);
@@ -349,7 +349,7 @@ interface AnnouncementEmailTask {
 export const sendSectionAnnouncement = onCall(
   { region: FUNCTIONS_REGION, secrets: [unsubscribeSecret, govNotifyApiKey] },
   async (request): Promise<SendAnnouncementResult> => {
-    requireAuth(request);
+    requireEnabled(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     const templateUuid = requireString(request.data?.templateUuid, "templateUuid");
     const templateName: string | null = typeof request.data?.templateName === "string"
@@ -519,7 +519,7 @@ export const processAnnouncementEmail = onTaskDispatched<AnnouncementEmailTask>(
 export const getAnnouncementSendHistory = onCall(
   { region: FUNCTIONS_REGION },
   async (request): Promise<{ sends: AnnouncementSend[] }> => {
-    requireAuth(request);
+    requireEnabled(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     await requireSectionModerator(request.auth!.uid, sectionId, request.auth!.token?.admin === true);
 
@@ -562,7 +562,7 @@ export const getAnnouncementSendHistory = onCall(
 export const getAnnouncementSendRecipients = onCall(
   { region: FUNCTIONS_REGION },
   async (request): Promise<{ recipients: AnnouncementRecipient[] }> => {
-    requireAuth(request);
+    requireEnabled(request);
     const sendId = requireString(request.data?.sendId, "sendId");
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     await requireSectionModerator(request.auth!.uid, sectionId, request.auth!.token?.admin === true);

--- a/functions/src/guestTicketRequests.ts
+++ b/functions/src/guestTicketRequests.ts
@@ -145,9 +145,6 @@ export const reviewGuestTicketRequest = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request) => {
     requireAdmin(request);
-    if (request.auth!.token.enabled !== true) {
-      throw new HttpsError("permission-denied", "Account must be enabled");
-    }
 
     const id = validateUUID(request.data?.id, "id") as UUIDString;
     const status = request.data?.status;

--- a/functions/src/helpers.ts
+++ b/functions/src/helpers.ts
@@ -23,12 +23,17 @@ export function requireEnabled(request: CallableRequest): void {
 }
 
 /**
- * Ensures the request is authenticated and the user is an admin
+ * Ensures the request is authenticated, enabled, and an admin.
+ * An admin claim never bypasses account revocation: admin callables use the
+ * same enabled-account boundary as member and moderator surfaces.
  */
 export function requireAdmin(request: CallableRequest): void {
   requireAuth(request);
   if (request.auth!.token.admin !== true) {
     throw new HttpsError("permission-denied", "Admins only");
+  }
+  if (request.auth!.token.enabled !== true) {
+    throw new HttpsError("permission-denied", "Account must be enabled");
   }
 }
 
@@ -150,4 +155,3 @@ export function handleFunctionError(error: any, context: string): never {
   logger.error(`Error ${context}:`, error);
   throw new HttpsError("internal", "Internal server error");
 }
-

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -1,7 +1,7 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
 import * as admin from "firebase-admin";
-import { requireAuth, handleFunctionError } from "./helpers";
+import { requireEnabled, handleFunctionError } from "./helpers";
 import { canUserChangeStatus, canUserResignMembership, isNonRestrictedStatus, type MembershipStatus } from "./validation";
 import { FUNCTIONS_REGION } from "./constants";
 import {
@@ -48,7 +48,7 @@ export async function sendMembershipStatusEmailIfChanged(args: {
 export const updateMembershipStatus = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request) => {
-  requireAuth(request);
+  requireEnabled(request);
 
   const { userId, newStatus } = request.data;
 
@@ -115,7 +115,7 @@ export const updateMembershipStatus = onCall(
 export const resignMembership = onCall(
   { region: FUNCTIONS_REGION, secrets: [govNotifyApiKey] },
   async (request) => {
-    requireAuth(request);
+    requireEnabled(request);
 
     const userId = request.auth!.uid;
     const callerEnabled = request.auth!.token.enabled === true;

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -1,6 +1,6 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
-import { requireAuth, requireEnabled, requireString, handleFunctionError } from "./helpers";
+import { requireEnabled, requireString, handleFunctionError } from "./helpers";
 import {
   getSectionById,
   getSectionMembers,
@@ -103,7 +103,7 @@ async function resolveSectionAccess(sectionId: string, callerUid: string): Promi
 export const getSectionMembersMerged = onCall(
   { region: FUNCTIONS_REGION },
   async (request) => {
-    requireAuth(request);
+    requireEnabled(request);
     const sectionId = requireString(request.data?.sectionId, "sectionId");
     const callerUid = request.auth!.uid;
 


### PR DESCRIPTION
## Summary

- require enabled accounts for section member-directory and announcement callables before role or group checks
- require enabled administrators across admin-only callables, so an admin claim cannot bypass account revocation
- preserve the two intentional authentication-only onboarding entry points
- document the security boundary and add behavioral and guard-contract coverage

## Impact

Disabled users are rejected even if they retain a matching section group or an admin claim. Enabled members, moderators, and administrators continue through the existing authorization checks.

## Validation

- `npm run lint`
- `npm run test:run` — 65 files, 546 tests
- `npm run build`
- `cd functions && npm run lint -- --no-warn-ignored`
- `cd functions && npm run test:coverage` — 44 files, 395 tests
- `cd functions && npm run build`

Closes #368
Part of #365