### PR TITLE
[#398] Resolve hardening review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ npm run dev
 ```sh
 cd functions
 npm install
+npm run lint
 npm run build
 ```
 

--- a/docs/contributor-workflow.md
+++ b/docs/contributor-workflow.md
@@ -57,6 +57,15 @@ cd functions
 npm run test -- authGuards dataconnectAuthContracts functionEntryGuardContracts --run
 ```
 
+Functions linting is self-contained: its ESLint dependencies and flat configuration live in
+`functions/`, so the same check also works after a Functions-only install:
+
+```sh
+cd functions
+npm ci
+npm run lint
+```
+
 ### Functions coverage
 
 `npm --prefix functions run test:coverage` reports on every hand-authored TypeScript file under `functions/src`, including files that no test imports. Build output, generated Data Connect code, generated email-template manifests, declarations, tests, and test helpers are excluded. HTML and JSON summary reports are written to `functions/coverage/`, which is ignored by Git and ESLint.
@@ -74,6 +83,7 @@ Higher grouped thresholds protect code at critical boundaries:
 
 - authorization, validation, and rate limiting (`helpers`, `rateLimiter`, `sections`, `validation`): 77% statements, 66% branches, 80% functions, 77% lines
 - deterministic payment, Stripe webhook, and state-transition logic: 90% statements, 73% branches, 100% functions, 94% lines
+- member-facing Stripe artifact retrieval: 95% statements, 78% branches, 100% functions, 95% lines
 - notification delivery and callback handling: 81% statements, 68% branches, 69% functions, 82% lines
 - notification delivery lease and idempotency logic: 65% statements, 50% branches, 57% functions, 64% lines
 

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -33,7 +33,7 @@ flowchart LR
 
 Takeover uses a conditional Data Connect update matching the row's status and previous attempt count. Only one concurrent invocation can win. `SENT` and `FAILED` completion updates also match the owning attempt count, so an expired invocation cannot overwrite a newer attempt if it resumes late. A direct domain retry can reclaim `FAILED` immediately; scheduled recovery applies a cooldown to avoid hammering the provider.
 
-Before sending an email with a stable Notify reference, the mailer queries GOV.UK Notify for an existing notification with that reference. If Notify accepted the earlier attempt but the function terminated before recording `SENT`, recovery adopts the existing provider notification ID and completes the ledger instead of sending a duplicate email.
+Before sending an email with a stable Notify reference, the mailer queries GOV.UK Notify for an existing notification with that reference. Multi-recipient dispatchers scope that reference to one recipient using a stable hash, so provider-side deduplication cannot suppress later recipients in the fan-out. If Notify accepted the earlier attempt but the function terminated before recording `SENT`, recovery adopts the existing provider notification ID and completes the ledger instead of sending a duplicate email.
 
 Every new delivery stores a versioned `recoveryPayload` containing the minimum routing
 context needed to reconstruct its dispatcher. Fan-out workflows also store the original

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,6 @@ export default defineConfig([
     files: [
       '*.config.{js,mjs,cjs,ts,mts,cts}',
       '.github/scripts/**/*.{js,mjs,cjs}',
-      'functions/*.config.{js,mjs,cjs,ts,mts,cts}',
     ],
     languageOptions: {
       ecmaVersion: 2022,
@@ -61,26 +60,6 @@ export default defineConfig([
       'react-hooks/refs': 'off',
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/set-state-in-render': 'off',
-    },
-  },
-  {
-    files: ['functions/src/**/*.ts', 'functions/scripts/**/*.ts'],
-    languageOptions: {
-      ecmaVersion: 2022,
-      globals: globals.node,
-      sourceType: 'module',
-    },
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-          argsIgnorePattern: '^_',
-          varsIgnorePattern: '^_',
-          caughtErrorsIgnorePattern: '^_',
-        },
-      ],
-      quotes: ['error', 'double'],
     },
   },
   {

--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -1,0 +1,43 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+import { defineConfig, globalIgnores } from "eslint/config";
+
+export default defineConfig([
+  globalIgnores([
+    "coverage",
+    "lib",
+    "src/dataconnect-admin-generated",
+    "src/generatedEmailTemplateManifest.ts",
+  ]),
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.ts", "scripts/**/*.ts"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      sourceType: "module",
+    },
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+      quotes: ["error", "double"],
+    },
+  },
+  {
+    files: ["*.config.{js,mjs,cjs,ts,mts,cts}"],
+    languageOptions: {
+      ecmaVersion: 2022,
+      globals: globals.node,
+      sourceType: "module",
+    },
+  },
+]);

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,11 +13,15 @@
         "stripe": "^22.0.2"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.1",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
+        "eslint": "^9.39.1",
         "firebase-functions-test": "^0.3.3",
+        "globals": "^16.5.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
+        "typescript-eslint": "^8.46.4",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -133,6 +137,163 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -417,6 +578,72 @@
         "node": ">=6"
       }
     },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -665,9 +892,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -685,9 +909,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,9 +926,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,9 +943,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -745,9 +960,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,9 +977,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,6 +1209,13 @@
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -1106,6 +1322,288 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
+      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/type-utils": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.64.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
+      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
+      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.64.0",
+        "@typescript-eslint/types": "^8.64.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
+      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
+      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
+      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
+      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
+      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.64.0",
+        "@typescript-eslint/tsconfig-utils": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/visitor-keys": "8.64.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
+      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.64.0",
+        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
+      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.64.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.9",
@@ -1312,6 +1810,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -1334,6 +1842,23 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1348,8 +1873,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1379,6 +1904,13 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -1472,6 +2004,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1540,6 +2079,17 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1584,6 +2134,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1592,6 +2152,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cliui": {
@@ -1613,8 +2190,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1626,8 +2203,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1640,6 +2217,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1704,6 +2288,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -1729,6 +2328,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1914,6 +2520,163 @@
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -1922,6 +2685,16 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2035,6 +2808,20 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
@@ -2136,6 +2923,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -2168,6 +2968,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/firebase-admin": {
       "version": "13.10.0",
@@ -2244,6 +3061,20 @@
       "peerDependencies": {
         "firebase-admin": ">=6.0.0",
         "firebase-functions": ">=2.0.0"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -2460,6 +3291,32 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/google-auth-library": {
@@ -2765,6 +3622,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2780,6 +3674,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2788,6 +3692,19 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -2815,6 +3732,13 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -2871,6 +3795,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-yaml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
@@ -2879,6 +3826,27 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
@@ -2937,6 +3905,30 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -3082,9 +4074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3106,9 +4095,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3130,9 +4116,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3154,9 +4137,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3217,6 +4197,22 @@
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
       "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -3271,6 +4267,13 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -3422,6 +4425,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -3456,6 +4472,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -3588,12 +4611,30 @@
         "wrappy": "1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3604,6 +4645,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -3611,6 +4681,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -3627,6 +4707,16 @@
       "optional": true,
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -3691,6 +4781,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/proto3-json-serializer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/proto3-json-serializer/-/proto3-json-serializer-2.0.2.tgz",
@@ -3747,6 +4847,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -3812,6 +4922,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/retry": {
@@ -3982,6 +5102,29 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -4165,6 +5308,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stripe": {
       "version": "22.0.2",
       "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.0.2.tgz",
@@ -4332,6 +5488,19 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -4382,6 +5551,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -4409,6 +5591,30 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.64.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
+      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.64.0",
+        "@typescript-eslint/parser": "8.64.0",
+        "@typescript-eslint/typescript-estree": "8.64.0",
+        "@typescript-eslint/utils": "8.64.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4422,6 +5628,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -4688,6 +5904,22 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4703,6 +5935,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -4805,8 +6047,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=10"
       },

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "cd .. && ./node_modules/.bin/eslint functions/src functions/scripts functions/vitest.config.ts",
+    "lint": "eslint src scripts vitest.config.ts eslint.config.mjs",
     "generate:templates": "ts-node --project tsconfig.scripts.json scripts/generate-template-manifest.ts",
     "check:template-sync": "ts-node --project tsconfig.scripts.json scripts/check-template-sync.ts",
     "prebuild": "npm run generate:templates",
@@ -29,11 +29,15 @@
     "stripe": "^22.0.2"
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
+    "eslint": "^9.39.1",
     "firebase-functions-test": "^0.3.3",
+    "globals": "^16.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
+    "typescript-eslint": "^8.46.4",
     "vitest": "^4.1.9"
   },
   "private": true,

--- a/functions/src/__tests__/guestTicketRequestEmails.test.ts
+++ b/functions/src/__tests__/guestTicketRequestEmails.test.ts
@@ -6,6 +6,7 @@ import {
   guestTicketBookerDeliveryKey,
   guestTicketModeratorDeliveryKey,
   notifyBookerGuestTicketRequestReviewed,
+  notifyModeratorsGuestTicketRequestSubmitted,
 } from "../guestTicketRequestEmails";
 import * as notificationDelivery from "../notificationDelivery";
 
@@ -87,5 +88,61 @@ describe("notifyBookerGuestTicketRequestReviewed", () => {
         }),
       })
     );
+  });
+});
+
+describe("notifyModeratorsGuestTicketRequestSubmitted", () => {
+  beforeEach(() => {
+    mockGetRequest.mockReset();
+    mockSendOnce.mockReset();
+    mockSendOnce.mockResolvedValue({ outcome: "sent" });
+  });
+
+  it("uses a distinct provider reference for every moderator", async () => {
+    mockGetRequest.mockResolvedValue({
+      data: {
+        guestTicketRequest: {
+          id: "00000000-0000-4000-8000-000000000001",
+          status: GuestTicketRequestStatus.PENDING,
+          requestedGuestCount: 2,
+          guestDisplayName: "Guest One",
+          dietaryNote: null,
+          moderatorNote: null,
+          guestTicketType: { id: "tt", title: "Guest ticket" },
+          booking: {
+            id: "00000000-0000-4000-8000-000000000002",
+            booker: {
+              id: "booker-1",
+              firstName: "Sam",
+              lastName: "Booker",
+              email: "sam@example.com",
+            },
+            event: {
+              id: "evt",
+              title: "Annual dinner",
+              section: { id: "sec-1", name: "Events" },
+            },
+          },
+        },
+      },
+    } as Awaited<ReturnType<typeof admin.getGuestTicketRequestForNotification>>);
+    const sendEmail = vi.fn().mockResolvedValue({
+      provider: "govuk_notify",
+      providerNotificationId: "n-1",
+    });
+
+    await notifyModeratorsGuestTicketRequestSubmitted({
+      requestId: "00000000-0000-4000-8000-000000000001",
+      appBaseUrl: "https://app.example/",
+      recipientEmails: ["first@example.com", "second@example.com"],
+      getMailer: () => ({ sendEmail }),
+    });
+
+    expect(mockSendOnce).toHaveBeenCalledTimes(2);
+    await mockSendOnce.mock.calls[0][0].send();
+    await mockSendOnce.mock.calls[1][0].send();
+    const references = sendEmail.mock.calls.map(([request]) => request.reference);
+    expect(new Set(references)).toHaveLength(2);
+    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
   });
 });

--- a/functions/src/__tests__/mailer.test.ts
+++ b/functions/src/__tests__/mailer.test.ts
@@ -14,6 +14,7 @@ import {
   govNotifyTemplateEnvVarName,
   MailerConfigurationError,
   readGovNotifyTemplateIds,
+  recipientScopedNotifyReference,
   type NotifyEmailClient,
 } from "../mailer";
 
@@ -59,6 +60,17 @@ describe("mailer", () => {
         GOV_NOTIFY_EMAIL_REPLY_TO_ID: "reply-to-id",
       })
     ).toHaveProperty("sendEmail");
+  });
+
+  it("builds stable recipient-scoped references without exposing recipient PII", () => {
+    const first = recipientScopedNotifyReference("event-123", " First@Example.com ");
+    const sameRecipient = recipientScopedNotifyReference("event-123", "first@example.com");
+    const second = recipientScopedNotifyReference("event-123", "second@example.com");
+
+    expect(first).toBe(sameRecipient);
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^event-123:[0-9a-f]{24}$/);
+    expect(first).not.toContain("example.com");
   });
 
   it("fails with a typed configuration error before contacting Notify", async () => {
@@ -162,6 +174,64 @@ describe("mailer", () => {
     });
 
     expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("sends every fan-out recipient while still deduplicating retries", async () => {
+    const accepted: Array<{ id: string; reference: string }> = [];
+    const getNotifications = vi.fn<NotifyEmailClient["getNotifications"]>(
+      async (_templateType, _status, reference) => ({
+        data: {
+          notifications: accepted.filter((notification) => notification.reference === reference),
+        },
+      })
+    );
+    const sendEmail = vi.fn<NotifyEmailClient["sendEmail"]>(
+      async (_templateId, _emailAddress, options) => {
+        const notification = {
+          id: `notify-${accepted.length + 1}`,
+          reference: options?.reference ?? "",
+        };
+        accepted.push(notification);
+        return { data: notification };
+      }
+    );
+    const mailer = createGovNotifyMailer<TestTemplates>({
+      apiKey: "notify-api-key",
+      templateIds: { paymentConfirmation: "template-paid" },
+      clientFactory: () => ({ getNotifications, sendEmail }),
+      logger: fakeLogger(),
+    });
+    const personalisation = {
+      event_title: "Annual Dinner",
+      amount_paid: "GBP 10.00",
+    };
+    const firstReference = recipientScopedNotifyReference("order-123", "first@example.com");
+    const secondReference = recipientScopedNotifyReference("order-123", "second@example.com");
+
+    await mailer.sendEmail({
+      templateName: "paymentConfirmation",
+      to: "first@example.com",
+      personalisation,
+      reference: firstReference,
+    });
+    await mailer.sendEmail({
+      templateName: "paymentConfirmation",
+      to: "second@example.com",
+      personalisation,
+      reference: secondReference,
+    });
+    await mailer.sendEmail({
+      templateName: "paymentConfirmation",
+      to: "first@example.com",
+      personalisation,
+      reference: firstReference,
+    });
+
+    expect(sendEmail).toHaveBeenCalledTimes(2);
+    expect(accepted.map((notification) => notification.reference)).toEqual([
+      firstReference,
+      secondReference,
+    ]);
   });
 
   it("logs provider failures without recipient PII", async () => {

--- a/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
+++ b/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
@@ -85,7 +85,9 @@ describe("payment ops internal alert orchestration", () => {
   });
 
   it("deduplicates recipients and sends reconciliation context through the ledger", async () => {
-    const sendEmail = vi.fn(async () => ({ providerNotificationId: "notify-1" }));
+    const sendEmail = vi.fn(async (_request: { reference?: string }) => ({
+      providerNotificationId: "notify-1",
+    }));
 
     await notifyPaymentOpsReconciliationExceptionOpened({
       orderId: ORDER_ID,
@@ -120,6 +122,9 @@ describe("payment ops internal alert orchestration", () => {
         }),
       })
     );
+    const references = sendEmail.mock.calls.map(([request]) => request.reference);
+    expect(new Set(references)).toHaveLength(2);
+    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
   });
 
   it("continues to the next recipient after one ledger delivery fails", async () => {
@@ -175,7 +180,9 @@ describe("payment ops internal alert orchestration", () => {
   });
 
   it("sends complete dispute state to the targeted recipient", async () => {
-    const sendEmail = vi.fn(async () => ({ providerNotificationId: "notify-dispute" }));
+    const sendEmail = vi.fn(async (_request: { reference?: string }) => ({
+      providerNotificationId: "notify-dispute",
+    }));
 
     await notifyPaymentOpsDisputeSideState({
       orderId: ORDER_ID,
@@ -186,7 +193,7 @@ describe("payment ops internal alert orchestration", () => {
       disputeLocalState: "DISPUTE_UPDATED",
       stripeDisputeId: "dp_1",
       appBaseUrl: "https://app.example/",
-      recipientEmails: ["OPS@example.com"],
+      recipientEmails: ["OPS@example.com", "finance@example.com"],
       getMailer: () => ({ sendEmail } as never),
     });
 
@@ -211,5 +218,8 @@ describe("payment ops internal alert orchestration", () => {
         }),
       })
     );
+    const references = sendEmail.mock.calls.map(([request]) => request.reference);
+    expect(new Set(references)).toHaveLength(2);
+    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
   });
 });

--- a/functions/src/__tests__/paymentReconciliationService.test.ts
+++ b/functions/src/__tests__/paymentReconciliationService.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@dataconnect/admin-generated";
 import {
   applyPaymentTransitionToOrders,
+  PaymentTransitionBatchError,
   paymentReconciliationExceptionId,
   reconcilePaidCheckoutSessionOrders,
   upsertReconciliationSnapshot,
@@ -283,6 +284,47 @@ describe("applyPaymentTransitionToOrders", () => {
     });
     expect(harness.emitNotification).toHaveBeenCalledTimes(2);
     expect(harness.upsertSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("continues processing sibling orders before reporting a per-order failure", async () => {
+    const failure = new Error("delivery ledger permanently unavailable for order 1");
+    const harness = transitionDependencies();
+    harness.getOrder.mockImplementation(async ({ id }: { id: UUIDString }) => ({
+      data: { ticketOrder: order(id) },
+    }) as never);
+    harness.runTransition.mockImplementation(async ({ orderId }) => ({
+      action: "applied" as const,
+      reason: "legal_transition",
+      orderId,
+      fromStatus: TicketOrderStatus.PENDING,
+      targetStatus: TicketOrderStatus.PAID,
+      intent: "MARK_PAID" as const,
+    }));
+    harness.emitNotification.mockImplementation(async ({ orderId }) => {
+      if (orderId === ORDER_1) {
+        throw failure;
+      }
+    });
+
+    const result = applyPaymentTransitionToOrders(
+      {
+        orderIds: [ORDER_1, ORDER_2],
+        intent: "MARK_PAID",
+        webhookEventId: "evt_partial_failure",
+      },
+      harness.dependencies
+    );
+
+    await expect(result).rejects.toBeInstanceOf(PaymentTransitionBatchError);
+    await expect(result).rejects.toMatchObject({
+      failures: [{ orderId: ORDER_1, error: failure }],
+    });
+    expect(harness.runTransition).toHaveBeenCalledTimes(2);
+    expect(harness.emitNotification).toHaveBeenCalledTimes(2);
+    expect(harness.upsertSnapshot).toHaveBeenCalledOnce();
+    expect(harness.upsertSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ orderId: ORDER_2 })
+    );
   });
 
   it("retries notification setup and snapshot work after the transition committed", async () => {

--- a/functions/src/__tests__/paymentStripeArtifacts.test.ts
+++ b/functions/src/__tests__/paymentStripeArtifacts.test.ts
@@ -1,6 +1,43 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as admin from "@dataconnect/admin-generated";
 import type { StripeClient } from "../paymentConfig";
-import { fetchStripeArtifactsForOrder } from "../paymentStripeArtifacts";
+
+const paymentConfigMocks = vi.hoisted(() => ({
+  requireStripe: vi.fn(),
+}));
+
+vi.mock("firebase-functions/v2/https", () => ({
+  onCall: vi.fn().mockImplementation((_options: unknown, handler: unknown) => handler),
+  HttpsError: class HttpsError extends Error {
+    constructor(public code: string, message: string) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock("../paymentConfig", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../paymentConfig")>()),
+  requireStripe: paymentConfigMocks.requireStripe,
+  stripeSecret: { value: () => "sk_test" },
+}));
+
+import {
+  fetchStripeArtifactsForOrder,
+  getMyTicketOrderStripeArtifactsBatch,
+} from "../paymentStripeArtifacts";
+
+const USER_ID = "user-1";
+const ORDER_1 = "11111111-1111-4111-8111-111111111111";
+const ORDER_2 = "22222222-2222-4222-8222-222222222222";
+const consumeRateLimit = vi.spyOn(admin, "consumeCallableRateLimit");
+const getOrder = vi.spyOn(admin, "getTicketOrderStripeArtifactsForCallable");
+
+type Handler = (request: {
+  auth?: { uid: string; token: Record<string, unknown> };
+  data: Record<string, unknown>;
+}) => Promise<unknown>;
+
+const handler = getMyTicketOrderStripeArtifactsBatch as unknown as Handler;
 
 function stripeClientWith(args: {
   session?: unknown;
@@ -89,5 +126,162 @@ describe("fetchStripeArtifactsForOrder", () => {
       })
     ).resolves.toEqual({ receiptUrl: "https://stripe.test/list-receipt" });
     expect(client.listCharges).toHaveBeenCalledWith({ payment_intent: "pi_4", limit: 1 });
+  });
+});
+
+describe("getMyTicketOrderStripeArtifactsBatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consumeRateLimit.mockResolvedValue({ data: {} } as never);
+  });
+
+  it("authorizes, rate-limits, verifies ownership, and returns Stripe artifacts", async () => {
+    const client = stripeClientWith({
+      paymentIntent: {
+        latest_charge: { id: "ch_1", receipt_url: "https://stripe.test/receipt" },
+      },
+    });
+    paymentConfigMocks.requireStripe.mockReturnValue(client.stripeClient);
+    getOrder.mockResolvedValue({
+      data: {
+        ticketOrder: {
+          id: ORDER_1,
+          user: { id: USER_ID },
+          stripeCheckoutSessionId: null,
+          stripePaymentIntentId: "pi_1",
+        },
+      },
+    } as never);
+
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds: [ORDER_1] },
+      })
+    ).resolves.toEqual({
+      artifactsByOrderId: {
+        [ORDER_1]: { receiptUrl: "https://stripe.test/receipt" },
+      },
+    });
+
+    expect(consumeRateLimit).toHaveBeenCalledWith({
+      userId: USER_ID,
+      functionName: "getMyTicketOrderStripeArtifactsBatch",
+      windowStart: expect.any(String),
+      limit: 10,
+    });
+    expect(getOrder).toHaveBeenCalledWith({ id: ORDER_1 });
+    expect(consumeRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      getOrder.mock.invocationCallOrder[0]
+    );
+    expect(paymentConfigMocks.requireStripe).toHaveBeenCalledWith("sk_test");
+  });
+
+  it("rejects disabled callers before rate limiting or reading orders", async () => {
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: false } },
+        data: { orderIds: [ORDER_1] },
+      })
+    ).rejects.toMatchObject({ code: "permission-denied" });
+
+    expect(consumeRateLimit).not.toHaveBeenCalled();
+    expect(getOrder).not.toHaveBeenCalled();
+    expect(paymentConfigMocks.requireStripe).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["an empty batch", []],
+    ["more than 50 ids", Array.from({ length: 51 }, () => ORDER_1)],
+  ])("rejects %s before reading orders", async (_label, orderIds) => {
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds },
+      })
+    ).rejects.toMatchObject({ code: "invalid-argument" });
+
+    expect(consumeRateLimit).toHaveBeenCalledOnce();
+    expect(getOrder).not.toHaveBeenCalled();
+    expect(paymentConfigMocks.requireStripe).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed order ids before reading orders", async () => {
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds: ["not-a-uuid"] },
+      })
+    ).rejects.toMatchObject({ code: "invalid-argument" });
+
+    expect(consumeRateLimit).toHaveBeenCalledOnce();
+    expect(getOrder).not.toHaveBeenCalled();
+  });
+
+  it("rejects the whole batch when any order belongs to another user", async () => {
+    getOrder
+      .mockResolvedValueOnce({
+        data: {
+          ticketOrder: {
+            id: ORDER_1,
+            user: { id: USER_ID },
+            stripeCheckoutSessionId: null,
+            stripePaymentIntentId: null,
+          },
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        data: {
+          ticketOrder: {
+            id: ORDER_2,
+            user: { id: "other-user" },
+            stripeCheckoutSessionId: null,
+            stripePaymentIntentId: "pi_other",
+          },
+        },
+      } as never);
+
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds: [ORDER_1, ORDER_2] },
+      })
+    ).rejects.toMatchObject({ code: "permission-denied" });
+
+    expect(getOrder).toHaveBeenCalledTimes(2);
+    expect(paymentConfigMocks.requireStripe).not.toHaveBeenCalled();
+  });
+
+  it("returns null artifacts for missing orders without leaking order details", async () => {
+    paymentConfigMocks.requireStripe.mockReturnValue(stripeClientWith({}).stripeClient);
+    getOrder.mockResolvedValue({ data: { ticketOrder: null } } as never);
+
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds: [ORDER_1] },
+      })
+    ).resolves.toEqual({
+      artifactsByOrderId: {
+        [ORDER_1]: {
+          receiptUrl: null,
+          hostedInvoiceUrl: null,
+          invoicePdfUrl: null,
+        },
+      },
+    });
+  });
+
+  it("propagates order lookup failures without initializing Stripe", async () => {
+    getOrder.mockRejectedValueOnce(new Error("Data Connect unavailable"));
+
+    await expect(
+      handler({
+        auth: { uid: USER_ID, token: { enabled: true } },
+        data: { orderIds: [ORDER_1] },
+      })
+    ).rejects.toThrow("Data Connect unavailable");
+
+    expect(paymentConfigMocks.requireStripe).not.toHaveBeenCalled();
   });
 });

--- a/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
+++ b/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
@@ -134,6 +134,7 @@ describe("notifyAdminsUserPendingApproval", () => {
     expect(mockSendOnce.mock.calls[0][0].notificationType).toBe("USER_PENDING_APPROVAL");
 
     await mockSendOnce.mock.calls[0][0].send();
+    await mockSendOnce.mock.calls[1][0].send();
     expect(sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         templateName: "newUserPendingApprovalAlert",
@@ -146,6 +147,9 @@ describe("notifyAdminsUserPendingApproval", () => {
         }),
       })
     );
+    const references = sendEmail.mock.calls.map(([request]) => request.reference);
+    expect(new Set(references)).toHaveLength(2);
+    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
   });
 
   it("skips sending (without throwing) when there are no admin recipients", async () => {

--- a/functions/src/guestTicketRequestEmails.ts
+++ b/functions/src/guestTicketRequestEmails.ts
@@ -5,7 +5,11 @@ import {
   NotificationChannel,
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
-import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import {
+  createConfiguredGovNotifyMailer,
+  GOV_NOTIFY_PROVIDER,
+  recipientScopedNotifyReference,
+} from "./mailer";
 import { sanitizeMailerError } from "./mailerErrors";
 import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
 import { sendNotificationOnce } from "./notificationDelivery";
@@ -146,7 +150,7 @@ export async function notifyModeratorsGuestTicketRequestSubmitted(args: {
               templateName: "guestTicketRequestSubmittedModerator",
               to,
               personalisation,
-              reference,
+              reference: recipientScopedNotifyReference(reference, to),
             });
             return { providerMessageId: r.providerNotificationId ?? null };
           },

--- a/functions/src/mailer.ts
+++ b/functions/src/mailer.ts
@@ -1,6 +1,7 @@
 import { defineSecret } from "firebase-functions/params";
 import * as logger from "firebase-functions/logger";
 import { NotifyClient } from "notifications-node-client";
+import { createHash } from "node:crypto";
 import { sanitizeMailerError } from "./mailerErrors";
 
 export const govNotifyApiKey = defineSecret("GOV_NOTIFY_API_KEY");
@@ -125,6 +126,18 @@ export function readGovNotifyTemplateIds<TTemplateName extends string>(
 
 export function getGovNotifyEmailReplyToId(env: NodeJS.ProcessEnv = process.env): string | undefined {
   return maybeNonEmpty(env[GOV_NOTIFY_EMAIL_REPLY_TO_ID_ENV]);
+}
+
+/**
+ * Keeps provider-side idempotency scoped to one recipient without placing their
+ * email address in GOV.UK Notify metadata.
+ */
+export function recipientScopedNotifyReference(reference: string, recipientEmail: string): string {
+  const recipientHash = createHash("sha256")
+    .update(recipientEmail.trim().toLowerCase())
+    .digest("hex")
+    .slice(0, 24);
+  return `${reference}:${recipientHash}`;
 }
 
 export function createGovNotifyMailer<TPayloads extends TransactionalEmailPayloads<TPayloads>>(

--- a/functions/src/paymentOpsInternalAlerts.ts
+++ b/functions/src/paymentOpsInternalAlerts.ts
@@ -5,7 +5,11 @@ import {
   PaymentReconciliationExceptionType,
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
-import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import {
+  createConfiguredGovNotifyMailer,
+  GOV_NOTIFY_PROVIDER,
+  recipientScopedNotifyReference,
+} from "./mailer";
 import { sanitizeMailerError } from "./mailerErrors";
 import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
 import { sendNotificationOnce } from "./notificationDelivery";
@@ -164,7 +168,7 @@ export async function notifyPaymentOpsReconciliationExceptionOpened(args: {
               templateName: "paymentReconciliationExceptionAlert",
               to,
               personalisation,
-              reference,
+              reference: recipientScopedNotifyReference(reference, to),
             });
             return { providerMessageId: r.providerNotificationId ?? null };
           },
@@ -265,7 +269,7 @@ export async function notifyPaymentOpsDisputeSideState(args: {
               templateName: "paymentDisputeOpsAlert",
               to,
               personalisation,
-              reference,
+              reference: recipientScopedNotifyReference(reference, to),
             });
             return { providerMessageId: r.providerNotificationId ?? null };
           },

--- a/functions/src/paymentReconciliationService.ts
+++ b/functions/src/paymentReconciliationService.ts
@@ -195,6 +195,21 @@ export interface PaymentTransitionOrchestrationDependencies {
   now: () => string;
 }
 
+export interface PaymentTransitionOrderFailure {
+  orderId: UUIDString;
+  error: unknown;
+}
+
+export class PaymentTransitionBatchError extends Error {
+  constructor(public readonly failures: readonly PaymentTransitionOrderFailure[]) {
+    const details = failures
+      .map(({ orderId, error }) => `${orderId}: ${error instanceof Error ? error.message : String(error)}`)
+      .join("; ");
+    super(`Payment transition processing failed for ${failures.length} order(s): ${details}`);
+    this.name = "PaymentTransitionBatchError";
+  }
+}
+
 const defaultPaymentTransitionDependencies: PaymentTransitionOrchestrationDependencies = {
   getOrder: getTicketOrderForWebhook,
   runTransition: runTicketOrderTransition,
@@ -227,70 +242,83 @@ export async function applyPaymentTransitionToOrders(
 ): Promise<{ appliedCount: number; reconciledOrderIds: UUIDString[] }> {
   let appliedCount = 0;
   const reconciledOrderIds: UUIDString[] = [];
+  const failures: PaymentTransitionOrderFailure[] = [];
 
   for (const [orderIndex, orderId] of args.orderIds.entries()) {
-    const orderRow = await dependencies.getOrder({ id: orderId });
-    const currentOrder = orderRow.data?.ticketOrder;
-    if (!currentOrder) {
-      continue;
-    }
-    const transitionResult = await dependencies.runTransition(
-      {
-        orderId,
-        currentStatus: currentOrder.status,
-        intent: args.intent,
-        webhookEventId: args.webhookEventId,
-        recoverFailedCheckoutPayment: args.recoverFailedCheckoutPayment,
-        paidContext:
-          args.intent === "MARK_PAID" && args.paidContext
-            ? paidContextForMultiOrderWebhook(orderIndex, args.paidContext)
-            : undefined,
-        refundContext: args.refundContext,
-      },
-      {
-        markPaid: markTicketOrderPaidFromWebhook,
-        markFailed: markTicketOrderFailedFromWebhook,
-        markRefunded: markTicketOrderRefundedFromWebhook,
+    try {
+      const orderRow = await dependencies.getOrder({ id: orderId });
+      const currentOrder = orderRow.data?.ticketOrder;
+      if (!currentOrder) {
+        continue;
       }
-    );
-    const isApplied = transitionResult.action === "applied";
-    const isRecoverableReplay =
-      transitionResult.action === "noop_replay" &&
-      args.recoverPostTransitionSideEffects === true &&
-      currentOrder.webhookEventId === args.webhookEventId;
-    if (!isApplied && !isRecoverableReplay) {
-      continue;
-    }
-    if (isApplied) {
-      appliedCount += 1;
-    }
-    reconciledOrderIds.push(orderId);
-    const notificationType =
-      args.intent === "MARK_PAID" ? "PAYMENT_PAID" : args.intent === "MARK_FAILED" ? "PAYMENT_FAILED" : "PAYMENT_REFUNDED";
-    await dependencies.emitNotification(
-      {
-        type: notificationType,
+      const transitionResult = await dependencies.runTransition(
+        {
+          orderId,
+          currentStatus: currentOrder.status,
+          intent: args.intent,
+          webhookEventId: args.webhookEventId,
+          recoverFailedCheckoutPayment: args.recoverFailedCheckoutPayment,
+          paidContext:
+            args.intent === "MARK_PAID" && args.paidContext
+              ? paidContextForMultiOrderWebhook(orderIndex, args.paidContext)
+              : undefined,
+          refundContext: args.refundContext,
+        },
+        {
+          markPaid: markTicketOrderPaidFromWebhook,
+          markFailed: markTicketOrderFailedFromWebhook,
+          markRefunded: markTicketOrderRefundedFromWebhook,
+        }
+      );
+      const isApplied = transitionResult.action === "applied";
+      const isRecoverableReplay =
+        transitionResult.action === "noop_replay" &&
+        args.recoverPostTransitionSideEffects === true &&
+        currentOrder.webhookEventId === args.webhookEventId;
+      if (!isApplied && !isRecoverableReplay) {
+        continue;
+      }
+      if (isApplied) {
+        appliedCount += 1;
+      }
+      reconciledOrderIds.push(orderId);
+      const notificationType =
+        args.intent === "MARK_PAID"
+          ? "PAYMENT_PAID"
+          : args.intent === "MARK_FAILED"
+            ? "PAYMENT_FAILED"
+            : "PAYMENT_REFUNDED";
+      await dependencies.emitNotification(
+        {
+          type: notificationType,
+          orderId,
+          eventId: currentOrder.event.id,
+          stripeEventId: args.webhookEventId,
+          status: transitionResult.targetStatus,
+          occurredAt: dependencies.now(),
+        },
+        govNotifyTicketOrderDispatcher,
+        sendNotificationOnce,
+        { userId: currentOrder.user.id, provider: GOV_NOTIFY_PROVIDER }
+      );
+      await dependencies.upsertSnapshot({
         orderId,
-        eventId: currentOrder.event.id,
+        snapshot: {
+          status: transitionResult.targetStatus,
+          totalAmountMinor: currentOrder.totalAmountMinor,
+          refundedAmountMinor: args.refundAmountFromEvent ?? currentOrder.refundedAmountMinor ?? null,
+          stripePaymentIntentId: args.paymentIntentIdFromEvent ?? currentOrder.stripePaymentIntentId ?? null,
+          disputeStatus: currentOrder.disputeStatus ?? null,
+        },
         stripeEventId: args.webhookEventId,
-        status: transitionResult.targetStatus,
-        occurredAt: dependencies.now(),
-      },
-      govNotifyTicketOrderDispatcher,
-      sendNotificationOnce,
-      { userId: currentOrder.user.id, provider: GOV_NOTIFY_PROVIDER }
-    );
-    await dependencies.upsertSnapshot({
-      orderId,
-      snapshot: {
-        status: transitionResult.targetStatus,
-        totalAmountMinor: currentOrder.totalAmountMinor,
-        refundedAmountMinor: args.refundAmountFromEvent ?? currentOrder.refundedAmountMinor ?? null,
-        stripePaymentIntentId: args.paymentIntentIdFromEvent ?? currentOrder.stripePaymentIntentId ?? null,
-        disputeStatus: currentOrder.disputeStatus ?? null,
-      },
-      stripeEventId: args.webhookEventId,
-    });
+      });
+    } catch (error) {
+      failures.push({ orderId, error });
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new PaymentTransitionBatchError(failures);
   }
 
   return { appliedCount, reconciledOrderIds };

--- a/functions/src/pendingApprovalAdminAlert.ts
+++ b/functions/src/pendingApprovalAdminAlert.ts
@@ -1,6 +1,10 @@
 import * as logger from "firebase-functions/logger";
 import { getUserById, NotificationChannel } from "@dataconnect/admin-generated";
-import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
+import {
+  createConfiguredGovNotifyMailer,
+  GOV_NOTIFY_PROVIDER,
+  recipientScopedNotifyReference,
+} from "./mailer";
 import { sanitizeMailerError } from "./mailerErrors";
 import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
 import { sendNotificationOnce } from "./notificationDelivery";
@@ -133,7 +137,7 @@ export async function notifyAdminsUserPendingApproval(args: {
               templateName: "newUserPendingApprovalAlert",
               to,
               personalisation,
-              reference,
+              reference: recipientScopedNotifyReference(reference, to),
             });
             return { providerMessageId: r.providerNotificationId ?? null };
           },

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -78,6 +78,12 @@ export default defineConfig({
           functions: 70,
           lines: 93,
         },
+        'src/paymentStripeArtifacts.ts': {
+          statements: 95,
+          branches: 78,
+          functions: 100,
+          lines: 95,
+        },
         'src/paymentWebhook.ts': {
           statements: 85,
           branches: 65,


### PR DESCRIPTION
## Summary

- scope GOV.UK Notify idempotency references to each recipient using a stable hash, preventing multi-recipient fan-out from silently suppressing later emails
- continue processing sibling payment orders when one order fails, then return a structured batch failure so Stripe can retry the failed work
- give the Functions package its own ESLint dependencies and flat configuration, removing the root-install dependency
- add callable-level security, ownership, validation, and failure tests for Stripe artifact retrieval, protected by a per-file coverage ratchet
- regenerate the Functions lockfile under Node 24 Linux so platform-specific optional dependencies are represented for CI

## Root cause and impact

Provider-side notification deduplication previously shared one reference across all recipients, so only the first recipient could receive a fan-out message while later delivery rows were marked successful. Multi-order reconciliation also aborted at the first permanent per-order failure, starving later orders on every retry.

The Functions lint command depended implicitly on the root package installation, and Stripe-artifact ownership behavior lacked runtime callable coverage.

## Validation

- Node 24 Linux Docker: clean `npm ci`
- Node 24 Linux Docker: Functions lint and TypeScript build
- Node 24 Linux Docker: full Functions coverage suite — 56 files and 508 tests passed
- Stripe-artifacts coverage: 97.95% statements, 80.64% branches, 100% functions, 97.95% lines
- root lint
- `git diff --check`

Closes #398