### PR TITLE
[#378] Add missing newUserPendingApprovalAlert template + CI parity check

### DIFF
--- a/functions/email-templates/README.md
+++ b/functions/email-templates/README.md
@@ -56,3 +56,9 @@ Fill in UUIDs after creating/locating each template in the GOV Notify dashboard 
 ## Admin drift detection
 
 The admin panel includes a **Template sync** page that fetches each template from GOV Notify via the API and compares it against the `.md` file. This catches cases where the dashboard was updated without updating the codebase, or vice versa. A diff is shown for any template that has drifted.
+
+## Relationship to `docs/operations/govuk-notify-template-copy.md`
+
+That file is a separate, hand-maintained human reference (registration runbook, sample personalisation) — it is **not** read by any code, so adding a template there does nothing on its own. This directory (`.md` files + `template-registry.json`, compiled into `generatedEmailTemplateManifest.ts`) is the actual source the Template sync page checks.
+
+When adding or removing a template, update both in the same PR: a `### \`templateKey\`` heading must exist in `docs/operations/govuk-notify-template-copy.md` for every template here, and vice versa. `functions/src/__tests__/emailTemplateDocsContracts.test.ts` enforces this (presence only, not that the copy text itself matches) and fails CI if either side gets a template the other doesn't — this is exactly what went wrong in #271, where the docs were updated but this directory wasn't, and the new template silently never appeared on the Template sync page (#378).

--- a/functions/email-templates/newUserPendingApprovalAlert.md
+++ b/functions/email-templates/newUserPendingApprovalAlert.md
@@ -1,0 +1,22 @@
+---
+subject: "[SODC] New member awaiting approval — ((firstName)) ((lastName))"
+templateKey: newUserPendingApprovalAlert
+variables:
+  - firstName
+  - lastName
+  - email
+  - serviceNumber
+  - serviceBackgroundSummary
+  - requestedMembershipStatus
+  - approveUsersUrl
+---
+A new member has completed their profile and is awaiting approval.
+
+Name: ((firstName)) ((lastName))
+Email: ((email))
+Service number: ((serviceNumber))
+Service background: ((serviceBackgroundSummary))
+Requested status: ((requestedMembershipStatus))
+
+Review in Approve Users:
+((approveUsersUrl))

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -63,5 +63,10 @@
     "dev": "da2fccf1-d5e2-44c4-a730-dabaafc95d60",
     "beta": "",
     "production": ""
+  },
+  "newUserPendingApprovalAlert": {
+    "dev": "",
+    "beta": "",
+    "production": ""
   }
 }

--- a/functions/src/__tests__/emailTemplateDocsContracts.test.ts
+++ b/functions/src/__tests__/emailTemplateDocsContracts.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { EMAIL_TEMPLATE_MANIFEST } from "../generatedEmailTemplateManifest";
+
+const repoRoot = path.resolve(process.cwd(), "..");
+const DOCS_PATH = "docs/operations/govuk-notify-template-copy.md";
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+/**
+ * functions/email-templates/*.md (compiled into EMAIL_TEMPLATE_MANIFEST) is the machine-readable
+ * source consumed by getTemplateSyncStatus. docs/operations/govuk-notify-template-copy.md is a
+ * separate, hand-maintained human reference with no code dependency on the source. #271 updated
+ * the docs but never created the matching functions/email-templates/*.md file, so the new
+ * template silently never appeared in the Email Template Sync page rather than showing as
+ * unconfigured (see #378). These checks catch either direction of that drift — a template added
+ * to one side without the other — even though they can't catch the docs' prose copy silently
+ * diverging from the actual source content.
+ */
+describe("GOV Notify template docs parity (#378)", () => {
+  const docs = readRepoFile(DOCS_PATH);
+  const manifestKeys = Object.keys(EMAIL_TEMPLATE_MANIFEST);
+  const documentedKeys = [...docs.matchAll(/^### `([a-zA-Z0-9]+)`/gm)].map((match) => match[1]);
+
+  it("finds template keys in both the manifest and the docs to compare", () => {
+    expect(manifestKeys.length).toBeGreaterThan(0);
+    expect(documentedKeys.length).toBeGreaterThan(0);
+  });
+
+  for (const key of manifestKeys) {
+    it(`documents ${key} (present in functions/email-templates/) in ${DOCS_PATH}`, () => {
+      expect(documentedKeys, `${key} exists in functions/email-templates/ but has no "### \`${key}\`" heading in ${DOCS_PATH}`).toContain(key);
+    });
+  }
+
+  for (const key of documentedKeys) {
+    it(`has a functions/email-templates/${key}.md source for the "${key}" section documented in ${DOCS_PATH}`, () => {
+      expect(manifestKeys, `${DOCS_PATH} documents ${key} but functions/email-templates/${key}.md doesn't exist (or isn't in the generated manifest — run npm run generate:templates)`).toContain(key);
+    });
+  }
+});

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -109,6 +109,19 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     ],
     body: "Dear ((customerFirstName)),\n\nYour SODC membership is now active. Your membership status is ((membershipStatusLabel)).\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nWe recommend completing your profile before making your first booking:\n\n((profileUrl))\n\nWelcome aboard.\n\nSODC",
   },
+  newUserPendingApprovalAlert: {
+    subject: "[SODC] New member awaiting approval — ((firstName)) ((lastName))",
+    variables: [
+    "firstName",
+    "lastName",
+    "email",
+    "serviceNumber",
+    "serviceBackgroundSummary",
+    "requestedMembershipStatus",
+    "approveUsersUrl"
+    ],
+    body: "A new member has completed their profile and is awaiting approval.\n\nName: ((firstName)) ((lastName))\nEmail: ((email))\nService number: ((serviceNumber))\nService background: ((serviceBackgroundSummary))\nRequested status: ((requestedMembershipStatus))\n\nReview in Approve Users:\n((approveUsersUrl))",
+  },
   paymentDisputeOpsAlert: {
     subject: "[SODC OPS] Payment dispute — ((orderId))",
     variables: [


### PR DESCRIPTION
## Summary

Two parts, per the issue's two acceptance criteria:

**1. The missing template itself**
- Added `functions/email-templates/newUserPendingApprovalAlert.md`, matching the copy #271 already drafted in `docs/operations/govuk-notify-template-copy.md` and what `pendingApprovalAdminAlert.ts` actually sends.
- Added its `template-registry.json` entry with empty UUIDs per environment — it's not yet registered in GOV Notify, so it should surface as `not_configured`, not `in_sync`.
- Verified live against the Dev backend: the Template Sync page now lists 13 templates, with `newUserPendingApprovalAlert` showing "UUID not configured" instead of being silently missing.

**2. The process gap** (decided via discussion: add a CI check rather than generate docs from source, to keep the docs free-form/prose-friendly)
- New `functions/src/__tests__/emailTemplateDocsContracts.test.ts`: checks presence in both directions between `functions/email-templates/*.md` (compiled into the manifest) and `docs/operations/govuk-notify-template-copy.md`'s `### \`key\`` headings. Doesn't catch the copy text itself diverging, only a template existing on one side and not the other.
- Confirmed it actually catches #271's exact failure mode: temporarily removed `newUserPendingApprovalAlert.md`, watched the test fail with a clear message, restored it.
- Documented the relationship and the new check in `functions/email-templates/README.md`.

## Test plan
- [x] `npx vitest run` (functions) — 57 files, 547 tests passing
- [x] `npm run lint` (functions) — clean
- [x] Confirmed the new contract test fails without the fix (reverted `newUserPendingApprovalAlert.md`) and passes with it
- [x] Deployed `getTemplateSyncStatus` to Dev and verified live in the browser

Closes #378.