### PR TITLE
Implement GOV.UK Notify password reset (#410)

### DIFF
--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -1,6 +1,6 @@
 # Callable abuse protection
 
-Firebase callable functions use authentication and authorization as the first access boundary. Callables with material abuse, enumeration, external-API, or fan-out cost also consume a per-user fixed-window allowance through `functions/src/rateLimiter.ts`.
+Firebase callable functions normally use authentication and authorization as the first access boundary. Public account-recovery callables instead use a pseudonymous request key and a neutral response. Callables with material abuse, enumeration, external-API, or fan-out cost consume a fixed-window allowance through `functions/src/rateLimiter.ts`.
 
 `CALLABLE_RATE_LIMITS` is the canonical limit configuration. Call sites must reference a named policy; do not add inline limit or window values.
 
@@ -21,6 +21,7 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 
 | Callable | Limit | Window | Primary risk |
 |---|---:|---:|---|
+| `requestPasswordReset` | 5 | 1 hour | Account enumeration, Firebase Auth and GOV.UK Notify |
 | `grantAdmin` | 20 | 1 hour | Firebase Auth claim write |
 | `revokeAdmin` | 20 | 1 hour | Firebase Auth enumeration and claim write |
 | `listAdminUsers` | 30 | 5 minutes | Firebase Auth enumeration |
@@ -61,6 +62,7 @@ Risk levels are relative to other authenticated callables in this application. â
 
 | Callable | Abuse | Enumeration | External API | Cost / fan-out | Control |
 |---|---|---|---|---|---|
+| `requestPasswordReset` | High | High | Firebase Auth, GOV.UK Notify | Medium | Public; email/IP-derived pseudonymous key; neutral success response; 5/hour |
 | `grantAdmin` | High | Low | Firebase Auth | Medium | Admin + enabled; 20/hour |
 | `revokeAdmin` | High | Medium | Firebase Auth | Medium | Admin + enabled; 20/hour; last-admin guard |
 | `listAdminUsers` | Medium | High | Firebase Auth | Medium | Admin + enabled; 30/5 minutes |

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -40,11 +40,12 @@ Defined via `.env*` files and read from `import.meta.env`:
 | `SECTION_FILES_BUCKET` | env var | Private GCS bucket used by the section-file backend | required when section files are enabled |
 | `SECTION_FILE_MALWARE_SCAN_MODE` | env var | `REQUIRED`; emulator-only tests may use `MOCK_CLEAN` or `MOCK_INFECTED` when `FUNCTIONS_EMULATOR=true` | required when section files are enabled |
 | `SECTION_FILE_MALWARE_SCANNER_URL` | env var | HTTPS URL of the authenticated scale-to-zero Cloud Run scanner | required when scan mode is `REQUIRED` |
-| `APP_BASE_URL` | env var | Checkout success/cancel URLs and internal ops email links | yes for non-local |
+| `APP_BASE_URL` | env var | Public site origin used for checkout, internal ops, and Firebase Auth action links | yes for non-local |
 | `ENV_NAME` | env var | dev reset guardrail | required for reset tooling |
 | `PERMITTED_PROJECT_IDS` | env var | dev reset guardrail | required for reset tooling |
 | `GOV_NOTIFY_EMAIL_REPLY_TO_ID` | env var | Optional GOV.UK Notify reply-to selection | optional |
 | `GOV_NOTIFY_TEMPLATE_<TEMPLATE_NAME>` | env var | GOV.UK Notify template IDs for app-owned transactional email templates | required for each enabled app email template |
+| `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET` | env var | Notify template UUID for the site-managed password-reset email | required for password reset |
 | `PAYMENT_OPS_ALERT_EMAILS` | env var | Comma-separated internal recipient emails for payment reconciliation / dispute ops alerts (Stripe webhook path); unset disables sends | optional |
 | `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT` | env var | Notify template UUID for internal reconciliation-exception alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
 | `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT` | env var | Notify template UUID for internal dispute side-state alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
@@ -69,6 +70,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 - Keep environment docs and deployment settings aligned when adding new variables.
 - Configure GOV.UK Notify API keys and template IDs independently per Firebase environment.
 - Template env var names are derived from typed template names in `functions/src/mailer.ts`; for example, `paymentConfirmation` maps to `GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION`.
+- Site-managed password reset (#410): template key `passwordReset` maps to `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET`; `APP_BASE_URL` must be the canonical HTTPS site origin so emailed links return to `/auth/action`.
 - Ticket order lifecycle emails (issue #186): template keys `ticketOrderPaid`, `ticketOrderFailed`, `ticketOrderRefunded` — full placeholder spec and env var mapping in [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md).
 - Internal payment ops / finance alerts (reconciliation exceptions and dispute side-state): see [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md).
 - Membership approval / account access emails (#188): template keys `membershipActivated`, `membershipAccessRestricted` — see [govuk-notify-membership-templates.md](./govuk-notify-membership-templates.md).

--- a/docs/operations/govuk-notify-template-copy.md
+++ b/docs/operations/govuk-notify-template-copy.md
@@ -371,3 +371,31 @@ Review in Approve Users:
 ```
 
 **Placeholders used:** `firstName`, `lastName`, `email`, `serviceNumber`, `serviceBackgroundSummary`, `requestedMembershipStatus`, `approveUsersUrl`
+
+---
+
+## Account access
+
+### `passwordReset`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET`
+
+**Subject:** Reset your SODC password
+
+**Body:**
+
+```
+We received a request to reset the password for your SODC account.
+
+Use this secure link to choose a new password:
+
+((resetLink))
+
+If you did not request this, you can ignore this email. Your password will not change.
+
+For your security, do not forward this email or share the link.
+
+SODC
+```
+
+**Placeholders used:** `resetLink`

--- a/docs/operations/govuk-notify-template-registration.md
+++ b/docs/operations/govuk-notify-template-registration.md
@@ -40,10 +40,11 @@ Use this checklist when creating templates in Notify for **Dev**, **Beta**, and 
 | `bookingConfirmation` | `GOV_NOTIFY_TEMPLATE_BOOKING_CONFIRMATION` | | | | [ ] |
 | `bookingRevision` | `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION` | | | | [ ] |
 | `newUserPendingApprovalAlert` | `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT` | | | | [ ] |
+| `passwordReset` | `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET` | | | | [ ] |
 
 ## Suggested order
 
-1. Dev — all 13 templates, then E2E smoke tests  
+1. Dev — all 14 templates, then E2E smoke tests
 2. Beta — clone copy, new UUIDs, repeat smoke tests  
 3. Prod — final copy review, register UUIDs, enable sends  
 
@@ -53,7 +54,7 @@ Use this checklist when creating templates in Notify for **Dev**, **Beta**, and 
 |---------|----------------|
 | Notify API `template` error | Wrong UUID in `GOV_NOTIFY_TEMPLATE_*` for this environment |
 | Missing placeholder error | Dashboard placeholder name does not match code (see `govuk-notify-*.md`) |
-| No email sent | `GOV_NOTIFY_LIVE_API_KEY` missing, template ID env unset, or ops recipient list empty (`PAYMENT_OPS_ALERT_EMAILS`) |
+| No email sent | The key for the effective delivery mode is missing, the template ID env is unset, or the ops recipient list is empty (`PAYMENT_OPS_ALERT_EMAILS`) |
 | Duplicate emails | Expected on webhook retry only if delivery ledger failed; check `NotificationDelivery` |
 
 ## Related issues

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -1,6 +1,6 @@
 # Transactional email workflows
 
-App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts) and idempotent delivery via [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Firebase Auth still sends verification emails.
+App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts). Domain-event messages use the idempotent delivery ledger in [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Password reset uses a one-time Firebase action code delivered by Notify; email verification remains Firebase-managed until #411.
 
 Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. **Draft Notify subject/body copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration runbook:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md). Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
 
@@ -26,6 +26,14 @@ flowchart LR
   ledger -->|atomic claim| notify
   notify -->|awaited completion| ledger
 ```
+
+Password-reset messages deliberately do not use the recovery ledger: persisting or
+replaying an account action URL would extend exposure of its one-time credential.
+`requestPasswordReset` generates a fresh Firebase Admin link, rewrites it to the
+site-owned `/auth/action` route, sends it once through the configured Notify delivery
+mode, and always returns the same success response for existing and unknown accounts.
+The public callable is limited to five attempts per hour using a hash derived from the
+normalized email address and requester IP; logs do not contain either value or the link.
 
 ## Retry and stale-claim recovery
 

--- a/functions/email-templates/password-reset.md
+++ b/functions/email-templates/password-reset.md
@@ -1,0 +1,17 @@
+---
+templateKey: passwordReset
+subject: Reset your SODC password
+variables:
+  - resetLink
+---
+We received a request to reset the password for your SODC account.
+
+Use this secure link to choose a new password:
+
+((resetLink))
+
+If you did not request this, you can ignore this email. Your password will not change.
+
+For your security, do not forward this email or share the link.
+
+SODC

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -68,5 +68,10 @@
     "dev": "",
     "beta": "",
     "production": ""
+  },
+  "passwordReset": {
+    "dev": "199789e9-790f-43c9-ada8-103568a91c54",
+    "beta": "",
+    "production": ""
   }
 }

--- a/functions/src/__tests__/authEmailActions.test.ts
+++ b/functions/src/__tests__/authEmailActions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TransactionalMailer } from "../mailer";
+import {
+  applicationPasswordResetLink,
+  passwordResetRateLimitKey,
+  requestPasswordResetForEmail,
+  type AuthEmailTemplates,
+} from "../authEmailActions";
+
+function mailer(): TransactionalMailer<AuthEmailTemplates> {
+  return {
+    sendEmail: vi.fn(async () => ({
+      provider: "govuk_notify" as const,
+      deliveryMode: {
+        requestedMode: "LIVE" as const,
+        siteMode: "LIVE" as const,
+        effectiveMode: "LIVE" as const,
+      },
+    })),
+  };
+}
+
+describe("auth email actions", () => {
+  it("rewrites Firebase's generated reset link to the application handler", () => {
+    const result = applicationPasswordResetLink(
+      "https://example.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=secret-code&apiKey=public-key&continueUrl=https%3A%2F%2Fevil.example&lang=en",
+      "https://members.example.org",
+    );
+
+    expect(result).toBe(
+      "https://members.example.org/auth/action?mode=resetPassword&oobCode=secret-code&lang=en",
+    );
+    expect(result).not.toContain("continueUrl");
+    expect(result).not.toContain("apiKey");
+  });
+
+  it("rejects an unexpected generated action mode", () => {
+    expect(() =>
+      applicationPasswordResetLink(
+        "https://example.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=secret-code",
+        "https://members.example.org",
+      ),
+    ).toThrow("invalid password-reset action link");
+  });
+
+  it("uses a pseudonymous combined email and IP rate-limit key", () => {
+    const key = passwordResetRateLimitKey("member@example.org", "203.0.113.1");
+    expect(key).toMatch(/^password-reset:[a-f0-9]{64}$/);
+    expect(key).not.toContain("member@example.org");
+    expect(key).not.toContain("203.0.113.1");
+    expect(key).not.toBe(
+      passwordResetRateLimitKey("member@example.org", "203.0.113.2"),
+    );
+  });
+
+  it("generates a Firebase action and sends an ephemeral Notify link", async () => {
+    const sendMailer = mailer();
+    const generatePasswordResetLink = vi.fn(async () =>
+      "https://example.firebaseapp.com/__/auth/action?mode=resetPassword&oobCode=secret-code"
+    );
+
+    await requestPasswordResetForEmail("member@example.org", {
+      generatePasswordResetLink,
+      mailer: sendMailer,
+    });
+
+    expect(generatePasswordResetLink).toHaveBeenCalledWith(
+      "member@example.org",
+      expect.objectContaining({ handleCodeInApp: false }),
+    );
+    expect(sendMailer.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateName: "passwordReset",
+        to: "member@example.org",
+        personalisation: {
+          resetLink:
+            "http://localhost:5173/auth/action?mode=resetPassword&oobCode=secret-code",
+        },
+        requestedDeliveryMode: "LIVE",
+      }),
+    );
+    const request = vi.mocked(sendMailer.sendEmail).mock.calls[0][0];
+    expect(request.reference).toMatch(/^PASSWORD_RESET:[0-9a-f-]{36}$/);
+  });
+});

--- a/functions/src/__tests__/emailTemplateDocsContracts.test.ts
+++ b/functions/src/__tests__/emailTemplateDocsContracts.test.ts
@@ -5,6 +5,7 @@ import { EMAIL_TEMPLATE_MANIFEST } from "../generatedEmailTemplateManifest";
 
 const repoRoot = path.resolve(process.cwd(), "..");
 const DOCS_PATH = "docs/operations/govuk-notify-template-copy.md";
+const REGISTRY_PATH = "functions/email-templates/template-registry.json";
 
 function readRepoFile(relativePath: string): string {
   return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
@@ -22,6 +23,7 @@ function readRepoFile(relativePath: string): string {
  */
 describe("GOV Notify template docs parity (#378)", () => {
   const docs = readRepoFile(DOCS_PATH);
+  const registry = JSON.parse(readRepoFile(REGISTRY_PATH)) as Record<string, unknown>;
   const manifestKeys = Object.keys(EMAIL_TEMPLATE_MANIFEST);
   const documentedKeys = [...docs.matchAll(/^### `([a-zA-Z0-9]+)`/gm)].map((match) => match[1]);
 
@@ -33,6 +35,13 @@ describe("GOV Notify template docs parity (#378)", () => {
   for (const key of manifestKeys) {
     it(`documents ${key} (present in functions/email-templates/) in ${DOCS_PATH}`, () => {
       expect(documentedKeys, `${key} exists in functions/email-templates/ but has no "### \`${key}\`" heading in ${DOCS_PATH}`).toContain(key);
+    });
+
+    it(`registers ${key} in ${REGISTRY_PATH}`, () => {
+      expect(
+        registry,
+        `${key} exists in the generated manifest but has no registry entry`,
+      ).toHaveProperty(key);
     });
   }
 

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -109,6 +109,19 @@ describe("function entry guard contracts", () => {
     expect(guardedSources).not.toContain("requireAuth(request);");
   });
 
+  it("keeps password reset public, neutral, and rate limited", () => {
+    const authEmailActions = readSource("authEmailActions.ts");
+    assertOnCallGuard(
+      authEmailActions,
+      "requestPasswordReset",
+      "enforceRateLimit(\"requestPasswordReset\"",
+      700,
+    );
+    expect(authEmailActions).not.toContain("requireAuth(request);");
+    expect(authEmailActions).toContain("return neutralResponse();");
+    expect(authEmailActions).not.toContain("logger.warn(email");
+  });
+
   it("applies centralized rate limits to the high-risk callables named in #344 and #369", () => {
     const admin = readSource("admin.ts");
     for (const fn of ["grantAdmin", "revokeAdmin", "listAdminUsers"]) {

--- a/functions/src/authEmailActions.ts
+++ b/functions/src/authEmailActions.ts
@@ -1,0 +1,133 @@
+import * as admin from "firebase-admin";
+import * as logger from "firebase-functions/logger";
+import { onCall } from "firebase-functions/v2/https";
+import { createHash, randomUUID } from "node:crypto";
+import { FUNCTIONS_REGION } from "./constants";
+import { validateEmail } from "./helpers";
+import {
+  createConfiguredGovNotifyMailer,
+  govNotifySecrets,
+  type TransactionalMailer,
+} from "./mailer";
+import { enforceRateLimit } from "./rateLimiter";
+
+export const AUTH_EMAIL_TEMPLATE_KEYS = ["passwordReset"] as const;
+
+export type AuthEmailTemplates = {
+  passwordReset: {
+    resetLink: string;
+  };
+};
+
+export interface PasswordResetDependencies {
+  generatePasswordResetLink(
+    email: string,
+    settings: admin.auth.ActionCodeSettings,
+  ): Promise<string>;
+  mailer: TransactionalMailer<AuthEmailTemplates>;
+}
+
+const APP_BASE_URL = (() => {
+  const value = process.env.APP_BASE_URL || "http://localhost:5173";
+  try {
+    const parsed = new URL(value);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new Error("unsupported protocol");
+    }
+    return parsed.toString().replace(/\/$/, "");
+  } catch {
+    throw new Error(`APP_BASE_URL is not a valid HTTP(S) URL: "${value}"`);
+  }
+})();
+
+function createAuthEmailMailer(): TransactionalMailer<AuthEmailTemplates> {
+  return createConfiguredGovNotifyMailer<AuthEmailTemplates>([...AUTH_EMAIL_TEMPLATE_KEYS]);
+}
+
+function neutralResponse(): { success: true } {
+  return { success: true };
+}
+
+export function passwordResetRateLimitKey(email: string, ipAddress: string): string {
+  return `password-reset:${createHash("sha256")
+    .update(`${email}\n${ipAddress}`)
+    .digest("hex")}`;
+}
+
+/**
+ * Firebase Admin returns a Firebase-hosted handler URL. The one-time code is
+ * portable to the documented custom-handler route, so expose only the
+ * parameters the application needs and keep onward navigation server-owned.
+ */
+export function applicationPasswordResetLink(firebaseLink: string, appBaseUrl: string): string {
+  const generated = new URL(firebaseLink);
+  const mode = generated.searchParams.get("mode");
+  const oobCode = generated.searchParams.get("oobCode");
+  if (mode !== "resetPassword" || !oobCode) {
+    throw new Error("Firebase generated an invalid password-reset action link");
+  }
+
+  const target = new URL("/auth/action", `${appBaseUrl.replace(/\/$/, "")}/`);
+  target.searchParams.set("mode", "resetPassword");
+  target.searchParams.set("oobCode", oobCode);
+  const lang = generated.searchParams.get("lang");
+  if (lang) {
+    target.searchParams.set("lang", lang);
+  }
+  return target.toString();
+}
+
+export async function requestPasswordResetForEmail(
+  email: string,
+  dependencies: PasswordResetDependencies,
+): Promise<void> {
+  const firebaseLink = await dependencies.generatePasswordResetLink(email, {
+    url: `${APP_BASE_URL}/account`,
+    handleCodeInApp: false,
+  });
+  const resetLink = applicationPasswordResetLink(firebaseLink, APP_BASE_URL);
+
+  await dependencies.mailer.sendEmail({
+    templateName: "passwordReset",
+    to: email,
+    personalisation: { resetLink },
+    reference: `PASSWORD_RESET:${randomUUID()}`,
+    requestedDeliveryMode: "LIVE",
+  });
+}
+
+/**
+ * Public and deliberately enumeration-safe. Valid email addresses receive the
+ * same response whether the account exists, uses another provider, or delivery
+ * fails. Operational failures are logged without the address or action link.
+ */
+export const requestPasswordReset = onCall(
+  { region: FUNCTIONS_REGION, secrets: [...govNotifySecrets] },
+  async (request): Promise<{ success: true }> => {
+    const email = validateEmail(
+      typeof request.data?.email === "string" ? request.data.email : "",
+    );
+    const rateLimitKey = passwordResetRateLimitKey(
+      email,
+      request.rawRequest.ip || "unknown",
+    );
+    await enforceRateLimit("requestPasswordReset", rateLimitKey);
+
+    try {
+      await requestPasswordResetForEmail(email, {
+        generatePasswordResetLink: (address, settings) =>
+          admin.auth().generatePasswordResetLink(address, settings),
+        mailer: createAuthEmailMailer(),
+      });
+    } catch (error: unknown) {
+      logger.warn("password-reset request could not be delivered", {
+        errorCode:
+          typeof error === "object" && error && "code" in error
+            ? String(error.code)
+            : "unknown",
+      });
+    }
+
+    return neutralResponse();
+  },
+);

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -122,6 +122,13 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     ],
     body: "A new member has completed their profile and is awaiting approval.\n\nName: ((firstName)) ((lastName))\nEmail: ((email))\nService number: ((serviceNumber))\nService background: ((serviceBackgroundSummary))\nRequested status: ((requestedMembershipStatus))\n\nReview in Approve Users:\n((approveUsersUrl))",
   },
+  passwordReset: {
+    subject: "Reset your SODC password",
+    variables: [
+    "resetLink"
+    ],
+    body: "We received a request to reset the password for your SODC account.\n\nUse this secure link to choose a new password:\n\n((resetLink))\n\nIf you did not request this, you can ignore this email. Your password will not change.\n\nFor your security, do not forward this email or share the link.\n\nSODC",
+  },
   paymentDisputeOpsAlert: {
     subject: "[SODC OPS] Payment dispute — ((orderId))",
     variables: [

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -18,6 +18,7 @@ export * from "./notificationRecovery";
 export * from "./sectionFiles";
 export * from "./sectionFileReconciliation";
 export * from "./govNotifyDeliveryAdmin";
+export * from "./authEmailActions";
 
 // Initialize Firebase Admin
 if (!admin.apps.length) {

--- a/functions/src/rateLimiter.ts
+++ b/functions/src/rateLimiter.ts
@@ -51,6 +51,7 @@ export const CALLABLE_RATE_LIMITS = {
   finalizeSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
   cancelSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
   deleteSectionFile: { limit: 30, windowMs: HOUR_MS },
+  requestPasswordReset: { limit: 5, windowMs: HOUR_MS },
 } as const satisfies Record<string, RateLimitPolicy>;
 
 export type RateLimitedCallableName = keyof typeof CALLABLE_RATE_LIMITS;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ const RegisterPage = lazy(() => import("./features/auth/components/RegisterPage"
 const OnboardingShell = lazy(() => import("./features/auth/components/OnboardingShell"));
 const UnsubscribeConfirmedPage = lazy(() => import("./features/account/components/UnsubscribeConfirmedPage"));
 const SectionFileDownloadPage = lazy(() => import("./features/sections/components/SectionFileDownloadPage"));
+const PasswordResetRequestPage = lazy(() => import("./features/auth/components/PasswordResetRequestPage"));
+const AuthActionPage = lazy(() => import("./features/auth/components/AuthActionPage"));
 
 // Loading fallback component
 const LoadingFallback = () => (
@@ -103,6 +105,7 @@ function AppContent() {
   const { isEnabled, isEnabledClaimResolved } = useEnabledClaim(user);
   const checkoutReturn = isCheckoutReturnSearch(location.search);
   const authReturnTo = safeReturnTo(location.search);
+  const isPublicAuthAction = location.pathname === ROUTES.AUTH_ACTION;
   const isAdmin = useAdminClaim(user);
   const { userData, loading: userDataLoading, refetch } = useUserData(user, isEnabled);
   const {
@@ -178,7 +181,7 @@ function AppContent() {
     );
   }
 
-  if (emailNotVerified) {
+  if (emailNotVerified && !isPublicAuthAction) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -226,7 +229,7 @@ function AppContent() {
     );
   }
 
-  if (user && !isEnabledClaimResolved) {
+  if (user && !isEnabledClaimResolved && !isPublicAuthAction) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -237,7 +240,12 @@ function AppContent() {
     );
   }
 
-  if (user && needsProfileCompletion && location.pathname !== ROUTES.PROFILE_COMPLETION) {
+  if (
+    user &&
+    needsProfileCompletion &&
+    location.pathname !== ROUTES.PROFILE_COMPLETION &&
+    !isPublicAuthAction
+  ) {
     return (
       <Box sx={{ minHeight: "100vh", width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
         {header}
@@ -246,7 +254,7 @@ function AppContent() {
     );
   }
 
-  if (user && !isEnabled && !needsProfileCompletion) {
+  if (user && !isEnabled && !needsProfileCompletion && !isPublicAuthAction) {
     const inactiveUserData =
       userData ||
       (membershipStatusForUnenabled
@@ -461,6 +469,26 @@ function AppContent() {
                       ) : (
                         <Navigate to={ROUTES.ACCOUNT} replace />
                       )}
+                    </Box>
+                  }
+                />
+                <Route
+                  path={ROUTES.PASSWORD_RESET_REQUEST}
+                  element={
+                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                      <Suspense fallback={<LoadingFallback />}>
+                        <PasswordResetRequestPage />
+                      </Suspense>
+                    </Box>
+                  }
+                />
+                <Route
+                  path={ROUTES.AUTH_ACTION}
+                  element={
+                    <Box sx={{ maxWidth: { sm: "600px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+                      <Suspense fallback={<LoadingFallback />}>
+                        <AuthActionPage />
+                      </Suspense>
                     </Box>
                   }
                 />

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -164,6 +164,14 @@ vi.mock("../features/auth/components/RegisterPage", () => ({
   default: () => <h1>Register Page</h1>,
 }));
 
+vi.mock("../features/auth/components/PasswordResetRequestPage", () => ({
+  default: () => <h1>Password Reset Request Page</h1>,
+}));
+
+vi.mock("../features/auth/components/AuthActionPage", () => ({
+  default: () => <h1>Authentication Action Page</h1>,
+}));
+
 vi.mock("../features/auth/components/OnboardingShell", () => ({
   default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -338,6 +346,31 @@ describe("App routing", () => {
 
     expect(await screen.findByRole("heading", { name: "Account Page" })).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.ACCOUNT);
+  });
+
+  it("renders password reset request from a public deep link", async () => {
+    renderApp([ROUTES.PASSWORD_RESET_REQUEST]);
+
+    expect(
+      await screen.findByRole("heading", { name: "Password Reset Request Page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      ROUTES.PASSWORD_RESET_REQUEST,
+    );
+  });
+
+  it("keeps the public auth action reachable for an unverified user", async () => {
+    currentUser = createMockUser({ emailVerified: false });
+    enabledClaim = false;
+
+    renderApp([`${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=code`]);
+
+    expect(
+      await screen.findByRole("heading", { name: "Authentication Action Page" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(
+      `${ROUTES.AUTH_ACTION}?mode=resetPassword&oobCode=code`,
+    );
   });
 
   it("renders welcome dashboard for enabled users at home", async () => {

--- a/src/constants/__tests__/routes.test.ts
+++ b/src/constants/__tests__/routes.test.ts
@@ -12,6 +12,8 @@ describe('routes', () => {
     expect(ROUTES.APPROVE_USERS).toBe('/admin/users/approvals');
     expect(ROUTES.REGISTER).toBe('/register');
     expect(ROUTES.PROFILE_COMPLETION).toBe('/profile-completion');
+    expect(ROUTES.PASSWORD_RESET_REQUEST).toBe('/account/reset-password');
+    expect(ROUTES.AUTH_ACTION).toBe('/auth/action');
     expect(ROUTES.SECTION_FILE).toBe('/sections/:sectionId/files/:fileId');
   });
 
@@ -25,6 +27,8 @@ describe('routes', () => {
       ROUTES.APPROVE_USERS,
       ROUTES.REGISTER,
       ROUTES.PROFILE_COMPLETION,
+      ROUTES.PASSWORD_RESET_REQUEST,
+      ROUTES.AUTH_ACTION,
       ROUTES.SECTION_FILE,
     ];
     

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -24,6 +24,8 @@ export const ROUTES = {
   EMAIL_DELIVERY: "/admin/email-delivery",
   REGISTER: "/register",
   PROFILE_COMPLETION: "/profile-completion",
+  PASSWORD_RESET_REQUEST: "/account/reset-password",
+  AUTH_ACTION: "/auth/action",
   UNSUBSCRIBE_CONFIRMED: "/unsubscribe/confirmed",
 } as const;
 

--- a/src/features/auth/components/AuthActionPage.tsx
+++ b/src/features/auth/components/AuthActionPage.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState, type FormEvent } from "react";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Link,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import {
+  confirmPasswordReset,
+  verifyPasswordResetCode,
+} from "firebase/auth";
+import { auth } from "../../../config/firebase";
+import { ROUTES } from "../../../constants";
+import {
+  getRegistrationPasswordHelperText,
+  validateRegistrationPassword,
+} from "../utils/passwordValidation";
+
+type ActionState = "checking" | "ready" | "invalid" | "complete";
+
+function resetErrorMessage(error: unknown): string {
+  const code =
+    typeof error === "object" && error && "code" in error
+      ? String(error.code)
+      : "";
+  if (code.includes("expired-action-code")) {
+    return "This reset link has expired. Request a new one to continue.";
+  }
+  if (code.includes("invalid-action-code")) {
+    return "This reset link is invalid or has already been used. Request a new one to continue.";
+  }
+  if (code.includes("weak-password")) {
+    return getRegistrationPasswordHelperText();
+  }
+  return "The reset could not be completed. Please request a new link.";
+}
+
+export default function AuthActionPage() {
+  const [searchParams] = useSearchParams();
+  const mode = searchParams.get("mode");
+  const oobCode = searchParams.get("oobCode") ?? "";
+  const [state, setState] = useState<ActionState>("checking");
+  const [password, setPassword] = useState("");
+  const [confirmation, setConfirmation] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    if (mode !== "resetPassword" || !oobCode) {
+      setState("invalid");
+      setError("This email action link is invalid.");
+      return () => {
+        active = false;
+      };
+    }
+
+    verifyPasswordResetCode(auth, oobCode)
+      .then(() => {
+        if (active) {
+          setState("ready");
+        }
+      })
+      .catch((verificationError: unknown) => {
+        if (active) {
+          setError(resetErrorMessage(verificationError));
+          setState("invalid");
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [mode, oobCode]);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    const validation = validateRegistrationPassword(password);
+    if (!validation.isValid) {
+      setError(validation.error ?? "Choose a stronger password.");
+      return;
+    }
+    if (password !== confirmation) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await confirmPasswordReset(auth, oobCode, password);
+      setPassword("");
+      setConfirmation("");
+      setState("complete");
+    } catch (completionError: unknown) {
+      setError(resetErrorMessage(completionError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: "640px", mx: "auto", width: "100%" }}>
+      <Stack spacing={2}>
+        <Typography variant="h5" sx={{ color: "primary.light" }}>
+          Reset your password
+        </Typography>
+
+        {state === "checking" ? (
+          <Stack direction="row" spacing={2} alignItems="center">
+            <CircularProgress size={24} />
+            <Typography>Checking your reset link…</Typography>
+          </Stack>
+        ) : null}
+
+        {error ? <Alert severity="error">{error}</Alert> : null}
+
+        {state === "ready" ? (
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={2}>
+              <TextField
+                label="New password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="new-password"
+                helperText={getRegistrationPasswordHelperText()}
+                disabled={submitting}
+                required
+                fullWidth
+              />
+              <TextField
+                label="Confirm new password"
+                type="password"
+                value={confirmation}
+                onChange={(event) => setConfirmation(event.target.value)}
+                autoComplete="new-password"
+                disabled={submitting}
+                required
+                fullWidth
+              />
+              <Button type="submit" variant="contained" disabled={submitting}>
+                {submitting ? <CircularProgress size={24} /> : "Set new password"}
+              </Button>
+            </Stack>
+          </form>
+        ) : null}
+
+        {state === "invalid" ? (
+          <Button component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST} variant="contained">
+            Request a new link
+          </Button>
+        ) : null}
+
+        {state === "complete" ? (
+          <>
+            <Alert severity="success">Your password has been reset.</Alert>
+            <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
+              Sign in
+            </Button>
+          </>
+        ) : null}
+
+        {state !== "complete" ? (
+          <Link component={RouterLink} to={ROUTES.ACCOUNT}>
+            Back to sign in
+          </Link>
+        ) : null}
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -141,6 +141,9 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
             autoComplete="current-password"
             fullWidth
           />
+          <Link component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST}>
+            Forgot password?
+          </Link>
 
           <Button
             type="submit"

--- a/src/features/auth/components/PasswordResetRequestPage.tsx
+++ b/src/features/auth/components/PasswordResetRequestPage.tsx
@@ -1,0 +1,94 @@
+import { useState, type FormEvent } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Link,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { ROUTES } from "../../../constants";
+import { requestPasswordResetEmail } from "../../../shared/utils/firebaseFunctions";
+
+const NEUTRAL_CONFIRMATION =
+  "If an account exists for that address, we’ll send a password reset link.";
+
+export default function PasswordResetRequestPage() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    if (!email.trim() || submitting) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await requestPasswordResetEmail(email.trim());
+      setSent(true);
+    } catch (requestError: unknown) {
+      const code =
+        typeof requestError === "object" && requestError && "code" in requestError
+          ? String(requestError.code)
+          : "";
+      setError(
+        code.includes("resource-exhausted")
+          ? "Too many reset requests. Please wait before trying again."
+          : "We couldn’t request a reset link. Check your connection and try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: "640px", mx: "auto", width: "100%" }}>
+      <Stack spacing={2}>
+        <Typography variant="h5" sx={{ color: "primary.light" }}>
+          Reset your password
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Enter the email address used for your SODC account.
+        </Typography>
+
+        {sent ? <Alert severity="success">{NEUTRAL_CONFIRMATION}</Alert> : null}
+        {error ? <Alert severity="error">{error}</Alert> : null}
+
+        {!sent ? (
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={2}>
+              <TextField
+                label="Email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                required
+                fullWidth
+                disabled={submitting}
+              />
+              <Button
+                type="submit"
+                variant="contained"
+                disabled={submitting || !email.trim()}
+              >
+                {submitting ? <CircularProgress size={24} /> : "Send reset link"}
+              </Button>
+            </Stack>
+          </form>
+        ) : null}
+
+        <Link component={RouterLink} to={ROUTES.ACCOUNT}>
+          Back to sign in
+        </Link>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/features/auth/components/__tests__/AuthActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/AuthActionPage.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  confirmPasswordReset,
+  verifyPasswordResetCode,
+} from "firebase/auth";
+import AuthActionPage from "../AuthActionPage";
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("firebase/auth")>();
+  return {
+    ...original,
+    verifyPasswordResetCode: vi.fn(),
+    confirmPasswordReset: vi.fn(),
+  };
+});
+
+describe("AuthActionPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderAction(search: string) {
+    return render(
+      <MemoryRouter initialEntries={[`/auth/action${search}`]}>
+        <AuthActionPage />
+      </MemoryRouter>,
+    );
+  }
+
+  it("verifies the code and completes a password reset", async () => {
+    vi.mocked(verifyPasswordResetCode).mockResolvedValue("member@example.org");
+    vi.mocked(confirmPasswordReset).mockResolvedValue();
+    renderAction("?mode=resetPassword&oobCode=valid-code");
+
+    expect(await screen.findByLabelText(/New password/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText(/New password/), {
+      target: { value: "a-secure-password" },
+    });
+    fireEvent.change(screen.getByLabelText(/Confirm new password/), {
+      target: { value: "a-secure-password" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Set new password" }));
+
+    await waitFor(() =>
+      expect(confirmPasswordReset).toHaveBeenCalledWith(
+        expect.anything(),
+        "valid-code",
+        "a-secure-password",
+      )
+    );
+    expect(await screen.findByText("Your password has been reset.")).toBeInTheDocument();
+  });
+
+  it("rejects unsupported action modes without calling Firebase", async () => {
+    renderAction("?mode=recoverEmail&oobCode=some-code");
+
+    expect(await screen.findByText("This email action link is invalid.")).toBeInTheDocument();
+    expect(verifyPasswordResetCode).not.toHaveBeenCalled();
+    expect(screen.getByRole("link", { name: "Request a new link" })).toBeInTheDocument();
+  });
+
+  it("offers a new link when the code has expired", async () => {
+    vi.mocked(verifyPasswordResetCode).mockRejectedValue({
+      code: "auth/expired-action-code",
+    });
+    renderAction("?mode=resetPassword&oobCode=expired-code");
+
+    expect(
+      await screen.findByText("This reset link has expired. Request a new one to continue."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/auth/components/__tests__/PasswordResetRequestPage.test.tsx
+++ b/src/features/auth/components/__tests__/PasswordResetRequestPage.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PasswordResetRequestPage from "../PasswordResetRequestPage";
+import { requestPasswordResetEmail } from "../../../../shared/utils/firebaseFunctions";
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  requestPasswordResetEmail: vi.fn(),
+}));
+
+describe("PasswordResetRequestPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the neutral confirmation after requesting a reset", async () => {
+    vi.mocked(requestPasswordResetEmail).mockResolvedValue();
+    render(
+      <MemoryRouter>
+        <PasswordResetRequestPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Email/ }), {
+      target: { value: "Member@Example.org" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    await waitFor(() =>
+      expect(requestPasswordResetEmail).toHaveBeenCalledWith("Member@Example.org")
+    );
+    expect(
+      screen.getByText(
+        "If an account exists for that address, we’ll send a password reset link.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: /Email/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a safe rate-limit message", async () => {
+    vi.mocked(requestPasswordResetEmail).mockRejectedValue({
+      code: "functions/resource-exhausted",
+    });
+    render(
+      <MemoryRouter>
+        <PasswordResetRequestPage />
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Email/ }), {
+      target: { value: "member@example.org" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Send reset link" }));
+
+    expect(
+      await screen.findByText("Too many reset requests. Please wait before trying again."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/shared/utils/firebaseFunctions.ts
+++ b/src/shared/utils/firebaseFunctions.ts
@@ -8,3 +8,4 @@ export * from "./firebaseFunctions/bookingPayments";
 export * from "./firebaseFunctions/guestTickets";
 export * from "./firebaseFunctions/announcements";
 export * from "./firebaseFunctions/sectionFiles";
+export * from "./firebaseFunctions/authEmailActions";

--- a/src/shared/utils/firebaseFunctions/authEmailActions.ts
+++ b/src/shared/utils/firebaseFunctions/authEmailActions.ts
@@ -1,0 +1,10 @@
+import { httpsCallable } from "firebase/functions";
+import { functions } from "../../../config/firebase";
+
+export async function requestPasswordResetEmail(email: string): Promise<void> {
+  const callable = httpsCallable<{ email: string }, { success: true }>(
+    functions,
+    "requestPasswordReset",
+  );
+  await callable({ email });
+}


### PR DESCRIPTION
## Summary

- add a public, enumeration-safe password reset callable that sends through GOV.UK Notify
- handle Firebase password action codes on the SODC site
- add request and reset interfaces, routing, rate limiting, tests, and deployment documentation
- register the password-reset Notify template for the Dev template-sync dashboard

## Why

Issue #410 requires password reset to use the site-owned email and action flow instead of Firebase-generated email delivery. This is the first child of the account-access and migration workstream.

## User impact

Users can request a reset from the sign-in screen, receive a GOV.UK Notify email, and choose a new password without leaving the site. Unknown accounts receive the same response to prevent enumeration.

## Validation

- frontend lint and production build
- frontend coverage: 74 files, 592 tests
- Functions lint and build
- Functions coverage: 66 files, 635 tests
- template manifest generation and registry parity tests
- Dev deployment smoke test of `requestPasswordReset` and `getTemplateSyncStatus`