### PR TITLE
Strengthen per-recipient reference test assertions (clears CodeQL #4-7)

### DIFF
--- a/functions/src/__tests__/guestTicketRequestEmails.test.ts
+++ b/functions/src/__tests__/guestTicketRequestEmails.test.ts
@@ -143,6 +143,8 @@ describe("notifyModeratorsGuestTicketRequestSubmitted", () => {
     await mockSendOnce.mock.calls[1][0].send();
     const references = sendEmail.mock.calls.map(([request]) => request.reference);
     expect(new Set(references)).toHaveLength(2);
-    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
+    for (const reference of references) {
+      expect(reference).toMatch(/^GUEST_REQUEST_SUBMITTED:[0-9a-f-]+:[0-9a-f]{24}$/);
+    }
   });
 });

--- a/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
+++ b/functions/src/__tests__/paymentOpsInternalAlerts.test.ts
@@ -124,7 +124,9 @@ describe("payment ops internal alert orchestration", () => {
     );
     const references = sendEmail.mock.calls.map(([request]) => request.reference);
     expect(new Set(references)).toHaveLength(2);
-    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
+    for (const reference of references) {
+      expect(reference).toMatch(/^reconciliation-ops:[0-9a-f-]+:[A-Z_]+:[a-z0-9_]+:[0-9a-f]{24}$/);
+    }
   });
 
   it("continues to the next recipient after one ledger delivery fails", async () => {
@@ -220,6 +222,8 @@ describe("payment ops internal alert orchestration", () => {
     );
     const references = sendEmail.mock.calls.map(([request]) => request.reference);
     expect(new Set(references)).toHaveLength(2);
-    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
+    for (const reference of references) {
+      expect(reference).toMatch(/^dispute-ops:[0-9a-f-]+:[a-z0-9_]+:[0-9a-f]{24}$/);
+    }
   });
 });

--- a/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
+++ b/functions/src/__tests__/pendingApprovalAdminAlert.test.ts
@@ -149,7 +149,9 @@ describe("notifyAdminsUserPendingApproval", () => {
     );
     const references = sendEmail.mock.calls.map(([request]) => request.reference);
     expect(new Set(references)).toHaveLength(2);
-    expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
+    for (const reference of references) {
+      expect(reference).toMatch(/^PENDING_APPROVAL:[0-9a-f-]+:[0-9a-f]{24}$/);
+    }
   });
 
   it("skips sending (without throwing) when there are no admin recipients", async () => {


### PR DESCRIPTION
## Summary

CodeQL flagged 4 open alerts on PR #397 (\`js/incomplete-url-substring-sanitization\`, High), all the same shape:

\`\`\`ts
expect(references.every((reference) => !reference?.includes("example.com"))).toBe(true);
\`\`\`

False positive as a security finding — this checks an opaque GOV Notify \`reference\` string for a leaked email domain, not a URL host for a redirect/SSRF check, which is what that rule targets. But the assertion itself was genuinely weaker than the guarantee it's meant to prove: it only rules out one bad pattern, not that the reference actually has the correct \`recipientScopedNotifyReference\` shape (\`baseReference:24-hex-char-hash\`).

Replaced each with an exact-format regex derived from the real \`recipientScopedNotifyReference\` output (\`mailer.ts\`) and each test's actual fixture values:

| File | New assertion |
|---|---|
| \`guestTicketRequestEmails.test.ts\` | \`/^GUEST_REQUEST_SUBMITTED:[0-9a-f-]+:[0-9a-f]{24}$/\` |
| \`paymentOpsInternalAlerts.test.ts\` (reconciliation) | \`/^reconciliation-ops:[0-9a-f-]+:[A-Z_]+:[a-z0-9_]+:[0-9a-f]{24}$/\` |
| \`paymentOpsInternalAlerts.test.ts\` (dispute) | \`/^dispute-ops:[0-9a-f-]+:[a-z0-9_]+:[0-9a-f]{24}$/\` |
| \`pendingApprovalAdminAlert.test.ts\` | \`/^PENDING_APPROVAL:[0-9a-f-]+:[0-9a-f]{24}$/\` |

This proves the actual intended structure rather than just absence of one bad pattern (a stronger test), and removes the \`.includes()\`-on-domain-like-string shape CodeQL was pattern-matching, which should clear alerts #4, #5, #6, #7 on the next scan rather than requiring a manual dismissal.

## Test plan
- [x] \`npx vitest run\` (functions) — 57 files, 547 tests passing
- [x] \`npm run lint\` (functions) — clean
- [x] \`npx tsc -b --force\` — clean
- [ ] Confirm CodeQL alerts #4-7 clear on the next scan of this branch/PR