### PR TITLE
[#389] Extend lint coverage to repository tooling

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,18 @@ export default defineConfig([
     files: ['src/**/*.{ts,tsx}'],
   },
   {
+    files: [
+      '*.config.{js,mjs,cjs,ts,mts,cts}',
+      '.github/scripts/**/*.{js,mjs,cjs}',
+      'functions/*.config.{js,mjs,cjs,ts,mts,cts}',
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      sourceType: 'module',
+    },
+  },
+  {
     files: ['src/**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "cd .. && ./node_modules/.bin/eslint functions/src functions/scripts",
+    "lint": "cd .. && ./node_modules/.bin/eslint functions/src functions/scripts functions/vitest.config.ts",
     "generate:templates": "ts-node --project tsconfig.scripts.json scripts/generate-template-manifest.ts",
     "check:template-sync": "ts-node --project tsconfig.scripts.json scripts/check-template-sync.ts",
     "prebuild": "npm run generate:templates",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint src",
+    "lint": "eslint src eslint.config.js vite.config.ts vitest.config.ts .github/scripts",
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",


### PR DESCRIPTION
## Summary

- extend the root lint command to cover ESLint, Vite, Vitest, and repository-owned tooling under `.github/scripts`
- extend the Functions lint command to cover `functions/vitest.config.ts`
- configure Node globals and module parsing for hand-authored configuration and tooling files
- retain the existing exclusions for generated code, coverage reports, and build outputs

## Why

The existing lint commands covered application source and Functions source/scripts, but left hand-authored build, test, and CI tooling outside the enforced lint boundary. This closes that residual gap from #372 without weakening the current rules.

## Developer impact

CI now catches lint regressions in repository configuration and tooling files as well as application code. There are no runtime or public API changes.

## Validation

- root lint with CI warning enforcement
- Functions lint with CI warning enforcement
- root build
- Functions build
- frontend tests: 66 files, 555 tests
- Functions tests: 56 files, 487 tests
- git diff whitespace checks

Closes #389