### PR TITLE
[#387] Correct deployment ordering

### DIFF
--- a/dataconnect/README.md
+++ b/dataconnect/README.md
@@ -114,11 +114,16 @@ All auth patterns are documented in `AUTH_EXPRESSIONS.md`. Key patterns:
 
 ## Deployment
 
-After making changes:
+After making changes, generate and compile against the SDKs **before** changing a remote environment:
 
-1. Deploy schema changes: `firebase deploy --only dataconnect:schema`
-2. Deploy operations: `firebase deploy --only dataconnect:api`
-3. Regenerate SDK: `firebase dataconnect:sdk:generate`
+1. Run `npx firebase dataconnect:sdk:generate` from the repository root.
+2. Run `git diff --exit-code -- src/dataconnect-generated functions/src/dataconnect-admin-generated` and `git status --short -- src/dataconnect-generated functions/src/dataconnect-admin-generated`; both must produce no output, including no untracked generated files.
+3. Run `npm run build` and `npm --prefix functions run build` to verify frontend and Admin SDK compatibility.
+4. Deploy the schema and `api` connector together with `firebase deploy --only dataconnect --project <dev|beta|prod>`.
+5. Confirm the service with `firebase dataconnect:services:list --project <dev|beta|prod>` and complete the Data Connect smoke-test checkpoint.
+6. Only then deploy dependent Functions, followed by Hosting, using the central [Dev, Beta, and Prod rollout runbook](../docs/operations/environments-dev-beta-prod.md#full-stack-rollout-sequence).
+
+The Firebase CLI applies required SQL migration steps before updating the Data Connect schema and connectors. Granular targets such as `dataconnect:sodc-web-service:schema` or `dataconnect:sodc-web-service:api` are reserved for an explicitly planned expand/contract rollout; they are not the default application release path.
 
 ## Related Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `architecture/booking-submission-api.md`: callable contract for `submitEventBooking`.
 - `architecture/security-and-permissions.md`: auth model across Data Connect and Cloud Functions.
 - `operations/environment-and-secrets.md`: environment variables and secrets matrix.
-- `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, deploy flow, and local setup (cloud-backed dev; no emulators).
+- `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, schema-first deploy flow, smoke-test and rollback checkpoints, and local setup (cloud-backed dev; no emulators).
 - `operations/transactional-email-workflows.md`: transactional email triggers by domain (payments, bookings, membership, guest tickets, ops alerts) with links to GOV.UK Notify template specs.
 - `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 - `operations/transactional-email-policy.md`: operational vs optional/marketing email policy (#191).

--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -14,7 +14,7 @@ Firebase callable functions use authentication and authorization as the first ac
 
 The bucket key is `(userId, functionName, windowStart)`. PostgreSQL serializes concurrent updates to the same bucket, so parallel function instances cannot overwrite one another's counts. `CallableInvocation` and its old operations remain temporarily available only to permit a connector-first rollout; new Functions code does not use them.
 
-Deploy Data Connect schema and connector changes before deploying Functions. After all environments run the new Functions version, the legacy counter can be removed in a separate cleanup.
+Deploy Data Connect schema and connector changes before deploying Functions. Generated frontend and Admin SDKs must be regenerated and both consumers compiled before that deployment. Follow the per-environment checkpoints in the [central rollout runbook](../operations/environments-dev-beta-prod.md#full-stack-rollout-sequence). After all environments run the new Functions version, the legacy counter can be removed in a separate cleanup.
 
 ## Central limits
 

--- a/docs/operations/environments-dev-beta-prod.md
+++ b/docs/operations/environments-dev-beta-prod.md
@@ -17,6 +17,7 @@ This document describes how we run **three isolated Firebase-backed environments
 1. **One Firebase project per environment** — Data Connect and Functions are **project-scoped**. Hosting preview channels do **not** duplicate backends; they only swap static frontend bundles within a single project.
 2. **Frontend config is baked at build time** — Vite reads `VITE_*` variables when you run `npm run build`. There is no runtime injection from Hosting for Firebase web SDK config. Each deploy pipeline must build with the correct `.env` for that target project.
 3. **Secrets and Stripe differ per project** — Use separate webhook endpoints, Stripe secrets, and Firebase secrets per environment (see [environment-and-secrets.md](./environment-and-secrets.md)).
+4. **Backend dependencies deploy schema-first** — For a full-stack release, verify generated Data Connect SDKs locally, deploy and validate Data Connect, deploy and validate Functions, then deploy Hosting. Do not use one unscoped `firebase deploy` command for a release that changes these dependencies.
 
 ## Firebase CLI aliases
 
@@ -35,10 +36,10 @@ firebase use dev    # or beta / prod
 firebase projects:list
 ```
 
-Override without switching default:
+Inspect a project without switching the default alias:
 
 ```sh
-firebase deploy --project beta
+firebase dataconnect:services:list --project beta
 ```
 
 The repo expects a **beta** Firebase project whose ID matches the `beta` entry in `.firebaserc` (currently `sodc-web-beta`). If that project does not exist yet, create it in the [Firebase Console](https://console.firebase.google.com/) with that ID **or** pick another ID and update `.firebaserc` accordingly. Until the project exists, `firebase use beta` will fail until the alias points at a real project.
@@ -55,19 +56,11 @@ The repo expects a **beta** Firebase project whose ID matches the `beta` entry i
    npm run dev
    ```
 
-4. **Functions / Data Connect changes** — Deploy to **dev** when you need others (or your deployed web build) to hit updated server behavior:
+4. **Functions / Data Connect changes** — Deploy to **dev** when you need others (or your deployed web build) to hit updated server behavior. Follow the full-stack rollout below; Data Connect must be deployed and checked before dependent Functions.
 
-   ```sh
-   firebase use dev
-   firebase deploy --only functions
-   firebase deploy --only dataconnect
-   ```
+## Building and deploying the SPA (Hosting-only changes)
 
-   Coordinate schema changes: Data Connect updates must be applied to each environment in order (typically dev → beta → prod) after review.
-
-## Building and deploying the SPA
-
-Always build with the environment variables for **the project you are about to deploy to**:
+For a Hosting-only change, always build with the environment variables for **the project you are about to deploy to**. If the release also changes Data Connect or Functions, use the full-stack rollout sequence instead and do not deploy Hosting until its backend checkpoints pass.
 
 ```sh
 # Example: deploy Hosting to beta — ensure VITE_* point at the beta Firebase web app
@@ -82,13 +75,91 @@ Common mistakes:
 
 Recommendation: maintain **separate env files** that are **not committed**, e.g. `.env.dev.local`, `.env.beta.local`, `.env.prod.local`, and copy or symlink the right one before `npm run build`, or use your shell/CI to export variables.
 
+## Full-stack rollout sequence
+
+Run this sequence independently for **Dev**, then **Beta**, then **Prod**. Complete the smoke-test checkpoint for one environment before promoting the same reviewed commit to the next. Replace `dev` below with `beta` or `prod` as appropriate.
+
+### 1. Pin the target and release revision
+
+```sh
+export FIREBASE_PROJECT=dev
+git status --short
+git rev-parse HEAD
+firebase dataconnect:services:list --project "$FIREBASE_PROJECT"
+```
+
+Start from a clean checkout of the reviewed release commit. Record the commit SHA and confirm that the Firebase alias resolves to the intended project. Beta and Prod must use the same commit that passed the preceding environment unless a new fix has been reviewed and the sequence restarts from Dev.
+
+### 2. Verify generated SDK compatibility
+
+Generate both the frontend and Admin SDKs from the checked-in schema and connector operations, then prove that the generated output is already committed and that both consumers compile:
+
+```sh
+npx firebase dataconnect:sdk:generate
+git diff --exit-code -- src/dataconnect-generated functions/src/dataconnect-admin-generated
+git status --short -- src/dataconnect-generated functions/src/dataconnect-admin-generated
+npm run build
+npm --prefix functions run build
+```
+
+The diff and status commands must both produce no output; the status check also catches new untracked generated files. If generation changes anything, stop and commit/review the generated files. If either build fails, stop before changing the remote environment. Do not deploy Functions compiled against stale generated operations.
+
+### 3. Deploy and validate Data Connect
+
+```sh
+firebase deploy --only dataconnect --project "$FIREBASE_PROJECT"
+firebase dataconnect:services:list --project "$FIREBASE_PROJECT"
+```
+
+Review migration and connector compatibility messages; do not add `--force` merely to bypass a warning or breaking-change assessment. Before continuing:
+
+1. confirm the `sodc-web-service` schema and `api` connector deployment completed;
+2. use the currently deployed client or Data Connect console to run a harmless existing read;
+3. exercise a new or changed read-only operation when the release adds one; and
+4. confirm existing Hosting and Functions traffic still works against the expanded schema.
+
+Schema changes that remove or rename fields require an expand/migrate/contract rollout across separate releases. Do not approve destructive migration steps during an ordinary application deploy.
+
+### 4. Deploy and validate Functions
+
+Only after the Data Connect checkpoint passes:
+
+```sh
+firebase deploy --only functions --project "$FIREBASE_PROJECT"
+```
+
+Smoke-test the changed callable, HTTP, or scheduled Function through a non-destructive path. Check Functions logs for startup, Data Connect operation, authorization, and secret/configuration errors. Also repeat one established callable flow to catch connector compatibility regressions.
+
+### 5. Build and deploy Hosting
+
+Confirm the active `.env` contains the target project's `VITE_*` values, rebuild, and deploy Hosting last:
+
+```sh
+npm run build
+firebase deploy --only hosting --project "$FIREBASE_PROJECT"
+```
+
+Smoke-test sign-in, one Data Connect read, one callable action, a deep link, and the release's changed browser flow. For CSP/header changes, also follow [firebase-hosting-security-headers.md](./firebase-hosting-security-headers.md).
+
+## Partial failure and rollback checkpoints
+
+| Failure point | Safe response |
+|---|---|
+| SDK generation or either build fails | Stop. No remote state has changed; regenerate, fix, review, and restart. |
+| Data Connect migration or connector deployment fails | Do not deploy Functions or Hosting. Preserve CLI output, inspect the service state, and prefer a forward-compatible fix. A schema migration may already have run even if a later connector step failed. |
+| Data Connect smoke test fails | Stop before Functions. Restore the previous connector/schema from the last known-good commit only when that rollback is non-destructive; otherwise ship a reviewed forward fix. |
+| Functions deploy or smoke test fails | Do not deploy Hosting. Keep the backward-compatible expanded schema in place and redeploy Functions from the last known-good release commit, then repeat the Function checkpoint. |
+| Hosting build, deploy, or smoke test fails | Backend checkpoints remain valid. Rebuild/redeploy Hosting from the last known-good release commit with the correct environment variables. |
+
+Checking out and redeploying a previous Data Connect definition cannot restore data removed by a destructive migration. Take a database backup and use a separately reviewed migration/rollback plan for destructive changes. Record the failed stage, target project, commit SHA, and corrective action before resuming promotion.
+
 ## Promotion flow (recommended)
 
 A practical sequence:
 
-1. Implement and integrate on **dev** (`firebase use dev`).
-2. When ready for wider validation, deploy the same revision (after review) to **beta** (`firebase use beta` or `--project beta`).
-3. After beta sign-off, deploy to **prod** (`firebase use prod` or `--project prod`) using prod secrets and Stripe configuration.
+1. Implement and integrate on **Dev**, completing all five rollout checkpoints.
+2. Deploy the same reviewed commit to **Beta** and repeat SDK verification, Data Connect, Functions, Hosting, and smoke tests.
+3. After Beta sign-off, repeat the complete sequence for **Prod** using production secrets and Stripe configuration.
 
 Branch ↔ environment mapping is a **team convention** (e.g. feature branches → dev only; `main` → beta then prod). Document any automation (GitHub Actions) in the workflow repo settings.
 

--- a/docs/operations/firebase-hosting-security-headers.md
+++ b/docs/operations/firebase-hosting-security-headers.md
@@ -49,7 +49,7 @@ subdomains before adding `includeSubDomains` or `preload`.
 
 ## Deployment verification
 
-Deploy to Beta first:
+For a full-stack release, complete the Data Connect and Functions checkpoints in the [central rollout runbook](./environments-dev-beta-prod.md#full-stack-rollout-sequence) before this Hosting step. For a Hosting-only change, deploy to Beta first:
 
 ```bash
 npm run build

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -80,8 +80,9 @@ Recover those legacy rows through a reviewed domain-specific replay; a new-code 
 backfills the recovery payload when it reclaims the existing row.
 
 Deploy the Data Connect schema and generated connector operations before deploying the
-scheduled Function. Confirm `GOV_NOTIFY_API_KEY` is available to the Function in each
-environment.
+scheduled Function. Use the SDK compatibility, Data Connect, and Function checkpoints in
+the [central rollout runbook](./environments-dev-beta-prod.md#full-stack-rollout-sequence).
+Confirm `GOV_NOTIFY_API_KEY` is available to the Function in each environment.
 
 Check Functions logs for `notification delivery failed`, `notification recovery attempt failed`, `notification delivery sent after its lease was replaced`, or `notification delivery failure occurred after its lease was replaced`. Because every server entry path awaits its dispatcher, ordinary provider errors are normally recorded as `FAILED` within the originating invocation; stale recovery is primarily for process termination after a claim.
 

--- a/functions/src/__tests__/deploymentRunbookContracts.test.ts
+++ b/functions/src/__tests__/deploymentRunbookContracts.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(process.cwd(), "..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function section(markdown: string, heading: string, nextHeading: string): string {
+  const start = markdown.indexOf(heading);
+  const end = markdown.indexOf(nextHeading, start + heading.length);
+  expect(start, `missing ${heading}`).toBeGreaterThanOrEqual(0);
+  expect(end, `missing ${nextHeading}`).toBeGreaterThan(start);
+  return markdown.slice(start, end);
+}
+
+describe("deployment runbook contracts", () => {
+  it("orders full-stack releases schema-first in every environment", () => {
+    const runbook = readRepoFile("docs/operations/environments-dev-beta-prod.md");
+    const rollout = section(
+      runbook,
+      "## Full-stack rollout sequence",
+      "## Partial failure and rollback checkpoints"
+    );
+
+    const generate = rollout.indexOf("dataconnect:sdk:generate");
+    const generatedDiff = rollout.indexOf("git diff --exit-code");
+    const generatedStatus = rollout.indexOf("git status --short --");
+    const dataConnect = rollout.indexOf("firebase deploy --only dataconnect");
+    const functions = rollout.indexOf("firebase deploy --only functions");
+    const hosting = rollout.indexOf("firebase deploy --only hosting");
+
+    expect(generate).toBeGreaterThanOrEqual(0);
+    expect(generatedDiff).toBeGreaterThan(generate);
+    expect(generatedStatus).toBeGreaterThan(generatedDiff);
+    expect(dataConnect).toBeGreaterThan(generatedStatus);
+    expect(functions).toBeGreaterThan(dataConnect);
+    expect(hosting).toBeGreaterThan(functions);
+    expect(rollout).toContain("**Dev**, then **Beta**, then **Prod**");
+    expect(rollout).not.toContain("firebase deploy --project");
+  });
+
+  it("documents smoke and rollback stops between remote deployment stages", () => {
+    const runbook = readRepoFile("docs/operations/environments-dev-beta-prod.md");
+    const rollback = section(
+      runbook,
+      "## Partial failure and rollback checkpoints",
+      "## Promotion flow"
+    );
+
+    expect(runbook).toContain("Before continuing:");
+    expect(runbook).toContain("Only after the Data Connect checkpoint passes:");
+    expect(rollback).toContain("Do not deploy Functions or Hosting");
+    expect(rollback).toContain("Do not deploy Hosting");
+    expect(rollback).toContain("destructive migration");
+  });
+
+  it("keeps the Data Connect guide generate-before-deploy", () => {
+    const guide = readRepoFile("dataconnect/README.md");
+    const generate = guide.indexOf("dataconnect:sdk:generate");
+    const deploy = guide.indexOf("firebase deploy --only dataconnect");
+
+    expect(generate).toBeGreaterThanOrEqual(0);
+    expect(deploy).toBeGreaterThan(generate);
+    expect(guide).not.toContain("firebase deploy --only dataconnect:schema");
+    expect(guide).not.toContain("firebase deploy --only dataconnect:api");
+  });
+});


### PR DESCRIPTION
## Summary

- make the central Dev/Beta/Prod runbook use a schema-first full-stack rollout
- verify generated frontend and Admin Data Connect SDKs before any remote deployment
- deploy and smoke-test Data Connect before dependent Functions, with Hosting last
- document checkpoints and rollback responses for SDK, Data Connect, Functions, and Hosting failures
- correct the contradictory generate-after-deploy guidance in the Data Connect guide
- align the callable abuse protection, transactional email, and Hosting guides with the central sequence
- add a contract test that prevents deployment-order regressions

## Why

The previous central runbook deployed Functions before Data Connect. Functions introduced by this epic depend immediately on new schema fields and connector operations, so that order could leave an environment partially deployed or broken if Data Connect subsequently failed.

## Developer and operator impact

Every environment now follows the same gated sequence: pin the release revision, regenerate and compile SDK consumers, deploy and validate Data Connect, deploy and validate Functions, then build and deploy Hosting. Destructive schema changes require a separate expand/migrate/contract plan rather than an ordinary application release.

## Validation

- Functions lint and TypeScript build
- 52 Functions test files / 446 tests
- frontend lint and production build
- 66 frontend test files / 555 tests
- `git diff --check`

Closes #387