### PR TITLE
[#371] Add Firebase Hosting security headers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 - `operations/transactional-email-policy.md`: operational vs optional/marketing email policy (#191).
 - `operations/section-announcement-audiences.md`: explicit and membership-status-derived audience, eligibility, deduplication, and opt-out rules for section announcements.
+- `operations/firebase-hosting-security-headers.md`: production CSP and browser hardening policy, HSTS ownership, and post-deploy verification.
 
 ## User Guides
 

--- a/docs/operations/firebase-hosting-security-headers.md
+++ b/docs/operations/firebase-hosting-security-headers.md
@@ -1,0 +1,73 @@
+# Firebase Hosting security headers
+
+Firebase Hosting applies the policy in [`firebase.json`](../../firebase.json) to every hosted path
+before rewrite processing. This covers the SPA document and assets, deep-link rewrites to
+`index.html`, and the `/unsubscribe` Function rewrite.
+
+## Policy
+
+| Header | Decision |
+|---|---|
+| `Content-Security-Policy` | Default to same-origin content; deny plugins, framing, and foreign form targets; allow only the Firebase, Google Analytics, and reCAPTCHA origins required by browser code. |
+| `X-Content-Type-Options` | `nosniff` prevents MIME-type guessing. |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` retains same-origin diagnostics without leaking paths to external sites. |
+| `Permissions-Policy` | Disables camera, microphone, geolocation, payment, USB, and unused motion/media capabilities. |
+| `X-Frame-Options` | `DENY` backs up CSP `frame-ancestors 'none'` for older clients. |
+
+MUI/Emotion generates style elements at runtime, so `style-src` retains `'unsafe-inline'`.
+JavaScript does not allow `'unsafe-inline'` or `'unsafe-eval'`.
+
+### Allowed browser services
+
+- Firebase Authentication: Identity Toolkit, Secure Token, and each environment's
+  `*.firebaseapp.com` auth frame.
+- callable Functions: the fixed `europe-west2` endpoint for Dev, Beta, and Prod.
+- Data Connect: `firebasedataconnect.googleapis.com`.
+- App Check: `firebaseappcheck.googleapis.com` plus the
+  [reCAPTCHA CSP origins](https://developers.google.com/recaptcha/docs/faq#im_using_content-security-policy_csp_on_my_website_how_can_i_configure_it_to_work_with_recaptcha).
+- optional Firebase Analytics: Firebase web configuration, Google Tag Manager, and Google Analytics collection origins.
+
+Stripe is intentionally absent from the CSP allowlist. The application assigns the Checkout
+Session URL to `window.location`, sending the browser to a
+[Stripe-hosted page](https://docs.stripe.com/payments/checkout/how-checkout-works); it does not
+embed Stripe scripts, frames, or API calls in the application origin. GOV.UK Notify is server-side,
+and links from email are ordinary top-level navigation, so it also needs no browser CSP source.
+
+## HSTS ownership
+
+Do not configure `Strict-Transport-Security` for the current default Hosting domains. Firebase
+[overwrites HSTS on `*.web.app` and other default subdomains](https://firebase.google.com/docs/hosting/full-config#headers),
+and live checks on 17 July 2026 confirmed that Dev, Beta, and Prod return:
+
+```text
+strict-transport-security: max-age=31556926; includeSubDomains; preload
+```
+
+If a custom domain is connected, revisit this decision before launch. Firebase serves the
+repository-configured HSTS value on custom domains, so confirm HTTPS coverage and ownership of all
+subdomains before adding `includeSubDomains` or `preload`.
+
+## Deployment verification
+
+Deploy to Beta first:
+
+```bash
+npm run build
+firebase deploy --only hosting --project beta
+curl -sS -D - -o /dev/null https://sodc-web-beta.web.app/
+curl -sS -D - -o /dev/null https://sodc-web-beta.web.app/sections/example
+```
+
+Confirm the five configured headers appear on both responses, HSTS remains present, and the CSP
+has not been duplicated or truncated. Then smoke-test:
+
+1. registration, email/password sign-in, sign-out, and account settings;
+2. section/event Data Connect reads and a callable Function action;
+3. App Check/reCAPTCHA with `VITE_RECAPTCHA_SITE_KEY` configured;
+4. Analytics collection when a measurement ID is configured;
+5. Stripe Checkout redirect, return, and receipt links; and
+6. announcement unsubscribe GET redirect and one-click POST.
+
+Use the browser console and Network panel to investigate CSP violations. Add an origin only after
+confirming which application feature requires it; do not add broad `https:` or wildcard Google
+sources to silence violations.

--- a/firebase.json
+++ b/firebase.json
@@ -31,6 +31,33 @@
       "**/.*",
       "**/node_modules/**"
     ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' https://www.googletagmanager.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google.com https://www.gstatic.com https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; font-src 'self' data:; connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebaseappcheck.googleapis.com https://firebaseinstallations.googleapis.com https://firebase.googleapis.com https://firebasedataconnect.googleapis.com https://europe-west2-sodc-web.cloudfunctions.net https://europe-west2-sodc-web-beta.cloudfunctions.net https://europe-west2-sodc-web-production.cloudfunctions.net https://www.google.com/recaptcha/ https://www.googletagmanager.com https://www.google-analytics.com https://*.google-analytics.com; frame-src 'self' https://sodc-web.firebaseapp.com https://sodc-web-beta.firebaseapp.com https://sodc-web-production.firebaseapp.com https://www.google.com/recaptcha/ https://recaptcha.google.com/recaptcha/; worker-src 'self' blob:; manifest-src 'self'; media-src 'self'; upgrade-insecure-requests"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "Permissions-Policy",
+            "value": "accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          }
+        ]
+      }
+    ],
     "rewrites": [
       {
         "source": "/unsubscribe",

--- a/src/__tests__/firebaseHostingSecurityHeaders.test.ts
+++ b/src/__tests__/firebaseHostingSecurityHeaders.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import firebaseConfigJson from "../../firebase.json?raw";
+
+interface HostingHeader {
+  key: string;
+  value: string;
+}
+
+interface FirebaseConfig {
+  hosting?: {
+    headers?: Array<{
+      source: string;
+      headers: HostingHeader[];
+    }>;
+    rewrites?: Array<{ source: string }>;
+  };
+}
+
+const config = JSON.parse(firebaseConfigJson) as FirebaseConfig;
+
+const globalRule = config.hosting?.headers?.find(({ source }) => source === "**");
+const headers = new Map(globalRule?.headers.map(({ key, value }) => [key.toLowerCase(), value]));
+
+function cspDirective(name: string): string[] {
+  const csp = headers.get("content-security-policy") ?? "";
+  const directive = csp
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part === name || part.startsWith(`${name} `));
+  return directive?.split(/\s+/).slice(1) ?? [];
+}
+
+describe("Firebase Hosting security headers", () => {
+  it("applies the policy to static files and routes before rewrites", () => {
+    expect(globalRule).toBeDefined();
+    expect(config.hosting?.rewrites?.map(({ source }) => source)).toEqual(
+      expect.arrayContaining(["/unsubscribe", "**"])
+    );
+  });
+
+  it("sets the browser hardening headers", () => {
+    expect(headers.get("x-content-type-options")).toBe("nosniff");
+    expect(headers.get("referrer-policy")).toBe("strict-origin-when-cross-origin");
+    expect(headers.get("x-frame-options")).toBe("DENY");
+    expect(headers.get("permissions-policy")).toContain("camera=()");
+    expect(headers.get("permissions-policy")).toContain("microphone=()");
+    expect(headers.get("permissions-policy")).toContain("payment=()");
+  });
+
+  it("locks down executable and embeddable content", () => {
+    expect(cspDirective("default-src")).toEqual(["'self'"]);
+    expect(cspDirective("base-uri")).toEqual(["'self'"]);
+    expect(cspDirective("object-src")).toEqual(["'none'"]);
+    expect(cspDirective("frame-ancestors")).toEqual(["'none'"]);
+    expect(cspDirective("form-action")).toEqual(["'self'"]);
+    expect(cspDirective("script-src")).not.toContain("'unsafe-inline'");
+    expect(cspDirective("script-src")).not.toContain("'unsafe-eval'");
+  });
+
+  it("allows the required Firebase browser APIs in every environment", () => {
+    const connectSources = cspDirective("connect-src");
+
+    expect(connectSources).toEqual(
+      expect.arrayContaining([
+        "https://identitytoolkit.googleapis.com",
+        "https://securetoken.googleapis.com",
+        "https://firebaseappcheck.googleapis.com",
+        "https://firebaseinstallations.googleapis.com",
+        "https://firebase.googleapis.com",
+        "https://firebasedataconnect.googleapis.com",
+        "https://europe-west2-sodc-web.cloudfunctions.net",
+        "https://europe-west2-sodc-web-beta.cloudfunctions.net",
+        "https://europe-west2-sodc-web-production.cloudfunctions.net",
+      ])
+    );
+  });
+
+  it("allows the documented reCAPTCHA and Firebase Auth frames", () => {
+    expect(cspDirective("script-src")).toEqual(
+      expect.arrayContaining([
+        "https://www.google.com/recaptcha/",
+        "https://www.gstatic.com/recaptcha/",
+      ])
+    );
+    expect(cspDirective("frame-src")).toEqual(
+      expect.arrayContaining([
+        "https://sodc-web.firebaseapp.com",
+        "https://sodc-web-beta.firebaseapp.com",
+        "https://sodc-web-production.firebaseapp.com",
+        "https://www.google.com/recaptcha/",
+        "https://recaptcha.google.com/recaptcha/",
+      ])
+    );
+  });
+
+  it("leaves HSTS under Firebase control for the default Hosting domains", () => {
+    expect(headers.has("strict-transport-security")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add a restrictive Content Security Policy for the Firebase, Google Analytics, and reCAPTCHA origins used by the browser application
- add MIME sniffing, referrer, permissions, and framing protections to every Firebase Hosting route and asset
- document Firebase-owned HSTS behaviour, CSP decisions, and the Beta deployment verification process
- add regression tests for the Hosting header configuration and required environment endpoints

## Impact

The application will receive production browser security headers from Firebase Hosting. Authentication, callable Functions, Data Connect, App Check/reCAPTCHA, optional Analytics, and the hosted Stripe Checkout redirect remain supported by the explicit policy.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:run` — 552 tests passed
- `npm run test:coverage` — 552 tests passed
- Firebase Hosting emulator returned HTTP 200 with all five configured headers
- `git diff --check`

A Beta deployment and browser smoke test are documented as the final post-deployment verification.

Closes #371