### PR TITLE
Implement in-app password reset flow

### DIFF
--- a/docs/operations/firebase-auth-email-actions.md
+++ b/docs/operations/firebase-auth-email-actions.md
@@ -1,0 +1,58 @@
+# Firebase Authentication email actions
+
+The application handles Firebase Authentication email actions at `/auth/action`.
+Issue #410 implements password reset; issue #411 extends the same route for email
+verification. Firebase continues to generate and validate one-time action codes.
+
+## Firebase Console configuration
+
+Apply the following configuration separately to every Firebase project/environment:
+
+1. In **Authentication → Settings → Authorised domains**, add the deployed application
+   host for that environment. Do not add `localhost` to production projects.
+2. In **Authentication → Templates → Password reset**, customise the action URL to:
+   `https://<application-host>/auth/action`.
+3. Review the password-reset sender name, subject, body, and reply-to address. Do not put
+   passwords, action codes, or account-existence claims into custom copy.
+4. Confirm Firebase Hosting continues to rewrite `/auth/action` and
+   `/account/password-reset` to `index.html` so both routes support direct navigation.
+
+`sendPasswordResetEmail` supplies an application-owned continue URL ending in `/account`.
+The completion page does not redirect to the incoming `continueUrl`; after success it offers
+a fixed link to the sign-in route. This prevents an attacker-controlled action URL from becoming
+an open redirect.
+
+## Runtime behaviour
+
+1. The request page normalises and validates the submitted email locally.
+2. The UI uses the same neutral confirmation for a successful request and Firebase's legacy
+   `auth/user-not-found` response, avoiding an account-existence disclosure.
+3. The action page accepts only `mode=resetPassword` with a non-empty `oobCode`.
+4. It calls `verifyPasswordResetCode` before showing the new-password form.
+5. It validates the new password using the registration/change-password policy, then calls
+   `confirmPasswordReset`.
+6. It does not sign the user in automatically. Firebase password resets revoke existing refresh
+   tokens, so the user is directed to authenticate again with the new password.
+
+The application must never log complete action URLs, out-of-band codes, or passwords.
+
+## Manual end-to-end check
+
+Run this check in a non-production environment before promoting the change:
+
+1. Open `/account`, choose **Forgot password?**, and submit a known email/password account.
+2. Confirm the UI shows a neutral response that does not reveal whether the account exists.
+3. Open the email and verify its link lands on `/auth/action` in the same environment.
+4. Set a password shorter than the application minimum and confirm it is rejected locally.
+5. Set a valid password and confirm the page directs you back to sign in without automatically
+   authenticating you.
+6. Sign in with the new password and confirm the old password no longer works.
+7. Reopen the used link and confirm it shows the invalid/expired recovery state.
+8. Repeat with an expired or deliberately altered `oobCode`, a wrong `mode`, and an unknown email.
+9. Confirm a signed-in but unverified user can still open the public action route.
+
+References:
+
+- [Firebase custom email action handlers](https://firebase.google.com/docs/auth/custom-email-handler)
+- [Firebase password reset](https://firebase.google.com/docs/auth/web/manage-users#send_a_password_reset_email)
+- [Firebase session revocation](https://firebase.google.com/docs/auth/admin/manage-sessions)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,8 @@ const MemberWelcomePage = lazy(() => import("./features/welcome/components/Membe
 const PublicHomePage = lazy(() => import("./features/welcome/components/PublicHomePage"));
 const AccountSettingsPage = lazy(() => import("./features/account/components/AccountSettingsPage"));
 const RegisterPage = lazy(() => import("./features/auth/components/RegisterPage"));
+const PasswordResetRequestPage = lazy(() => import("./features/auth/components/PasswordResetRequestPage"));
+const PasswordResetActionPage = lazy(() => import("./features/auth/components/PasswordResetActionPage"));
 const OnboardingShell = lazy(() => import("./features/auth/components/OnboardingShell"));
 const UnsubscribeConfirmedPage = lazy(() => import("./features/account/components/UnsubscribeConfirmedPage"));
 
@@ -116,6 +118,8 @@ function AppContent() {
 
   // Check if email is verified
   const emailNotVerified = user && !user.emailVerified;
+  const isPublicAuthActionRoute =
+    location.pathname === ROUTES.PASSWORD_RESET_REQUEST || location.pathname === ROUTES.AUTH_ACTION;
 
   const navigationLinks = useMemo(
     () => buildNavigationLinks({ isEnabled, isAdmin, sectionsData: userSectionsData }),
@@ -166,7 +170,7 @@ function AppContent() {
     );
   }
 
-  if (emailNotVerified) {
+  if (emailNotVerified && !isPublicAuthActionRoute) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -214,7 +218,7 @@ function AppContent() {
     );
   }
 
-  if (user && !isEnabledClaimResolved) {
+  if (user && !isEnabledClaimResolved && !isPublicAuthActionRoute) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -225,7 +229,12 @@ function AppContent() {
     );
   }
 
-  if (user && needsProfileCompletion && location.pathname !== ROUTES.PROFILE_COMPLETION) {
+  if (
+    user &&
+    needsProfileCompletion &&
+    location.pathname !== ROUTES.PROFILE_COMPLETION &&
+    !isPublicAuthActionRoute
+  ) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -234,7 +243,7 @@ function AppContent() {
     );
   }
 
-  if (user && !isEnabled && !needsProfileCompletion) {
+  if (user && !isEnabled && !needsProfileCompletion && !isPublicAuthActionRoute) {
     const inactiveUserData =
       userData ||
       (membershipStatusForUnenabled
@@ -424,6 +433,22 @@ function AppContent() {
                         </Suspense>
                       )}
                     </Box>
+                  }
+                />
+                <Route
+                  path={ROUTES.PASSWORD_RESET_REQUEST}
+                  element={
+                    <Suspense fallback={<LoadingFallback />}>
+                      <PasswordResetRequestPage />
+                    </Suspense>
+                  }
+                />
+                <Route
+                  path={ROUTES.AUTH_ACTION}
+                  element={
+                    <Suspense fallback={<LoadingFallback />}>
+                      <PasswordResetActionPage />
+                    </Suspense>
                   }
                 />
                 <Route

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -164,6 +164,14 @@ vi.mock("../features/auth/components/RegisterPage", () => ({
   default: () => <h1>Register Page</h1>,
 }));
 
+vi.mock("../features/auth/components/PasswordResetRequestPage", () => ({
+  default: () => <h1>Password Reset Request Page</h1>,
+}));
+
+vi.mock("../features/auth/components/PasswordResetActionPage", () => ({
+  default: () => <h1>Password Reset Action Page</h1>,
+}));
+
 vi.mock("../features/auth/components/OnboardingShell", () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -328,6 +336,25 @@ describe("App routing", () => {
 
     expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.ACCOUNT);
+  });
+
+  it("renders password reset request and action routes while logged out", async () => {
+    const requestRender = renderApp([ROUTES.PASSWORD_RESET_REQUEST]);
+    expect(await screen.findByRole("heading", { name: "Password Reset Request Page" })).toBeInTheDocument();
+    requestRender.unmount();
+
+    renderApp([`${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=test-code`]);
+    expect(await screen.findByRole("heading", { name: "Password Reset Action Page" })).toBeInTheDocument();
+  });
+
+  it("does not let the unverified-account gate hide the public action route", async () => {
+    currentUser = createMockUser({ emailVerified: false });
+    enabledClaim = false;
+
+    renderApp([`${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=test-code`]);
+
+    expect(await screen.findByRole("heading", { name: "Password Reset Action Page" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Email Verification Page" })).not.toBeInTheDocument();
   });
 
   it("renders welcome dashboard for enabled users at home", async () => {

--- a/src/constants/__tests__/routes.test.ts
+++ b/src/constants/__tests__/routes.test.ts
@@ -11,6 +11,8 @@ describe('routes', () => {
     expect(ROUTES.MANAGE_USERS).toBe('/admin/users');
     expect(ROUTES.APPROVE_USERS).toBe('/admin/users/approvals');
     expect(ROUTES.REGISTER).toBe('/register');
+    expect(ROUTES.PASSWORD_RESET_REQUEST).toBe('/account/password-reset');
+    expect(ROUTES.AUTH_ACTION).toBe('/auth/action');
     expect(ROUTES.PROFILE_COMPLETION).toBe('/profile-completion');
   });
 
@@ -23,6 +25,8 @@ describe('routes', () => {
       ROUTES.MANAGE_USERS,
       ROUTES.APPROVE_USERS,
       ROUTES.REGISTER,
+      ROUTES.PASSWORD_RESET_REQUEST,
+      ROUTES.AUTH_ACTION,
       ROUTES.PROFILE_COMPLETION,
     ];
     
@@ -32,4 +36,3 @@ describe('routes', () => {
     });
   });
 });
-

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -21,6 +21,8 @@ export const ROUTES = {
   SECTION_ADMIN: "/admin/section/:sectionId",
   EMAIL_TEMPLATES: "/admin/email-templates",
   REGISTER: "/register",
+  PASSWORD_RESET_REQUEST: "/account/password-reset",
+  AUTH_ACTION: "/auth/action",
   PROFILE_COMPLETION: "/profile-completion",
   UNSUBSCRIBE_CONFIRMED: "/unsubscribe/confirmed",
 } as const;
@@ -29,4 +31,3 @@ export const ROUTES = {
  * Route type
  */
 export type Route = typeof ROUTES[keyof typeof ROUTES];
-

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -142,6 +142,10 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
             fullWidth
           />
 
+          <Link component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST} sx={{ alignSelf: "flex-end" }}>
+            Forgot password?
+          </Link>
+
           <Button
             type="submit"
             variant="contained"

--- a/src/features/auth/components/PasswordResetActionPage.tsx
+++ b/src/features/auth/components/PasswordResetActionPage.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { Alert, Box, Button, CircularProgress, Link, Stack, TextField, Typography } from "@mui/material";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { confirmPasswordReset, verifyPasswordResetCode } from "firebase/auth";
+import { auth } from "../../../config/firebase";
+import { ROUTES } from "../../../constants";
+import {
+  getRegistrationPasswordHelperText,
+  validateRegistrationPassword,
+} from "../utils/passwordValidation";
+import { isPasswordResetAction, parseEmailActionParameters } from "../utils/emailAction";
+import {
+  getPasswordResetCompletionError,
+  isInvalidPasswordResetCode,
+} from "../utils/passwordResetErrors";
+
+type VerificationState = "verifying" | "ready" | "invalid" | "error";
+
+export default function PasswordResetActionPage() {
+  const [searchParams] = useSearchParams();
+  const parameters = useMemo(() => parseEmailActionParameters(searchParams), [searchParams]);
+  const [verificationState, setVerificationState] = useState<VerificationState>("verifying");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [complete, setComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [verificationAttempt, setVerificationAttempt] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setComplete(false);
+    setNewPassword("");
+    setConfirmPassword("");
+    setSubmitting(false);
+    setError(null);
+
+    if (!isPasswordResetAction(parameters)) {
+      setVerificationState("invalid");
+      return () => { active = false; };
+    }
+
+    setVerificationState("verifying");
+    void verifyPasswordResetCode(auth, parameters.oobCode)
+      .then(() => {
+        if (active) setVerificationState("ready");
+      })
+      .catch((verificationError) => {
+        if (!active) return;
+        if (isInvalidPasswordResetCode(verificationError)) {
+          setVerificationState("invalid");
+        } else {
+          setError(getPasswordResetCompletionError(verificationError));
+          setVerificationState("error");
+        }
+      });
+
+    return () => { active = false; };
+  }, [parameters, verificationAttempt]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!isPasswordResetAction(parameters) || verificationState !== "ready") return;
+
+    const validation = validateRegistrationPassword(newPassword);
+    if (!validation.isValid) {
+      setError(validation.error ?? "Password does not meet the minimum requirements.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await confirmPasswordReset(auth, parameters.oobCode, newPassword);
+      setNewPassword("");
+      setConfirmPassword("");
+      setComplete(true);
+    } catch (completionError) {
+      if (isInvalidPasswordResetCode(completionError)) {
+        setVerificationState("invalid");
+      } else {
+        setError(getPasswordResetCompletionError(completionError));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: "600px", mx: "auto", px: { xs: 3, sm: 4 } }}>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        <Typography variant="h4" component="h1" sx={{ color: "primary.light" }}>
+          Choose a new password
+        </Typography>
+
+        {verificationState === "verifying" && (
+          <Box role="status" aria-label="Checking password reset link" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <CircularProgress size={24} />
+            <Typography>Checking your reset link…</Typography>
+          </Box>
+        )}
+
+        {verificationState === "invalid" && (
+          <>
+            <Alert severity="error">
+              This password reset link is invalid, has expired, or has already been used.
+            </Alert>
+            <Button component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST} variant="contained">
+              Request a new reset link
+            </Button>
+            <Link component={RouterLink} to={ROUTES.ACCOUNT}>Back to sign in</Link>
+          </>
+        )}
+
+        {verificationState === "error" && (
+          <>
+            <Alert severity="error">{error}</Alert>
+            <Button variant="contained" onClick={() => setVerificationAttempt((attempt) => attempt + 1)}>
+              Try checking the link again
+            </Button>
+            <Link component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST}>Request a new reset link</Link>
+            <Link component={RouterLink} to={ROUTES.ACCOUNT}>Back to sign in</Link>
+          </>
+        )}
+
+        {verificationState === "ready" && complete && (
+          <>
+            <Alert severity="success">
+              Your password has been reset. For your security, sign in again with your new password.
+            </Alert>
+            <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
+              Continue to sign in
+            </Button>
+          </>
+        )}
+
+        {verificationState === "ready" && !complete && (
+          <>
+            <Typography variant="body2" color="text.secondary">
+              {getRegistrationPasswordHelperText()}.
+            </Typography>
+            {error && <Alert severity="error">{error}</Alert>}
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2}>
+                <TextField
+                  label="New password"
+                  type="password"
+                  value={newPassword}
+                  onChange={(event) => setNewPassword(event.target.value)}
+                  autoComplete="new-password"
+                  disabled={submitting}
+                  required
+                  fullWidth
+                />
+                <TextField
+                  label="Confirm new password"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(event) => setConfirmPassword(event.target.value)}
+                  autoComplete="new-password"
+                  disabled={submitting}
+                  required
+                  fullWidth
+                />
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={submitting || !newPassword || !confirmPassword}
+                  aria-label={submitting ? "Resetting password" : undefined}
+                >
+                  {submitting ? <CircularProgress size={24} color="inherit" aria-label="Resetting password" /> : "Reset password"}
+                </Button>
+              </Stack>
+            </Box>
+          </>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/PasswordResetRequestPage.tsx
+++ b/src/features/auth/components/PasswordResetRequestPage.tsx
@@ -1,0 +1,108 @@
+import { useState, type FormEvent } from "react";
+import { Alert, Box, Button, CircularProgress, Link, Stack, TextField, Typography } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { sendPasswordResetEmail } from "firebase/auth";
+import { auth } from "../../../config/firebase";
+import { MAX_EMAIL_LENGTH, ROUTES } from "../../../constants";
+import { buildPasswordResetActionCodeSettings } from "../utils/emailAction";
+import { isValidEmailAddress, normalizeEmailAddress } from "../utils/emailAddress";
+import {
+  getPasswordResetRequestError,
+  isEnumerationSafeResetRequestSuccess,
+} from "../utils/passwordResetErrors";
+
+const NEUTRAL_CONFIRMATION =
+  "If an account exists for that email address, we’ve sent a password reset link. Check your inbox and spam folder.";
+
+export default function PasswordResetRequestPage() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!isValidEmailAddress(email)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await sendPasswordResetEmail(
+        auth,
+        normalizeEmailAddress(email),
+        buildPasswordResetActionCodeSettings(window.location.origin),
+      );
+      setSubmitted(true);
+    } catch (requestError) {
+      // Firebase projects with email-enumeration protection may resolve unknown
+      // users neutrally; older configurations can still return user-not-found.
+      if (isEnumerationSafeResetRequestSuccess(requestError)) {
+        setSubmitted(true);
+      } else {
+        setError(getPasswordResetRequestError(requestError));
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: "600px", mx: "auto", px: { xs: 3, sm: 4 } }}>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        <Typography variant="h4" component="h1" sx={{ color: "primary.light" }}>
+          Reset your password
+        </Typography>
+
+        {submitted ? (
+          <>
+            <Alert severity="success">{NEUTRAL_CONFIRMATION}</Alert>
+            <Typography variant="body2" color="text.secondary">
+              The link will expire. If it no longer works, request another one from this page.
+            </Typography>
+            <Button variant="outlined" onClick={() => setSubmitted(false)}>
+              Send another reset link
+            </Button>
+          </>
+        ) : (
+          <>
+            <Typography variant="body2" color="text.secondary">
+              Enter the email address you use to sign in. We’ll send instructions if it belongs to an account.
+            </Typography>
+            {error && <Alert severity="error">{error}</Alert>}
+            <Box component="form" onSubmit={handleSubmit} noValidate>
+              <Stack spacing={2}>
+                <TextField
+                  label="Email"
+                  type="email"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  autoComplete="email"
+                  inputProps={{ maxLength: MAX_EMAIL_LENGTH }}
+                  disabled={submitting}
+                  required
+                  fullWidth
+                />
+                <Button
+                  type="submit"
+                  variant="contained"
+                  disabled={submitting || !email.trim()}
+                  aria-label={submitting ? "Sending reset link" : undefined}
+                >
+                  {submitting ? <CircularProgress size={24} color="inherit" aria-label="Sending reset link" /> : "Send reset link"}
+                </Button>
+              </Stack>
+            </Box>
+          </>
+        )}
+
+        <Link component={RouterLink} to={ROUTES.ACCOUNT}>
+          Back to sign in
+        </Link>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/__tests__/AuthGate.test.tsx
+++ b/src/features/auth/components/__tests__/AuthGate.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "../../../../test-utils";
+import AuthGate from "../AuthGate";
+
+vi.mock("firebase/auth", () => ({
+  onAuthStateChanged: vi.fn((_auth, callback: (user: null) => void) => {
+    callback(null);
+    return vi.fn();
+  }),
+  signInWithEmailAndPassword: vi.fn(),
+}));
+
+vi.mock("../../../users/hooks/useEnabledClaim", () => ({
+  useEnabledClaim: () => ({ isEnabled: false, isEnabledClaimResolved: true }),
+}));
+
+describe("AuthGate", () => {
+  it("links signed-out users to password recovery", async () => {
+    render(
+      <MemoryRouter>
+        <AuthGate />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole("link", { name: "Forgot password?" })).toHaveAttribute(
+      "href",
+      "/account/password-reset",
+    );
+  });
+});

--- a/src/features/auth/components/__tests__/PasswordResetActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/PasswordResetActionPage.test.tsx
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "../../../../test-utils";
+import { confirmPasswordReset, verifyPasswordResetCode } from "firebase/auth";
+import PasswordResetActionPage from "../PasswordResetActionPage";
+
+vi.mock("firebase/auth", () => ({
+  confirmPasswordReset: vi.fn(),
+  verifyPasswordResetCode: vi.fn(),
+}));
+
+function renderPage(search = "?mode=resetPassword&oobCode=valid-code") {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/action${search}`]}>
+      <PasswordResetActionPage />
+    </MemoryRouter>,
+  );
+}
+
+async function fillValidPasswords(user: ReturnType<typeof userEvent.setup>) {
+  await user.type(await screen.findByLabelText(/^New password/i), "a-secure-password");
+  await user.type(screen.getByLabelText(/^Confirm new password/i), "a-secure-password");
+}
+
+describe("PasswordResetActionPage", () => {
+  beforeEach(() => {
+    vi.mocked(verifyPasswordResetCode).mockReset();
+    vi.mocked(confirmPasswordReset).mockReset();
+    vi.mocked(verifyPasswordResetCode).mockResolvedValue("member@example.com");
+    vi.mocked(confirmPasswordReset).mockResolvedValue(undefined);
+  });
+
+  it("verifies the code before enabling password completion", async () => {
+    renderPage();
+
+    expect(screen.getByRole("status", { name: "Checking password reset link" })).toBeInTheDocument();
+    expect(await screen.findByLabelText(/^New password/i)).toBeInTheDocument();
+    expect(verifyPasswordResetCode).toHaveBeenCalledWith(expect.anything(), "valid-code");
+  });
+
+  it.each([
+    ["?mode=verifyEmail&oobCode=valid-code"],
+    ["?mode=resetPassword"],
+    ["?oobCode=valid-code"],
+  ])("rejects malformed or wrong-mode action parameters: %s", async (search) => {
+    renderPage(search);
+
+    expect(await screen.findByText(/link is invalid/i)).toBeInTheDocument();
+    expect(verifyPasswordResetCode).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Request a new reset link" })).toHaveAttribute(
+      "href",
+      "/account/password-reset",
+    );
+  });
+
+  it("handles an expired or invalid code without exposing Firebase details", async () => {
+    vi.mocked(verifyPasswordResetCode).mockRejectedValue({ code: "auth/expired-action-code" });
+    renderPage();
+
+    expect(await screen.findByText(/link is invalid, has expired, or has already been used/i)).toBeInTheDocument();
+    expect(screen.queryByText(/auth\/expired-action-code/i)).not.toBeInTheDocument();
+  });
+
+  it("lets the user retry a network failure while verifying the code", async () => {
+    vi.mocked(verifyPasswordResetCode)
+      .mockRejectedValueOnce({ code: "auth/network-request-failed" })
+      .mockResolvedValueOnce("member@example.com");
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText(/could not connect/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try checking the link again" }));
+
+    expect(await screen.findByLabelText(/^New password/i)).toBeInTheDocument();
+    expect(verifyPasswordResetCode).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses the shared password policy and requires matching confirmation", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(await screen.findByLabelText(/^New password/i), "short");
+    await user.type(screen.getByLabelText(/^Confirm new password/i), "short");
+    await user.click(screen.getByRole("button", { name: "Reset password" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Password must be at least 12 characters");
+
+    await user.clear(screen.getByLabelText(/^New password/i));
+    await user.clear(screen.getByLabelText(/^Confirm new password/i));
+    await user.type(screen.getByLabelText(/^New password/i), "a-secure-password");
+    await user.type(screen.getByLabelText(/^Confirm new password/i), "different-password");
+    await user.click(screen.getByRole("button", { name: "Reset password" }));
+    expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
+    expect(confirmPasswordReset).not.toHaveBeenCalled();
+  });
+
+  it("completes the reset and ignores an attacker-controlled continue URL", async () => {
+    const user = userEvent.setup();
+    renderPage("?mode=resetPassword&oobCode=valid-code&continueUrl=https://evil.example/phish");
+    await fillValidPasswords(user);
+
+    await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+    await waitFor(() => expect(confirmPasswordReset).toHaveBeenCalledWith(
+      expect.anything(),
+      "valid-code",
+      "a-secure-password",
+    ));
+    expect(screen.getByText(/sign in again with your new password/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Continue to sign in" })).toHaveAttribute("href", "/account");
+    expect(document.body).not.toHaveTextContent("evil.example");
+  });
+
+  it("moves a code rejected during confirmation to the recovery state", async () => {
+    vi.mocked(confirmPasswordReset).mockRejectedValue({ code: "auth/invalid-action-code" });
+    const user = userEvent.setup();
+    renderPage();
+    await fillValidPasswords(user);
+
+    await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+    expect(await screen.findByText(/link is invalid/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Request a new reset link" })).toBeInTheDocument();
+  });
+
+  it("shows retryable completion errors safely", async () => {
+    vi.mocked(confirmPasswordReset).mockRejectedValue({ code: "auth/network-request-failed" });
+    const user = userEvent.setup();
+    renderPage();
+    await fillValidPasswords(user);
+
+    await user.click(screen.getByRole("button", { name: "Reset password" }));
+
+    expect(await screen.findByText(/could not connect/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reset password" })).toBeEnabled();
+  });
+});

--- a/src/features/auth/components/__tests__/PasswordResetRequestPage.test.tsx
+++ b/src/features/auth/components/__tests__/PasswordResetRequestPage.test.tsx
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "../../../../test-utils";
+import { sendPasswordResetEmail } from "firebase/auth";
+import PasswordResetRequestPage from "../PasswordResetRequestPage";
+
+vi.mock("firebase/auth", () => ({
+  sendPasswordResetEmail: vi.fn(),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <PasswordResetRequestPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("PasswordResetRequestPage", () => {
+  beforeEach(() => {
+    vi.mocked(sendPasswordResetEmail).mockReset();
+    vi.mocked(sendPasswordResetEmail).mockResolvedValue(undefined);
+  });
+
+  it("normalises the email and sends fixed application-owned action settings", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/^Email/i), "  MEMBER@Example.COM  ");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    await waitFor(() => expect(sendPasswordResetEmail).toHaveBeenCalledWith(
+      expect.anything(),
+      "member@example.com",
+      {
+        url: `${window.location.origin}/account`,
+        handleCodeInApp: false,
+      },
+    ));
+    expect(screen.getByText(/if an account exists/i)).toBeInTheDocument();
+  });
+
+  it("shows the same neutral response when Firebase reports an unknown account", async () => {
+    vi.mocked(sendPasswordResetEmail).mockRejectedValue({ code: "auth/user-not-found" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/^Email/i), "unknown@example.com");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(await screen.findByText(/if an account exists/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not found/i)).not.toBeInTheDocument();
+  });
+
+  it("rejects a malformed email before calling Firebase", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/^Email/i), "not-an-email");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(screen.getByText("Enter a valid email address.")).toBeInTheDocument();
+    expect(sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["auth/too-many-requests", /too many reset requests/i],
+    ["auth/network-request-failed", /could not connect/i],
+    ["auth/internal-error", /could not send a password reset email/i],
+  ])("maps %s to a safe error", async (code, expectedMessage) => {
+    vi.mocked(sendPasswordResetEmail).mockRejectedValue({ code });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/^Email/i), "member@example.com");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
+  });
+
+  it("disables repeat submission while the request is in flight", async () => {
+    let finishRequest!: () => void;
+    vi.mocked(sendPasswordResetEmail).mockImplementation(() => new Promise<void>((resolve) => {
+      finishRequest = resolve;
+    }));
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/^Email/i), "member@example.com");
+    await user.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(screen.getByRole("button", { name: "Sending reset link" })).toBeDisabled();
+    expect(sendPasswordResetEmail).toHaveBeenCalledOnce();
+    finishRequest();
+    expect(await screen.findByText(/if an account exists/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/auth/utils/emailAction.ts
+++ b/src/features/auth/utils/emailAction.ts
@@ -1,0 +1,29 @@
+import type { ActionCodeSettings } from "firebase/auth";
+import { ROUTES } from "../../../constants";
+
+export interface EmailActionParameters {
+  mode: string | null;
+  oobCode: string | null;
+}
+
+export function parseEmailActionParameters(search: URLSearchParams): EmailActionParameters {
+  return {
+    mode: search.get("mode"),
+    oobCode: search.get("oobCode"),
+  };
+}
+
+export function isPasswordResetAction(
+  parameters: EmailActionParameters,
+): parameters is EmailActionParameters & { mode: "resetPassword"; oobCode: string } {
+  return parameters.mode === "resetPassword" && Boolean(parameters.oobCode?.trim());
+}
+
+export function buildPasswordResetActionCodeSettings(origin: string): ActionCodeSettings {
+  return {
+    url: new URL(ROUTES.ACCOUNT, origin).toString(),
+    // The web app owns the custom action handler. This flag is for native/mobile
+    // app-first links, so keep it false for this web-only flow.
+    handleCodeInApp: false,
+  };
+}

--- a/src/features/auth/utils/emailAddress.ts
+++ b/src/features/auth/utils/emailAddress.ts
@@ -1,0 +1,12 @@
+import { MAX_EMAIL_LENGTH } from "../../../constants";
+
+const EMAIL_ADDRESS_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function normalizeEmailAddress(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function isValidEmailAddress(value: string): boolean {
+  const normalized = normalizeEmailAddress(value);
+  return normalized.length <= MAX_EMAIL_LENGTH && EMAIL_ADDRESS_PATTERN.test(normalized);
+}

--- a/src/features/auth/utils/passwordResetErrors.ts
+++ b/src/features/auth/utils/passwordResetErrors.ts
@@ -1,0 +1,46 @@
+const INVALID_ACTION_CODES = new Set([
+  "auth/expired-action-code",
+  "auth/invalid-action-code",
+  "auth/user-disabled",
+  "auth/user-not-found",
+]);
+
+function authErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export function isEnumerationSafeResetRequestSuccess(error: unknown): boolean {
+  return authErrorCode(error) === "auth/user-not-found";
+}
+
+export function getPasswordResetRequestError(error: unknown): string {
+  switch (authErrorCode(error)) {
+    case "auth/too-many-requests":
+      return "Too many reset requests have been made. Please wait a while before trying again.";
+    case "auth/network-request-failed":
+      return "We could not connect to the password reset service. Check your connection and try again.";
+    case "auth/unauthorized-continue-uri":
+      return "Password reset is not configured for this site. Please contact support.";
+    default:
+      return "We could not send a password reset email. Please try again later.";
+  }
+}
+
+export function isInvalidPasswordResetCode(error: unknown): boolean {
+  return INVALID_ACTION_CODES.has(authErrorCode(error) ?? "");
+}
+
+export function getPasswordResetCompletionError(error: unknown): string {
+  switch (authErrorCode(error)) {
+    case "auth/weak-password":
+      return "That password does not meet the required password policy.";
+    case "auth/too-many-requests":
+      return "Too many attempts have been made. Please wait a while before trying again.";
+    case "auth/network-request-failed":
+      return "We could not connect to the password reset service. Check your connection and try again.";
+    default:
+      return "We could not reset your password. Please try again.";
+  }
+}

--- a/src/test-utils/mocks/firebase.ts
+++ b/src/test-utils/mocks/firebase.ts
@@ -46,6 +46,8 @@ export const mockAuth = {
   signOut: vi.fn(),
   createUserWithEmailAndPassword: vi.fn(),
   sendEmailVerification: vi.fn(),
+  sendPasswordResetEmail: vi.fn(),
+  verifyPasswordResetCode: vi.fn(),
+  confirmPasswordReset: vi.fn(),
   reload: vi.fn(),
 };
-

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -26,6 +26,9 @@ vi.mock('../config/firebase', () => ({
     signOut: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),
     sendEmailVerification: vi.fn(),
+    sendPasswordResetEmail: vi.fn(),
+    verifyPasswordResetCode: vi.fn(),
+    confirmPasswordReset: vi.fn(),
     reload: vi.fn(),
   },
   dataConnect: {},
@@ -45,4 +48,3 @@ vi.mock('firebase/functions', () => ({
   getFunctions: vi.fn(),
   httpsCallable: vi.fn(),
 }));
-


### PR DESCRIPTION
## Summary

- add an enumeration-safe password reset request page linked from sign-in
- handle Firebase password reset action codes inside the application
- apply the shared password policy and provide safe recovery states for invalid, expired, throttled, and network-failed requests
- prevent action-link redirect parameters from controlling post-reset navigation
- document the required Firebase Console email-action configuration

## Why

Password reset completion currently depends on Firebase-hosted handling. Moving the flow into the application provides consistent validation, branding, security behavior, and recovery messaging as part of the in-app account-management epic.

## Impact

Users can request and complete password resets without leaving the application. Successful resets do not automatically authenticate the user; they return to the fixed sign-in route. The Firebase password-reset template must be configured per environment to target `/auth/action`.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:run` — 577 tests passed
- `npm run test:coverage`
- `git diff --check`

Closes #410