### PR TITLE
[#421] Fix extractTemplateVariables mis-parsing a placeholder preceded by an extra '('

### DIFF
--- a/functions/src/__tests__/announcements.test.ts
+++ b/functions/src/__tests__/announcements.test.ts
@@ -362,6 +362,30 @@ describe("extractTemplateVariables", () => {
     expect(result).toEqual([]);
     expect(elapsedMs).toBeLessThan(200);
   });
+
+  it("extracts a placeholder wrapped in markdown link syntax, e.g. [Unsubscribe](((unsubscribeUrl))) (#421)", () => {
+    const body =
+      "Dear ((firstName)),\n\nYou are a member of the ((section)) section.\n\n" +
+      "[Unsubscribe](((unsubscribeUrl)))\n\nSODC";
+
+    expect(extractTemplateVariables(body, "Test Message")).toEqual(
+      expect.arrayContaining(["firstName", "section", "unsubscribeUrl"])
+    );
+    // The historical bug produced a corrupted name with a leading "(" instead.
+    expect(extractTemplateVariables(body, "Test Message")).not.toEqual(
+      expect.arrayContaining(["(unsubscribeUrl"])
+    );
+  });
+
+  it("stays linear time with many placeholders each preceded by an extra '(' (#421)", () => {
+    const adversarial = "[link](((placeholder)))".repeat(20_000);
+    const start = performance.now();
+    const result = extractTemplateVariables(adversarial, "");
+    const elapsedMs = performance.now() - start;
+
+    expect(result).toEqual(["placeholder"]);
+    expect(elapsedMs).toBeLessThan(200);
+  });
 });
 
 describe("buildRecipientPersonalisation (#362)", () => {

--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -137,8 +137,15 @@ export function extractTemplateVariables(body: string, subject: string): string[
   const found = new Set<string>();
   let index = 0;
   while (index < text.length) {
-    const start = text.indexOf("((", index);
+    let start = text.indexOf("((", index);
     if (start === -1) break;
+    // A run of more than two consecutive "(" — e.g. a placeholder URL wrapped in markdown
+    // link syntax, "[Unsubscribe](((unsubscribeUrl)))" — means the genuine "((" delimiter is
+    // the last pair in the run, not the first. Slide forward through the run so a leading,
+    // unrelated "(" (from the markdown link itself) doesn't get swept into the extracted name.
+    while (text[start + 2] === "(") {
+      start += 1;
+    }
     const end = text.indexOf("))", start + 2);
     if (end === -1) break;
     const name = text.slice(start + 2, end).trim();


### PR DESCRIPTION
## Summary

Sending the "BULK: Test — Test Message" section announcement failed live with `Missing personalisation: unsubscribeUrl`.

Root cause: that template's unsubscribe link is written as markdown link syntax wrapping a GOV Notify placeholder — `[Unsubscribe](((unsubscribeUrl)))`. `extractTemplateVariables`'s manual scanner (introduced by #362 to avoid a ReDoS-vulnerable regex) finds the *first* `((` it sees without checking for an extra, unrelated `(` immediately before a genuine pair, so it extracted the corrupted name `"(unsubscribeUrl"` instead of `"unsubscribeUrl"`. `buildRecipientPersonalisation`'s filter then never matched the real key, silently dropping `unsubscribeUrl` from the personalisation sent to GOV Notify (while the separate, always-sent `oneClickUnsubscribeURL` parameter still had the correct value) — and GOV Notify's own template renderer, which parses the nested placeholder correctly, rejected the send.

Confirmed directly against live data before writing the fix:
- Fetched the live template body via the GOV Notify API and reproduced the exact corrupted output (`'(unsubscribeUrl'`) from the current `extractTemplateVariables`.
- Queried the live `AnnouncementSend.recipientSnapshot` for the actual failed send and confirmed `personalisation` was missing `unsubscribeUrl` while the top-level `unsubscribeUrl` field (used for `oneClickUnsubscribeURL`) was present and correct.

## Fix

When a run of more than two consecutive `(` is found, slide the match forward so the genuine `((` delimiter is the *last* pair in the run — any unrelated leading `(` (from markdown link syntax) stays outside the extracted name. The closing side needed no change: `indexOf` already finds the *first* `))` in a closing run, which is the correct pairing.

Checked all 47 live GOV Notify templates in Dev plus every `functions/email-templates/*.md` source for the same `(((` pattern — only the one template that already failed was affected.

## Test plan
- [x] New test reproduces the exact real-world shape (`[Unsubscribe](((unsubscribeUrl)))`) and asserts the correct extraction, plus that the historical corrupted output no longer occurs
- [x] New test confirms linear-time performance is preserved for many repeated extra-paren-prefixed placeholders (not just the original single-massive-run ReDoS case)
- [x] `npx vitest run` (functions) — 58 files, 560 tests passing
- [x] `npm run lint` (functions) — clean
- [x] `npx tsc -b --force` — clean

Closes #421.