### PR TITLE
Add member section file library and email-link flow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,9 @@
 # Documentation Index
 
+## Member guidance
+
+- [Section files](member-section-files.md)
+
 This folder captures architecture, domain decisions, and contributor-facing guidance.
 
 ## Architecture

--- a/docs/member-section-files.md
+++ b/docs/member-section-files.md
@@ -1,0 +1,22 @@
+# Section files
+
+Enabled members can find files on the page for any section they currently
+have access to. Each entry shows its member-facing name, optional description,
+file type, size, and upload date. Select **Download** to request a fresh,
+short-lived download.
+
+Moderators may also send a stable link in an email:
+
+```text
+https://members.example.org/sections/SECTION_ID/files/FILE_ID
+```
+
+If you open one of these links while signed out, the site takes you to sign-in
+and then returns you to the file. The link itself does not grant access. The
+site checks your enabled account and current section access every time it
+creates a download, so a deleted file or revoked membership can no longer be
+used through an older email.
+
+If the site says the file is unavailable, it deliberately does not reveal
+whether the file was removed or your access changed. Return to the section or
+contact a section moderator if you believe you should still have access.

--- a/functions/src/__tests__/sectionFileApiContracts.test.ts
+++ b/functions/src/__tests__/sectionFileApiContracts.test.ts
@@ -5,6 +5,12 @@ import { describe, expect, it } from "vitest";
 const source = fs.readFileSync(path.resolve(process.cwd(), "src", "sectionFiles.ts"), "utf8");
 
 describe("section file API security contracts", () => {
+  it("returns stable application URLs built from APP_BASE_URL", () => {
+    expect(source).toContain("canonicalUrl:");
+    expect(source).toContain("APP_BASE_URL");
+    expect(source).toContain("/sections/${file.sectionId}/files/${file.id}");
+  });
+
   it("derives all object paths from trusted section and file identifiers", () => {
     expect(source).toContain("`section-file-uploads/${sectionId}/${fileId}/${uploadId}`");
     expect(source).toContain("`section-files/${sectionId}/${fileId}/${inspected.generation}`");

--- a/functions/src/sectionFiles.ts
+++ b/functions/src/sectionFiles.ts
@@ -33,6 +33,16 @@ const MAX_FILENAME_LENGTH = 255;
 const MAX_DISPLAY_NAME_LENGTH = 160;
 const MAX_DESCRIPTION_LENGTH = 1000;
 const LIST_LIMIT = 500;
+const APP_BASE_URL = (() => {
+  const value = process.env.APP_BASE_URL || "http://localhost:5173";
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) throw new Error("invalid protocol");
+    return url.origin;
+  } catch {
+    throw new Error(`APP_BASE_URL is not a valid HTTP(S) URL: "${value}"`);
+  }
+})();
 
 const ALLOWED_CONTENT_TYPES = new Set([
   "application/pdf",
@@ -212,6 +222,7 @@ function fileResponse(file: SectionFileRecord) {
     uploadedBy: file.uploadedBy,
     createdAt: file.createdAt,
     updatedAt: file.updatedAt,
+    canonicalUrl: `${APP_BASE_URL}/sections/${file.sectionId}/files/${file.id}`,
   };
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { useAppAuthSession } from "./shared/appShell/useAppAuthSession";
 import { useCheckoutQueryState } from "./shared/appShell/useCheckoutQueryState";
 import { useOnlineStatus } from "./shared/appShell/useOnlineStatus";
 import { useUnenabledProfileCheck } from "./shared/appShell/useUnenabledProfileCheck";
+import { accountSignInPath, safeReturnTo } from "./shared/navigation/authReturnTo";
 
 // Lazy load route components for code splitting
 const AuthGate = lazy(() => import("./features/auth/components/AuthGate"));
@@ -50,6 +51,7 @@ const AccountSettingsPage = lazy(() => import("./features/account/components/Acc
 const RegisterPage = lazy(() => import("./features/auth/components/RegisterPage"));
 const OnboardingShell = lazy(() => import("./features/auth/components/OnboardingShell"));
 const UnsubscribeConfirmedPage = lazy(() => import("./features/account/components/UnsubscribeConfirmedPage"));
+const SectionFileDownloadPage = lazy(() => import("./features/sections/components/SectionFileDownloadPage"));
 
 // Loading fallback component
 const LoadingFallback = () => (
@@ -73,6 +75,14 @@ function SectionDetailRoute() {
   return <SectionDetail sectionId={sectionId} onBack={handleBack} />;
 }
 
+function SectionFileRoute() {
+  const { sectionId, fileId } = useParams<{ sectionId: string; fileId: string }>();
+  if (!sectionId || !fileId) {
+    return <Navigate to={ROUTES.SECTIONS} replace />;
+  }
+  return <SectionFileDownloadPage sectionId={sectionId} fileId={fileId} />;
+}
+
 function AppContent() {
   const navigate = useNavigate();
   const location = useLocation();
@@ -91,6 +101,7 @@ function AppContent() {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const { isEnabled, isEnabledClaimResolved } = useEnabledClaim(user);
   const checkoutReturn = isCheckoutReturnSearch(location.search);
+  const authReturnTo = safeReturnTo(location.search);
   const isAdmin = useAdminClaim(user);
   const { userData, loading: userDataLoading, refetch } = useUserData(user, isEnabled);
   const {
@@ -326,7 +337,12 @@ function AppContent() {
     if (checkoutReturn) {
       return <Navigate to={{ pathname: ROUTES.ACCOUNT, search: location.search }} replace />;
     }
-    return <Navigate to={ROUTES.ACCOUNT} replace />;
+    return (
+      <Navigate
+        to={accountSignInPath(`${location.pathname}${location.search}${location.hash}`)}
+        replace
+      />
+    );
   };
 
   return (
@@ -453,6 +469,8 @@ function AppContent() {
                     user && isEnabled ? (
                       checkoutReturn ? (
                         <Navigate to={{ pathname: ROUTES.MY_PAYMENTS, search: location.search }} replace />
+                      ) : authReturnTo ? (
+                        <Navigate to={authReturnTo} replace />
                       ) : (
                         <Navigate to={ROUTES.HOME} replace />
                       )
@@ -597,6 +615,10 @@ function AppContent() {
                 <Route
                   path={ROUTES.SECTION_DETAIL}
                   element={protectedRoute(<Suspense fallback={<LoadingFallback />}><SectionDetailRoute /></Suspense>)}
+                />
+                <Route
+                  path={ROUTES.SECTION_FILE}
+                  element={protectedRoute(<Suspense fallback={<LoadingFallback />}><SectionFileRoute /></Suspense>)}
                 />
                 <Route
                   path={ROUTES.UNSUBSCRIBE_CONFIRMED}

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -196,6 +196,12 @@ vi.mock("../features/sections/components/SectionDetail", () => ({
   ),
 }));
 
+vi.mock("../features/sections/components/SectionFileDownloadPage", () => ({
+  default: ({ sectionId, fileId }: { sectionId: string; fileId: string }) => (
+    <h1>Section File {sectionId} {fileId}</h1>
+  ),
+}));
+
 vi.mock("../features/sections/components/MyPayments", () => ({
   default: ({ onBack }: { onBack: () => void }) => (
     <div>
@@ -362,6 +368,37 @@ describe("App routing", () => {
 
     expect(await screen.findByRole("heading", { name: "Section Detail section-1" })).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent("/sections/section-1");
+  });
+
+  it("preserves a logged-out canonical file link through sign-in", async () => {
+    renderApp(["/sections/section-1/files/file-1"]);
+
+    expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/account?returnTo=%2Fsections%2Fsection-1%2Ffiles%2Ffile-1",
+    );
+  });
+
+  it("returns an enabled user from account to the canonical file route", async () => {
+    signInEnabledUser();
+    renderApp([
+      "/account?returnTo=%2Fsections%2Fsection-1%2Ffiles%2Ffile-1",
+    ]);
+
+    expect(
+      await screen.findByRole("heading", { name: "Section File section-1 file-1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      "/sections/section-1/files/file-1",
+    );
+  });
+
+  it("does not follow an external return target", async () => {
+    signInEnabledUser();
+    renderApp(["/account?returnTo=https%3A%2F%2Fevil.example%2Ffile"]);
+
+    expect(await screen.findByRole("heading", { name: "Welcome Dashboard" })).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME);
   });
 
   it("renders member payment history from a direct deep link for enabled users", async () => {

--- a/src/constants/__tests__/routes.test.ts
+++ b/src/constants/__tests__/routes.test.ts
@@ -12,6 +12,7 @@ describe('routes', () => {
     expect(ROUTES.APPROVE_USERS).toBe('/admin/users/approvals');
     expect(ROUTES.REGISTER).toBe('/register');
     expect(ROUTES.PROFILE_COMPLETION).toBe('/profile-completion');
+    expect(ROUTES.SECTION_FILE).toBe('/sections/:sectionId/files/:fileId');
   });
 
   it('should have Route type that matches route values', () => {
@@ -24,6 +25,7 @@ describe('routes', () => {
       ROUTES.APPROVE_USERS,
       ROUTES.REGISTER,
       ROUTES.PROFILE_COMPLETION,
+      ROUTES.SECTION_FILE,
     ];
     
     routes.forEach((route) => {
@@ -32,4 +34,3 @@ describe('routes', () => {
     });
   });
 });
-

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -17,6 +17,7 @@ export const ROUTES = {
   MY_BOOKINGS: "/bookings",
   SECTIONS: "/sections",
   SECTION_DETAIL: "/sections/:sectionId",
+  SECTION_FILE: "/sections/:sectionId/files/:fileId",
   MANAGE_SECTIONS: "/admin/sections",
   SECTION_ADMIN: "/admin/section/:sectionId",
   EMAIL_TEMPLATES: "/admin/email-templates",
@@ -29,4 +30,3 @@ export const ROUTES = {
  * Route type
  */
 export type Route = typeof ROUTES[keyof typeof ROUTES];
-

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -46,6 +46,7 @@ import {
   SectionEventsListView,
   SectionMembersView,
 } from "./SectionDetailViews";
+import SectionFilesList from "./SectionFilesList";
 
 interface SectionDetailProps {
   sectionId: string;
@@ -506,19 +507,22 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       />
 
       {!selectedEventId && (
-        <SectionDescriptionHeader
-          section={section}
-          isMembers={isMembers}
-          hasCurrentUser={Boolean(currentUser)}
-          canSubscribe={canSubscribe}
-          userIsMember={userIsMember}
-          userHasSectionAccess={userHasSectionAccess}
-          hasSubscribableMemberGroup={hasSubscribableMemberGroup}
-          subscribing={subscribing}
-          onSubscribe={handleSubscribe}
-          onUnsubscribe={handleUnsubscribe}
-          sectionId={sectionId}
-        />
+        <>
+          <SectionDescriptionHeader
+            section={section}
+            isMembers={isMembers}
+            hasCurrentUser={Boolean(currentUser)}
+            canSubscribe={canSubscribe}
+            userIsMember={userIsMember}
+            userHasSectionAccess={userHasSectionAccess}
+            hasSubscribableMemberGroup={hasSubscribableMemberGroup}
+            subscribing={subscribing}
+            onSubscribe={handleSubscribe}
+            onUnsubscribe={handleUnsubscribe}
+            sectionId={sectionId}
+          />
+          <SectionFilesList sectionId={sectionId} />
+        </>
       )}
 
       {isMembers ? (

--- a/src/features/sections/components/SectionFileDownloadPage.tsx
+++ b/src/features/sections/components/SectionFileDownloadPage.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { Alert, Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { requestSectionFileDownload } from "../../../shared/utils/firebaseFunctions";
+
+export default function SectionFileDownloadPage({
+  sectionId,
+  fileId,
+}: {
+  sectionId: string;
+  fileId: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setFailed(false);
+    void requestSectionFileDownload(sectionId, fileId)
+      .then(({ downloadUrl }) => {
+        if (active) window.location.assign(downloadUrl);
+      })
+      .catch(() => {
+        if (active) setFailed(true);
+      });
+    return () => {
+      active = false;
+    };
+  }, [sectionId, fileId, attempt]);
+
+  return (
+    <Box sx={{ maxWidth: 640, mx: "auto", py: 6 }}>
+      <Stack spacing={2} alignItems="flex-start">
+        <Typography variant="h4" component="h1">Section file</Typography>
+        {failed ? (
+          <>
+            <Alert severity="error">
+              This file is unavailable, or you no longer have access to it.
+            </Alert>
+            <Stack direction="row" spacing={1}>
+              <Button variant="contained" onClick={() => setAttempt((value) => value + 1)}>
+                Try again
+              </Button>
+              <Button component={RouterLink} to={`/sections/${sectionId}`}>
+                Back to section
+              </Button>
+            </Stack>
+          </>
+        ) : (
+          <Stack direction="row" spacing={1} alignItems="center">
+            <CircularProgress size={24} />
+            <Typography>Checking access and preparing your download…</Typography>
+          </Stack>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/sections/components/SectionFilesList.tsx
+++ b/src/features/sections/components/SectionFilesList.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  Typography,
+} from "@mui/material";
+import DownloadIcon from "@mui/icons-material/Download";
+import {
+  listSectionFiles,
+  requestSectionFileDownload,
+  type SectionFile,
+} from "../../../shared/utils/firebaseFunctions";
+
+function fileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function fileDate(value: string): string {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? ""
+    : new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(date);
+}
+
+export default function SectionFilesList({ sectionId }: { sectionId: string }) {
+  const [files, setFiles] = useState<SectionFile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      setFiles(await listSectionFiles(sectionId));
+    } catch {
+      setFiles([]);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [sectionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const download = async (file: SectionFile) => {
+    setDownloadingId(file.id);
+    try {
+      const result = await requestSectionFileDownload(sectionId, file.id);
+      window.location.assign(result.downloadUrl);
+    } catch {
+      setError(true);
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  return (
+    <Box component="section" aria-labelledby="section-files-heading" sx={{ mt: 3, mb: 3 }}>
+      <Typography id="section-files-heading" variant="h6" component="h2">
+        Files
+      </Typography>
+      {loading ? (
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ py: 2 }}>
+          <CircularProgress size={22} />
+          <Typography>Loading files…</Typography>
+        </Stack>
+      ) : error ? (
+        <Alert
+          severity="error"
+          action={<Button color="inherit" onClick={() => void load()}>Reload files</Button>}
+          sx={{ mt: 1 }}
+        >
+          Files could not be loaded. Your access may have changed.
+        </Alert>
+      ) : files.length === 0 ? (
+        <Typography color="text.secondary" sx={{ mt: 1 }}>
+          No files are available for this section.
+        </Typography>
+      ) : (
+        <List disablePadding>
+          {files.map((file) => (
+            <ListItem
+              key={file.id}
+              divider
+              disableGutters
+              secondaryAction={
+                <Button
+                  startIcon={downloadingId === file.id ? <CircularProgress size={16} /> : <DownloadIcon />}
+                  disabled={downloadingId !== null}
+                  onClick={() => void download(file)}
+                  aria-label={`Download ${file.displayName}`}
+                >
+                  Download
+                </Button>
+              }
+              sx={{ pr: 15 }}
+            >
+              <ListItemText
+                primary={file.displayName}
+                secondary={[
+                  file.description,
+                  [file.contentType, fileSize(file.sizeBytes), fileDate(file.createdAt)]
+                    .filter(Boolean)
+                    .join(" · "),
+                ].filter(Boolean).join(" — ")}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/src/features/sections/components/__tests__/SectionFilesList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionFilesList.test.tsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "../../../../test-utils";
+import SectionFilesList from "../SectionFilesList";
+import { listSectionFiles } from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  listSectionFiles: vi.fn(),
+  requestSectionFileDownload: vi.fn(),
+}));
+
+describe("SectionFilesList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows safe member-facing file metadata", async () => {
+    vi.mocked(listSectionFiles).mockResolvedValue([
+      {
+        id: "file-1",
+        sectionId: "section-1",
+        displayName: "Joining instructions",
+        originalFilename: "instructions.pdf",
+        description: "Read before attending",
+        contentType: "application/pdf",
+        sizeBytes: 1536,
+        uploadedBy: "moderator-1",
+        createdAt: "2026-07-20T12:00:00.000Z",
+        updatedAt: "2026-07-20T12:00:00.000Z",
+        canonicalUrl: "https://members.example.org/sections/section-1/files/file-1",
+      },
+    ]);
+
+    render(<SectionFilesList sectionId="section-1" />);
+
+    expect(await screen.findByText("Joining instructions")).toBeInTheDocument();
+    expect(screen.getByText(/Read before attending/)).toBeInTheDocument();
+    expect(screen.getByText(/application\/pdf/)).toBeInTheDocument();
+    expect(screen.getByText(/1.5 KB/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download Joining instructions" })).toBeInTheDocument();
+  });
+
+  it("shows an empty state", async () => {
+    vi.mocked(listSectionFiles).mockResolvedValue([]);
+    render(<SectionFilesList sectionId="section-1" />);
+    expect(await screen.findByText("No files are available for this section.")).toBeInTheDocument();
+  });
+
+  it("uses a non-enumerating error and supports retry", async () => {
+    vi.mocked(listSectionFiles)
+      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockResolvedValueOnce([]);
+    render(<SectionFilesList sectionId="section-1" />);
+
+    const reload = await screen.findByRole("button", { name: "Reload files" });
+    reload.click();
+    await waitFor(() => expect(listSectionFiles).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("No files are available for this section.")).toBeInTheDocument();
+  });
+});

--- a/src/shared/navigation/__tests__/authReturnTo.test.ts
+++ b/src/shared/navigation/__tests__/authReturnTo.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { accountSignInPath, safeReturnTo } from "../authReturnTo";
+
+describe("auth return targets", () => {
+  it("preserves an internal file route including query and hash", () => {
+    expect(
+      safeReturnTo("?returnTo=%2Fsections%2Fsection-1%2Ffiles%2Ffile-1%3Fdownload%3D1%23file"),
+    ).toBe("/sections/section-1/files/file-1?download=1#file");
+  });
+
+  it.each([
+    "https://evil.example/file",
+    "//evil.example/file",
+    "/\\evil.example/file",
+    "/account",
+  ])("rejects unsafe target %s", (target) => {
+    expect(safeReturnTo(`?returnTo=${encodeURIComponent(target)}`)).toBeNull();
+  });
+
+  it("builds a sign-in URL with an encoded internal return target", () => {
+    expect(accountSignInPath("/sections/a/files/b")).toBe(
+      "/account?returnTo=%2Fsections%2Fa%2Ffiles%2Fb",
+    );
+  });
+});

--- a/src/shared/navigation/authReturnTo.ts
+++ b/src/shared/navigation/authReturnTo.ts
@@ -1,0 +1,24 @@
+import { ROUTES } from "../../constants";
+
+export function safeReturnTo(search: string): string | null {
+  const value = new URLSearchParams(search).get("returnTo");
+  if (!value || !value.startsWith("/") || value.startsWith("//") || value.includes("\\")) {
+    return null;
+  }
+  try {
+    const url = new URL(value, "https://app.invalid");
+    if (url.origin !== "https://app.invalid" || url.pathname === ROUTES.ACCOUNT) {
+      return null;
+    }
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function accountSignInPath(returnTo: string): string {
+  const safe = safeReturnTo(`?returnTo=${encodeURIComponent(returnTo)}`);
+  return safe
+    ? `${ROUTES.ACCOUNT}?returnTo=${encodeURIComponent(safe)}`
+    : ROUTES.ACCOUNT;
+}

--- a/src/shared/utils/__tests__/sectionFilesFirebaseFunctions.test.ts
+++ b/src/shared/utils/__tests__/sectionFilesFirebaseFunctions.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { httpsCallable } from "firebase/functions";
+import {
+  listSectionFiles,
+  requestSectionFileDownload,
+} from "../firebaseFunctions/sectionFiles";
+
+vi.mock("firebase/functions", () => ({
+  httpsCallable: vi.fn(),
+}));
+
+vi.mock("../../../config/firebase", () => ({
+  functions: { region: "europe-west2" },
+}));
+
+describe("section file callable clients", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists files without exposing storage paths", async () => {
+    const callable = vi.fn().mockResolvedValue({ data: { files: [] } });
+    vi.mocked(httpsCallable).mockReturnValue(callable as never);
+
+    await expect(listSectionFiles("section-1")).resolves.toEqual([]);
+    expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), "listSectionFiles");
+    expect(callable).toHaveBeenCalledWith({ sectionId: "section-1" });
+  });
+
+  it("requests a fresh download grant for the route identifiers", async () => {
+    const response = {
+      file: { id: "file-1" },
+      downloadUrl: "https://storage.example/signed",
+      expiresAt: "2026-07-26T18:00:00.000Z",
+    };
+    const callable = vi.fn().mockResolvedValue({ data: response });
+    vi.mocked(httpsCallable).mockReturnValue(callable as never);
+
+    await expect(requestSectionFileDownload("section-1", "file-1")).resolves.toEqual(response);
+    expect(httpsCallable).toHaveBeenCalledWith(
+      expect.anything(),
+      "requestSectionFileDownload",
+    );
+    expect(callable).toHaveBeenCalledWith({ sectionId: "section-1", fileId: "file-1" });
+  });
+});

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -7,3 +7,4 @@ export * from "./firebaseFunctions/sectionAccess";
 export * from "./firebaseFunctions/bookingPayments";
 export * from "./firebaseFunctions/guestTickets";
 export * from "./firebaseFunctions/announcements";
+export * from "./firebaseFunctions/sectionFiles";

--- a/src/shared/utils/firebaseFunctions/sectionFiles.ts
+++ b/src/shared/utils/firebaseFunctions/sectionFiles.ts
@@ -1,0 +1,35 @@
+import { httpsCallable } from "firebase/functions";
+import { functions } from "../../../config/firebase";
+
+export interface SectionFile {
+  id: string;
+  sectionId: string;
+  displayName: string;
+  originalFilename: string;
+  description: string | null;
+  contentType: string;
+  sizeBytes: number;
+  uploadedBy: string;
+  createdAt: string;
+  updatedAt: string;
+  canonicalUrl: string;
+}
+
+export async function listSectionFiles(sectionId: string): Promise<SectionFile[]> {
+  const callable = httpsCallable<{ sectionId: string }, { files: SectionFile[] }>(
+    functions,
+    "listSectionFiles",
+  );
+  return (await callable({ sectionId })).data.files;
+}
+
+export async function requestSectionFileDownload(
+  sectionId: string,
+  fileId: string,
+): Promise<{ file: SectionFile; downloadUrl: string; expiresAt: string }> {
+  const callable = httpsCallable<
+    { sectionId: string; fileId: string },
+    { file: SectionFile; downloadUrl: string; expiresAt: string }
+  >(functions, "requestSectionFileDownload");
+  return (await callable({ sectionId, fileId })).data;
+}


### PR DESCRIPTION
Closes #430

## What changed

- add a member-facing file list to accessible section pages
- add the stable `/sections/:sectionId/files/:fileId` application route
- request a fresh authorization-checked, short-lived download grant whenever a file link is opened
- preserve canonical file routes through sign-in using validated same-origin `returnTo` values
- reject external, protocol-relative, malformed, and account-loop return targets
- return canonical file URLs built from the backend `APP_BASE_URL`
- add accessible loading, empty, unavailable, retry, metadata, and download states
- add member guidance for section files and emailed links

## Impact

Members can browse files for sections they currently access and follow stable links from emails. Possession of a link is not authorization: the backend checks enabled status and current section access before every download grant. Revoked, deleted, missing, and wrong-section cases use the same non-enumerating unavailable experience.

## Validation

- Frontend: 70 test files / 571 tests passed
- Frontend build passed
- Frontend lint passed
- Functions: 61 test files / 578 tests passed
- Functions build passed
- Functions lint passed
- `git diff --check` passed
