### PR TITLE
Add moderator and admin section file management

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@
 
 - [Section files](member-section-files.md)
 
+## Moderator guidance
+
+- [Managing section files](moderator-section-files.md)
+
 This folder captures architecture, domain decisions, and contributor-facing guidance.
 
 ## Architecture

--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -52,6 +52,7 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 | `updateSectionFileMetadata` | 60 | 1 hour | Restricted metadata mutation |
 | `requestSectionFileReplacement` | 20 | 1 hour | Signed upload capability and lifecycle mutation |
 | `finalizeSectionFileReplacement` | 30 | 1 hour | Object validation, copy, cleanup, and metadata mutation |
+| `cancelSectionFileReplacement` | 30 | 1 hour | Replacement rollback and temporary-object cleanup |
 | `deleteSectionFile` | 30 | 1 hour | Object deletion and lifecycle mutation |
 
 ## Complete callable classification
@@ -97,6 +98,7 @@ Risk levels are relative to other authenticated callables in this application. â
 | `updateSectionFileMetadata` | Medium | None | None | Low | Enabled + section moderator/admin; 60/hour; lifecycle CAS |
 | `requestSectionFileReplacement` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 20/hour; generated temporary path |
 | `finalizeSectionFileReplacement` | High | None | Cloud Storage | Very high | Enabled + section moderator/admin; 30/hour; validation, CAS, deferred cleanup |
+| `cancelSectionFileReplacement` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 30/hour; trusted pending-path rollback |
 | `deleteSectionFile` | High | None | Cloud Storage | High | Enabled + section moderator/admin; 30/hour; metadata hidden before cleanup |
 
 ## App Check relationship

--- a/docs/moderator-section-files.md
+++ b/docs/moderator-section-files.md
@@ -1,0 +1,32 @@
+# Managing section files
+
+Section moderators can select **Administer** on a section and then **Manage
+Files**. Global administrators can do the same for any section.
+
+## Upload
+
+1. Choose an approved file of no more than 25 MB.
+2. Enter the name members should see and, optionally, a description.
+3. Select **Upload and verify**.
+4. Keep the page open while it shows **Uploading** and then **Verifying**.
+
+The file does not appear to members until the backend has checked its size,
+declared type, actual file signature, and storage location. If final verification
+fails, correct the file and retry; do not assume that an uploaded object is live.
+
+## Links and changes
+
+**Copy stable link** copies the application URL, not a temporary Storage URL.
+The link is suitable for email and continues to re-check the recipient's enabled
+account and current section access whenever it is opened.
+
+Editing the display name or description does not change the stable link.
+Replacing a file keeps the current version available until the replacement is
+uploaded and verified. If replacement fails, refresh before retrying.
+
+Deleting requires confirmation. The file is hidden before storage cleanup, so
+members and previously emailed links stop working immediately even if backend
+cleanup needs to be retried.
+
+All permissions are enforced by the backend. Seeing the management screen is
+not itself authority to upload or change a file.

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -78,6 +78,7 @@ describe("function entry guard contracts", () => {
       "updateSectionFileMetadata",
       "requestSectionFileReplacement",
       "finalizeSectionFileReplacement",
+      "cancelSectionFileReplacement",
       "deleteSectionFile",
     ]) {
       assertOnCallGuard(sectionFiles, fn, `requestContext(request, "${fn}"`, 450);
@@ -191,6 +192,7 @@ describe("function entry guard contracts", () => {
       "updateSectionFileMetadata",
       "requestSectionFileReplacement",
       "finalizeSectionFileReplacement",
+      "cancelSectionFileReplacement",
       "deleteSectionFile",
     ]) {
       assertOnCallGuard(sectionFiles, fn, `requestContext(request, "${fn}"`, 450);

--- a/functions/src/__tests__/sectionFileApiContracts.test.ts
+++ b/functions/src/__tests__/sectionFileApiContracts.test.ts
@@ -38,6 +38,12 @@ describe("section file API security contracts", () => {
     expect(source).toContain("action: \"read\"");
   });
 
+  it("provides a trusted rollback for interrupted replacements", () => {
+    expect(source).toContain("export const cancelSectionFileReplacement");
+    expect(source).toContain("abortSectionFileReplacement");
+    expect(source).toContain("bestEffortDelete(file.pendingStorageObjectPath");
+  });
+
   it("never includes internal object paths in member-facing file responses", () => {
     const start = source.indexOf("function fileResponse(");
     const end = source.indexOf("\n}", start);

--- a/functions/src/rateLimiter.ts
+++ b/functions/src/rateLimiter.ts
@@ -49,6 +49,7 @@ export const CALLABLE_RATE_LIMITS = {
   updateSectionFileMetadata: { limit: 60, windowMs: HOUR_MS },
   requestSectionFileReplacement: { limit: 20, windowMs: HOUR_MS },
   finalizeSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
+  cancelSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
   deleteSectionFile: { limit: 30, windowMs: HOUR_MS },
 } as const satisfies Record<string, RateLimitPolicy>;
 

--- a/functions/src/sectionFiles.ts
+++ b/functions/src/sectionFiles.ts
@@ -583,6 +583,33 @@ export const finalizeSectionFileReplacement = onCall(
   },
 );
 
+export const cancelSectionFileReplacement = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    const { uid, isAdmin } = await requestContext(request, "cancelSectionFileReplacement");
+    const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");
+    const fileId = validateUUID(requireString(request.data?.fileId, "fileId"), "fileId");
+    try {
+      await requireSectionModerator(sectionId, uid, isAdmin);
+      const file = await trustedFile(fileId, sectionId);
+      if (file.status !== SectionFileStatus.REPLACING || !file.pendingStorageObjectPath) {
+        throw new HttpsError("failed-precondition", "The replacement is not pending");
+      }
+      const transition = await abortSectionFileReplacement({
+        id: fileId,
+        pendingStorageObjectPath: file.pendingStorageObjectPath,
+        updatedBy: uid,
+      });
+      ensureTransition(transition.data.sectionFile_updateMany);
+      await bestEffortDelete(file.pendingStorageObjectPath, { sectionId, fileId });
+      return { fileId };
+    } catch (error) {
+      if (error instanceof HttpsError) throw error;
+      handleFunctionError(error, "cancelling section file replacement");
+    }
+  },
+);
+
 export const deleteSectionFile = onCall({ region: FUNCTIONS_REGION }, async (request) => {
   const { uid, isAdmin } = await requestContext(request, "deleteSectionFile");
   const sectionId = validateUUID(requireString(request.data?.sectionId, "sectionId"), "sectionId");

--- a/src/features/admin/components/ManageSectionFiles.tsx
+++ b/src/features/admin/components/ManageSectionFiles.tsx
@@ -1,0 +1,356 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  List,
+  ListItem,
+  ListItemText,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { ContentCopy, Delete, Edit, UploadFile } from "@mui/icons-material";
+import {
+  deleteSectionFile,
+  listSectionFiles,
+  replaceSectionFile,
+  updateSectionFileMetadata,
+  uploadSectionFile,
+  type SectionFile,
+} from "../../../shared/utils/firebaseFunctions";
+import PageHeader from "../../../shared/components/PageHeader";
+
+const MAX_BYTES = 25 * 1024 * 1024;
+const ALLOWED_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "text/plain",
+  "text/csv",
+  "application/json",
+  "application/rtf",
+  "application/vnd.oasis.opendocument.text",
+  "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+];
+
+function validateFile(file: File): string | null {
+  if (file.size <= 0) return "Choose a non-empty file.";
+  if (file.size > MAX_BYTES) return "Files must be 25 MB or smaller.";
+  if (!ALLOWED_TYPES.includes(file.type)) return "This file type is not supported.";
+  return null;
+}
+
+function errorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  if (/permission|unauth|denied/i.test(message)) {
+    return "You no longer have permission to manage files for this section.";
+  }
+  if (/precondition|changed|current state/i.test(message)) {
+    return "The file changed. Refresh the list and try again.";
+  }
+  return "The operation could not be completed. Please try again.";
+}
+
+export default function ManageSectionFiles({
+  sectionId,
+  sectionName,
+  onBack,
+}: {
+  sectionId: string;
+  sectionName: string;
+  onBack: () => void;
+}) {
+  const [files, setFiles] = useState<SectionFile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [stage, setStage] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ severity: "success" | "error"; text: string } | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [description, setDescription] = useState("");
+  const [editing, setEditing] = useState<SectionFile | null>(null);
+  const [deleting, setDeleting] = useState<SectionFile | null>(null);
+  const replacementInput = useRef<HTMLInputElement>(null);
+  const [replacing, setReplacing] = useState<SectionFile | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      setFiles(await listSectionFiles(sectionId));
+    } catch (error) {
+      setNotice({ severity: "error", text: errorMessage(error) });
+    } finally {
+      setLoading(false);
+    }
+  }, [sectionId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const run = async (operation: () => Promise<void>, success: string) => {
+    setBusy(true);
+    setNotice(null);
+    try {
+      await operation();
+      setNotice({ severity: "success", text: success });
+      await load();
+    } catch (error) {
+      setNotice({ severity: "error", text: errorMessage(error) });
+    } finally {
+      setBusy(false);
+      setStage(null);
+    }
+  };
+
+  const submitUpload = async () => {
+    if (!selectedFile) return;
+    const validation = validateFile(selectedFile);
+    if (validation) {
+      setNotice({ severity: "error", text: validation });
+      return;
+    }
+    if (!displayName.trim()) {
+      setNotice({ severity: "error", text: "Enter a display name." });
+      return;
+    }
+    await run(async () => {
+      await uploadSectionFile(
+        sectionId,
+        selectedFile,
+        { displayName: displayName.trim(), description: description.trim() || null },
+        (value) => setStage(value === "uploading" ? "Uploading file…" : "Verifying file…"),
+      );
+      setSelectedFile(null);
+      setDisplayName("");
+      setDescription("");
+    }, "File uploaded.");
+  };
+
+  const chooseReplacement = (file: SectionFile) => {
+    setReplacing(file);
+    replacementInput.current?.click();
+  };
+
+  const handleReplacement = async (file: File | undefined) => {
+    const target = replacing;
+    setReplacing(null);
+    if (!target || !file) return;
+    const validation = validateFile(file);
+    if (validation) {
+      setNotice({ severity: "error", text: validation });
+      return;
+    }
+    await run(
+      () => replaceSectionFile(
+        sectionId,
+        target.id,
+        file,
+        (value) => setStage(value === "uploading" ? "Uploading replacement…" : "Verifying replacement…"),
+      ),
+      "File replaced.",
+    );
+  };
+
+  const copyLink = async (file: SectionFile) => {
+    try {
+      await navigator.clipboard.writeText(file.canonicalUrl);
+      setNotice({ severity: "success", text: "Stable file link copied." });
+    } catch {
+      setNotice({ severity: "error", text: "The link could not be copied. Try again." });
+    }
+  };
+
+  return (
+    <Box className="page-container">
+      <PageHeader title={`Manage files — ${sectionName}`} onBack={onBack} />
+      <Typography color="text.secondary" sx={{ mb: 2 }}>
+        Upload files for members with access to this section. Stable links re-check access whenever opened.
+      </Typography>
+
+      {notice ? <Alert severity={notice.severity} sx={{ mb: 2 }}>{notice.text}</Alert> : null}
+      {busy ? (
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }} role="status">
+          <CircularProgress size={20} />
+          <Typography>{stage ?? "Saving changes…"}</Typography>
+        </Stack>
+      ) : null}
+
+      <Stack component="section" spacing={2} aria-labelledby="upload-file-heading">
+        <Typography id="upload-file-heading" variant="h6" component="h2">Upload a file</Typography>
+        <Button component="label" variant="outlined" startIcon={<UploadFile />} disabled={busy}>
+          Choose file
+          <input
+            hidden
+            type="file"
+            accept={ALLOWED_TYPES.join(",")}
+            onChange={(event) => {
+              const file = event.target.files?.[0] ?? null;
+              setSelectedFile(file);
+              if (file && !displayName) setDisplayName(file.name.replace(/\.[^.]+$/, ""));
+              event.target.value = "";
+            }}
+          />
+        </Button>
+        {selectedFile ? <Typography variant="body2">Selected: {selectedFile.name}</Typography> : null}
+        <TextField
+          label="Display name"
+          value={displayName}
+          onChange={(event) => setDisplayName(event.target.value)}
+          inputProps={{ maxLength: 160 }}
+          required
+        />
+        <TextField
+          label="Description (optional)"
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          inputProps={{ maxLength: 1000 }}
+          multiline
+          minRows={2}
+        />
+        <Button
+          variant="contained"
+          onClick={() => void submitUpload()}
+          disabled={busy || !selectedFile || !displayName.trim()}
+          sx={{ alignSelf: "flex-start" }}
+        >
+          Upload and verify
+        </Button>
+      </Stack>
+
+      <Divider sx={{ my: 4 }} />
+      <Typography variant="h6" component="h2">Existing files</Typography>
+      {loading ? <CircularProgress sx={{ mt: 2 }} /> : files.length === 0 ? (
+        <Typography color="text.secondary" sx={{ mt: 1 }}>No files have been uploaded.</Typography>
+      ) : (
+        <List>
+          {files.map((file) => (
+            <ListItem
+              key={file.id}
+              divider
+              disableGutters
+              sx={{
+                display: "flex",
+                alignItems: { xs: "flex-start", sm: "center" },
+                flexDirection: { xs: "column", sm: "row" },
+                gap: 1,
+              }}
+            >
+              <ListItemText
+                primary={file.displayName}
+                secondary={file.description || file.originalFilename}
+                sx={{ flex: 1 }}
+              />
+              <Stack direction="row" flexWrap="wrap" justifyContent="flex-end">
+                  <Tooltip title="Copy stable link">
+                    <IconButton aria-label={`Copy link for ${file.displayName}`} onClick={() => void copyLink(file)}>
+                      <ContentCopy />
+                    </IconButton>
+                  </Tooltip>
+                  <Tooltip title="Edit details">
+                    <IconButton aria-label={`Edit ${file.displayName}`} onClick={() => setEditing(file)}>
+                      <Edit />
+                    </IconButton>
+                  </Tooltip>
+                  <Button disabled={busy} onClick={() => chooseReplacement(file)}>Replace</Button>
+                  <Tooltip title="Delete file">
+                    <IconButton aria-label={`Delete ${file.displayName}`} color="error" onClick={() => setDeleting(file)}>
+                      <Delete />
+                    </IconButton>
+                  </Tooltip>
+              </Stack>
+            </ListItem>
+          ))}
+        </List>
+      )}
+
+      <input
+        ref={replacementInput}
+        hidden
+        type="file"
+        accept={ALLOWED_TYPES.join(",")}
+        onChange={(event) => {
+          void handleReplacement(event.target.files?.[0]);
+          event.target.value = "";
+        }}
+      />
+
+      <Dialog open={Boolean(editing)} onClose={() => !busy && setEditing(null)} fullWidth>
+        <DialogTitle>Edit file details</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ pt: 1 }}>
+            <TextField
+              label="Display name"
+              value={editing?.displayName ?? ""}
+              onChange={(event) => setEditing((value) => value ? { ...value, displayName: event.target.value } : value)}
+              inputProps={{ maxLength: 160 }}
+            />
+            <TextField
+              label="Description (optional)"
+              value={editing?.description ?? ""}
+              onChange={(event) => setEditing((value) => value ? { ...value, description: event.target.value } : value)}
+              inputProps={{ maxLength: 1000 }}
+              multiline
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditing(null)} disabled={busy}>Cancel</Button>
+          <Button
+            variant="contained"
+            disabled={busy || !editing?.displayName.trim()}
+            onClick={() => {
+              if (!editing) return;
+              const value = editing;
+              void run(
+                () => updateSectionFileMetadata(sectionId, value.id, {
+                  displayName: value.displayName.trim(),
+                  description: value.description?.trim() || null,
+                }),
+                "File details updated.",
+              ).then(() => setEditing(null));
+            }}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={Boolean(deleting)} onClose={() => !busy && setDeleting(null)}>
+        <DialogTitle>Delete file?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            {deleting ? `“${deleting.displayName}” will immediately stop appearing to members and its emailed link will no longer work.` : ""}
+          </Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleting(null)} disabled={busy}>Cancel</Button>
+          <Button
+            color="error"
+            variant="contained"
+            disabled={busy}
+            onClick={() => {
+              if (!deleting) return;
+              const value = deleting;
+              void run(() => deleteSectionFile(sectionId, value.id), "File deleted.")
+                .then(() => setDeleting(null));
+            }}
+          >
+            Delete file
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  );
+}

--- a/src/features/admin/components/SectionAdminPage.tsx
+++ b/src/features/admin/components/SectionAdminPage.tsx
@@ -10,11 +10,12 @@ import {
   CircularProgress,
   Typography,
 } from "@mui/material";
-import { Campaign, Event, Settings } from "@mui/icons-material";
+import { Campaign, Event, Folder, Settings } from "@mui/icons-material";
 import PageHeader from "../../../shared/components/PageHeader";
 import { ROUTES } from "../../../constants";
 import { useCanModerateSection } from "../../sections/hooks/useCanModerateSection";
 import SendAnnouncementPage from "./SendAnnouncementPage";
+import ManageSectionFiles from "./ManageSectionFiles";
 import "../../../shared/components/PageContainer.css";
 
 interface SectionAdminLocationState {
@@ -53,7 +54,7 @@ export default function SectionAdminPage() {
   const sectionType = state?.sectionType ?? "MEMBERS";
   const isEvents = sectionType === "EVENTS";
 
-  const [view, setView] = useState<"hub" | "announcement">("hub");
+  const [view, setView] = useState<"hub" | "announcement" | "files">("hub");
 
   const handleBack = () => {
     if (view !== "hub") {
@@ -97,6 +98,16 @@ export default function SectionAdminPage() {
     );
   }
 
+  if (view === "files") {
+    return (
+      <ManageSectionFiles
+        sectionId={sectionId}
+        sectionName={sectionName}
+        onBack={() => setView("hub")}
+      />
+    );
+  }
+
   return (
     <Box className="page-container">
       <PageHeader title={`Administer — ${sectionName}`} onBack={handleBack} />
@@ -106,6 +117,15 @@ export default function SectionAdminPage() {
       </Typography>
 
       <Box sx={{ display: "flex", flexWrap: "wrap", gap: 2 }}>
+        <Box sx={{ flex: "1 1 280px" }}>
+          <ActionCard
+            icon={<Folder fontSize="large" />}
+            title="Manage Files"
+            description="Upload, replace, rename, delete, and copy stable member links."
+            onClick={() => setView("files")}
+          />
+        </Box>
+
         <Box sx={{ flex: "1 1 280px" }}>
           <ActionCard
             icon={<Campaign fontSize="large" />}

--- a/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
+++ b/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
+import ManageSectionFiles from "../ManageSectionFiles";
+import {
+  deleteSectionFile,
+  listSectionFiles,
+  updateSectionFileMetadata,
+  uploadSectionFile,
+} from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  listSectionFiles: vi.fn(),
+  uploadSectionFile: vi.fn(),
+  replaceSectionFile: vi.fn(),
+  updateSectionFileMetadata: vi.fn(),
+  deleteSectionFile: vi.fn(),
+}));
+
+const file = {
+  id: "file-1",
+  sectionId: "section-1",
+  displayName: "Joining instructions",
+  originalFilename: "joining.pdf",
+  description: "Read before attending",
+  contentType: "application/pdf",
+  sizeBytes: 1024,
+  uploadedBy: "moderator-1",
+  createdAt: "2026-07-20T12:00:00.000Z",
+  updatedAt: "2026-07-20T12:00:00.000Z",
+  canonicalUrl: "https://members.example.org/sections/section-1/files/file-1",
+};
+
+describe("ManageSectionFiles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(listSectionFiles).mockResolvedValue([file]);
+    vi.mocked(updateSectionFileMetadata).mockResolvedValue();
+    vi.mocked(deleteSectionFile).mockResolvedValue();
+    vi.mocked(uploadSectionFile).mockResolvedValue("file-2");
+  });
+
+  it("lists files and copies only the stable application link", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
+
+    expect(await screen.findByText("Joining instructions")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Copy link for Joining instructions" }));
+
+    expect(writeText).toHaveBeenCalledWith(file.canonicalUrl);
+    expect(await screen.findByText("Stable file link copied.")).toBeInTheDocument();
+  });
+
+  it("uploads an approved file with member-facing metadata", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />,
+    );
+    await screen.findByText("Joining instructions");
+    const input = container.querySelector('input[type="file"]:not([hidden])')
+      ?? container.querySelector('input[type="file"]');
+    expect(input).not.toBeNull();
+    const upload = new File(["%PDF-test"], "orders.pdf", { type: "application/pdf" });
+    await user.upload(input as HTMLInputElement, upload);
+    await user.clear(screen.getByLabelText(/Display name/));
+    await user.type(screen.getByLabelText(/Display name/), "Orders");
+    await user.type(screen.getByLabelText("Description (optional)"), "Current orders");
+    await user.click(screen.getByRole("button", { name: "Upload and verify" }));
+
+    await waitFor(() => expect(uploadSectionFile).toHaveBeenCalledWith(
+      "section-1",
+      upload,
+      { displayName: "Orders", description: "Current orders" },
+      expect.any(Function),
+    ));
+    expect(listSectionFiles).toHaveBeenCalledTimes(2);
+  });
+
+  it("edits member-facing metadata and refreshes", async () => {
+    const user = userEvent.setup();
+    render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
+    await screen.findByText("Joining instructions");
+
+    await user.click(screen.getByRole("button", { name: "Edit Joining instructions" }));
+    const name = screen.getByLabelText("Display name");
+    await user.clear(name);
+    await user.type(name, "Updated instructions");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(updateSectionFileMetadata).toHaveBeenCalledWith(
+      "section-1",
+      "file-1",
+      { displayName: "Updated instructions", description: "Read before attending" },
+    ));
+    expect(listSectionFiles).toHaveBeenCalledTimes(2);
+  });
+
+  it("requires confirmation and explains that emailed links stop working", async () => {
+    const user = userEvent.setup();
+    render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
+    await screen.findByText("Joining instructions");
+
+    await user.click(screen.getByRole("button", { name: "Delete Joining instructions" }));
+    expect(screen.getByText(/emailed link will no longer work/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Delete file" }));
+
+    await waitFor(() => expect(deleteSectionFile).toHaveBeenCalledWith("section-1", "file-1"));
+  });
+
+  it("shows a permission-safe error when the list cannot be loaded", async () => {
+    vi.mocked(listSectionFiles).mockRejectedValue(new Error("permission-denied"));
+    render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
+    expect(await screen.findByText(/no longer have permission/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
+++ b/src/features/admin/components/__tests__/SectionAdminPage.test.tsx
@@ -46,6 +46,15 @@ vi.mock('../SendAnnouncementPage', () => ({
   ),
 }));
 
+vi.mock('../ManageSectionFiles', () => ({
+  default: ({ sectionName, onBack }: { sectionName: string; onBack: () => void }) => (
+    <div>
+      <div>Mock Manage Files for {sectionName}</div>
+      <button onClick={onBack}>Back to hub</button>
+    </div>
+  ),
+}));
+
 const sectionId = 'section-1';
 
 function mockCanModerate(canModerate: boolean) {
@@ -123,6 +132,19 @@ describe('SectionAdminPage', () => {
 
     await user.click(screen.getByText('Back to hub'));
     expect(screen.getByText('Send Announcement')).toBeInTheDocument();
+  });
+
+  it('opens and returns from Manage Files for a section moderator', async () => {
+    const user = userEvent.setup();
+    mockCanModerate(true);
+    renderSectionAdminPage();
+
+    await screen.findByText('Manage Files');
+    await user.click(screen.getByText('Manage Files'));
+    expect(screen.getByText('Mock Manage Files for Test Section')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Back to hub'));
+    expect(screen.getByText('Manage Files')).toBeInTheDocument();
   });
 
   it('navigates to Manage Sections with the managed section for an EVENTS section', async () => {

--- a/src/shared/utils/firebaseFunctions/sectionFiles.ts
+++ b/src/shared/utils/firebaseFunctions/sectionFiles.ts
@@ -15,6 +15,29 @@ export interface SectionFile {
   canonicalUrl: string;
 }
 
+export interface SectionFileMetadataInput {
+  displayName: string;
+  description: string | null;
+}
+
+interface UploadGrant {
+  fileId: string;
+  uploadUrl: string;
+  expiresAt: string;
+  requiredHeaders: Record<string, string>;
+}
+
+async function putFile(grant: UploadGrant, file: File): Promise<void> {
+  const response = await fetch(grant.uploadUrl, {
+    method: "PUT",
+    headers: grant.requiredHeaders,
+    body: file,
+  });
+  if (!response.ok) {
+    throw new Error(`Upload failed with status ${response.status}`);
+  }
+}
+
 export async function listSectionFiles(sectionId: string): Promise<SectionFile[]> {
   const callable = httpsCallable<{ sectionId: string }, { files: SectionFile[] }>(
     functions,
@@ -32,4 +55,114 @@ export async function requestSectionFileDownload(
     { file: SectionFile; downloadUrl: string; expiresAt: string }
   >(functions, "requestSectionFileDownload");
   return (await callable({ sectionId, fileId })).data;
+}
+
+export async function uploadSectionFile(
+  sectionId: string,
+  file: File,
+  metadata: SectionFileMetadataInput,
+  onStage?: (stage: "uploading" | "verifying") => void,
+): Promise<string> {
+  const requestGrant = httpsCallable<
+    {
+      sectionId: string;
+      displayName: string;
+      originalFilename: string;
+      description: string | null;
+      contentType: string;
+      sizeBytes: number;
+    },
+    UploadGrant
+  >(functions, "requestSectionFileUpload");
+  const grant = (await requestGrant({
+    sectionId,
+    ...metadata,
+    originalFilename: file.name,
+    contentType: file.type,
+    sizeBytes: file.size,
+  })).data;
+  onStage?.("uploading");
+  await putFile(grant, file);
+  onStage?.("verifying");
+  const finalize = httpsCallable<{ sectionId: string; fileId: string }, { fileId: string }>(
+    functions,
+    "finalizeSectionFileUpload",
+  );
+  return (await finalize({ sectionId, fileId: grant.fileId })).data.fileId;
+}
+
+export async function updateSectionFileMetadata(
+  sectionId: string,
+  fileId: string,
+  metadata: SectionFileMetadataInput,
+): Promise<void> {
+  const callable = httpsCallable<
+    { sectionId: string; fileId: string } & SectionFileMetadataInput,
+    { fileId: string }
+  >(functions, "updateSectionFileMetadata");
+  await callable({ sectionId, fileId, ...metadata });
+}
+
+export async function replaceSectionFile(
+  sectionId: string,
+  fileId: string,
+  file: File,
+  onStage?: (stage: "uploading" | "verifying") => void,
+): Promise<void> {
+  const requestGrant = httpsCallable<
+    {
+      sectionId: string;
+      fileId: string;
+      originalFilename: string;
+      contentType: string;
+      sizeBytes: number;
+    },
+    UploadGrant & {
+      replacement: { originalFilename: string; contentType: string; sizeBytes: number };
+    }
+  >(functions, "requestSectionFileReplacement");
+  const grant = (await requestGrant({
+    sectionId,
+    fileId,
+    originalFilename: file.name,
+    contentType: file.type,
+    sizeBytes: file.size,
+  })).data;
+  try {
+    onStage?.("uploading");
+    await putFile(grant, file);
+    onStage?.("verifying");
+    const finalize = httpsCallable<
+      {
+        sectionId: string;
+        fileId: string;
+        originalFilename: string;
+        contentType: string;
+        sizeBytes: number;
+      },
+      { fileId: string }
+    >(functions, "finalizeSectionFileReplacement");
+    await finalize({
+      sectionId,
+      fileId,
+      originalFilename: file.name,
+      contentType: file.type,
+      sizeBytes: file.size,
+    });
+  } catch (error) {
+    const cancel = httpsCallable<{ sectionId: string; fileId: string }, { fileId: string }>(
+      functions,
+      "cancelSectionFileReplacement",
+    );
+    await cancel({ sectionId, fileId }).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function deleteSectionFile(sectionId: string, fileId: string): Promise<void> {
+  const callable = httpsCallable<{ sectionId: string; fileId: string }, { fileId: string }>(
+    functions,
+    "deleteSectionFile",
+  );
+  await callable({ sectionId, fileId });
 }


### PR DESCRIPTION
Closes #431

## What changed

- add a **Manage Files** action to the section administration hub for moderators and global administrators
- add file selection, client-side size/type guidance, member-facing display name and description fields
- show distinct uploading and backend-verification stages before reporting success
- list existing files with responsive, keyboard-accessible copy, edit, replace, and delete actions
- copy canonical application URLs rather than signed Storage URLs
- preserve the existing downloadable object until a replacement is uploaded and verified
- add an authorization-checked replacement rollback callable for interrupted upload/finalisation failures
- confirm deletion and explain its effect on previously emailed links
- document moderator file-management behaviour and update callable abuse/security contracts

## Impact

Section moderators can manage files only for their own sections, while enabled global administrators can manage any section. Permission decisions remain server-side. Replacement failures now roll back to a manageable state while retaining the previous member download, and deletion hides the file before object cleanup.

## Validation

- Frontend: 71 test files / 577 tests passed
- Frontend build passed
- Frontend lint passed
- Functions: 61 test files / 579 tests passed
- Functions coverage gate passed
- Functions build passed
- Functions lint passed
- `git diff --check` passed
