### PR TITLE
[#404] Guard SectionDetail's data-fetching effects against stale responses

### DIFF
--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import {
   Box,
   Alert,
@@ -79,18 +79,28 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingSection, setLoadingSection] = useState(true);
   const [errorSection, setErrorSection] = useState(false);
 
+  // Guards against a superseded call (effect re-run on a sectionId change, a remount, or a
+  // manual refetchSection() from a retry/subscribe handler racing an in-flight one) overwriting
+  // state with a stale response. Only the most recently started call may still be pending when
+  // its own result arrives.
+  const sectionRequestIdRef = useRef(0);
   const refetchSection = useCallback(async () => {
     if (!sectionId) return;
+    const requestId = ++sectionRequestIdRef.current;
     setLoadingSection(true);
     setErrorSection(false);
     try {
       const result = await getSectionForUser(sectionId);
+      if (sectionRequestIdRef.current !== requestId) return;
       setSectionData({ section: result.section });
     } catch {
+      if (sectionRequestIdRef.current !== requestId) return;
       setSectionData(undefined);
       setErrorSection(true);
     } finally {
-      setLoadingSection(false);
+      if (sectionRequestIdRef.current === requestId) {
+        setLoadingSection(false);
+      }
     }
   }, [sectionId]);
 
@@ -98,11 +108,14 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     void refetchSection();
   }, [refetchSection]);
 
+  const membersRequestIdRef = useRef(0);
   const fetchMembers = useCallback(async () => {
+    const requestId = ++membersRequestIdRef.current;
     setLoadingMembers(true);
     setErrorMembers(null);
     try {
       const res = await getSectionMembersMerged(sectionId);
+      if (membersRequestIdRef.current !== requestId) return;
       const members: SectionMember[] = (res.members || []).map((m) => ({
         userId: m.id,
         firstName: m.firstName,
@@ -114,13 +127,16 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       }));
       setSectionMembers(members);
     } catch (err: unknown) {
+      if (membersRequestIdRef.current !== requestId) return;
       const message = err && typeof (err as { message?: string }).message === "string"
         ? (err as { message: string }).message
         : "Failed to load section members";
       setErrorMembers(message);
       setSectionMembers([]);
     } finally {
-      setLoadingMembers(false);
+      if (membersRequestIdRef.current === requestId) {
+        setLoadingMembers(false);
+      }
     }
   }, [sectionId]);
 
@@ -145,18 +161,24 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingEvents, setLoadingEvents] = useState(false);
   const [errorEvents, setErrorEvents] = useState(false);
 
+  const eventsRequestIdRef = useRef(0);
   const refetchEvents = useCallback(async () => {
     if (!sectionId) return;
+    const requestId = ++eventsRequestIdRef.current;
     setLoadingEvents(true);
     setErrorEvents(false);
     try {
       const result = await getSectionEventsForUser(sectionId);
+      if (eventsRequestIdRef.current !== requestId) return;
       setEventsData({ section: { events: result.events } });
     } catch {
+      if (eventsRequestIdRef.current !== requestId) return;
       setEventsData(undefined);
       setErrorEvents(true);
     } finally {
-      setLoadingEvents(false);
+      if (eventsRequestIdRef.current === requestId) {
+        setLoadingEvents(false);
+      }
     }
   }, [sectionId]);
 

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -1552,6 +1552,77 @@ describe('SectionDetail', () => {
     // If the callback fires without throwing, the test passes
   });
 
+  it('does not let a stale section-1 response overwrite section-2 data when sectionId changes mid-fetch (#404)', async () => {
+    const sectionOne = { id: 'section-1', name: 'Section One', type: 'MEMBERS', purposeLinks: [] } as unknown as NonNullable<
+      Awaited<ReturnType<typeof getSectionForUser>>['section']
+    >;
+    const sectionTwo = { id: 'section-2', name: 'Section Two', type: 'MEMBERS', purposeLinks: [] } as unknown as NonNullable<
+      Awaited<ReturnType<typeof getSectionForUser>>['section']
+    >;
+
+    let resolveSectionOne!: (value: Awaited<ReturnType<typeof getSectionForUser>>) => void;
+    const sectionOnePromise = new Promise<Awaited<ReturnType<typeof getSectionForUser>>>((resolve) => {
+      resolveSectionOne = resolve;
+    });
+    let resolveMembersOne!: (value: Awaited<ReturnType<typeof getSectionMembersMerged>>) => void;
+    const membersOnePromise = new Promise<Awaited<ReturnType<typeof getSectionMembersMerged>>>((resolve) => {
+      resolveMembersOne = resolve;
+    });
+
+    vi.mocked(getSectionForUser).mockImplementation(async (id: string) => {
+      if (id === 'section-1') return sectionOnePromise;
+      return { section: sectionTwo, hasAccess: true, canModerate: false };
+    });
+    vi.mocked(getSectionMembersMerged).mockImplementation(async (id: string) => {
+      if (id === 'section-1') return membersOnePromise;
+      return {
+        members: [
+          { id: 'user-2', firstName: 'Two', lastName: 'Member', email: null, membershipStatus: 'REGULAR', rank: null, sharesContactInfo: false },
+        ],
+      };
+    });
+
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <SectionDetail sectionId="section-1" onBack={mockOnBack} />
+      </MemoryRouter>
+    );
+
+    // Switch sections before section-1's requests resolve
+    rerender(
+      <MemoryRouter>
+        <SectionDetail sectionId="section-2" onBack={mockOnBack} />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Section Two', level: 4 })).toBeInTheDocument();
+    });
+    expect(screen.getByText('Two Member')).toBeInTheDocument();
+
+    // Now let the stale section-1 responses resolve
+    resolveSectionOne({ section: sectionOne, hasAccess: true, canModerate: false });
+    resolveMembersOne({
+      members: [
+        { id: 'user-1', firstName: 'One', lastName: 'Member', email: null, membershipStatus: 'REGULAR', rank: null, sharesContactInfo: false },
+      ],
+    });
+
+    // Give the (would-be, pre-fix) stale updates a chance to apply, then confirm they didn't
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Section Two', level: 4 })).toBeInTheDocument();
+    });
+    expect(screen.getByText('Two Member')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Section One', level: 4 })).not.toBeInTheDocument();
+    expect(screen.queryByText('One Member')).not.toBeInTheDocument();
+  });
+
   it('should navigate back to upcoming events from past events view', async () => {
     const mockSectionData = {
       section: {


### PR DESCRIPTION
## Summary
- `SectionDetail.tsx`'s three main data-fetching effects (`refetchSection`, `fetchMembers`, `refetchEvents`) had no cancellation guard, unlike their sibling hooks (`useCanModerateSection`, `useSectionMemberSeatingOptions`) which already ignore stale responses.
- Added a per-fetch incrementing request-id ref so only the most recently started call for each can update state — these functions are also called imperatively (retry/subscribe handlers), so a simple per-effect `cancelled` flag wouldn't cover all call sites.
- This is a state-correctness fix only — it does not cancel or reduce actual network requests, per the issue's explicit scope note (this distinction is what got it wrongly conflated with a rate-limiting fix in the now-closed #400).

## Test plan
- [x] New regression test: switches `sectionId` mid-fetch, confirms a stale response for the old section can't overwrite the new section's data. Confirmed it fails without the fix (verified by temporarily reverting) and passes with it.
- [x] `npx vitest run` (root) — 66 files, 556 tests passing
- [x] `npx tsc -b --force` — clean
- [x] `npm run lint` — clean
- [x] Live in the browser: navigated between two different MEMBERS sections, each shows its own distinct member list with no cross-section bleed or console errors

Closes #404.