### PR TITLE
Add secure section file APIs

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -174,6 +174,7 @@ mutation BeginSectionFileReplacement(
 mutation FinalizeSectionFileReplacement(
   $id: UUID!
   $pendingStorageObjectPath: String!
+  $storageObjectPath: String!
   $originalFilename: String!
   $objectGeneration: String!
   $checksumSha256: String!
@@ -188,7 +189,7 @@ mutation FinalizeSectionFileReplacement(
       pendingStorageObjectPath: { eq: $pendingStorageObjectPath }
     }
     data: {
-      storageObjectPath: $pendingStorageObjectPath
+      storageObjectPath: $storageObjectPath
       pendingStorageObjectPath: null
       originalFilename: $originalFilename
       objectGeneration: $objectGeneration

--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -45,6 +45,14 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 | `previewAnnouncementTemplate` | 30 | 5 minutes | GOV.UK Notify preview API |
 | `sendSectionAnnouncement` | 5 | 1 hour | Recipient resolution and bulk task/email fan-out |
 | `getAnnouncementSendRecipients` | 60 | 5 minutes | Recipient PII enumeration |
+| `requestSectionFileUpload` | 20 | 1 hour | Signed upload capability and storage allocation |
+| `finalizeSectionFileUpload` | 30 | 1 hour | Object validation, hashing, copy, and metadata write |
+| `listSectionFiles` | 60 | 5 minutes | Restricted metadata enumeration |
+| `requestSectionFileDownload` | 120 | 5 minutes | Signed download capability and storage egress |
+| `updateSectionFileMetadata` | 60 | 1 hour | Restricted metadata mutation |
+| `requestSectionFileReplacement` | 20 | 1 hour | Signed upload capability and lifecycle mutation |
+| `finalizeSectionFileReplacement` | 30 | 1 hour | Object validation, copy, cleanup, and metadata mutation |
+| `deleteSectionFile` | 30 | 1 hour | Object deletion and lifecycle mutation |
 
 ## Complete callable classification
 
@@ -82,6 +90,14 @@ Risk levels are relative to other authenticated callables in this application. â
 | `sendSectionAnnouncement` | High | High | GOV.UK Notify | Very high | Enabled + moderator; 5/hour; queued delivery |
 | `getAnnouncementSendHistory` | Low | Medium | None | Low | Enabled + moderator; bounded history query |
 | `getAnnouncementSendRecipients` | High | High | None | Medium | Enabled + moderator; 60/5 minutes; send/section binding |
+| `requestSectionFileUpload` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 20/hour; validated size/type; generated path |
+| `finalizeSectionFileUpload` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 30/hour; stored-object validation; lifecycle CAS |
+| `listSectionFiles` | Medium | Medium | None | Medium | Enabled + current section access; 60/5 minutes; available objects only |
+| `requestSectionFileDownload` | High | Low | Cloud Storage | High | Enabled + current section access; 120/5 minutes; 5-minute signed URL |
+| `updateSectionFileMetadata` | Medium | None | None | Low | Enabled + section moderator/admin; 60/hour; lifecycle CAS |
+| `requestSectionFileReplacement` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 20/hour; generated temporary path |
+| `finalizeSectionFileReplacement` | High | None | Cloud Storage | Very high | Enabled + section moderator/admin; 30/hour; validation, CAS, deferred cleanup |
+| `deleteSectionFile` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 30/hour; metadata hidden before cleanup |
 
 ## App Check relationship
 

--- a/docs/architecture/security-and-permissions.md
+++ b/docs/architecture/security-and-permissions.md
@@ -44,6 +44,8 @@ This document summarizes how access is enforced across Data Connect and Firebase
 | Callable | `submitEventBooking` | enabled user |
 | Callable | `createTicketCheckoutSession` | enabled user |
 | Callable | `grantAdmin` / `revokeAdmin` / `listAdminUsers` | enabled admin |
+| Callable | section-file list/download | enabled user with current section access, or enabled global admin |
+| Callable | section-file upload/manage/delete | enabled moderator of that section, or enabled global admin |
 | Webhook | `stripeWebhook` | Stripe signature-verified request |
 
 ## Function guard model
@@ -61,6 +63,7 @@ Guard helpers in `functions/src/helpers.ts`:
 Typical usage:
 
 - Member flows (`submitEventBooking`, checkout start, membership self-service): `requireEnabled`.
+- Section-file reads require current `ACCESS` or `MODERATOR` purpose after `requireEnabled`; management requires current `MODERATOR` purpose. Enabled global admins may bypass the relationship check, while disabled admins remain denied.
 - PII-bearing member directories and all announcement template, preview, send, history, and recipient callables: `requireEnabled` before section/group checks.
 - Admin-only operations: `requireAdmin`, which also enforces `enabled: true`.
 - A caller with `admin: true` but `enabled !== true` is rejected; admin status is not an access-revocation bypass.

--- a/docs/operations/new-production-instance.md
+++ b/docs/operations/new-production-instance.md
@@ -217,8 +217,89 @@ Before enabling the section-file feature:
 6. complete the IAM, public-access prevention, lifecycle, CORS, and verification
    steps in [section-file-storage.md](./section-file-storage.md).
 
+Use the real production values below. Do not copy the Dev project number,
+bucket, or service account:
+
+```sh
+export PROJECT_ID="sodc-web-production"
+export SECTION_FILES_BUCKET_NAME="sodc-web-production.firebasestorage.app"
+
+gcloud storage buckets update "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --uniform-bucket-level-access \
+  --public-access-prevention \
+  --lifecycle-file="config/storage/section-files-lifecycle.json"
+
+firebase deploy --only storage --project prod
+```
+
+After the #429 Functions have been deployed—but before invoking an upload or
+download—resolve the actual Gen 2 runtime service account:
+
+```sh
+gcloud functions describe requestSectionFileUpload \
+  --gen2 \
+  --region="europe-west2" \
+  --project="${PROJECT_ID}" \
+  --format="value(serviceConfig.serviceAccountEmail)"
+```
+
+Copy the exact returned address into this variable:
+
+```sh
+export FUNCTIONS_SERVICE_ACCOUNT="<returned-runtime-service-account>"
+```
+
+Grant only the required object and keyless-signing permissions:
+
+```sh
+gcloud storage buckets add-iam-policy-binding \
+  "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --member="serviceAccount:${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --role="roles/storage.objectAdmin"
+
+gcloud services enable iamcredentials.googleapis.com \
+  --project="${PROJECT_ID}"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --role="roles/iam.serviceAccountTokenCreator"
+```
+
+Verify the bucket configuration and both explicit IAM grants:
+
+```sh
+gcloud storage buckets describe "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --format="yaml(name,location,uniform_bucket_level_access,public_access_prevention,lifecycle_config,cors_config)"
+
+gcloud storage buckets get-iam-policy \
+  "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --format="table(bindings.role,bindings.members)"
+
+gcloud iam service-accounts get-iam-policy \
+  "${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --project="${PROJECT_ID}"
+```
+
+The bucket policy must show `roles/storage.objectAdmin`; the service-account
+policy must show the runtime identity bound to
+`roles/iam.serviceAccountTokenCreator`. The bucket description must show
+uniform access enabled, public-access prevention enforced, and lifecycle
+deletion restricted to `section-file-uploads/`. Apply the exact production CORS
+file using the command in [section-file-storage.md](./section-file-storage.md);
+never use a wildcard origin.
+
 Do not continue if Storage has not been initialized or if the CLI deploy targets
-a Dev/Beta bucket. Do not share the Dev or Beta bucket with Prod.
+a Dev/Beta bucket. Resolve the actual production Functions runtime service
+account and explicitly grant it `roles/storage.objectAdmin` on the production
+bucket. Enable `iamcredentials.googleapis.com` and grant that same identity
+`roles/iam.serviceAccountTokenCreator` on itself for keyless V4 signed URLs.
+Verify both policies before the upload/download smoke test. Do not share the Dev
+or Beta bucket or runtime identity with Prod, and do not create a downloaded
+service-account key.
 
 ## 7. Configure Functions environment and secrets
 
@@ -437,6 +518,7 @@ Connect or user data.
 - [ ] Data Connect read and a non-destructive callable action succeed.
 - [ ] Firebase Storage is initialized in Prod and the exact bucket name is recorded in both frontend and Functions configuration.
 - [ ] Section-file bucket isolation, IAM, lifecycle, CORS, deployed deny-all rules, and direct-access denial are verified before the feature is enabled.
+- [ ] Production Functions runtime has explicit bucket `roles/storage.objectAdmin` and self `roles/iam.serviceAccountTokenCreator` grants; IAM Credentials API is enabled.
 - [ ] Stripe live Checkout redirect/return and signed webhook delivery succeed.
 - [ ] Notify template drift check and one send per email domain succeed.
 - [ ] First and second administrators can sign in; an ordinary member cannot access Admin routes/actions.

--- a/docs/operations/section-file-storage.md
+++ b/docs/operations/section-file-storage.md
@@ -64,11 +64,24 @@ only a safety net; the backend should delete rejected objects immediately and
 the reconciliation work in #432 must report stale metadata and orphaned
 objects.
 
+This includes fully uploaded temporary objects whose browser never completed
+the finalization call—for example after a closed tab, network failure, rejected
+validation, failed replacement, or Function interruption. An HTTP upload that
+never completes normally does not create a complete object, but any completed
+temporary object left under `section-file-uploads/` is eligible for deletion
+after one day. Permanent objects under `section-files/` do not match this rule.
+
 Finalization must inspect the stored object rather than trusting browser
 metadata. It must verify the expected temporary path, object generation,
 actual byte size, approved content type, and checksum before atomically
 promoting the Data Connect row. A zero-row compare-and-swap result means the
 lifecycle changed and the caller must not continue.
+
+The #429 backend enforces a 25 MiB per-file limit and an explicit content-type
+allowlist. Upload grants expire after 15 minutes and download grants after 5
+minutes. Available metadata never exposes either internal object path, and a
+requested `sectionId` is always cross-checked against the file's authoritative
+Data Connect relationship before a grant or mutation is issued.
 
 ## Enable Firebase Storage in each project
 
@@ -128,13 +141,54 @@ gcloud storage buckets update "gs://${SECTION_FILES_BUCKET_NAME}" \
 gcloud storage buckets add-iam-policy-binding "gs://${SECTION_FILES_BUCKET_NAME}" \
   --member="serviceAccount:${FUNCTIONS_SERVICE_ACCOUNT}" \
   --role="roles/storage.objectAdmin"
+
+gcloud services enable iamcredentials.googleapis.com \
+  --project="${PROJECT_ID}"
+
+gcloud iam service-accounts add-iam-policy-binding \
+  "${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --role="roles/iam.serviceAccountTokenCreator"
 ```
 
 Resolve the deployed Functions runtime service account from the Firebase/GCP
-configuration; do not assume the example address. If the implementation signs
-URLs through IAM credentials rather than a local private key, grant only the
-additional service-account signing permission required by that implementation
-and document the exact principal.
+configuration; do not assume the example address. For a deployed Gen 2
+function:
+
+```sh
+gcloud functions describe requestSectionFileUpload \
+  --gen2 \
+  --region="europe-west2" \
+  --project="${PROJECT_ID}" \
+  --format="value(serviceConfig.serviceAccountEmail)"
+```
+
+`roles/storage.objectAdmin` is scoped to the section-file bucket and permits the
+runtime to inspect, copy, read, and delete objects without administering the
+bucket. The self-binding for `roles/iam.serviceAccountTokenCreator` supplies
+`iam.serviceAccounts.signBlob`, which lets that runtime identity create V4
+signed URLs without a downloaded private key. Do not create a service-account
+JSON key.
+
+Verify both explicit grants:
+
+```sh
+gcloud storage buckets get-iam-policy \
+  "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --format="table(bindings.role,bindings.members)"
+
+gcloud iam service-accounts get-iam-policy \
+  "${FUNCTIONS_SERVICE_ACCOUNT}" \
+  --project="${PROJECT_ID}"
+```
+
+The first output must include `roles/storage.objectAdmin`; the second must bind
+the runtime identity to `roles/iam.serviceAccountTokenCreator`. Bucket policy
+output does not include project-inherited roles, so require and verify these
+explicit bindings for each environment.
 
 Set `SECTION_FILES_BUCKET` in the project-specific ignored Functions env file,
 for example:
@@ -175,8 +229,30 @@ gcloud storage buckets update "gs://${SECTION_FILES_BUCKET_NAME}" \
   --cors-file="/secure/path/section-files-cors.json"
 
 gcloud storage buckets describe "gs://${SECTION_FILES_BUCKET_NAME}" \
-  --format="yaml(name,location,iamConfiguration,lifecycle,cors)"
+  --format="yaml(name,location,uniform_bucket_level_access,public_access_prevention,lifecycle_config,cors_config)"
 ```
+
+The standardized output must include:
+
+```text
+uniform_bucket_level_access: true
+public_access_prevention: enforced
+```
+
+Do not use `iamConfiguration`, `lifecycle`, or `cors` in the normal
+`gcloud storage` format expression. Those are raw JSON API field names and may
+silently produce no output in the standardized view. If the access fields are
+missing or need deeper inspection, use:
+
+```sh
+gcloud storage buckets describe "gs://${SECTION_FILES_BUCKET_NAME}" \
+  --raw \
+  --format="yaml(iamConfiguration)"
+```
+
+The raw result must show
+`iamConfiguration.uniformBucketLevelAccess.enabled: true` and
+`iamConfiguration.publicAccessPrevention: enforced`.
 
 Changing the application domain requires adding the new exact origin before
 cutover. Remove the old origin after traffic and rollback windows have ended.
@@ -211,6 +287,8 @@ bucket IAM.
 - [ ] Direct Firebase Storage SDK reads/writes are denied.
 - [ ] The Functions identity can create, inspect, copy, sign, and delete only
       the intended bucket objects.
+- [ ] IAM Credentials API is enabled and the runtime identity has an explicit
+      self-binding for `roles/iam.serviceAccountTokenCreator`.
 - [ ] The lifecycle rule applies only to `section-file-uploads/`.
 - [ ] CORS contains exact approved origins and only the required upload method.
 - [ ] `PENDING`, `REPLACING`, `DELETING`, and `DELETED` records never appear in

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -67,6 +67,25 @@ describe("function entry guard contracts", () => {
     }
   });
 
+  it("keeps section-file callables behind enabled-user and section authorization", () => {
+    const sectionFiles = readSource("sectionFiles.ts");
+    expect(sectionFiles).toContain("requireEnabled(request);");
+    for (const fn of [
+      "requestSectionFileUpload",
+      "finalizeSectionFileUpload",
+      "listSectionFiles",
+      "requestSectionFileDownload",
+      "updateSectionFileMetadata",
+      "requestSectionFileReplacement",
+      "finalizeSectionFileReplacement",
+      "deleteSectionFile",
+    ]) {
+      assertOnCallGuard(sectionFiles, fn, `requestContext(request, "${fn}"`, 450);
+    }
+    expect(sectionFiles).toContain("requireSectionAccess(");
+    expect(sectionFiles).toContain("requireSectionModerator(");
+  });
+
   it("keeps only intentional pre-approval entry points authentication-only", () => {
     const users = readSource("users.ts");
     for (const fn of ["updateDisplayName", "syncPendingUserClaims"]) {
@@ -161,6 +180,20 @@ describe("function entry guard contracts", () => {
       "getAnnouncementSendRecipients",
     ]) {
       assertOnCallGuard(announcements, fn, `enforceRateLimit("${fn}"`, 350);
+    }
+
+    const sectionFiles = readSource("sectionFiles.ts");
+    for (const fn of [
+      "requestSectionFileUpload",
+      "finalizeSectionFileUpload",
+      "listSectionFiles",
+      "requestSectionFileDownload",
+      "updateSectionFileMetadata",
+      "requestSectionFileReplacement",
+      "finalizeSectionFileReplacement",
+      "deleteSectionFile",
+    ]) {
+      assertOnCallGuard(sectionFiles, fn, `requestContext(request, "${fn}"`, 450);
     }
   });
 

--- a/functions/src/__tests__/sectionAccess.test.ts
+++ b/functions/src/__tests__/sectionAccess.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as admin from "@dataconnect/admin-generated";
+import { MembershipStatus } from "@dataconnect/admin-generated";
+import { requireSectionAccess, requireSectionModerator } from "../sectionAccess";
+
+const mockGetSectionById = vi.spyOn(admin, "getSectionById");
+const mockGetUserAccessGroupsById = vi.spyOn(admin, "getUserAccessGroupsById");
+const mockGetUserMembershipStatus = vi.spyOn(admin, "getUserMembershipStatus");
+
+const sectionId = "00000000-0000-4000-8000-000000000001";
+const accessGroupId = "00000000-0000-4000-8000-0000000000a1";
+const moderatorGroupId = "00000000-0000-4000-8000-0000000000a2";
+
+function mockSection() {
+  mockGetSectionById.mockResolvedValue({
+    data: {
+      section: {
+        id: sectionId,
+        name: "Files",
+        type: "MEMBERS",
+        description: null,
+        isOpenForRegistration: false,
+        allowedUserGroups: null,
+        purposeLinks: [
+          {
+            purposes: ["ACCESS"],
+            userGroup: {
+              id: accessGroupId,
+              name: "Members",
+              description: null,
+              subscribable: false,
+              membershipStatuses: [MembershipStatus.REGULAR],
+            },
+          },
+          {
+            purposes: ["MODERATOR"],
+            userGroup: {
+              id: moderatorGroupId,
+              name: "Moderators",
+              description: null,
+              subscribable: false,
+              membershipStatuses: null,
+            },
+          },
+        ],
+      },
+    },
+  } as unknown as Awaited<ReturnType<typeof admin.getSectionById>>);
+}
+
+function mockCaller(groupIds: string[], status = MembershipStatus.INDUSTRY) {
+  mockGetUserAccessGroupsById.mockResolvedValue({
+    data: {
+      user: {
+        id: "caller",
+        userGroups: groupIds.map((id) => ({
+          userGroup: { id, name: "Group", description: null },
+        })),
+      },
+    },
+  } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+  mockGetUserMembershipStatus.mockResolvedValue({
+    data: { user: { membershipStatus: status } },
+  } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+}
+
+describe("section access service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSection();
+  });
+
+  it("allows an explicit section member to read but not manage files", async () => {
+    mockCaller([accessGroupId]);
+    await expect(requireSectionAccess(sectionId, "caller", false)).resolves.toMatchObject({
+      hasAccess: true,
+      canModerate: false,
+    });
+    await expect(requireSectionModerator(sectionId, "caller", false)).rejects.toMatchObject({
+      code: "not-found",
+    });
+  });
+
+  it("allows a correct-section moderator to read and manage files", async () => {
+    mockCaller([moderatorGroupId]);
+    await expect(requireSectionModerator(sectionId, "caller", false)).resolves.toMatchObject({
+      hasAccess: true,
+      canModerate: true,
+    });
+  });
+
+  it("includes membership-status-derived ACCESS", async () => {
+    mockCaller([], MembershipStatus.REGULAR);
+    await expect(requireSectionAccess(sectionId, "caller", false)).resolves.toMatchObject({
+      hasAccess: true,
+      canModerate: false,
+    });
+  });
+
+  it("returns a non-enumerating denial for a caller from another section", async () => {
+    mockCaller([]);
+    await expect(requireSectionAccess(sectionId, "caller", false)).rejects.toMatchObject({
+      code: "not-found",
+      message: "Resource not found",
+    });
+  });
+
+  it("allows an enabled global admin at the relationship layer", async () => {
+    mockCaller([]);
+    await expect(requireSectionModerator(sectionId, "caller", true)).resolves.toMatchObject({
+      canModerate: false,
+    });
+  });
+});

--- a/functions/src/__tests__/sectionFileApiContracts.test.ts
+++ b/functions/src/__tests__/sectionFileApiContracts.test.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = fs.readFileSync(path.resolve(process.cwd(), "src", "sectionFiles.ts"), "utf8");
+
+describe("section file API security contracts", () => {
+  it("derives all object paths from trusted section and file identifiers", () => {
+    expect(source).toContain("`section-file-uploads/${sectionId}/${fileId}/${uploadId}`");
+    expect(source).toContain("`section-files/${sectionId}/${fileId}/${inspected.generation}`");
+    expect(source).not.toMatch(/request\.data\?\.(?:storageObjectPath|pendingStorageObjectPath)/);
+  });
+
+  it("cross-checks file metadata against the authorized section", () => {
+    expect(source).toContain("file.sectionId !== sectionId");
+    expect(source).toContain("await requireSectionAccess(sectionId, uid, isAdmin)");
+    expect(source).toContain("await requireSectionModerator(sectionId, uid, isAdmin)");
+  });
+
+  it("validates stored object properties before lifecycle promotion", () => {
+    expect(source).toContain("actualSize !== expected.sizeBytes");
+    expect(source).toContain("actualType !== expected.contentType");
+    expect(source).toContain("validateFileSignature(bytes, actualType)");
+    expect(source).toContain("createHash(\"sha256\")");
+    expect(source).toContain("ensureTransition(result.data.sectionFile_updateMany)");
+  });
+
+  it("uses short-lived V4 upload and download grants", () => {
+    expect(source).toContain("SIGNED_UPLOAD_TTL_MS = 15 * 60 * 1000");
+    expect(source).toContain("SIGNED_DOWNLOAD_TTL_MS = 5 * 60 * 1000");
+    expect(source).toContain("action: \"write\"");
+    expect(source).toContain("action: \"read\"");
+  });
+
+  it("never includes internal object paths in member-facing file responses", () => {
+    const start = source.indexOf("function fileResponse(");
+    const end = source.indexOf("\n}", start);
+    const responseBlock = source.slice(start, end);
+    expect(responseBlock).not.toContain("storageObjectPath");
+    expect(responseBlock).not.toContain("pendingStorageObjectPath");
+  });
+});

--- a/functions/src/__tests__/sectionFileStorageContracts.test.ts
+++ b/functions/src/__tests__/sectionFileStorageContracts.test.ts
@@ -77,4 +77,39 @@ describe("section file storage foundation", () => {
     expect(lifecycle.rule).toHaveLength(1);
     expect(lifecycle.rule[0].condition.matchesPrefix).toEqual(["section-file-uploads/"]);
   });
+
+  it("documents gcloud's standardized bucket verification fields", () => {
+    const docs = readRepoFile("docs/operations/section-file-storage.md");
+
+    expect(docs).toContain("uniform_bucket_level_access");
+    expect(docs).toContain("public_access_prevention");
+    expect(docs).toContain("lifecycle_config");
+    expect(docs).toContain("cors_config");
+    expect(docs).toContain("--raw");
+    expect(docs).toContain("--format=\"yaml(iamConfiguration)\"");
+  });
+
+  it("documents exact runtime object and signed-URL IAM requirements", () => {
+    const docs = readRepoFile("docs/operations/section-file-storage.md");
+    const prod = readRepoFile("docs/operations/new-production-instance.md");
+
+    for (const marker of [
+      "roles/storage.objectAdmin",
+      "iamcredentials.googleapis.com",
+      "roles/iam.serviceAccountTokenCreator",
+      "iam.serviceAccounts.signBlob",
+      "serviceConfig.serviceAccountEmail",
+    ]) {
+      expect(docs).toContain(marker);
+    }
+    expect(prod).toContain("roles/storage.objectAdmin");
+    expect(prod).toContain("roles/iam.serviceAccountTokenCreator");
+    expect(prod).toContain("IAM Credentials API is enabled");
+    expect(prod).toContain("gcloud functions describe requestSectionFileUpload");
+    expect(prod).toContain("gcloud storage buckets add-iam-policy-binding");
+    expect(prod).toContain("gcloud services enable iamcredentials.googleapis.com");
+    expect(prod).toContain("gcloud iam service-accounts add-iam-policy-binding");
+    expect(prod).toContain("gcloud storage buckets get-iam-policy");
+    expect(prod).toContain("gcloud iam service-accounts get-iam-policy");
+  });
 });

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -686,6 +686,7 @@ export interface FinalizeSectionFileReplacementData {
 export interface FinalizeSectionFileReplacementVariables {
   id: UUIDString;
   pendingStorageObjectPath: string;
+  storageObjectPath: string;
   originalFilename: string;
   objectGeneration: string;
   checksumSha256: string;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -15,6 +15,7 @@ export * from "./announcements";
 export * from "./unsubscribe";
 export * from "./notifyCallback";
 export * from "./notificationRecovery";
+export * from "./sectionFiles";
 
 // Initialize Firebase Admin
 if (!admin.apps.length) {

--- a/functions/src/rateLimiter.ts
+++ b/functions/src/rateLimiter.ts
@@ -42,6 +42,14 @@ export const CALLABLE_RATE_LIMITS = {
   previewAnnouncementTemplate: { limit: 30, windowMs: 5 * MINUTE_MS },
   sendSectionAnnouncement: { limit: 5, windowMs: HOUR_MS },
   getAnnouncementSendRecipients: { limit: 60, windowMs: 5 * MINUTE_MS },
+  requestSectionFileUpload: { limit: 20, windowMs: HOUR_MS },
+  finalizeSectionFileUpload: { limit: 30, windowMs: HOUR_MS },
+  listSectionFiles: { limit: 60, windowMs: 5 * MINUTE_MS },
+  requestSectionFileDownload: { limit: 120, windowMs: 5 * MINUTE_MS },
+  updateSectionFileMetadata: { limit: 60, windowMs: HOUR_MS },
+  requestSectionFileReplacement: { limit: 20, windowMs: HOUR_MS },
+  finalizeSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
+  deleteSectionFile: { limit: 30, windowMs: HOUR_MS },
 } as const satisfies Record<string, RateLimitPolicy>;
 
 export type RateLimitedCallableName = keyof typeof CALLABLE_RATE_LIMITS;

--- a/functions/src/sectionAccess.ts
+++ b/functions/src/sectionAccess.ts
@@ -1,0 +1,83 @@
+import { HttpsError } from "firebase-functions/v2/https";
+import {
+  getSectionById,
+  getUserAccessGroupsById,
+  getUserMembershipStatus,
+  type GetSectionByIdData,
+} from "@dataconnect/admin-generated";
+
+export interface SectionAccess {
+  section: NonNullable<GetSectionByIdData["section"]>;
+  hasAccess: boolean;
+  canModerate: boolean;
+}
+
+export function linkHasPurpose(
+  link: { purpose?: string; purposes?: string[] | null },
+  target: string,
+): boolean {
+  return link.purpose === target || (link.purposes?.includes(target) ?? false);
+}
+
+export async function resolveSectionAccess(
+  sectionId: string,
+  callerUid: string,
+): Promise<SectionAccess> {
+  const [sectionResult, callerGroupsResult, userStatusResult] = await Promise.all([
+    getSectionById({ id: sectionId }),
+    getUserAccessGroupsById({ userId: callerUid }),
+    getUserMembershipStatus({ id: callerUid }),
+  ]);
+
+  const section = sectionResult.data?.section;
+  if (!section) {
+    throw new HttpsError("not-found", "Resource not found");
+  }
+
+  const purposeLinks = section.purposeLinks ?? [];
+  const callerGroupIds = new Set(
+    (callerGroupsResult.data?.user?.userGroups ?? []).map(
+      (ug: { userGroup: { id: string } }) => ug.userGroup.id,
+    ),
+  );
+  const userStatus = userStatusResult.data?.user?.membershipStatus;
+  const matchesPurpose = (target: string) =>
+    purposeLinks.some((link) => {
+      if (!linkHasPurpose(link, target)) return false;
+      if (callerGroupIds.has(link.userGroup.id)) return true;
+      return userStatus
+        ? (link.userGroup.membershipStatuses?.includes(userStatus) ?? false)
+        : false;
+    });
+
+  const canModerate = matchesPurpose("MODERATOR");
+  return {
+    section,
+    canModerate,
+    hasAccess: canModerate || matchesPurpose("ACCESS"),
+  };
+}
+
+export async function requireSectionAccess(
+  sectionId: string,
+  callerUid: string,
+  callerIsAdmin: boolean,
+): Promise<SectionAccess> {
+  const access = await resolveSectionAccess(sectionId, callerUid);
+  if (!callerIsAdmin && !access.hasAccess) {
+    throw new HttpsError("not-found", "Resource not found");
+  }
+  return access;
+}
+
+export async function requireSectionModerator(
+  sectionId: string,
+  callerUid: string,
+  callerIsAdmin: boolean,
+): Promise<SectionAccess> {
+  const access = await resolveSectionAccess(sectionId, callerUid);
+  if (!callerIsAdmin && !access.canModerate) {
+    throw new HttpsError("not-found", "Resource not found");
+  }
+  return access;
+}

--- a/functions/src/sectionFiles.ts
+++ b/functions/src/sectionFiles.ts
@@ -1,0 +1,599 @@
+import { createHash, randomUUID } from "node:crypto";
+import { getStorage } from "firebase-admin/storage";
+import * as logger from "firebase-functions/logger";
+import { HttpsError, onCall, type CallableRequest } from "firebase-functions/v2/https";
+import {
+  abortSectionFileReplacement,
+  beginSectionFileDeletion,
+  beginSectionFileReplacement,
+  createPendingSectionFile,
+  finalizePendingSectionFile,
+  finalizeSectionFileReplacement as finalizeReplacementMetadata,
+  getSectionFileById,
+  listSectionFilesByStatus,
+  markSectionFileDeleted,
+  SectionFileStatus,
+  updateAvailableSectionFileMetadata,
+} from "@dataconnect/admin-generated";
+import { FUNCTIONS_REGION } from "./constants";
+import {
+  handleFunctionError,
+  requireEnabled,
+  requireString,
+  validateStringLength,
+  validateUUID,
+} from "./helpers";
+import { enforceRateLimit, type RateLimitedCallableName } from "./rateLimiter";
+import { requireSectionAccess, requireSectionModerator } from "./sectionAccess";
+
+const MAX_SECTION_FILE_BYTES = 25 * 1024 * 1024;
+const SIGNED_UPLOAD_TTL_MS = 15 * 60 * 1000;
+const SIGNED_DOWNLOAD_TTL_MS = 5 * 60 * 1000;
+const MAX_FILENAME_LENGTH = 255;
+const MAX_DISPLAY_NAME_LENGTH = 160;
+const MAX_DESCRIPTION_LENGTH = 1000;
+const LIST_LIMIT = 500;
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "text/plain",
+  "text/csv",
+  "application/json",
+  "application/rtf",
+  "application/vnd.oasis.opendocument.text",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]);
+
+type SectionFileRecord = NonNullable<
+  Awaited<ReturnType<typeof getSectionFileById>>["data"]["sectionFile"]
+>;
+
+interface ValidatedUpload {
+  displayName: string;
+  originalFilename: string;
+  description: string | null;
+  contentType: string;
+  sizeBytes: number;
+}
+
+function bucketName(): string {
+  const value = process.env.SECTION_FILES_BUCKET?.trim();
+  if (!value) {
+    throw new HttpsError("failed-precondition", "Section file storage is not configured");
+  }
+  if (value.startsWith("gs://") || value.includes("/")) {
+    throw new HttpsError("failed-precondition", "Section file storage configuration is invalid");
+  }
+  return value;
+}
+
+function parseSize(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new HttpsError("invalid-argument", "sizeBytes must be a positive integer");
+  }
+  const size = Number(value);
+  if (size > MAX_SECTION_FILE_BYTES) {
+    throw new HttpsError(
+      "invalid-argument",
+      `Files must be no larger than ${MAX_SECTION_FILE_BYTES} bytes`,
+    );
+  }
+  return size;
+}
+
+function validateContentType(value: unknown): string {
+  const contentType = requireString(value, "contentType").toLowerCase();
+  if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+    throw new HttpsError("invalid-argument", "This file type is not allowed");
+  }
+  return contentType;
+}
+
+function validateFilename(value: unknown): string {
+  const filename = validateStringLength(
+    requireString(value, "originalFilename"),
+    "originalFilename",
+    MAX_FILENAME_LENGTH,
+  );
+  if (
+    filename === "." ||
+    filename === ".." ||
+    filename.includes("/") ||
+    filename.includes("\\") ||
+    Array.from(filename).some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0;
+      return codePoint <= 0x1f || codePoint === 0x7f;
+    })
+  ) {
+    throw new HttpsError("invalid-argument", "originalFilename is invalid");
+  }
+  return filename;
+}
+
+function validateUpload(data: Record<string, unknown>): ValidatedUpload {
+  const rawDescription = data.description;
+  return {
+    displayName: validateStringLength(
+      requireString(data.displayName, "displayName"),
+      "displayName",
+      MAX_DISPLAY_NAME_LENGTH,
+    ),
+    originalFilename: validateFilename(data.originalFilename),
+    description:
+      rawDescription === null || rawDescription === undefined || rawDescription === ""
+        ? null
+        : validateStringLength(
+            requireString(rawDescription, "description"),
+            "description",
+            MAX_DESCRIPTION_LENGTH,
+          ),
+    contentType: validateContentType(data.contentType),
+    sizeBytes: parseSize(data.sizeBytes),
+  };
+}
+
+function startsWith(bytes: Buffer, signature: number[]): boolean {
+  return signature.every((value, index) => bytes[index] === value);
+}
+
+function validateFileSignature(bytes: Buffer, contentType: string): void {
+  const utf8Prefix = bytes.subarray(0, Math.min(bytes.length, 16)).toString("utf8");
+  const valid = (() => {
+    switch (contentType) {
+      case "application/pdf":
+        return utf8Prefix.startsWith("%PDF-");
+      case "image/png":
+        return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      case "image/jpeg":
+        return startsWith(bytes, [0xff, 0xd8, 0xff]);
+      case "application/msword":
+        return startsWith(bytes, [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+      case "application/rtf":
+        return utf8Prefix.startsWith("{\\rtf");
+      case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+        return (
+          startsWith(bytes, [0x50, 0x4b, 0x03, 0x04]) &&
+          bytes.includes(Buffer.from("word/"))
+        );
+      case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
+        return (
+          startsWith(bytes, [0x50, 0x4b, 0x03, 0x04]) &&
+          bytes.includes(Buffer.from("xl/"))
+        );
+      case "application/vnd.oasis.opendocument.text":
+        return (
+          startsWith(bytes, [0x50, 0x4b, 0x03, 0x04]) &&
+          bytes.includes(Buffer.from("application/vnd.oasis.opendocument.text"))
+        );
+      case "application/json":
+        try {
+          JSON.parse(bytes.toString("utf8"));
+          return true;
+        } catch {
+          return false;
+        }
+      case "text/plain":
+      case "text/csv":
+        return !bytes.includes(0);
+      default:
+        return false;
+    }
+  })();
+  if (!valid) {
+    throw new HttpsError("invalid-argument", "Stored file content does not match its file type");
+  }
+}
+
+function requestContext(
+  request: CallableRequest,
+  rateLimitName: RateLimitedCallableName,
+): Promise<{ uid: string; isAdmin: boolean }> {
+  requireEnabled(request);
+  const uid = request.auth!.uid;
+  return enforceRateLimit(rateLimitName, uid).then(() => ({
+    uid,
+    isAdmin: request.auth!.token.admin === true,
+  }));
+}
+
+function fileResponse(file: SectionFileRecord) {
+  return {
+    id: file.id,
+    sectionId: file.sectionId,
+    displayName: file.displayName,
+    originalFilename: file.originalFilename,
+    description: file.description ?? null,
+    contentType: file.contentType,
+    sizeBytes: file.sizeBytes,
+    uploadedBy: file.uploadedBy,
+    createdAt: file.createdAt,
+    updatedAt: file.updatedAt,
+  };
+}
+
+async function trustedFile(fileId: string, sectionId: string): Promise<SectionFileRecord> {
+  const result = await getSectionFileById({ id: fileId });
+  const file = result.data?.sectionFile;
+  if (!file || file.sectionId !== sectionId || file.status === SectionFileStatus.DELETED) {
+    throw new HttpsError("not-found", "File not found");
+  }
+  return file;
+}
+
+async function signedUploadUrl(path: string, contentType: string): Promise<string> {
+  const [url] = await getStorage()
+    .bucket(bucketName())
+    .file(path)
+    .getSignedUrl({
+      version: "v4",
+      action: "write",
+      expires: Date.now() + SIGNED_UPLOAD_TTL_MS,
+      contentType,
+    });
+  return url;
+}
+
+async function inspectUpload(path: string, expected: ValidatedUpload) {
+  const file = getStorage().bucket(bucketName()).file(path);
+  const [metadata] = await file.getMetadata();
+  const actualSize = Number(metadata.size);
+  const actualType = String(metadata.contentType ?? "").toLowerCase();
+  if (
+    !Number.isSafeInteger(actualSize) ||
+    actualSize !== expected.sizeBytes ||
+    actualSize > MAX_SECTION_FILE_BYTES ||
+    actualType !== expected.contentType ||
+    !ALLOWED_CONTENT_TYPES.has(actualType)
+  ) {
+    await file.delete({ ignoreNotFound: true });
+    throw new HttpsError("invalid-argument", "Stored file does not match the approved upload");
+  }
+  const [bytes] = await file.download();
+  if (bytes.byteLength !== actualSize) {
+    await file.delete({ ignoreNotFound: true });
+    throw new HttpsError("invalid-argument", "Stored file size could not be verified");
+  }
+  try {
+    validateFileSignature(bytes, actualType);
+  } catch (error) {
+    await file.delete({ ignoreNotFound: true });
+    throw error;
+  }
+  return {
+    file,
+    generation: String(metadata.generation ?? ""),
+    checksumSha256: createHash("sha256").update(bytes).digest("hex"),
+    contentType: actualType,
+    sizeBytes: actualSize,
+  };
+}
+
+function ensureTransition(updated: number): void {
+  if (updated !== 1) {
+    throw new HttpsError("failed-precondition", "The file changed; refresh and try again");
+  }
+}
+
+async function bestEffortDelete(path: string, context: Record<string, string>): Promise<void> {
+  try {
+    await getStorage().bucket(bucketName()).file(path).delete({ ignoreNotFound: true });
+  } catch (error) {
+    logger.warn("Section file cleanup deferred to reconciliation", {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export const requestSectionFileUpload = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "requestSectionFileUpload");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const input = validateUpload(request.data ?? {});
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      const fileId = randomUUID();
+      const uploadId = randomUUID();
+      const pendingPath = `section-file-uploads/${sectionId}/${fileId}/${uploadId}`;
+      await createPendingSectionFile({
+        id: fileId,
+        sectionId,
+        pendingStorageObjectPath: pendingPath,
+        ...input,
+        uploadedBy: uid,
+        now: new Date().toISOString(),
+      });
+      const uploadUrl = await signedUploadUrl(pendingPath, input.contentType);
+      logger.info("Section file upload granted", { sectionId, fileId, actorUid: uid });
+      return {
+        fileId,
+        uploadUrl,
+        expiresAt: new Date(Date.now() + SIGNED_UPLOAD_TTL_MS).toISOString(),
+        requiredHeaders: { "Content-Type": input.contentType },
+      };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "requesting section file upload");
+    }
+  },
+);
+
+export const finalizeSectionFileUpload = onCall(
+  { region: FUNCTIONS_REGION, timeoutSeconds: 120, memory: "512MiB" },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "finalizeSectionFileUpload");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      const file = await trustedFile(fileId, sectionId);
+      if (file.status !== SectionFileStatus.PENDING || !file.pendingStorageObjectPath) {
+        throw new HttpsError("failed-precondition", "The upload is not pending");
+      }
+      const inspected = await inspectUpload(file.pendingStorageObjectPath, {
+        displayName: file.displayName,
+        originalFilename: file.originalFilename,
+        description: file.description ?? null,
+        contentType: file.contentType,
+        sizeBytes: file.sizeBytes,
+      });
+      const finalPath = `section-files/${sectionId}/${fileId}/${inspected.generation}`;
+      const finalObject = getStorage().bucket(bucketName()).file(finalPath);
+      await inspected.file.copy(finalObject);
+      const [finalMetadata] = await finalObject.getMetadata();
+      const result = await finalizePendingSectionFile({
+        id: fileId,
+        pendingStorageObjectPath: file.pendingStorageObjectPath,
+        storageObjectPath: finalPath,
+        objectGeneration: String(finalMetadata.generation ?? ""),
+        checksumSha256: inspected.checksumSha256,
+        contentType: inspected.contentType,
+        sizeBytes: inspected.sizeBytes,
+        updatedBy: uid,
+      });
+      try {
+        ensureTransition(result.data.sectionFile_updateMany);
+      } catch (error) {
+        await finalObject.delete({ ignoreNotFound: true });
+        throw error;
+      }
+      await bestEffortDelete(file.pendingStorageObjectPath, { sectionId, fileId });
+      logger.info("Section file finalized", { sectionId, fileId, actorUid: uid });
+      return { fileId };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "finalizing section file upload");
+    }
+  },
+);
+
+export const listSectionFiles = onCall({ region: FUNCTIONS_REGION }, async (request) => {
+  const { uid, isAdmin } = await requestContext(request, "listSectionFiles");
+  const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+  try {
+    await requireSectionAccess(sectionId, uid, isAdmin);
+    const [available, replacing] = await Promise.all([
+      listSectionFilesByStatus({ sectionId, status: SectionFileStatus.AVAILABLE, limit: LIST_LIMIT }),
+      listSectionFilesByStatus({ sectionId, status: SectionFileStatus.REPLACING, limit: LIST_LIMIT }),
+    ]);
+    const files = [...(available.data.sectionFiles ?? []), ...(replacing.data.sectionFiles ?? [])]
+      .sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)))
+      .map(fileResponse);
+    return { files };
+  } catch (error) {
+    if (error instanceof HttpsError) throw error;
+    handleFunctionError(error, "listing section files");
+  }
+});
+
+export const requestSectionFileDownload = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "requestSectionFileDownload");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    try {
+      await requireSectionAccess(sectionId, uid, isAdmin);
+      const file = await trustedFile(fileId, sectionId);
+      if (
+        ![SectionFileStatus.AVAILABLE, SectionFileStatus.REPLACING].includes(file.status) ||
+        !file.storageObjectPath
+      ) {
+        throw new HttpsError("not-found", "File not found");
+      }
+      const safeFilename = file.originalFilename.replace(/["\r\n]/g, "_");
+      const [downloadUrl] = await getStorage()
+        .bucket(bucketName())
+        .file(file.storageObjectPath)
+        .getSignedUrl({
+          version: "v4",
+          action: "read",
+          expires: Date.now() + SIGNED_DOWNLOAD_TTL_MS,
+          responseDisposition: `attachment; filename="${safeFilename}"`,
+          responseType: file.contentType,
+        });
+      logger.info("Section file download granted", { sectionId, fileId, actorUid: uid });
+      return {
+        file: fileResponse(file),
+        downloadUrl,
+        expiresAt: new Date(Date.now() + SIGNED_DOWNLOAD_TTL_MS).toISOString(),
+      };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "requesting section file download");
+    }
+  },
+);
+
+export const updateSectionFileMetadata = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "updateSectionFileMetadata");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    const displayName = validateStringLength(
+      requireString(request.data?.displayName, "displayName"),
+      "displayName",
+      MAX_DISPLAY_NAME_LENGTH,
+    );
+    const description =
+      request.data?.description === null || request.data?.description === ""
+        ? null
+        : validateStringLength(
+            requireString(request.data?.description, "description"),
+            "description",
+            MAX_DESCRIPTION_LENGTH,
+          );
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      await trustedFile(fileId, sectionId);
+      const result = await updateAvailableSectionFileMetadata({
+        id: fileId,
+        displayName,
+        description,
+        updatedBy: uid,
+      });
+      ensureTransition(result.data.sectionFile_updateMany);
+      return { fileId };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "updating section file metadata");
+    }
+  },
+);
+
+export const requestSectionFileReplacement = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "requestSectionFileReplacement");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    const originalFilename = validateFilename(request.data?.originalFilename);
+    const contentType = validateContentType(request.data?.contentType);
+    const sizeBytes = parseSize(request.data?.sizeBytes);
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      const file = await trustedFile(fileId, sectionId);
+      if (file.status !== SectionFileStatus.AVAILABLE) {
+        throw new HttpsError("failed-precondition", "The file cannot be replaced in its current state");
+      }
+      const pendingPath = `section-file-uploads/${sectionId}/${fileId}/${randomUUID()}`;
+      const transition = await beginSectionFileReplacement({
+        id: fileId,
+        pendingStorageObjectPath: pendingPath,
+        updatedBy: uid,
+      });
+      ensureTransition(transition.data.sectionFile_updateMany);
+      try {
+        const uploadUrl = await signedUploadUrl(pendingPath, contentType);
+        return {
+          fileId,
+          uploadUrl,
+          expiresAt: new Date(Date.now() + SIGNED_UPLOAD_TTL_MS).toISOString(),
+          requiredHeaders: { "Content-Type": contentType },
+          replacement: { originalFilename, contentType, sizeBytes },
+        };
+      } catch (error) {
+        await abortSectionFileReplacement({
+          id: fileId,
+          pendingStorageObjectPath: pendingPath,
+          updatedBy: uid,
+        });
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "requesting section file replacement");
+    }
+  },
+);
+
+export const finalizeSectionFileReplacement = onCall(
+  { region: FUNCTIONS_REGION, timeoutSeconds: 120, memory: "512MiB" },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "finalizeSectionFileReplacement");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    const originalFilename = validateFilename(request.data?.originalFilename);
+    const contentType = validateContentType(request.data?.contentType);
+    const sizeBytes = parseSize(request.data?.sizeBytes);
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      const file = await trustedFile(fileId, sectionId);
+      if (
+        file.status !== SectionFileStatus.REPLACING ||
+        !file.pendingStorageObjectPath ||
+        !file.storageObjectPath
+      ) {
+        throw new HttpsError("failed-precondition", "The replacement is not pending");
+      }
+      const inspected = await inspectUpload(file.pendingStorageObjectPath, {
+        displayName: file.displayName,
+        originalFilename,
+        description: file.description ?? null,
+        contentType,
+        sizeBytes,
+      });
+      const finalPath = `section-files/${sectionId}/${fileId}/${inspected.generation}`;
+      const finalObject = getStorage().bucket(bucketName()).file(finalPath);
+      await inspected.file.copy(finalObject);
+      const [finalMetadata] = await finalObject.getMetadata();
+      const transition = await finalizeReplacementMetadata({
+        id: fileId,
+        pendingStorageObjectPath: file.pendingStorageObjectPath,
+        storageObjectPath: finalPath,
+        originalFilename,
+        objectGeneration: String(finalMetadata.generation ?? ""),
+        checksumSha256: inspected.checksumSha256,
+        contentType: inspected.contentType,
+        sizeBytes: inspected.sizeBytes,
+        updatedBy: uid,
+      });
+      try {
+        ensureTransition(transition.data.sectionFile_updateMany);
+      } catch (error) {
+        await finalObject.delete({ ignoreNotFound: true });
+        throw error;
+      }
+      await Promise.all([
+        bestEffortDelete(file.pendingStorageObjectPath, { sectionId, fileId }),
+        bestEffortDelete(file.storageObjectPath, { sectionId, fileId }),
+      ]);
+      return { fileId };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "finalizing section file replacement");
+    }
+  },
+);
+
+export const deleteSectionFile = onCall({ region: FUNCTIONS_REGION }, async (request) => {
+  const { uid, isAdmin } = await requestContext(request, "deleteSectionFile");
+  const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+  const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+  try {
+    await requireSectionModerator(sectionId, uid, isAdmin);
+    const file = await trustedFile(fileId, sectionId);
+    const transition = await beginSectionFileDeletion({ id: fileId, updatedBy: uid });
+    ensureTransition(transition.data.sectionFile_updateMany);
+    const bucket = getStorage().bucket(bucketName());
+    await Promise.all(
+      [file.storageObjectPath, file.pendingStorageObjectPath]
+        .filter((path): path is string => Boolean(path))
+        .map((path) => bucket.file(path).delete({ ignoreNotFound: true })),
+    );
+    const deletedAt = new Date().toISOString();
+    const marked = await markSectionFileDeleted({ id: fileId, deletedAt, updatedBy: uid });
+    ensureTransition(marked.data.sectionFile_updateMany);
+    logger.info("Section file deleted", { sectionId, fileId, actorUid: uid });
+    return { fileId };
+  } catch (error) {
+    if (error instanceof HttpsError) throw error;
+    handleFunctionError(error, "deleting section file");
+  }
+});

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -13,6 +13,7 @@ import {
   type GetSectionByIdData,
 } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
+import { linkHasPurpose, resolveSectionAccess } from "./sectionAccess";
 
 export interface SectionMemberResponse {
   id: string;
@@ -44,57 +45,6 @@ function toSectionMemberResponse(u: {
     sharesContactInfo,
     email: sharesContactInfo ? u.email : null,
   };
-}
-
-function linkHasPurpose(link: { purpose?: string; purposes?: string[] | null }, target: string): boolean {
-  return link.purpose === target || (link.purposes?.includes(target) ?? false);
-}
-
-interface SectionAccess {
-  section: NonNullable<GetSectionByIdData["section"]>;
-  hasAccess: boolean;
-  canModerate: boolean;
-}
-
-/**
- * Fetches a section and determines whether callerUid has ACCESS/MODERATOR purpose on it
- * (explicit group membership or membership-status-derived), independent of callerIsAdmin.
- * Used by every section/event lookup a non-admin member is allowed to make, since the
- * underlying GetSectionById/GetEventsForSection/GetEventById Data Connect queries are
- * admin-only — this is the only path a regular member has to that data, and it's gated
- * on their actual relationship to the section rather than an arbitrary client-supplied id.
- */
-async function resolveSectionAccess(sectionId: string, callerUid: string): Promise<SectionAccess> {
-  const [sectionResult, callerGroupsResult, userStatusResult] = await Promise.all([
-    getSectionById({ id: sectionId }),
-    getUserAccessGroupsById({ userId: callerUid }),
-    getUserMembershipStatus({ id: callerUid }),
-  ]);
-
-  const section = sectionResult.data?.section;
-  if (!section) {
-    throw new HttpsError("not-found", "Section not found");
-  }
-
-  const purposeLinks = section.purposeLinks ?? [];
-  const callerGroupIds = new Set(
-    (callerGroupsResult.data?.user?.userGroups ?? []).map(
-      (ug: { userGroup: { id: string } }) => ug.userGroup.id
-    )
-  );
-  const userStatus = userStatusResult.data?.user?.membershipStatus;
-
-  const matchesPurpose = (target: string) =>
-    purposeLinks.some((pl) => {
-      if (!linkHasPurpose(pl, target)) return false;
-      if (callerGroupIds.has(pl.userGroup.id)) return true;
-      return userStatus ? (pl.userGroup.membershipStatuses?.includes(userStatus) ?? false) : false;
-    });
-
-  const canModerate = matchesPurpose("MODERATOR");
-  const hasAccess = canModerate || matchesPurpose("ACCESS");
-
-  return { section, hasAccess, canModerate };
 }
 
 /**

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
         branches: 42,
         functions: 57,
         lines: 46,
-        'src/{helpers,rateLimiter,sections,validation}.ts': {
+        'src/{helpers,rateLimiter,sectionAccess,sections,validation}.ts': {
           statements: 77,
           branches: 66,
           functions: 80,

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -8310,7 +8310,7 @@ import { connectorConfig, finalizePendingSectionFile, FinalizePendingSectionFile
 const finalizePendingSectionFileVars: FinalizePendingSectionFileVariables = {
   id: ..., 
   pendingStorageObjectPath: ..., 
-  storageObjectPath: ..., 
+  storageObjectPath: ...,
   objectGeneration: ..., 
   checksumSha256: ..., 
   contentType: ..., 
@@ -8347,7 +8347,7 @@ import { connectorConfig, finalizePendingSectionFileRef, FinalizePendingSectionF
 const finalizePendingSectionFileVars: FinalizePendingSectionFileVariables = {
   id: ..., 
   pendingStorageObjectPath: ..., 
-  storageObjectPath: ..., 
+  storageObjectPath: ...,
   objectGeneration: ..., 
   checksumSha256: ..., 
   contentType: ..., 
@@ -8646,6 +8646,7 @@ The `FinalizeSectionFileReplacement` mutation requires an argument of type `Fina
 export interface FinalizeSectionFileReplacementVariables {
   id: UUIDString;
   pendingStorageObjectPath: string;
+  storageObjectPath: string;
   originalFilename: string;
   objectGeneration: string;
   checksumSha256: string;
@@ -8673,6 +8674,7 @@ import { connectorConfig, finalizeSectionFileReplacement, FinalizeSectionFileRep
 const finalizeSectionFileReplacementVars: FinalizeSectionFileReplacementVariables = {
   id: ..., 
   pendingStorageObjectPath: ..., 
+  storageObjectPath: ...,
   originalFilename: ..., 
   objectGeneration: ..., 
   checksumSha256: ..., 
@@ -8685,7 +8687,7 @@ const finalizeSectionFileReplacementVars: FinalizeSectionFileReplacementVariable
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await finalizeSectionFileReplacement(finalizeSectionFileReplacementVars);
 // Variables can be defined inline as well.
-const { data } = await finalizeSectionFileReplacement({ id: ..., pendingStorageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
+const { data } = await finalizeSectionFileReplacement({ id: ..., pendingStorageObjectPath: ..., storageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -8710,6 +8712,7 @@ import { connectorConfig, finalizeSectionFileReplacementRef, FinalizeSectionFile
 const finalizeSectionFileReplacementVars: FinalizeSectionFileReplacementVariables = {
   id: ..., 
   pendingStorageObjectPath: ..., 
+  storageObjectPath: ...,
   originalFilename: ..., 
   objectGeneration: ..., 
   checksumSha256: ..., 
@@ -8721,7 +8724,7 @@ const finalizeSectionFileReplacementVars: FinalizeSectionFileReplacementVariable
 // Call the `finalizeSectionFileReplacementRef()` function to get a reference to the mutation.
 const ref = finalizeSectionFileReplacementRef(finalizeSectionFileReplacementVars);
 // Variables can be defined inline as well.
-const ref = finalizeSectionFileReplacementRef({ id: ..., pendingStorageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
+const ref = finalizeSectionFileReplacementRef({ id: ..., pendingStorageObjectPath: ..., storageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -18513,4 +18516,3 @@ executeMutation(ref).then((response) => {
   console.log(data.sectionAnnouncementOptOut_delete);
 });
 ```
-

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -704,6 +704,7 @@ export interface FinalizeSectionFileReplacementData {
 export interface FinalizeSectionFileReplacementVariables {
   id: UUIDString;
   pendingStorageObjectPath: string;
+  storageObjectPath: string;
   originalFilename: string;
   objectGeneration: string;
   checksumSha256: string;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -6676,7 +6676,7 @@ export default function FinalizePendingSectionFileComponent() {
   const finalizePendingSectionFileVars: FinalizePendingSectionFileVariables = {
     id: ..., 
     pendingStorageObjectPath: ..., 
-    storageObjectPath: ..., 
+    storageObjectPath: ...,
     objectGeneration: ..., 
     checksumSha256: ..., 
     contentType: ..., 
@@ -6925,6 +6925,7 @@ The `FinalizeSectionFileReplacement` Mutation requires an argument of type `Fina
 export interface FinalizeSectionFileReplacementVariables {
   id: UUIDString;
   pendingStorageObjectPath: string;
+  storageObjectPath: string;
   originalFilename: string;
   objectGeneration: string;
   checksumSha256: string;
@@ -6982,6 +6983,7 @@ export default function FinalizeSectionFileReplacementComponent() {
   const finalizeSectionFileReplacementVars: FinalizeSectionFileReplacementVariables = {
     id: ..., 
     pendingStorageObjectPath: ..., 
+    storageObjectPath: ...,
     originalFilename: ..., 
     objectGeneration: ..., 
     checksumSha256: ..., 
@@ -6991,7 +6993,7 @@ export default function FinalizeSectionFileReplacementComponent() {
   };
   mutation.mutate(finalizeSectionFileReplacementVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ id: ..., pendingStorageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
+  mutation.mutate({ id: ..., pendingStorageObjectPath: ..., storageObjectPath: ..., originalFilename: ..., objectGeneration: ..., checksumSha256: ..., contentType: ..., sizeBytes: ..., updatedBy: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {
@@ -15279,4 +15281,3 @@ export default function OptInSectionAnnouncementComponent() {
   return <div>Mutation execution {mutation.isSuccess ? 'successful' : 'failed'}!</div>;
 }
 ```
-


### PR DESCRIPTION
Closes #429

## What changed

- add authenticated callable APIs for section-file upload, finalisation, listing, download, metadata updates, replacement, and deletion
- centralise section membership and moderator/administrator access checks
- use short-lived signed Storage URLs with trusted object paths, lifecycle checks, content validation, SHA-256 verification, and orphan cleanup
- add per-operation abuse-protection policies and contract/unit coverage
- update Data Connect replacement finalisation and regenerate bindings
- document Firebase Storage provisioning, IAM, CORS, lifecycle, security, and production deployment commands

## Impact

Moderators and administrators now have the secure backend required to manage files for a section. Members can only obtain download URLs after current section access is checked. The UI remains part of the later issue in the #427 workstream.

## Validation

- Functions: 61 test files / 577 tests passed
- Functions build passed
- Functions lint passed
- Frontend: 67 test files / 557 tests passed
- Frontend build passed
- Frontend lint passed
- `git diff --check` passed after generated-document cleanup
