### PR TITLE
Handle email verification inside the application

### DIFF
--- a/docs/operations/firebase-auth-email-actions.md
+++ b/docs/operations/firebase-auth-email-actions.md
@@ -10,17 +10,24 @@ Apply the following configuration separately to every Firebase project/environme
 
 1. In **Authentication → Settings → Authorised domains**, add the deployed application
    host for that environment. Do not add `localhost` to production projects.
-2. In **Authentication → Templates → Password reset**, customise the action URL to:
+2. In **Authentication → Templates → Password reset**, customise the action URL to
    `https://<application-host>/auth/action`.
-3. Review the password-reset sender name, subject, body, and reply-to address. Do not put
+3. In **Authentication → Templates → Email address verification**, customise the action URL to
+   the same `https://<application-host>/auth/action` route.
+4. Review both templates' sender name, subject, body, branding, and reply-to address. Do not put
    passwords, action codes, or account-existence claims into custom copy.
-4. Confirm Firebase Hosting continues to rewrite `/auth/action` and
+5. Confirm Firebase Hosting continues to rewrite `/auth/action` and
    `/account/password-reset` to `index.html` so both routes support direct navigation.
 
 `sendPasswordResetEmail` supplies an application-owned continue URL ending in `/account`.
 The completion page does not redirect to the incoming `continueUrl`; after success it offers
 a fixed link to the sign-in route. This prevents an attacker-controlled action URL from becoming
 an open redirect.
+
+Initial and replacement verification emails supply an application-owned continue URL ending in
+`/profile-completion`. The action page ignores incoming `continueUrl`, `email`, and other optional
+parameters. It chooses only between fixed profile-completion and sign-in destinations based on the
+authoritative signed-in Firebase user state after applying the code.
 
 ## Runtime behaviour
 
@@ -33,6 +40,16 @@ an open redirect.
    `confirmPasswordReset`.
 6. It does not sign the user in automatically. Firebase password resets revoke existing refresh
    tokens, so the user is directed to authenticate again with the new password.
+
+For email verification:
+
+1. Registration and resend calls use the same fixed `ActionCodeSettings`.
+2. The shared action page accepts only `mode=verifyEmail` with a non-empty `oobCode`.
+3. It calls `checkActionCode` and then `applyActionCode`, deduplicating concurrent completion calls.
+4. If the matching user is signed in, it reloads the user and refreshes their ID token before
+   linking to profile completion. Signed-out or unmatched sessions receive a clear sign-in path.
+5. The verification waiting screen does not poll Firebase. Resends use a 60-second client cooldown,
+   while Firebase remains authoritative for server-side throttling.
 
 The application must never log complete action URLs, out-of-band codes, or passwords.
 
@@ -51,8 +68,23 @@ Run this check in a non-production environment before promoting the change:
 8. Repeat with an expired or deliberately altered `oobCode`, a wrong `mode`, and an unknown email.
 9. Confirm a signed-in but unverified user can still open the public action route.
 
+Then verify the email-verification flow:
+
+1. Register a new account and confirm the first verification link lands on `/auth/action` with
+   `mode=verifyEmail`.
+2. Open it in the registration browser and confirm the app continues to profile completion.
+3. Repeat in a private or different browser and confirm verification succeeds with a sign-in path.
+4. Reopen the used link and test expired, altered, missing-code, and wrong-mode links; each must
+   show a safe recovery state without exposing Firebase details or URL-provided email data.
+5. From the verification waiting screen, resend once and confirm the control enters a 60-second
+   cooldown. Test Firebase throttling and a disconnected network.
+6. Add an attacker-controlled `continueUrl` and confirm every visible destination remains on the
+   application-owned sign-in or profile-completion route.
+
 References:
 
 - [Firebase custom email action handlers](https://firebase.google.com/docs/auth/custom-email-handler)
 - [Firebase password reset](https://firebase.google.com/docs/auth/web/manage-users#send_a_password_reset_email)
+- [Firebase email verification](https://firebase.google.com/docs/auth/web/manage-users#send_a_user_a_verification_email)
+- [Firebase ActionCodeSettings](https://firebase.google.com/docs/reference/js/auth.actioncodesettings)
 - [Firebase session revocation](https://firebase.google.com/docs/auth/admin/manage-sessions)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,7 @@ const PublicHomePage = lazy(() => import("./features/welcome/components/PublicHo
 const AccountSettingsPage = lazy(() => import("./features/account/components/AccountSettingsPage"));
 const RegisterPage = lazy(() => import("./features/auth/components/RegisterPage"));
 const PasswordResetRequestPage = lazy(() => import("./features/auth/components/PasswordResetRequestPage"));
-const PasswordResetActionPage = lazy(() => import("./features/auth/components/PasswordResetActionPage"));
+const EmailActionPage = lazy(() => import("./features/auth/components/EmailActionPage"));
 const OnboardingShell = lazy(() => import("./features/auth/components/OnboardingShell"));
 const UnsubscribeConfirmedPage = lazy(() => import("./features/account/components/UnsubscribeConfirmedPage"));
 
@@ -86,7 +86,6 @@ function AppContent() {
     authInitialized,
     logoutSuccess,
     setLogoutSuccess,
-    triggerEmailCheck,
   } = useAppAuthSession(handleLoggedOut);
   const { checkoutQueryState, dismissCheckoutStatus } = useCheckoutQueryState(location, navigate);
   const isOnline = useOnlineStatus();
@@ -192,10 +191,7 @@ function AppContent() {
           >
             <Suspense fallback={<LoadingFallback />}>
               <OnboardingShell activeStep="verify">
-                <EmailVerificationMessage
-                  user={user}
-                  onVerified={async () => triggerEmailCheck()}
-                />
+                <EmailVerificationMessage user={user} />
               </OnboardingShell>
             </Suspense>
           </Box>
@@ -447,7 +443,7 @@ function AppContent() {
                   path={ROUTES.AUTH_ACTION}
                   element={
                     <Suspense fallback={<LoadingFallback />}>
-                      <PasswordResetActionPage />
+                      <EmailActionPage />
                     </Suspense>
                   }
                 />

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -168,8 +168,8 @@ vi.mock("../features/auth/components/PasswordResetRequestPage", () => ({
   default: () => <h1>Password Reset Request Page</h1>,
 }));
 
-vi.mock("../features/auth/components/PasswordResetActionPage", () => ({
-  default: () => <h1>Password Reset Action Page</h1>,
+vi.mock("../features/auth/components/EmailActionPage", () => ({
+  default: () => <h1>Email Action Page</h1>,
 }));
 
 vi.mock("../features/auth/components/OnboardingShell", () => ({
@@ -344,16 +344,16 @@ describe("App routing", () => {
     requestRender.unmount();
 
     renderApp([`${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=test-code`]);
-    expect(await screen.findByRole("heading", { name: "Password Reset Action Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Email Action Page" })).toBeInTheDocument();
   });
 
   it("does not let the unverified-account gate hide the public action route", async () => {
     currentUser = createMockUser({ emailVerified: false });
     enabledClaim = false;
 
-    renderApp([`${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=test-code`]);
+    renderApp([`${ROUTES.AUTH_ACTION}?mode=verifyEmail&oobCode=test-code`]);
 
-    expect(await screen.findByRole("heading", { name: "Password Reset Action Page" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Email Action Page" })).toBeInTheDocument();
     expect(screen.queryByRole("heading", { name: "Email Verification Page" })).not.toBeInTheDocument();
   });
 

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -23,10 +23,9 @@ import { canAttemptSignIn } from "../utils/passwordValidation";
 interface AuthGateProps {
   userData?: UserData | null;
   onRegisterComplete?: () => void;
-  onProfileComplete?: () => void;
 }
 
-export default function AuthGate({ userData, onRegisterComplete, onProfileComplete }: AuthGateProps) {
+export default function AuthGate({ userData, onRegisterComplete }: AuthGateProps) {
   const [user, setUser] = useState<User | null>(null);
   const [initialising, setInitialising] = useState(true);
 
@@ -74,14 +73,7 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
     if (!user.emailVerified) {
       return (
         <OnboardingShell activeStep="verify">
-          <EmailVerificationMessage
-            user={user}
-            onVerified={() => {
-              if (onProfileComplete) {
-                onProfileComplete();
-              }
-            }}
-          />
+          <EmailVerificationMessage user={user} />
         </OnboardingShell>
       );
     }

--- a/src/features/auth/components/EmailActionPage.tsx
+++ b/src/features/auth/components/EmailActionPage.tsx
@@ -1,0 +1,27 @@
+import { Alert, Box, Button, Stack, Typography } from "@mui/material";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { ROUTES } from "../../../constants";
+import EmailVerificationActionPage from "./EmailVerificationActionPage";
+import PasswordResetActionPage from "./PasswordResetActionPage";
+
+export default function EmailActionPage() {
+  const [searchParams] = useSearchParams();
+  const mode = searchParams.get("mode");
+
+  if (mode === "resetPassword") return <PasswordResetActionPage />;
+  if (mode === "verifyEmail") return <EmailVerificationActionPage />;
+
+  return (
+    <Box sx={{ maxWidth: "600px", mx: "auto", px: { xs: 3, sm: 4 } }}>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        <Typography variant="h4" component="h1" sx={{ color: "primary.light" }}>
+          Email action unavailable
+        </Typography>
+        <Alert severity="error">This email action link is invalid or is not supported.</Alert>
+        <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
+          Continue to sign in
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/EmailVerificationActionPage.tsx
+++ b/src/features/auth/components/EmailVerificationActionPage.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useMemo, useState } from "react";
+import { Alert, Box, Button, CircularProgress, Link, Stack, Typography } from "@mui/material";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { applyActionCode, checkActionCode, reload, type User } from "firebase/auth";
+import { auth } from "../../../config/firebase";
+import { ROUTES } from "../../../constants";
+import { isEmailVerificationAction, parseEmailActionParameters } from "../utils/emailAction";
+import {
+  getEmailVerificationActionError,
+  isInvalidEmailVerificationCode,
+} from "../utils/emailVerificationErrors";
+import { normalizeEmailAddress } from "../utils/emailAddress";
+
+type VerificationState = "verifying" | "complete" | "invalid" | "error";
+
+interface VerificationCompletion {
+  continueToProfile: boolean;
+}
+
+const inFlightCompletions = new Map<string, Promise<VerificationCompletion>>();
+
+function completeEmailVerification(oobCode: string): Promise<VerificationCompletion> {
+  const existing = inFlightCompletions.get(oobCode);
+  if (existing) return existing;
+
+  const completion = checkActionCode(auth, oobCode)
+    .then(async (actionInfo) => {
+      await applyActionCode(auth, oobCode);
+      const verifiedEmail = typeof actionInfo.data.email === "string" ? actionInfo.data.email : null;
+      const refreshedUser = await refreshSignedInUser(verifiedEmail);
+      return { continueToProfile: Boolean(refreshedUser?.emailVerified) };
+    })
+    .finally(() => {
+      // Keep only concurrent StrictMode/equivalent callers deduplicated; action
+      // codes are never persisted after this operation settles.
+      inFlightCompletions.delete(oobCode);
+    });
+  inFlightCompletions.set(oobCode, completion);
+  return completion;
+}
+
+async function refreshSignedInUser(verifiedEmail: string | null): Promise<User | null> {
+  const currentUser = auth.currentUser;
+  if (
+    !currentUser?.email ||
+    !verifiedEmail ||
+    normalizeEmailAddress(currentUser.email) !== normalizeEmailAddress(verifiedEmail)
+  ) {
+    return null;
+  }
+
+  try {
+    await reload(currentUser);
+    await currentUser.getIdToken(true);
+    return currentUser;
+  } catch {
+    // Verification has completed even if this browser cannot refresh its
+    // existing session. Signing in again will load the authoritative state.
+    return null;
+  }
+}
+
+export default function EmailVerificationActionPage() {
+  const [searchParams] = useSearchParams();
+  const parameters = useMemo(() => parseEmailActionParameters(searchParams), [searchParams]);
+  const [state, setState] = useState<VerificationState>("verifying");
+  const [error, setError] = useState<string | null>(null);
+  const [continueToProfile, setContinueToProfile] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setError(null);
+    setContinueToProfile(false);
+
+    if (!isEmailVerificationAction(parameters)) {
+      setState("invalid");
+      return () => { active = false; };
+    }
+
+    setState("verifying");
+    void completeEmailVerification(parameters.oobCode)
+      .then(({ continueToProfile: canContinueToProfile }) => {
+        if (!active) return;
+        setContinueToProfile(canContinueToProfile);
+        setState("complete");
+      })
+      .catch((verificationError) => {
+        if (!active) return;
+        if (isInvalidEmailVerificationCode(verificationError)) {
+          setState("invalid");
+        } else {
+          setError(getEmailVerificationActionError(verificationError));
+          setState("error");
+        }
+      });
+
+    return () => { active = false; };
+  }, [attempt, parameters]);
+
+  const destination = continueToProfile ? ROUTES.PROFILE_COMPLETION : ROUTES.ACCOUNT;
+  const destinationLabel = continueToProfile ? "Continue account setup" : "Continue to sign in";
+
+  return (
+    <Box sx={{ maxWidth: "600px", mx: "auto", px: { xs: 3, sm: 4 } }}>
+      <Stack spacing={2} sx={{ mt: 2 }}>
+        <Typography variant="h4" component="h1" sx={{ color: "primary.light" }}>
+          Verify your email
+        </Typography>
+
+        {state === "verifying" && (
+          <Box role="status" aria-label="Verifying email address" sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+            <CircularProgress size={24} />
+            <Typography>Checking your verification link…</Typography>
+          </Box>
+        )}
+
+        {state === "complete" && (
+          <>
+            <Alert severity="success">Your email address has been verified.</Alert>
+            {!continueToProfile && (
+              <Typography variant="body2" color="text.secondary">
+                Sign in with the verified account to continue setting up your membership.
+              </Typography>
+            )}
+            <Button component={RouterLink} to={destination} variant="contained">
+              {destinationLabel}
+            </Button>
+          </>
+        )}
+
+        {state === "invalid" && (
+          <>
+            <Alert severity="error">
+              This email verification link is invalid, has expired, or has already been used.
+            </Alert>
+            <Typography variant="body2" color="text.secondary">
+              Sign in to request a new verification email.
+            </Typography>
+            <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
+              Continue to sign in
+            </Button>
+          </>
+        )}
+
+        {state === "error" && (
+          <>
+            <Alert severity="error">{error}</Alert>
+            <Button variant="contained" onClick={() => setAttempt((current) => current + 1)}>
+              Try verifying again
+            </Button>
+            <Link component={RouterLink} to={ROUTES.ACCOUNT}>Continue to sign in</Link>
+          </>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/EmailVerificationMessage.tsx
+++ b/src/features/auth/components/EmailVerificationMessage.tsx
@@ -1,84 +1,47 @@
-import { useState, useEffect } from "react";
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Stack,
-  Typography,
-} from "@mui/material";
-import { sendEmailVerification, reload, type User } from "firebase/auth";
+import { useEffect, useState } from "react";
+import { Alert, Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { sendEmailVerification, type User } from "firebase/auth";
+import { buildEmailVerificationActionCodeSettings } from "../utils/emailAction";
+import { getEmailVerificationSendError } from "../utils/emailVerificationErrors";
+
+const RESEND_COOLDOWN_SECONDS = 60;
 
 interface EmailVerificationMessageProps {
   user: User;
-  onVerified?: () => void;
 }
 
-export default function EmailVerificationMessage({
-  user,
-  onVerified,
-}: EmailVerificationMessageProps) {
+export default function EmailVerificationMessage({ user }: EmailVerificationMessageProps) {
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [checking, setChecking] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+  const cooldownActive = cooldownSeconds > 0;
+
+  useEffect(() => {
+    if (!cooldownActive) return;
+    const interval = window.setInterval(() => {
+      setCooldownSeconds((remaining) => Math.max(0, remaining - 1));
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [cooldownActive]);
 
   const handleResend = async () => {
+    if (sending || cooldownActive) return;
     setError(null);
     setSending(true);
     try {
-      await sendEmailVerification(user);
+      await sendEmailVerification(
+        user,
+        buildEmailVerificationActionCodeSettings(window.location.origin),
+      );
       setSent(true);
-      setTimeout(() => setSent(false), 5000);
-    } catch (e: any) {
-      setError(e?.message || "Failed to resend verification email");
+      setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+    } catch (sendError) {
+      setError(getEmailVerificationSendError(sendError));
     } finally {
       setSending(false);
     }
   };
-
-  const checkVerification = async () => {
-    setChecking(true);
-    setError(null);
-    try {
-      await reload(user);
-      await user.getIdToken(true);
-      await new Promise((resolve) => setTimeout(resolve, 100));
-
-      if (user.emailVerified) {
-        if (onVerified) {
-          await onVerified();
-        }
-      } else {
-        setError("Email not yet verified. Please check your inbox and click the verification link.");
-      }
-    } catch (e: any) {
-      setError(e?.message || "Failed to check verification status");
-    } finally {
-      setChecking(false);
-    }
-  };
-
-  useEffect(() => {
-    if (user?.emailVerified) {
-      return;
-    }
-
-    const interval = setInterval(async () => {
-      if (user && !user.emailVerified) {
-        try {
-          await reload(user);
-          if (user.emailVerified && onVerified) {
-            onVerified();
-          }
-        } catch {
-          // Silently fail auto-checks
-        }
-      }
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, [user, onVerified]);
 
   return (
     <Box sx={{ textAlign: "left" }}>
@@ -86,44 +49,34 @@ export default function EmailVerificationMessage({
         Verify your email
       </Typography>
       <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
-        We sent a link to <strong>{user.email}</strong>. Click the link in that email, then come
-        back here to continue.
+        We sent a link to <strong>{user.email}</strong>. Open it to verify your address and continue
+        account setup in the app.
       </Typography>
 
       <Alert severity="info" sx={{ mb: 2 }}>
         Check your spam folder if the message does not arrive within a few minutes.
       </Alert>
 
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }}>
-          {error}
-        </Alert>
-      )}
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
       {sent && (
         <Alert severity="success" sx={{ mb: 2 }}>
-          Verification email sent!
+          Verification email sent. The link will open this application.
         </Alert>
       )}
 
-      <Stack direction={{ xs: "column", sm: "row" }} spacing={2}>
-        <Button
-          variant="contained"
-          onClick={checkVerification}
-          disabled={checking}
-          sx={{
-            backgroundColor: "secondary.main",
-            color: "white",
-            "&:hover": {
-              backgroundColor: "secondary.main",
-              opacity: 0.9,
-            },
-          }}
-        >
-          {checking ? <CircularProgress size={24} /> : "I've clicked the link"}
+      <Stack spacing={1}>
+        <Button variant="outlined" onClick={handleResend} disabled={sending || cooldownActive}>
+          {sending ? (
+            <CircularProgress size={24} color="inherit" aria-label="Sending verification email" />
+          ) : cooldownActive ? (
+            `Resend available in ${cooldownSeconds}s`
+          ) : (
+            "Resend verification email"
+          )}
         </Button>
-        <Button variant="outlined" onClick={handleResend} disabled={sending || sent}>
-          {sending ? <CircularProgress size={24} /> : "Resend email"}
-        </Button>
+        <Typography variant="caption" color="text.secondary">
+          You can safely close this page after opening the verification link.
+        </Typography>
       </Stack>
     </Box>
   );

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -16,6 +16,8 @@ import {
   validateRegistrationPassword,
 } from "../utils/passwordValidation";
 import { REGISTRATION_MIN_PASSWORD_LENGTH } from "../../../constants/auth";
+import { buildEmailVerificationActionCodeSettings } from "../utils/emailAction";
+import { getEmailVerificationSendError } from "../utils/emailVerificationErrors";
 
 interface RegisterProps {
   onSuccess?: () => void;
@@ -75,7 +77,10 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
       }
       await userCredential.user.getIdToken(true);
 
-      await sendEmailVerification(userCredential.user);
+      await sendEmailVerification(
+        userCredential.user,
+        buildEmailVerificationActionCodeSettings(window.location.origin),
+      );
 
       setSuccess(true);
       setPassword("");
@@ -92,7 +97,9 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
         errorMessage = "Invalid email address";
       } else if (e?.code === "auth/weak-password") {
         errorMessage = "Password is too weak";
-      } else if (e?.message) {
+      } else if (e?.code?.startsWith("auth/")) {
+        errorMessage = getEmailVerificationSendError(e);
+      } else if (e instanceof Error) {
         errorMessage = e.message;
       }
       setError(errorMessage);
@@ -108,8 +115,8 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
           You&apos;re in — now check your inbox.
         </Alert>
         <Typography variant="body2" sx={{ color: "text.secondary" }}>
-          We sent a verification link to <strong>{email}</strong>. Click the link in that email,
-          then come back here to complete your profile. We look forward to welcoming you to SODC.
+          We sent a verification link to <strong>{email}</strong>. Open the link to verify your
+          address and continue your profile in the app. We look forward to welcoming you to SODC.
         </Typography>
         {onSignInClick && (
           <Button variant="contained" onClick={onSignInClick}>

--- a/src/features/auth/components/__tests__/EmailActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/EmailActionPage.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { render, screen } from "../../../../test-utils";
+import EmailActionPage from "../EmailActionPage";
+
+vi.mock("../PasswordResetActionPage", () => ({
+  default: () => <h1>Password reset handler</h1>,
+}));
+
+vi.mock("../EmailVerificationActionPage", () => ({
+  default: () => <h1>Email verification handler</h1>,
+}));
+
+function renderPage(search: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/auth/action${search}`]}>
+      <EmailActionPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("EmailActionPage", () => {
+  it("dispatches password reset actions", () => {
+    renderPage("?mode=resetPassword&oobCode=code");
+    expect(screen.getByRole("heading", { name: "Password reset handler" })).toBeInTheDocument();
+  });
+
+  it("dispatches email verification actions", () => {
+    renderPage("?mode=verifyEmail&oobCode=code");
+    expect(screen.getByRole("heading", { name: "Email verification handler" })).toBeInTheDocument();
+  });
+
+  it.each(["", "?mode=recoverEmail&oobCode=code", "?mode=unknown"])(
+    "rejects unsupported action modes: %s",
+    (search) => {
+      renderPage(search);
+      expect(screen.getByText("This email action link is invalid or is not supported.")).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Continue to sign in" })).toHaveAttribute("href", "/account");
+    },
+  );
+});

--- a/src/features/auth/components/__tests__/EmailVerificationActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/EmailVerificationActionPage.test.tsx
@@ -1,0 +1,163 @@
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+import { applyActionCode, checkActionCode, reload, type User } from "firebase/auth";
+import { render, screen, waitFor } from "../../../../test-utils";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
+import EmailVerificationActionPage from "../EmailVerificationActionPage";
+
+let currentUser: User | null = null;
+
+vi.mock("firebase/auth", () => ({
+  applyActionCode: vi.fn(),
+  checkActionCode: vi.fn(),
+  reload: vi.fn(),
+}));
+
+vi.mock("../../../../config/firebase", () => ({
+  auth: {
+    get currentUser() {
+      return currentUser;
+    },
+  },
+}));
+
+function renderPage(
+  search = "?mode=verifyEmail&oobCode=valid-code",
+  strict = false,
+) {
+  const page = (
+    <MemoryRouter initialEntries={[`/auth/action${search}`]}>
+      <EmailVerificationActionPage />
+    </MemoryRouter>
+  );
+  return render(strict ? <StrictMode>{page}</StrictMode> : page);
+}
+
+describe("EmailVerificationActionPage", () => {
+  beforeEach(() => {
+    currentUser = null;
+    vi.mocked(checkActionCode).mockReset().mockResolvedValue({
+      data: { email: "test@example.com" },
+    } as never);
+    vi.mocked(applyActionCode).mockReset().mockResolvedValue(undefined);
+    vi.mocked(reload).mockReset().mockResolvedValue(undefined);
+  });
+
+  it("checks and applies a valid action code in order", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(checkActionCode).mockImplementation(async () => {
+      callOrder.push("check");
+      return { data: { email: "test@example.com" } } as never;
+    });
+    vi.mocked(applyActionCode).mockImplementation(async () => {
+      callOrder.push("apply");
+    });
+
+    renderPage();
+
+    expect(screen.getByRole("status", { name: "Verifying email address" })).toBeInTheDocument();
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(callOrder).toEqual(["check", "apply"]);
+    expect(checkActionCode).toHaveBeenCalledWith(expect.anything(), "valid-code");
+    expect(applyActionCode).toHaveBeenCalledWith(expect.anything(), "valid-code");
+  });
+
+  it("deduplicates completion when React StrictMode repeats the effect", async () => {
+    renderPage("?mode=verifyEmail&oobCode=strict-code", true);
+
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(checkActionCode).toHaveBeenCalledTimes(1);
+    expect(applyActionCode).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["?mode=resetPassword&oobCode=valid-code"],
+    ["?mode=verifyEmail"],
+    ["?oobCode=valid-code"],
+  ])("rejects malformed or wrong-mode parameters: %s", async (search) => {
+    renderPage(search);
+
+    expect(await screen.findByText(/link is invalid, has expired, or has already been used/i)).toBeInTheDocument();
+    expect(checkActionCode).not.toHaveBeenCalled();
+    expect(applyActionCode).not.toHaveBeenCalled();
+  });
+
+  it("shows a safe invalid state for expired and already-used codes", async () => {
+    vi.mocked(checkActionCode).mockRejectedValue({
+      code: "auth/expired-action-code",
+      message: "sensitive Firebase detail",
+    });
+    renderPage();
+
+    expect(await screen.findByText(/link is invalid, has expired, or has already been used/i)).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("sensitive Firebase detail");
+    expect(applyActionCode).not.toHaveBeenCalled();
+  });
+
+  it("lets the user retry a transient check failure", async () => {
+    vi.mocked(checkActionCode)
+      .mockRejectedValueOnce({ code: "auth/network-request-failed" })
+      .mockResolvedValueOnce({ data: { email: "test@example.com" } } as never);
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByText(/could not connect/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try verifying again" }));
+
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(checkActionCode).toHaveBeenCalledTimes(2);
+    expect(applyActionCode).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles a code rejected while applying it", async () => {
+    vi.mocked(applyActionCode).mockRejectedValue({ code: "auth/invalid-action-code" });
+    renderPage();
+
+    expect(await screen.findByText(/link is invalid, has expired, or has already been used/i)).toBeInTheDocument();
+  });
+
+  it("refreshes a matching signed-in session and continues account setup", async () => {
+    const signedInUser = createMockUser({ emailVerified: false });
+    currentUser = signedInUser;
+    vi.mocked(reload).mockImplementation(async () => {
+      Object.defineProperty(signedInUser, "emailVerified", { value: true, configurable: true });
+    });
+    renderPage();
+
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(reload).toHaveBeenCalledWith(signedInUser);
+    expect(signedInUser.getIdToken).toHaveBeenCalledWith(true);
+    expect(screen.getByRole("link", { name: "Continue account setup" })).toHaveAttribute(
+      "href",
+      "/profile-completion",
+    );
+  });
+
+  it("supports signed-out completion and ignores an attacker-controlled continue URL", async () => {
+    renderPage("?mode=verifyEmail&oobCode=valid-code&continueUrl=https://evil.example/phish&email=victim@example.com");
+
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Continue to sign in" })).toHaveAttribute("href", "/account");
+    expect(document.body).not.toHaveTextContent("evil.example");
+    expect(document.body).not.toHaveTextContent("victim@example.com");
+  });
+
+  it("does not continue onboarding for a different signed-in account", async () => {
+    currentUser = createMockUser({ email: "other@example.com", emailVerified: true });
+    renderPage();
+
+    expect(await screen.findByText("Your email address has been verified.")).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Continue to sign in" })).toHaveAttribute("href", "/account");
+  });
+
+  it("falls back to sign-in if the current session cannot be refreshed", async () => {
+    currentUser = createMockUser({ emailVerified: false });
+    vi.mocked(reload).mockRejectedValue(new Error("offline"));
+    renderPage();
+
+    await waitFor(() => expect(screen.getByRole("link", { name: "Continue to sign in" })).toBeInTheDocument());
+  });
+});

--- a/src/features/auth/components/__tests__/EmailVerificationMessage.test.tsx
+++ b/src/features/auth/components/__tests__/EmailVerificationMessage.test.tsx
@@ -1,0 +1,67 @@
+import { act, fireEvent, render, screen, waitFor } from "../../../../test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmailVerification } from "firebase/auth";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
+import EmailVerificationMessage from "../EmailVerificationMessage";
+
+vi.mock("firebase/auth", () => ({
+  sendEmailVerification: vi.fn(),
+}));
+
+describe("EmailVerificationMessage", () => {
+  beforeEach(() => {
+    vi.mocked(sendEmailVerification).mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resends with fixed application-owned action settings", async () => {
+    const user = createMockUser({ emailVerified: false });
+    render(<EmailVerificationMessage user={user} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend verification email" }));
+
+    await waitFor(() => expect(sendEmailVerification).toHaveBeenCalledWith(
+      user,
+      {
+        url: `${window.location.origin}/profile-completion`,
+        handleCodeInApp: false,
+      },
+    ));
+    expect(screen.getByText(/link will open this application/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /I've clicked the link/i })).not.toBeInTheDocument();
+  });
+
+  it("prevents repeated sends during a 60-second cooldown", async () => {
+    vi.useFakeTimers();
+    const user = createMockUser({ emailVerified: false });
+    render(<EmailVerificationMessage user={user} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend verification email" }));
+    await act(async () => { await Promise.resolve(); });
+
+    expect(screen.getByRole("button", { name: "Resend available in 60s" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Resend available in 60s" }));
+    expect(sendEmailVerification).toHaveBeenCalledTimes(1);
+
+    act(() => { vi.advanceTimersByTime(60_000); });
+    expect(screen.getByRole("button", { name: "Resend verification email" })).toBeEnabled();
+  });
+
+  it.each([
+    ["auth/too-many-requests", /too many verification emails/i],
+    ["auth/network-request-failed", /could not connect/i],
+    ["auth/unauthorized-continue-uri", /not configured for this site/i],
+    ["auth/internal-error", /could not send a verification email/i],
+  ])("shows a safe resend error for %s", async (code, expectedMessage) => {
+    vi.mocked(sendEmailVerification).mockRejectedValue({ code, message: "raw Firebase detail" });
+    render(<EmailVerificationMessage user={createMockUser({ emailVerified: false })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend verification email" }));
+
+    expect(await screen.findByText(expectedMessage)).toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent("raw Firebase detail");
+  });
+});

--- a/src/features/auth/components/__tests__/Register.test.tsx
+++ b/src/features/auth/components/__tests__/Register.test.tsx
@@ -3,6 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { render, screen, fireEvent } from "../../../../test-utils";
 import Register from "../Register";
 import { REGISTRATION_MIN_PASSWORD_LENGTH } from "../../../../constants/auth";
+import { createUserWithEmailAndPassword, sendEmailVerification } from "firebase/auth";
+import { syncPendingUserClaims } from "../../../../shared/utils/firebaseFunctions";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
 
 vi.mock("firebase/auth", () => ({
   createUserWithEmailAndPassword: vi.fn(),
@@ -20,6 +23,27 @@ async function fillForm(user: ReturnType<typeof userEvent.setup>, password: stri
 }
 
 describe("Register", () => {
+  it("sends the initial verification email with fixed application settings", async () => {
+    const user = userEvent.setup();
+    const newUser = createMockUser({ email: "new@example.com", emailVerified: false });
+    vi.mocked(createUserWithEmailAndPassword).mockResolvedValue({ user: newUser } as never);
+    vi.mocked(syncPendingUserClaims).mockResolvedValue({ success: true });
+    vi.mocked(sendEmailVerification).mockResolvedValue(undefined);
+    render(<Register />);
+
+    await fillForm(user, "a".repeat(REGISTRATION_MIN_PASSWORD_LENGTH));
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(await screen.findByText(/now check your inbox/i)).toBeInTheDocument();
+    expect(sendEmailVerification).toHaveBeenCalledWith(
+      newUser,
+      {
+        url: `${window.location.origin}/profile-completion`,
+        handleCodeInApp: false,
+      },
+    );
+  });
+
   it(`shows the ${REGISTRATION_MIN_PASSWORD_LENGTH}-character minimum in the password helper text`, () => {
     render(<Register />);
 

--- a/src/features/auth/utils/emailAction.ts
+++ b/src/features/auth/utils/emailAction.ts
@@ -19,11 +19,27 @@ export function isPasswordResetAction(
   return parameters.mode === "resetPassword" && Boolean(parameters.oobCode?.trim());
 }
 
+export function isEmailVerificationAction(
+  parameters: EmailActionParameters,
+): parameters is EmailActionParameters & { mode: "verifyEmail"; oobCode: string } {
+  return parameters.mode === "verifyEmail" && Boolean(parameters.oobCode?.trim());
+}
+
 export function buildPasswordResetActionCodeSettings(origin: string): ActionCodeSettings {
   return {
     url: new URL(ROUTES.ACCOUNT, origin).toString(),
     // The web app owns the custom action handler. This flag is for native/mobile
     // app-first links, so keep it false for this web-only flow.
+    handleCodeInApp: false,
+  };
+}
+
+export function buildEmailVerificationActionCodeSettings(origin: string): ActionCodeSettings {
+  return {
+    url: new URL(ROUTES.PROFILE_COMPLETION, origin).toString(),
+    // The custom web handler is configured in Firebase Authentication's email
+    // template. This continue URL is fixed application state, not navigation
+    // supplied by the incoming action link.
     handleCodeInApp: false,
   };
 }

--- a/src/features/auth/utils/emailVerificationErrors.ts
+++ b/src/features/auth/utils/emailVerificationErrors.ts
@@ -1,0 +1,41 @@
+const INVALID_VERIFICATION_CODES = new Set([
+  "auth/expired-action-code",
+  "auth/invalid-action-code",
+  "auth/user-disabled",
+  "auth/user-not-found",
+]);
+
+function authErrorCode(error: unknown): string | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+export function isInvalidEmailVerificationCode(error: unknown): boolean {
+  return INVALID_VERIFICATION_CODES.has(authErrorCode(error) ?? "");
+}
+
+export function getEmailVerificationActionError(error: unknown): string {
+  switch (authErrorCode(error)) {
+    case "auth/network-request-failed":
+      return "We could not connect to the email verification service. Check your connection and try again.";
+    case "auth/too-many-requests":
+      return "Too many verification attempts have been made. Please wait a while before trying again.";
+    default:
+      return "We could not verify your email address. Please try again.";
+  }
+}
+
+export function getEmailVerificationSendError(error: unknown): string {
+  switch (authErrorCode(error)) {
+    case "auth/too-many-requests":
+      return "Too many verification emails have been requested. Please wait before trying again.";
+    case "auth/network-request-failed":
+      return "We could not connect to the email service. Check your connection and try again.";
+    case "auth/unauthorized-continue-uri":
+    case "auth/invalid-continue-uri":
+      return "Email verification is not configured for this site. Please contact support.";
+    default:
+      return "We could not send a verification email. Please try again later.";
+  }
+}

--- a/src/shared/appShell/useAppAuthSession.ts
+++ b/src/shared/appShell/useAppAuthSession.ts
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
-import { onAuthStateChanged, reload, type User } from "firebase/auth";
+import { onAuthStateChanged, type User } from "firebase/auth";
 import { auth } from "../../config/firebase";
 
 export function useAppAuthSession(onLoggedOut: () => void) {
   const [user, setUser] = useState<User | null>(null);
   const [authInitialized, setAuthInitialized] = useState(false);
-  const [emailCheckTrigger, setEmailCheckTrigger] = useState(0);
   const [logoutSuccess, setLogoutSuccess] = useState(false);
 
   useEffect(() => {
@@ -13,7 +12,6 @@ export function useAppAuthSession(onLoggedOut: () => void) {
       setUser((previousUser) => {
         if (previousUser !== null && nextUser === null) {
           onLoggedOut();
-          setEmailCheckTrigger(0);
           setLogoutSuccess(true);
         }
         return nextUser;
@@ -23,19 +21,10 @@ export function useAppAuthSession(onLoggedOut: () => void) {
     return () => unsub();
   }, [onLoggedOut]);
 
-  useEffect(() => {
-    if (user && emailCheckTrigger > 0) {
-      reload(user).catch(() => {
-        // The UI can continue using the current auth state if reload fails.
-      });
-    }
-  }, [emailCheckTrigger, user]);
-
   return {
     user,
     authInitialized,
     logoutSuccess,
     setLogoutSuccess,
-    triggerEmailCheck: () => setEmailCheckTrigger((prev) => prev + 1),
   };
 }

--- a/src/test-utils/mocks/firebase.ts
+++ b/src/test-utils/mocks/firebase.ts
@@ -46,6 +46,8 @@ export const mockAuth = {
   signOut: vi.fn(),
   createUserWithEmailAndPassword: vi.fn(),
   sendEmailVerification: vi.fn(),
+  checkActionCode: vi.fn(),
+  applyActionCode: vi.fn(),
   sendPasswordResetEmail: vi.fn(),
   verifyPasswordResetCode: vi.fn(),
   confirmPasswordReset: vi.fn(),

--- a/src/test-utils/setup.ts
+++ b/src/test-utils/setup.ts
@@ -26,6 +26,8 @@ vi.mock('../config/firebase', () => ({
     signOut: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),
     sendEmailVerification: vi.fn(),
+    checkActionCode: vi.fn(),
+    applyActionCode: vi.fn(),
     sendPasswordResetEmail: vi.fn(),
     verifyPasswordResetCode: vi.fn(),
     confirmPasswordReset: vi.fn(),


### PR DESCRIPTION
## Summary

- extend the shared `/auth/action` route to dispatch email verification and password reset modes safely
- send initial and replacement verification emails with fixed application-owned `ActionCodeSettings`
- validate and apply Firebase verification codes in-app, with safe success, invalid, expired, used-code, and retry states
- refresh a matching signed-in Firebase session before continuing onboarding, while supporting signed-out and different-browser completion
- remove indefinite five-second polling and the manual “I've clicked the link” flow
- add a 60-second resend cooldown and safe Firebase throttling/network errors
- expand Firebase Console configuration and manual end-to-end documentation

## Why

Email verification currently completes through Firebase's hosted handler, while the application polls every five seconds and exposes raw resend errors. Owning the completion route gives users a consistent onboarding experience and lets the app enforce safe routing and error handling without replacing Firebase's action-code security.

## Security and user impact

Incoming query parameters are treated as untrusted. Only `mode=verifyEmail` with a non-empty Firebase action code is accepted; URL-provided email and continue destinations are ignored. A signed-in session advances to profile completion only when its email matches the authoritative email returned by Firebase's `checkActionCode`. Concurrent React Strict Mode execution is deduplicated so the code is applied once.

Users opening a valid link while signed out or in another browser can complete verification and then sign in. The waiting screen no longer polls Firebase continuously, and resend controls prevent accidental repeated requests.

## Dependency

This is an incremental stacked PR on #413 because it extends the shared email-action route introduced by #410. After #413 merges into `codex/412-in-app-account-management`, this PR should be retargeted to that epic branch.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:run` — 601 tests passed across 73 files
- `npm run test:coverage` — 79.12% statements, 71.99% branches
- `git diff --check`

## Operational requirement

For each Firebase environment, configure the email-address verification template's custom action URL as `https://<application-host>/auth/action` and verify the authorised domain and Hosting rewrites documented in `docs/operations/firebase-auth-email-actions.md`.

Closes #411