### PR TITLE
[#385] Reconcile enabled claims with membership status

### DIFF
--- a/docs/architecture/security-and-permissions.md
+++ b/docs/architecture/security-and-permissions.md
@@ -65,6 +65,14 @@ Typical usage:
 - Admin-only operations: `requireAdmin`, which also enforces `enabled: true`.
 - A caller with `admin: true` but `enabled !== true` is rejected; admin status is not an access-revocation bypass.
 
+The Data Connect membership status is the source of truth for the `enabled` claim,
+including for users who retain an `admin` claim. Restricted statuses always reconcile
+to `enabled: false`. Status changes use fail-closed cross-system write ordering, and an
+admin can repair drift by re-submitting the stored status. Notify-derived `LOST`
+transitions reuse the durable receipt retry when claim reconciliation fails. See
+[Enabled-claim reconciliation](../operations/enabled-claim-reconciliation.md) for the
+status mapping, failure modes, and recovery procedure.
+
 The only callable entry points intentionally using authentication without an enabled claim are pre-approval setup flows:
 
 - `updateDisplayName`, used while establishing the account profile.
@@ -107,6 +115,8 @@ npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts 
 
 - **Permission denied on callables**
   - Check auth token claims (`enabled`, `admin`) and entry guard expectations.
+  - If `enabled` disagrees with the Data Connect membership status, follow the
+    [enabled-claim reconciliation procedure](../operations/enabled-claim-reconciliation.md).
 - **Data Connect operation unexpectedly accessible/restricted**
   - Verify `@auth(...)` directive in source `.gql` and regenerate SDKs after changes.
 - **Webhook processing failures**

--- a/docs/operations/enabled-claim-reconciliation.md
+++ b/docs/operations/enabled-claim-reconciliation.md
@@ -1,0 +1,64 @@
+# Enabled-claim reconciliation
+
+Firebase Auth's `enabled` custom claim is the application access boundary used by
+Functions and Data Connect. The user's Data Connect `membershipStatus` is the source
+of truth for that claim:
+
+| Membership status | `enabled` |
+|---|---:|
+| `REGULAR`, `RETIRED`, `RESERVE`, `INDUSTRY`, `CIVIL_SERVICE` | `true` |
+| `PENDING`, `RESIGNED`, `LOST`, `DECEASED` | `false` |
+
+The rule applies to administrators too. The `admin` claim is preserved when access is
+revoked, but it never forces `enabled: true`; `requireAdmin` requires both claims.
+
+## Write ordering
+
+Membership changes span Data Connect and Firebase Auth, which cannot share a single
+transaction. `updateMembershipStatus` therefore uses fail-closed ordering:
+
+- Restricting access writes `enabled: false` before storing the restricted status.
+- Granting access stores the non-restricted status before writing `enabled: true`.
+- Auth claim errors are logged and returned as callable failures; they are not ignored.
+
+This ensures a partial failure cannot leave a restricted status with newly granted
+access. A failed restriction may temporarily leave an old active status with access
+already revoked, while a failed activation may leave an active status disabled. Both
+cases are repaired through the same idempotent reconciliation path below.
+
+## Automatic reconciliation paths
+
+- Admin and self-service status changes reconcile the claim in
+  `functions/src/membershipStatus.ts`.
+- A Notify permanent-failure threshold that marks a member `LOST` reconciles the claim
+  before its delivery receipt is marked processed.
+- If that Notify claim write fails, the receipt is marked `FAILED`. Reclaiming the same
+  receipt retries reconciliation even though the Data Connect status is already `LOST`.
+
+## Detecting drift
+
+Investigate Functions logs for either of these messages:
+
+- `Could not reconcile enabled claim with membership status`
+- `Membership access was revoked but the status write failed`
+
+Compare the user's Data Connect `membershipStatus` with their Firebase Auth custom
+claims using the mapping above. Do not remove unrelated claims while repairing access.
+
+## Repair procedure
+
+1. Confirm the intended membership status with an authorised administrator.
+2. Open the user's profile in the admin membership workflow and save it with the
+   intended status selected. Admin saves invoke `updateMembershipStatus` even when the
+   status is unchanged; the callable treats that as a claim-reconciliation request and
+   preserves all other custom claims.
+3. Confirm the callable succeeds and the Auth `enabled` claim matches the table above.
+4. Ask the affected user to sign out and back in, or otherwise refresh their Firebase ID
+   token, before testing access.
+5. For a Notify-derived `LOST` transition, also confirm the originating
+   `NotifyDeliveryReceipt` is `PROCESSED`. A `FAILED` row remains eligible for replay
+   with its original receipt ID.
+
+If a restriction revoked access but its Data Connect status write failed, either submit
+the intended restricted status to complete the change or re-submit the stored active
+status to restore access. Record which action was authorised.

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -49,6 +49,12 @@ Do not invent a new delivery key during recovery: that bypasses idempotency. Che
 
 `notifyDeliveryCallback` authenticates delivery receipts with `NOTIFY_CALLBACK_BEARER_TOKEN` and records every valid provider receipt ID in `NotifyDeliveryReceipt`. The provider ID is the table key, so an exact replay cannot create a second ledger entry. A receipt is processed under a 10-minute `PENDING` lease; failed or stale attempts can be reclaimed, while a concurrent callback for a fresh claim receives a retryable response.
 
+When the permanent-failure threshold changes a user's status to `LOST`, receipt
+processing also reconciles Firebase Auth to `enabled: false`. The receipt is not marked
+processed until that claim reconciliation succeeds. A failed claim write therefore
+leaves the receipt eligible for replay, including when the Data Connect status update
+already succeeded. See [Enabled-claim reconciliation](enabled-claim-reconciliation.md).
+
 Delivery ordering uses Notify's first valid timestamp in this order: `completed_at`, `sent_at`, then `created_at`. The function receive time is used only when Notify supplies none of those timestamps. The timestamp and receipt ID form a deterministic ordering key, so callbacks with equal timestamps still have a stable order.
 
 User bounce state is derived from the newest final receipts rather than incremented with an unprotected read/write pair:

--- a/functions/src/__tests__/enabledClaimReconciliation.test.ts
+++ b/functions/src/__tests__/enabledClaimReconciliation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  enabledClaimForMembershipStatus,
+  reconcileEnabledClaim,
+  type EnabledClaimAuthClient,
+} from "../enabledClaimReconciliation";
+import type { MembershipStatus } from "../validation";
+
+function authClient(args: {
+  customClaims?: Record<string, unknown>;
+  setError?: Error;
+} = {}) {
+  const getUser = vi.fn(async () => ({ customClaims: args.customClaims }));
+  const setCustomUserClaims = vi.fn(async () => {
+    if (args.setError) throw args.setError;
+  });
+  return {
+    client: { getUser, setCustomUserClaims } satisfies EnabledClaimAuthClient,
+    getUser,
+    setCustomUserClaims,
+  };
+}
+
+describe("enabledClaimForMembershipStatus", () => {
+  it.each<MembershipStatus>([
+    "REGULAR",
+    "RETIRED",
+    "RESERVE",
+    "INDUSTRY",
+    "CIVIL_SERVICE",
+  ])("enables non-restricted status %s", (membershipStatus) => {
+    expect(enabledClaimForMembershipStatus(membershipStatus)).toBe(true);
+  });
+
+  it.each<MembershipStatus>(["PENDING", "RESIGNED", "LOST", "DECEASED"])(
+    "disables restricted status %s",
+    (membershipStatus) => {
+      expect(enabledClaimForMembershipStatus(membershipStatus)).toBe(false);
+    }
+  );
+});
+
+describe("reconcileEnabledClaim", () => {
+  it("preserves existing claims while enabling a non-restricted member", async () => {
+    const auth = authClient({ customClaims: { admin: false, role: "moderator" } });
+
+    const result = await reconcileEnabledClaim("user-1", "REGULAR", auth.client);
+
+    expect(result).toEqual({ enabled: true, updated: true });
+    expect(auth.setCustomUserClaims).toHaveBeenCalledWith("user-1", {
+      admin: false,
+      role: "moderator",
+      enabled: true,
+    });
+  });
+
+  it("disables a restricted member even when the admin claim is present", async () => {
+    const auth = authClient({ customClaims: { admin: true, enabled: true } });
+
+    const result = await reconcileEnabledClaim("admin-1", "LOST", auth.client);
+
+    expect(result).toEqual({ enabled: false, updated: true });
+    expect(auth.setCustomUserClaims).toHaveBeenCalledWith("admin-1", {
+      admin: true,
+      enabled: false,
+    });
+  });
+
+  it("does not rewrite claims that already match the membership status", async () => {
+    const auth = authClient({ customClaims: { enabled: false, other: "kept" } });
+
+    const result = await reconcileEnabledClaim("user-1", "RESIGNED", auth.client);
+
+    expect(result).toEqual({ enabled: false, updated: false });
+    expect(auth.setCustomUserClaims).not.toHaveBeenCalled();
+  });
+
+  it("surfaces Firebase Auth claim-write failures", async () => {
+    const failure = new Error("Auth unavailable");
+    const auth = authClient({ customClaims: { enabled: true }, setError: failure });
+
+    await expect(
+      reconcileEnabledClaim("user-1", "DECEASED", auth.client)
+    ).rejects.toBe(failure);
+  });
+});

--- a/functions/src/__tests__/membershipStatusClaims.test.ts
+++ b/functions/src/__tests__/membershipStatusClaims.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { persistMembershipStatusWithEnabledClaim } from "../membershipStatus";
+import type { MembershipStatus } from "../validation";
+
+function dependencies(events: string[]) {
+  const updateMembershipStatus = vi.fn(
+    async (_userId: string, membershipStatus: MembershipStatus) => {
+      events.push(`status:${membershipStatus}`);
+    }
+  );
+  const reconcileEnabledClaim = vi.fn(
+    async (_userId: string, membershipStatus: MembershipStatus) => {
+      events.push(`claim:${membershipStatus}`);
+      return {
+        enabled: membershipStatus === "REGULAR",
+        updated: true,
+      };
+    }
+  );
+  return { updateMembershipStatus, reconcileEnabledClaim };
+}
+
+describe("persistMembershipStatusWithEnabledClaim", () => {
+  it("revokes the claim before persisting a restricted status", async () => {
+    const events: string[] = [];
+    await persistMembershipStatusWithEnabledClaim(
+      "user-1",
+      "RESIGNED",
+      dependencies(events)
+    );
+
+    expect(events).toEqual(["claim:RESIGNED", "status:RESIGNED"]);
+  });
+
+  it("persists an active status before granting enabled access", async () => {
+    const events: string[] = [];
+    await persistMembershipStatusWithEnabledClaim(
+      "user-1",
+      "REGULAR",
+      dependencies(events)
+    );
+
+    expect(events).toEqual(["status:REGULAR", "claim:REGULAR"]);
+  });
+
+  it("does not persist a restricted status when claim revocation fails", async () => {
+    const updateMembershipStatus = vi.fn(
+      async (_userId: string, _membershipStatus: MembershipStatus) => undefined
+    );
+    const failure = new Error("Auth unavailable");
+    const reconcileEnabledClaim = vi.fn(async () => {
+      throw failure;
+    });
+
+    await expect(
+      persistMembershipStatusWithEnabledClaim("user-1", "LOST", {
+        updateMembershipStatus,
+        reconcileEnabledClaim,
+      })
+    ).rejects.toBe(failure);
+    expect(updateMembershipStatus).not.toHaveBeenCalled();
+  });
+
+  it("surfaces activation claim failures after the status is persisted", async () => {
+    const events: string[] = [];
+    const updateMembershipStatus = vi.fn(async () => {
+      events.push("status");
+    });
+    const failure = new Error("Auth unavailable");
+    const reconcileEnabledClaim = vi.fn(async () => {
+      events.push("claim");
+      throw failure;
+    });
+
+    await expect(
+      persistMembershipStatusWithEnabledClaim("user-1", "REGULAR", {
+        updateMembershipStatus,
+        reconcileEnabledClaim,
+      })
+    ).rejects.toBe(failure);
+    expect(events).toEqual(["status", "claim"]);
+  });
+});

--- a/functions/src/__tests__/notifyCallback.test.ts
+++ b/functions/src/__tests__/notifyCallback.test.ts
@@ -565,6 +565,60 @@ describe("handleNotifyDelivery", () => {
     expect(onMembershipLost).toHaveBeenCalledTimes(1);
   });
 
+  it("retries LOST claim reconciliation after the status update has already applied", async () => {
+    const user = repository.addUser();
+    const onMembershipLost = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Firebase Auth unavailable"))
+      .mockResolvedValue(undefined);
+
+    await sendReceipt(
+      repository,
+      receipt({
+        id: "claim-retry-1",
+        status: "permanent-failure",
+        completed_at: "2026-07-17T10:00:00.000Z",
+      }),
+      onMembershipLost
+    );
+    await sendReceipt(
+      repository,
+      receipt({
+        id: "claim-retry-2",
+        status: "permanent-failure",
+        completed_at: "2026-07-17T11:00:00.000Z",
+      }),
+      onMembershipLost
+    );
+    const thresholdReceipt = receipt({
+      id: "claim-retry-3",
+      status: "permanent-failure",
+      completed_at: "2026-07-17T12:00:00.000Z",
+    });
+
+    await expect(
+      sendReceipt(repository, thresholdReceipt, onMembershipLost)
+    ).rejects.toThrow("Firebase Auth unavailable");
+    expect(user.membershipStatus).toBe(MembershipStatus.LOST);
+    expect(repository.receipts.get(thresholdReceipt.id)?.processingStatus).toBe(
+      NotifyDeliveryReceiptProcessingStatus.FAILED
+    );
+
+    const response = await sendReceipt(
+      repository,
+      thresholdReceipt,
+      onMembershipLost
+    );
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(onMembershipLost).toHaveBeenCalledTimes(2);
+    expect(repository.userStateApplyCount).toBe(3);
+    expect(repository.receipts.get(thresholdReceipt.id)?.attemptCount).toBe(2);
+    expect(repository.receipts.get(thresholdReceipt.id)?.processingStatus).toBe(
+      NotifyDeliveryReceiptProcessingStatus.PROCESSED
+    );
+  });
+
   it("keeps announcement delivery state ordered independently of callback arrival", async () => {
     const sendId = "11111111-1111-4111-8111-111111111111";
     const recipientId = "22222222-2222-4222-8222-222222222222";

--- a/functions/src/enabledClaimReconciliation.ts
+++ b/functions/src/enabledClaimReconciliation.ts
@@ -1,0 +1,74 @@
+import * as admin from "firebase-admin";
+import * as logger from "firebase-functions/logger";
+import { isNonRestrictedStatus, type MembershipStatus } from "./validation";
+
+interface AuthClaimsUser {
+  customClaims?: Record<string, unknown>;
+}
+
+export interface EnabledClaimAuthClient {
+  getUser(userId: string): Promise<AuthClaimsUser>;
+  setCustomUserClaims(userId: string, claims: Record<string, unknown>): Promise<void>;
+}
+
+export interface EnabledClaimReconciliationResult {
+  enabled: boolean;
+  updated: boolean;
+}
+
+/**
+ * Membership status is the source of truth for enabled access. Admin status is
+ * deliberately irrelevant: requireAdmin also requires enabled=true, so an
+ * admin claim must never bypass a restricted membership status.
+ */
+export function enabledClaimForMembershipStatus(
+  membershipStatus: MembershipStatus
+): boolean {
+  return isNonRestrictedStatus(membershipStatus);
+}
+
+/**
+ * Reconciles the Firebase Auth enabled claim with the stored membership status.
+ * Existing custom claims are preserved and write failures are surfaced to the
+ * caller so the originating operation can be retried or repaired.
+ */
+export async function reconcileEnabledClaim(
+  userId: string,
+  membershipStatus: MembershipStatus,
+  authClient: EnabledClaimAuthClient = admin.auth()
+): Promise<EnabledClaimReconciliationResult> {
+  const enabled = enabledClaimForMembershipStatus(membershipStatus);
+
+  try {
+    const userRecord = await authClient.getUser(userId);
+    const currentClaims = userRecord.customClaims ?? {};
+    if (currentClaims.enabled === enabled) {
+      logger.info("Enabled claim already matches membership status", {
+        userId,
+        membershipStatus,
+        enabled,
+      });
+      return { enabled, updated: false };
+    }
+
+    await authClient.setCustomUserClaims(userId, {
+      ...currentClaims,
+      enabled,
+    });
+    logger.info("Reconciled enabled claim with membership status", {
+      userId,
+      membershipStatus,
+      enabled,
+      admin: currentClaims.admin === true,
+    });
+    return { enabled, updated: true };
+  } catch (error: unknown) {
+    logger.error("Could not reconcile enabled claim with membership status", {
+      userId,
+      membershipStatus,
+      enabled,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    throw error;
+  }
+}

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -13,6 +13,7 @@ import { govNotifyApiKey } from "./mailer";
 import { notifyMembershipStatusEmailIfNeeded } from "./membershipStatusEmailDispatcher";
 import { invalidateDcProfileCache } from "./users";
 import { enforceRateLimit } from "./rateLimiter";
+import { reconcileEnabledClaim } from "./enabledClaimReconciliation";
 
 const APP_BASE_URL = (() => {
   const url = process.env.APP_BASE_URL || "http://localhost:5173";
@@ -36,6 +37,49 @@ export async function sendMembershipStatusEmailIfChanged(args: {
     newStatus: args.newStatus,
     appBaseUrl: args.appBaseUrl,
   });
+}
+
+interface MembershipStatusPersistenceDependencies {
+  updateMembershipStatus?: (
+    userId: string,
+    membershipStatus: MembershipStatus
+  ) => Promise<void>;
+  reconcileEnabledClaim?: typeof reconcileEnabledClaim;
+}
+
+/**
+ * Keeps status and access changes fail-closed across Data Connect and Firebase Auth.
+ * Restrictions revoke access before the status write; activations persist the status
+ * before granting access. Either partial failure can then be repaired by an admin
+ * re-submitting the stored status through updateMembershipStatus.
+ */
+export async function persistMembershipStatusWithEnabledClaim(
+  userId: string,
+  membershipStatus: MembershipStatus,
+  dependencies: MembershipStatusPersistenceDependencies = {}
+): Promise<void> {
+  const persistStatus =
+    dependencies.updateMembershipStatus ?? updateMembershipStatusInDataConnect;
+  const reconcileClaim =
+    dependencies.reconcileEnabledClaim ?? reconcileEnabledClaim;
+
+  if (isNonRestrictedStatus(membershipStatus)) {
+    await persistStatus(userId, membershipStatus);
+    await reconcileClaim(userId, membershipStatus);
+    return;
+  }
+
+  await reconcileClaim(userId, membershipStatus);
+  try {
+    await persistStatus(userId, membershipStatus);
+  } catch (error: unknown) {
+    logger.error("Membership access was revoked but the status write failed", {
+      userId,
+      membershipStatus,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    throw error;
+  }
 }
 
 // User groups may include membershipStatuses. Status-based membership is inherited (computed in
@@ -74,6 +118,29 @@ export const updateMembershipStatus = onCall(
     const targetUserIsAdmin = targetUser.customClaims?.admin === true;
     
     const currentStatus = await fetchCurrentStatusFromDataConnect(userId);
+
+    // Re-submitting the stored status is the supported admin recovery path for
+    // Auth/Data Connect claim drift. It is intentionally allowed even when the
+    // target retains an admin claim with a restricted membership status.
+    if (isAdmin && currentStatus === newStatus) {
+      const reconciliation = await reconcileEnabledClaim(
+        userId,
+        currentStatus as MembershipStatus
+      );
+      logger.info("Reconciled enabled claim from unchanged membership status", {
+        userId,
+        membershipStatus: currentStatus,
+        enabled: reconciliation.enabled,
+        updated: reconciliation.updated,
+        callerId: request.auth!.uid,
+      });
+      return {
+        success: true,
+        message: reconciliation.updated
+          ? "Account access claim reconciled successfully"
+          : "Account access claim already matched membership status",
+      };
+    }
     
     const validation = canUserChangeStatus(
       currentStatus,
@@ -88,10 +155,10 @@ export const updateMembershipStatus = onCall(
       throw new HttpsError("permission-denied", validation.error || "Invalid membership status transition");
     }
     
-    await updateMembershipStatusInDataConnect(userId, newStatus as MembershipStatus);
-    
-    // Automatically update the enabled claim based on membership status
-    await updateEnabledClaim(userId, newStatus as MembershipStatus);
+    await persistMembershipStatusWithEnabledClaim(
+      userId,
+      newStatus as MembershipStatus
+    );
     
     // Access group membership by status is computed at read time (admin UI and getSectionMembersMerged)
     // — we do not write UserAccessGroup rows when status changes.
@@ -142,8 +209,7 @@ export const resignMembership = onCall(
         throw new HttpsError("permission-denied", validation.error || "Cannot resign membership");
       }
 
-      await updateMembershipStatusInDataConnect(userId, newStatus);
-      await updateEnabledClaim(userId, newStatus);
+      await persistMembershipStatusWithEnabledClaim(userId, newStatus);
 
       await sendMembershipStatusEmailIfChanged({
         userId,
@@ -199,40 +265,5 @@ async function fetchCurrentStatusFromDataConnect(
       "internal",
       "Could not verify membership status"
     );
-  }
-}
-
-/**
- * Updates the enabled claim based on membership status
- * - enabled: true for non-restricted statuses (REGULAR, RETIRED, RESERVE, INDUSTRY, CIVIL_SERVICE)
- * - enabled: false for restricted statuses (PENDING, RESIGNED, LOST, DECEASED)
- * - enabled: always true for admins (admins cannot have restricted statuses)
- * Preserves existing claims (like admin) when updating
- */
-async function updateEnabledClaim(
-  userId: string,
-  membershipStatus: MembershipStatus
-): Promise<void> {
-  try {
-    // Get current user to preserve existing claims
-    const userRecord = await admin.auth().getUser(userId);
-    const currentClaims = userRecord.customClaims || {};
-    const isAdmin = currentClaims.admin === true;
-    
-    // Determine if account should be enabled based on membership status
-    // Admins must always be enabled (they cannot have restricted statuses)
-    const shouldBeEnabled = isAdmin ? true : isNonRestrictedStatus(membershipStatus);
-    
-    // Update claims, preserving existing ones
-    const updatedClaims = {
-      ...currentClaims,
-      enabled: shouldBeEnabled,
-    };
-    
-    await admin.auth().setCustomUserClaims(userId, updatedClaims);
-    logger.info(`Updated enabled claim for userId=${userId}: enabled=${shouldBeEnabled} (status=${membershipStatus}, admin=${isAdmin})`);
-  } catch (error: any) {
-    logger.error(`Could not update enabled claim for userId=${userId}:`, error);
-    // Don't throw - this is a side effect, we don't want to fail the status update if claim update fails
   }
 }

--- a/functions/src/notifyReceiptProcessor.ts
+++ b/functions/src/notifyReceiptProcessor.ts
@@ -21,6 +21,7 @@ import {
 import type { UUIDString } from "@dataconnect/admin-generated";
 import { parseAnnouncementReference } from "./announcementReference.js";
 import { invalidateDcProfileCache } from "./users.js";
+import { reconcileEnabledClaim } from "./enabledClaimReconciliation.js";
 
 export const BOUNCE_THRESHOLD = 3;
 export const DEFAULT_NOTIFY_RECEIPT_LEASE_MS = 10 * 60 * 1000;
@@ -478,8 +479,9 @@ async function applyDerivedUserState(args: {
   repository: NotifyReceiptRepository;
   userId: string;
   onMembershipLost: (userId: string) => void | Promise<void>;
+  reconcileExistingLost: boolean;
 }): Promise<"applied" | "no_state_change" | "no_user"> {
-  const { repository, userId, onMembershipLost } = args;
+  const { repository, userId, onMembershipLost, reconcileExistingLost } = args;
   for (let attempt = 0; attempt < MAX_CAS_ATTEMPTS; attempt += 1) {
     const [user, recentReceipts] = await Promise.all([
       repository.getUserById(userId),
@@ -491,13 +493,20 @@ async function applyDerivedUserState(args: {
 
     const markLost =
       derived.bounceCount >= BOUNCE_THRESHOLD && user.membershipStatus !== MembershipStatus.LOST;
+    const requiresLostClaimReconciliation =
+      derived.bounceCount >= BOUNCE_THRESHOLD &&
+      (markLost ||
+        (reconcileExistingLost && user.membershipStatus === MembershipStatus.LOST));
     const stateAlreadyCurrent =
       user.emailBounceCount === derived.bounceCount &&
       user.emailLastBounceAt === derived.lastBounceAt &&
       user.emailDeliveryStatus === derived.latest.notifyStatus &&
       user.emailDeliveryStatusUpdatedAt === derived.latest.eventAt &&
       user.emailDeliveryReceiptId === derived.latest.id;
-    if (stateAlreadyCurrent && !markLost) return "no_state_change";
+    if (stateAlreadyCurrent && !markLost) {
+      if (requiresLostClaimReconciliation) await onMembershipLost(userId);
+      return "no_state_change";
+    }
 
     const applied = await repository.tryApplyUserState({
       userId,
@@ -511,7 +520,7 @@ async function applyDerivedUserState(args: {
       markLost,
     });
     if (!applied) continue;
-    if (markLost) await onMembershipLost(userId);
+    if (requiresLostClaimReconciliation) await onMembershipLost(userId);
     return "applied";
   }
   throw new Error(`Unable to update Notify delivery state for user ${userId} after repeated contention`);
@@ -584,7 +593,10 @@ export async function processNotifyReceipt(
   const repository = dependencies.repository ?? dataConnectNotifyReceiptRepository;
   const receivedAt = dependencies.now?.() ?? new Date().toISOString();
   const leaseMs = dependencies.leaseMs ?? DEFAULT_NOTIFY_RECEIPT_LEASE_MS;
-  const onMembershipLost = dependencies.onMembershipLost ?? (() => invalidateDcProfileCache());
+  const onMembershipLost = dependencies.onMembershipLost ?? (async (userId: string) => {
+    invalidateDcProfileCache();
+    await reconcileEnabledClaim(userId, "LOST");
+  });
   if (!Number.isFinite(leaseMs) || leaseMs <= 0) {
     throw new Error("Notify receipt lease duration must be a positive number");
   }
@@ -611,7 +623,12 @@ export async function processNotifyReceipt(
       const parsedReference = parseAnnouncementReference(receipt.reference);
       const [userResult, announcementResult] = await Promise.all([
         initialUser
-          ? applyDerivedUserState({ repository, userId: initialUser.id, onMembershipLost })
+          ? applyDerivedUserState({
+              repository,
+              userId: initialUser.id,
+              onMembershipLost,
+              reconcileExistingLost: attemptCount > 1,
+            })
           : Promise.resolve<"no_user">("no_user"),
         parsedReference
           ? applyDerivedAnnouncementState({

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -26,7 +26,7 @@ import { parseDisplayName, validateUserForm } from "../../users/utils/userHelper
 import { updateUserDisplayName, updateMembershipStatus } from "../../../shared/utils/firebaseFunctions";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
-import { canUserChangeStatus, NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES } from "../../users/utils/membershipStatusValidation";
+import { canUserChangeStatus, membershipStatusSaveAction, NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES } from "../../users/utils/membershipStatusValidation";
 
 interface EditUserDialogProps {
   open: boolean;
@@ -139,12 +139,19 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
 
     // Check if target user is an admin
     const targetUserIsAdmin = user?.customClaims?.admin === true;
+    const statusSaveAction = membershipStatusSaveAction(
+      currentStatus,
+      membershipStatus,
+      isAdmin
+    );
     
     // Client-side validation (for immediate UX feedback)
-    const clientValidation = canUserChangeStatus(currentStatus, membershipStatus, isAdmin, targetUserIsAdmin);
-    if (!clientValidation.allowed) {
-      setUpdateMessage({ type: "error", text: clientValidation.error || "Invalid membership status change" });
-      return;
+    if (statusSaveAction !== "reconcile") {
+      const clientValidation = canUserChangeStatus(currentStatus, membershipStatus, isAdmin, targetUserIsAdmin);
+      if (!clientValidation.allowed) {
+        setUpdateMessage({ type: "error", text: clientValidation.error || "Invalid membership status change" });
+        return;
+      }
     }
 
     setSubmitting(true);
@@ -164,9 +171,9 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
       };
       await updateUser(dataConnect, vars);
 
-      // Update membership status separately via Firebase Function (validates and enforces rules)
-      // Only call if the status has actually changed
-      if (membershipStatus && membershipStatus !== currentStatus) {
+      // Admin saves also invoke the status callable when the value is unchanged. The
+      // server treats that as an idempotent enabled-claim reconciliation operation.
+      if (statusSaveAction !== "none") {
         const statusResult = await updateMembershipStatus(user.uid, membershipStatus);
         if (!statusResult.success) {
           setUpdateMessage({ type: "error", text: statusResult.error || "Failed to update membership status" });
@@ -392,4 +399,3 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
     </Dialog>
   );
 }
-

--- a/src/features/users/utils/__tests__/membershipStatusValidation.test.ts
+++ b/src/features/users/utils/__tests__/membershipStatusValidation.test.ts
@@ -5,6 +5,7 @@ import {
   RESTRICTED_STATUSES,
   canUserChangeStatus,
   canUserResignMembership,
+  membershipStatusSaveAction,
 } from '../membershipStatusValidation';
 import { MembershipStatus } from '../../../../dataconnect-generated';
 
@@ -238,5 +239,36 @@ describe('membershipStatusValidation', () => {
       expect(canUserResignMembership(null, false).allowed).toBe(false);
     });
   });
-});
 
+  describe('membershipStatusSaveAction', () => {
+    it('reconciles an unchanged status on an admin save', () => {
+      expect(
+        membershipStatusSaveAction(
+          MembershipStatus.LOST,
+          MembershipStatus.LOST,
+          true
+        )
+      ).toBe('reconcile');
+    });
+
+    it('does nothing for an unchanged status on a non-admin save', () => {
+      expect(
+        membershipStatusSaveAction(
+          MembershipStatus.REGULAR,
+          MembershipStatus.REGULAR,
+          false
+        )
+      ).toBe('none');
+    });
+
+    it('submits changed statuses as transitions', () => {
+      expect(
+        membershipStatusSaveAction(
+          MembershipStatus.PENDING,
+          MembershipStatus.REGULAR,
+          true
+        )
+      ).toBe('transition');
+    });
+  });
+});

--- a/src/features/users/utils/membershipStatusValidation.ts
+++ b/src/features/users/utils/membershipStatusValidation.ts
@@ -35,6 +35,22 @@ export function isRestrictedStatus(status: MembershipStatus): boolean {
   return RESTRICTED_STATUSES.includes(status);
 }
 
+export type MembershipStatusSaveAction = "none" | "transition" | "reconcile";
+
+/**
+ * Admin profile saves deliberately reconcile the enabled claim even when the
+ * selected status is unchanged. Non-admin saves retain the previous behaviour.
+ */
+export function membershipStatusSaveAction(
+  currentStatus: MembershipStatus | null,
+  selectedStatus: MembershipStatus,
+  isAdmin: boolean
+): MembershipStatusSaveAction {
+  if (isAdmin && selectedStatus === currentStatus) return "reconcile";
+  if (selectedStatus !== currentStatus) return "transition";
+  return "none";
+}
+
 /**
  * Validates if a user can change from one membership status to another
  * @param currentStatus - The user's current membership status (null if new user)
@@ -112,4 +128,3 @@ export function canUserResignMembership(
 
   return { allowed: true };
 }
-


### PR DESCRIPTION
Part of #365.

Closes #385.

## Summary

- centralise Firebase Auth `enabled` claim reconciliation around Data Connect membership status
- ensure restricted statuses resolve to `enabled: false` even when the user retains an `admin` claim
- use fail-closed cross-system write ordering for membership status transitions
- make unchanged admin status submissions an idempotent claim-repair operation
- retry Notify-derived `LOST` claim reconciliation through the durable receipt lifecycle
- expose claim-write failures instead of logging and silently continuing
- document drift detection and operational recovery

## Root cause

Membership status and Firebase Auth claims are stored in separate systems. The previous status-update path wrote Data Connect first, then swallowed Auth claim failures. The Notify callback only invalidated the profile cache after marking a member `LOST`, so a previously enabled user could retain `enabled: true`. Administrators were also forced enabled regardless of restricted membership status, conflicting with the shared `requireAdmin` revocation boundary.

## Behaviour

- restrictions revoke the Auth claim before persisting the restricted status
- activations persist the active status before granting access
- all unrelated custom claims are preserved
- an admin profile save invokes reconciliation even when the status is unchanged
- a failed Notify reconciliation leaves the receipt `FAILED`; reclaiming it retries the claim write without repeating the status mutation
- concurrent first-attempt callbacks still perform only one reconciliation

## Validation

- Functions lint
- Functions TypeScript build
- Functions tests: 427 passed
- Functions coverage gate passed
- Frontend lint
- Frontend production build
- Frontend tests: 555 passed
- `git diff --check`
