### PR TITLE
[#370] Include status-derived announcement recipients

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/transactional-email-workflows.md`: transactional email triggers by domain (payments, bookings, membership, guest tickets, ops alerts) with links to GOV.UK Notify template specs.
 - `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 - `operations/transactional-email-policy.md`: operational vs optional/marketing email policy (#191).
+- `operations/section-announcement-audiences.md`: explicit and membership-status-derived audience, eligibility, deduplication, and opt-out rules for section announcements.
 
 ## User Guides
 

--- a/docs/operations/section-announcement-audiences.md
+++ b/docs/operations/section-announcement-audiences.md
@@ -1,0 +1,37 @@
+# Section announcement audiences
+
+Section announcement recipients are resolved by
+[`functions/src/announcements.ts`](../../functions/src/announcements.ts) before one GOV.UK Notify
+task is queued per deliverable user.
+
+## Audience sources
+
+Only groups linked to the selected section with an `ACCESS` or `MODERATOR` purpose contribute
+recipients. The audience is the union of:
+
+1. users explicitly related to those groups through `UserUserGroup`; and
+2. users whose `membershipStatus` appears in those groups' `membershipStatuses` configuration.
+
+The two sources are merged by user ID, so an explicit user who also matches an inherited status
+receives one announcement. `MEMBER`, `BOOKER`, and other purpose links do not independently add
+announcement recipients.
+
+## Eligibility and opt-outs
+
+Only non-restricted membership statuses (`REGULAR`, `RETIRED`, `RESERVE`, `INDUSTRY`, and
+`CIVIL_SERVICE`) are eligible. Restricted users (`PENDING`, `RESIGNED`, `LOST`, and `DECEASED`)
+are excluded even if a stale explicit group relation remains or a group is misconfigured to list a
+restricted status.
+
+After explicit and status-derived users are merged, the section's `SectionAnnouncementOptOut`
+records are applied once to the combined audience. This ensures both recipient sources have the
+same opt-out behaviour. An empty audience is valid and records a send with zero queued recipients.
+
+## Operational checks
+
+Before sending a production announcement:
+
+- confirm the section's `ACCESS` and `MODERATOR` purpose links target the intended groups;
+- review each group's explicit users and inherited `membershipStatuses`; and
+- remember that adding a status to either eligible purpose group includes every non-restricted user
+  with that status unless they have opted out of that section's announcements.

--- a/functions/src/__tests__/announcementRecipients.test.ts
+++ b/functions/src/__tests__/announcementRecipients.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  mergeAnnouncementRecipients,
+  partitionAnnouncementRecipients,
+  type AnnouncementPurposeLink,
+  type AnnouncementAudienceRecipient,
+} from "../announcementRecipients";
+
+function user(
+  id: string,
+  membershipStatus = "REGULAR"
+): AnnouncementAudienceRecipient {
+  return {
+    id,
+    firstName: id,
+    lastName: "Member",
+    email: `${id}@example.com`,
+    serviceNumber: `S-${id}`,
+    membershipStatus,
+  };
+}
+
+function link(args: {
+  purposes: string[];
+  statuses?: string[];
+  users?: AnnouncementAudienceRecipient[];
+}): AnnouncementPurposeLink {
+  return {
+    purposes: args.purposes,
+    userGroup: {
+      id: args.purposes.join("-") || "group",
+      membershipStatuses: args.statuses ?? null,
+      users: (args.users ?? []).map((member) => ({ user: member })),
+    },
+  };
+}
+
+describe("announcement recipient resolution", () => {
+  it("includes explicit ACCESS and MODERATOR members but not unrelated purpose groups", () => {
+    const recipients = mergeAnnouncementRecipients(
+      [
+        link({ purposes: ["ACCESS"], users: [user("access")] }),
+        link({ purposes: ["MODERATOR"], users: [user("moderator")] }),
+        link({ purposes: ["MEMBER"], users: [user("member-only")] }),
+      ],
+      []
+    );
+
+    expect(recipients.map(({ id }) => id)).toEqual(["access", "moderator"]);
+  });
+
+  it("includes status-derived users only when their non-restricted status matches the audience", () => {
+    const recipients = mergeAnnouncementRecipients(
+      [link({ purposes: ["ACCESS"], statuses: ["REGULAR", "LOST"] })],
+      [user("regular", "REGULAR"), user("reserve", "RESERVE"), user("lost", "LOST")]
+    );
+
+    expect(recipients.map(({ id }) => id)).toEqual(["regular"]);
+  });
+
+  it("deduplicates a user present explicitly and through membership status", () => {
+    const overlappingUser = user("overlap", "REGULAR");
+    const recipients = mergeAnnouncementRecipients(
+      [link({ purposes: ["MODERATOR"], statuses: ["REGULAR"], users: [overlappingUser] })],
+      [overlappingUser]
+    );
+
+    expect(recipients).toEqual([overlappingUser]);
+  });
+
+  it("applies opt-outs equally to explicit and status-derived recipients", () => {
+    const explicit = user("explicit");
+    const inherited = user("inherited");
+    const recipients = mergeAnnouncementRecipients(
+      [link({ purposes: ["ACCESS"], statuses: ["REGULAR"], users: [explicit] })],
+      [inherited]
+    );
+
+    const partitioned = partitionAnnouncementRecipients(
+      recipients,
+      new Set([explicit.id, inherited.id])
+    );
+
+    expect(partitioned.deliverable).toEqual([]);
+    expect(partitioned.optedOut.map(({ id }) => id)).toEqual(["explicit", "inherited"]);
+  });
+
+  it("returns an empty audience when no eligible links or users exist", () => {
+    expect(mergeAnnouncementRecipients([], [])).toEqual([]);
+    expect(
+      mergeAnnouncementRecipients(
+        [link({ purposes: ["MEMBER"], statuses: ["REGULAR"], users: [user("member-only")] })],
+        [user("status-only")]
+      )
+    ).toEqual([]);
+  });
+
+  it("excludes restricted explicit users even if a stale group link remains", () => {
+    const recipients = mergeAnnouncementRecipients(
+      [link({ purposes: ["ACCESS"], users: [user("resigned", "RESIGNED")] })],
+      []
+    );
+
+    expect(recipients).toEqual([]);
+  });
+});

--- a/functions/src/__tests__/announcements.test.ts
+++ b/functions/src/__tests__/announcements.test.ts
@@ -6,6 +6,7 @@ import {
   sendSectionAnnouncement,
   getAnnouncementSendHistory,
   getAnnouncementSendRecipients,
+  resolveAnnouncementRecipients,
   extractTemplateVariables,
   buildRecipientPersonalisation,
 } from "../announcements";
@@ -13,6 +14,8 @@ import {
 const mockGetAnnouncementSendById = vi.spyOn(admin, "getAnnouncementSendById");
 const mockGetAnnouncementSendRecipients = vi.spyOn(admin, "getAnnouncementSendRecipients");
 const mockGetSectionById = vi.spyOn(admin, "getSectionById");
+const mockGetSectionMembers = vi.spyOn(admin, "getSectionMembers");
+const mockListUsers = vi.spyOn(admin, "listUsers");
 const mockConsumeCallableRateLimit = vi.spyOn(admin, "consumeCallableRateLimit");
 
 beforeEach(() => {
@@ -37,6 +40,72 @@ const announcementCallables = [
   getAnnouncementSendHistory,
   getAnnouncementSendRecipients,
 ] as const;
+
+describe("resolveAnnouncementRecipients", () => {
+  beforeEach(() => {
+    mockGetSectionMembers.mockReset();
+    mockListUsers.mockReset();
+  });
+
+  it("loads and merges users matching an eligible group's membership statuses", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionAId,
+          name: "Signals",
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              userGroup: {
+                id: "regular-access",
+                membershipStatuses: ["REGULAR"],
+                users: [],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+    mockListUsers.mockResolvedValue({
+      data: {
+        users: [
+          {
+            id: "status-user",
+            firstName: "Status",
+            lastName: "User",
+            email: "status@example.com",
+            serviceNumber: "S123",
+            membershipStatus: "REGULAR",
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.listUsers>>);
+
+    const result = await resolveAnnouncementRecipients(sectionAId);
+
+    expect(result.sectionName).toBe("Signals");
+    expect(result.recipients.map(({ id }) => id)).toEqual(["status-user"]);
+    expect(mockListUsers).toHaveBeenCalledOnce();
+  });
+
+  it("does not load all users when no eligible inherited statuses are configured", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionAId,
+          name: "Signals",
+          purposeLinks: [],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+
+    await expect(resolveAnnouncementRecipients(sectionAId)).resolves.toEqual({
+      recipients: [],
+      sectionName: "Signals",
+    });
+    expect(mockListUsers).not.toHaveBeenCalled();
+  });
+});
 
 describe("announcement callable enabled-account boundary", () => {
   beforeEach(() => {

--- a/functions/src/announcementRecipients.ts
+++ b/functions/src/announcementRecipients.ts
@@ -1,0 +1,95 @@
+import {
+  isNonRestrictedStatus,
+  type MembershipStatus,
+} from "./validation";
+
+export interface AnnouncementAudienceRecipient {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  serviceNumber: string;
+  membershipStatus: string;
+}
+
+export interface AnnouncementPurposeLink {
+  purpose?: string;
+  purposes?: readonly string[] | null;
+  userGroup: {
+    id: string;
+    membershipStatuses?: readonly string[] | null;
+    users?: readonly { user: AnnouncementAudienceRecipient }[] | null;
+  };
+}
+
+function linkHasAudiencePurpose(link: AnnouncementPurposeLink): boolean {
+  const purposes = link.purposes ?? (link.purpose ? [link.purpose] : []);
+  return purposes.includes("ACCESS") || purposes.includes("MODERATOR");
+}
+
+function isEligibleRecipientStatus(status: string): boolean {
+  return isNonRestrictedStatus(status as MembershipStatus);
+}
+
+/**
+ * Returns the non-restricted membership statuses that inherit an announcement
+ * audience through an ACCESS or MODERATOR group.
+ */
+export function getAnnouncementStatusFilters(
+  purposeLinks: readonly AnnouncementPurposeLink[]
+): Set<string> {
+  const statuses = new Set<string>();
+
+  for (const link of purposeLinks) {
+    if (!linkHasAudiencePurpose(link)) continue;
+    for (const status of link.userGroup.membershipStatuses ?? []) {
+      if (isEligibleRecipientStatus(status)) statuses.add(status);
+    }
+  }
+
+  return statuses;
+}
+
+/**
+ * Merges explicit ACCESS/MODERATOR group users with users inherited through
+ * those groups' membershipStatuses. Explicit users win when a user appears in
+ * both sources, and restricted users are excluded from either source.
+ */
+export function mergeAnnouncementRecipients(
+  purposeLinks: readonly AnnouncementPurposeLink[],
+  statusCandidates: readonly AnnouncementAudienceRecipient[]
+): AnnouncementAudienceRecipient[] {
+  const statusFilters = getAnnouncementStatusFilters(purposeLinks);
+  const recipients = new Map<string, AnnouncementAudienceRecipient>();
+
+  const addRecipient = (user: AnnouncementAudienceRecipient) => {
+    if (!isEligibleRecipientStatus(user.membershipStatus)) return;
+    if (!recipients.has(user.id)) recipients.set(user.id, user);
+  };
+
+  for (const link of purposeLinks) {
+    if (!linkHasAudiencePurpose(link)) continue;
+    for (const { user } of link.userGroup.users ?? []) addRecipient(user);
+  }
+
+  for (const user of statusCandidates) {
+    if (statusFilters.has(user.membershipStatus)) addRecipient(user);
+  }
+
+  return [...recipients.values()];
+}
+
+/** Applies the same section opt-out set after explicit and inherited users are merged. */
+export function partitionAnnouncementRecipients(
+  recipients: readonly AnnouncementAudienceRecipient[],
+  optedOutUserIds: ReadonlySet<string>
+): { deliverable: AnnouncementAudienceRecipient[]; optedOut: AnnouncementAudienceRecipient[] } {
+  const deliverable: AnnouncementAudienceRecipient[] = [];
+  const optedOut: AnnouncementAudienceRecipient[] = [];
+
+  for (const recipient of recipients) {
+    (optedOutUserIds.has(recipient.id) ? optedOut : deliverable).push(recipient);
+  }
+
+  return { deliverable, optedOut };
+}

--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -9,6 +9,7 @@ import {
   getSectionMembers,
   getUserAccessGroupsById,
   getUserMembershipStatus,
+  listUsers,
   getSectionAnnouncementOptOuts,
   createAnnouncementSend,
   createAnnouncementRecipient,
@@ -23,6 +24,13 @@ import { govNotifyApiKey } from "./mailer";
 import { FUNCTIONS_REGION } from "./constants";
 import { signUnsubscribeToken, unsubscribeSecret } from "./unsubscribe";
 import { buildAnnouncementReference } from "./announcementReference";
+import {
+  getAnnouncementStatusFilters,
+  mergeAnnouncementRecipients,
+  partitionAnnouncementRecipients,
+  type AnnouncementPurposeLink,
+  type AnnouncementAudienceRecipient,
+} from "./announcementRecipients";
 
 const BULK_PREFIX = "BULK:";
 
@@ -88,78 +96,23 @@ async function requireSectionModerator(
 
 // ── Recipient resolution ─────────────────────────────────────────────────────
 
-interface Recipient {
-  id: string;
-  firstName: string;
-  lastName: string;
-  email: string;
-  serviceNumber: string;
-  membershipStatus: string;
-}
-
 interface ResolveResult {
-  recipients: Recipient[];
+  recipients: AnnouncementAudienceRecipient[];
   sectionName: string;
 }
 
-async function resolveRecipients(sectionId: string, callerUid: string): Promise<ResolveResult> {
-  const [membersResult, callerGroupsResult, userStatusResult] = await Promise.all([
-    getSectionMembers({ sectionId }),
-    getUserAccessGroupsById({ userId: callerUid }),
-    getUserMembershipStatus({ id: callerUid }),
-  ]);
+export async function resolveAnnouncementRecipients(sectionId: string): Promise<ResolveResult> {
+  const membersResult = await getSectionMembers({ sectionId });
 
   const sectionData = membersResult.data?.section;
   if (!sectionData) throw new HttpsError("not-found", "Section not found");
 
-  const purposeLinks = sectionData.purposeLinks ?? [];
-  const accessGroupIds = new Set(
-    purposeLinks
-      .filter((pl) => linkHasPurpose(pl, "ACCESS") || linkHasPurpose(pl, "MODERATOR"))
-      .map((pl) => pl.userGroup.id)
-  );
-
-  const callerGroupIds = new Set(
-    (callerGroupsResult.data?.user?.userGroups ?? []).map(
-      (ug: { userGroup: { id: string } }) => ug.userGroup.id
-    )
-  );
-
-  // Explicit group members
-  const seen = new Set<string>();
-  const recipients: Recipient[] = [];
-
-  for (const link of purposeLinks) {
-    if (!accessGroupIds.has(link.userGroup.id)) continue;
-    for (const { user } of link.userGroup.users) {
-      if (!seen.has(user.id)) {
-        seen.add(user.id);
-        recipients.push({
-          id: user.id,
-          firstName: user.firstName,
-          lastName: user.lastName,
-          email: user.email,
-          serviceNumber: user.serviceNumber,
-          membershipStatus: user.membershipStatus,
-        });
-      }
-    }
-  }
-
-  // Status-derived members (those whose membership status grants access)
-  const userStatus = userStatusResult.data?.user?.membershipStatus;
-  const hasCallerDirectAccess = [...accessGroupIds].some((id) => callerGroupIds.has(id));
-  if (!hasCallerDirectAccess && userStatus) {
-    const grantedByStatus = purposeLinks.some(
-      (pl) =>
-        accessGroupIds.has(pl.userGroup.id) &&
-        (pl.userGroup.membershipStatuses?.includes(userStatus) ?? false)
-    );
-    if (grantedByStatus && !seen.has(callerUid)) {
-      // Status-derived members are handled by the existing groups; we trust getSectionMembers
-      // includes them via membershipStatuses. No extra action needed here.
-    }
-  }
+  const purposeLinks = (sectionData.purposeLinks ?? []) as AnnouncementPurposeLink[];
+  const statusFilters = getAnnouncementStatusFilters(purposeLinks);
+  const statusCandidates = statusFilters.size > 0
+    ? (await listUsers()).data?.users ?? []
+    : [];
+  const recipients = mergeAnnouncementRecipients(purposeLinks, statusCandidates);
 
   return { recipients, sectionName: sectionData.name ?? sectionId };
 }
@@ -371,7 +324,7 @@ export const sendSectionAnnouncement = onCall(
     const requiredPersonalisation = extractTemplateVariables(template.body ?? "", template.subject ?? "");
 
     const [{ recipients, sectionName }, optOutResult] = await Promise.all([
-      resolveRecipients(sectionId, callerUid),
+      resolveAnnouncementRecipients(sectionId),
       getSectionAnnouncementOptOuts({ sectionId }),
     ]);
 
@@ -380,22 +333,21 @@ export const sendSectionAnnouncement = onCall(
         (r: { user: { id: string } }) => r.user.id
       )
     );
+    const { deliverable, optedOut } = partitionAnnouncementRecipients(
+      recipients,
+      sectionOptOutIds
+    );
 
     const secret = unsubscribeSecret.value();
-    const skippedRecipients: { userId: string; email: string; firstName: string; lastName: string }[] = [];
+    const skippedRecipients = optedOut.map((recipient) => ({
+      userId: recipient.id,
+      email: recipient.email,
+      firstName: recipient.firstName,
+      lastName: recipient.lastName,
+    }));
     const tasks: AnnouncementEmailTask[] = [];
 
-    for (const recipient of recipients) {
-      if (sectionOptOutIds.has(recipient.id)) {
-        skippedRecipients.push({
-          userId: recipient.id,
-          email: recipient.email,
-          firstName: recipient.firstName,
-          lastName: recipient.lastName,
-        });
-        continue;
-      }
-
+    for (const recipient of deliverable) {
       const unsubscribeUrl = `${APP_BASE_URL}/unsubscribe?token=${signUnsubscribeToken(
         {
           userId: recipient.id,


### PR DESCRIPTION
## Summary

- include users whose membership status inherits an eligible section announcement audience
- merge explicit and status-derived ACCESS/MODERATOR recipients by user ID
- exclude restricted statuses and apply section opt-outs uniformly after merging
- document audience, eligibility, deduplication, and operational rules

## Why

Announcement recipient resolution assumed `GetSectionMembers` expanded a group's `membershipStatuses`, but that query only returns explicit `UserUserGroup` relations. Eligible status-derived users could therefore be omitted from section announcements.

## Impact

Announcements now use the same explicit-plus-inherited membership model as section access. Overlapping users receive one message, restricted users are excluded, and both recipient sources respect the same section opt-out records.

## Validation

- `cd functions && npm run lint -- --no-warn-ignored`
- `cd functions && npm run test:coverage` — 46 files, 409 tests
- `cd functions && npm run build`
- `npm run lint`
- `npm run test:run` — 65 files, 546 tests
- `npm run build`

Closes #370
Part of #365