### PR TITLE
Implement GOV.UK Notify email verification (#411)

### DIFF
--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -22,6 +22,7 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 | Callable | Limit | Window | Primary risk |
 |---|---:|---:|---|
 | `requestPasswordReset` | 5 | 1 hour | Account enumeration, Firebase Auth and GOV.UK Notify |
+| `requestEmailVerification` | 5 | 1 hour | Firebase Auth and GOV.UK Notify resend abuse |
 | `grantAdmin` | 20 | 1 hour | Firebase Auth claim write |
 | `revokeAdmin` | 20 | 1 hour | Firebase Auth enumeration and claim write |
 | `listAdminUsers` | 30 | 5 minutes | Firebase Auth enumeration |
@@ -63,6 +64,7 @@ Risk levels are relative to other authenticated callables in this application. â
 | Callable | Abuse | Enumeration | External API | Cost / fan-out | Control |
 |---|---|---|---|---|---|
 | `requestPasswordReset` | High | High | Firebase Auth, GOV.UK Notify | Medium | Public; email/IP-derived pseudonymous key; neutral success response; 5/hour |
+| `requestEmailVerification` | High | None | Firebase Auth, GOV.UK Notify | Medium | Authenticated onboarding exception; recipient derived from Auth; 5/hour |
 | `grantAdmin` | High | Low | Firebase Auth | Medium | Admin + enabled; 20/hour |
 | `revokeAdmin` | High | Medium | Firebase Auth | Medium | Admin + enabled; 20/hour; last-admin guard |
 | `listAdminUsers` | Medium | High | Firebase Auth | Medium | Admin + enabled; 30/5 minutes |

--- a/docs/architecture/security-and-permissions.md
+++ b/docs/architecture/security-and-permissions.md
@@ -80,6 +80,8 @@ The only callable entry points intentionally using authentication without an ena
 
 - `updateDisplayName`, used while establishing the account profile.
 - `syncPendingUserClaims`, used to reconcile the pre-approval Auth/profile state.
+- `requestEmailVerification`, which derives the recipient from Firebase Auth and
+  sends no member data to the caller.
 
 These exceptions must not return member-directory data, announcement data, or other enabled-member content. Adding another authentication-only callable requires an explicit security review and a contract-test update.
 

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -46,6 +46,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 | `GOV_NOTIFY_EMAIL_REPLY_TO_ID` | env var | Optional GOV.UK Notify reply-to selection | optional |
 | `GOV_NOTIFY_TEMPLATE_<TEMPLATE_NAME>` | env var | GOV.UK Notify template IDs for app-owned transactional email templates | required for each enabled app email template |
 | `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET` | env var | Notify template UUID for the site-managed password-reset email | required for password reset |
+| `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION` | env var | Notify template UUID for the site-managed email-verification message | required for registration and verification resend |
 | `PAYMENT_OPS_ALERT_EMAILS` | env var | Comma-separated internal recipient emails for payment reconciliation / dispute ops alerts (Stripe webhook path); unset disables sends | optional |
 | `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT` | env var | Notify template UUID for internal reconciliation-exception alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
 | `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT` | env var | Notify template UUID for internal dispute side-state alerts | required when `PAYMENT_OPS_ALERT_EMAILS` is set |
@@ -71,6 +72,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 - Configure GOV.UK Notify API keys and template IDs independently per Firebase environment.
 - Template env var names are derived from typed template names in `functions/src/mailer.ts`; for example, `paymentConfirmation` maps to `GOV_NOTIFY_TEMPLATE_PAYMENT_CONFIRMATION`.
 - Site-managed password reset (#410): template key `passwordReset` maps to `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET`; `APP_BASE_URL` must be the canonical HTTPS site origin so emailed links return to `/auth/action`.
+- Site-managed verification (#411): template key `emailVerification` maps to `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION` and uses the same `/auth/action` route.
 - Ticket order lifecycle emails (issue #186): template keys `ticketOrderPaid`, `ticketOrderFailed`, `ticketOrderRefunded` — full placeholder spec and env var mapping in [govuk-notify-ticket-order-templates.md](./govuk-notify-ticket-order-templates.md).
 - Internal payment ops / finance alerts (reconciliation exceptions and dispute side-state): see [govuk-notify-payment-ops-internal-templates.md](./govuk-notify-payment-ops-internal-templates.md).
 - Membership approval / account access emails (#188): template keys `membershipActivated`, `membershipAccessRestricted` — see [govuk-notify-membership-templates.md](./govuk-notify-membership-templates.md).

--- a/docs/operations/govuk-notify-template-copy.md
+++ b/docs/operations/govuk-notify-template-copy.md
@@ -399,3 +399,29 @@ SODC
 ```
 
 **Placeholders used:** `resetLink`
+
+---
+
+### `emailVerification`
+
+**Env var:** `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION`
+
+**Subject:** Verify your SODC email address
+
+**Body:**
+
+```
+Welcome to SODC.
+
+Use this secure link to verify your email address:
+
+((verificationLink))
+
+If you did not create an SODC account, you can ignore this email.
+
+For your security, do not forward this email or share the link.
+
+SODC
+```
+
+**Placeholders used:** `verificationLink`

--- a/docs/operations/govuk-notify-template-registration.md
+++ b/docs/operations/govuk-notify-template-registration.md
@@ -41,10 +41,11 @@ Use this checklist when creating templates in Notify for **Dev**, **Beta**, and 
 | `bookingRevision` | `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION` | | | | [ ] |
 | `newUserPendingApprovalAlert` | `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT` | | | | [ ] |
 | `passwordReset` | `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET` | | | | [ ] |
+| `emailVerification` | `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION` | | | | [ ] |
 
 ## Suggested order
 
-1. Dev — all 14 templates, then E2E smoke tests
+1. Dev — all 15 templates, then E2E smoke tests
 2. Beta — clone copy, new UUIDs, repeat smoke tests  
 3. Prod — final copy review, register UUIDs, enable sends  
 

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -1,6 +1,6 @@
 # Transactional email workflows
 
-App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts). Domain-event messages use the idempotent delivery ledger in [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Password reset uses a one-time Firebase action code delivered by Notify; email verification remains Firebase-managed until #411.
+App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts). Domain-event messages use the idempotent delivery ledger in [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Password reset and email verification use one-time Firebase action codes delivered by Notify and completed on the site-owned `/auth/action` route.
 
 Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. **Draft Notify subject/body copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration runbook:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md). Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
 
@@ -34,6 +34,11 @@ site-owned `/auth/action` route, sends it once through the configured Notify del
 mode, and always returns the same success response for existing and unknown accounts.
 The public callable is limited to five attempts per hour using a hash derived from the
 normalized email address and requester IP; logs do not contain either value or the link.
+
+Email-verification messages follow the same no-ledger rule. The authenticated
+`requestEmailVerification` callable derives the recipient from the Firebase Auth
+record, works before email verification/account enablement, and is limited to five
+requests per user per hour. Registration and resend both use this backend path.
 
 ## Retry and stale-claim recovery
 

--- a/functions/email-templates/email-verification.md
+++ b/functions/email-templates/email-verification.md
@@ -1,0 +1,17 @@
+---
+templateKey: emailVerification
+subject: Verify your SODC email address
+variables:
+  - verificationLink
+---
+Welcome to SODC.
+
+Use this secure link to verify your email address:
+
+((verificationLink))
+
+If you did not create an SODC account, you can ignore this email.
+
+For your security, do not forward this email or share the link.
+
+SODC

--- a/functions/email-templates/template-registry.json
+++ b/functions/email-templates/template-registry.json
@@ -73,5 +73,10 @@
     "dev": "199789e9-790f-43c9-ada8-103568a91c54",
     "beta": "",
     "production": ""
+  },
+  "emailVerification": {
+    "dev": "f13f16aa-a0f8-4baa-a6d2-812be3f6baaf",
+    "beta": "",
+    "production": ""
   }
 }

--- a/functions/src/__tests__/authEmailActions.test.ts
+++ b/functions/src/__tests__/authEmailActions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { TransactionalMailer } from "../mailer";
 import {
+  applicationEmailVerificationLink,
   applicationPasswordResetLink,
   passwordResetRateLimitKey,
   requestPasswordResetForEmail,
+  requestEmailVerificationForUser,
   type AuthEmailTemplates,
 } from "../authEmailActions";
 
@@ -81,5 +83,43 @@ describe("auth email actions", () => {
     );
     const request = vi.mocked(sendMailer.sendEmail).mock.calls[0][0];
     expect(request.reference).toMatch(/^PASSWORD_RESET:[0-9a-f-]{36}$/);
+  });
+
+  it("generates and sends an application-owned email verification link", async () => {
+    const sendMailer = mailer();
+    const generateEmailVerificationLink = vi.fn(async () =>
+      "https://example.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=verify-code&apiKey=public"
+    );
+
+    await requestEmailVerificationForUser("member@example.org", {
+      generateEmailVerificationLink,
+      mailer: sendMailer,
+    });
+
+    expect(generateEmailVerificationLink).toHaveBeenCalledWith(
+      "member@example.org",
+      expect.objectContaining({ handleCodeInApp: false }),
+    );
+    expect(sendMailer.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateName: "emailVerification",
+        to: "member@example.org",
+        personalisation: {
+          verificationLink:
+            "http://localhost:5173/auth/action?mode=verifyEmail&oobCode=verify-code",
+        },
+      }),
+    );
+  });
+
+  it("rewrites only valid Firebase verification links", () => {
+    expect(
+      applicationEmailVerificationLink(
+        "https://example.firebaseapp.com/__/auth/action?mode=verifyEmail&oobCode=verify-code&continueUrl=https%3A%2F%2Fevil.example",
+        "https://members.example.org",
+      ),
+    ).toBe(
+      "https://members.example.org/auth/action?mode=verifyEmail&oobCode=verify-code",
+    );
   });
 });

--- a/functions/src/__tests__/functionEntryGuardContracts.test.ts
+++ b/functions/src/__tests__/functionEntryGuardContracts.test.ts
@@ -117,9 +117,29 @@ describe("function entry guard contracts", () => {
       "enforceRateLimit(\"requestPasswordReset\"",
       700,
     );
-    expect(authEmailActions).not.toContain("requireAuth(request);");
+    const passwordResetEntry = authEmailActions.slice(
+      authEmailActions.indexOf("export const requestPasswordReset"),
+      authEmailActions.indexOf("export const requestEmailVerification"),
+    );
+    expect(passwordResetEntry).not.toContain("requireAuth(request);");
     expect(authEmailActions).toContain("return neutralResponse();");
     expect(authEmailActions).not.toContain("logger.warn(email");
+  });
+
+  it("allows signed-in onboarding users to request rate-limited verification", () => {
+    const authEmailActions = readSource("authEmailActions.ts");
+    assertOnCallGuard(
+      authEmailActions,
+      "requestEmailVerification",
+      "requireAuth(request);",
+      900,
+    );
+    assertOnCallGuard(
+      authEmailActions,
+      "requestEmailVerification",
+      "enforceRateLimit(\"requestEmailVerification\"",
+      900,
+    );
   });
 
   it("applies centralized rate limits to the high-risk callables named in #344 and #369", () => {

--- a/functions/src/authEmailActions.ts
+++ b/functions/src/authEmailActions.ts
@@ -3,7 +3,7 @@ import * as logger from "firebase-functions/logger";
 import { onCall } from "firebase-functions/v2/https";
 import { createHash, randomUUID } from "node:crypto";
 import { FUNCTIONS_REGION } from "./constants";
-import { validateEmail } from "./helpers";
+import { requireAuth, validateEmail } from "./helpers";
 import {
   createConfiguredGovNotifyMailer,
   govNotifySecrets,
@@ -11,16 +11,27 @@ import {
 } from "./mailer";
 import { enforceRateLimit } from "./rateLimiter";
 
-export const AUTH_EMAIL_TEMPLATE_KEYS = ["passwordReset"] as const;
+export const AUTH_EMAIL_TEMPLATE_KEYS = ["passwordReset", "emailVerification"] as const;
 
 export type AuthEmailTemplates = {
   passwordReset: {
     resetLink: string;
   };
+  emailVerification: {
+    verificationLink: string;
+  };
 };
 
 export interface PasswordResetDependencies {
   generatePasswordResetLink(
+    email: string,
+    settings: admin.auth.ActionCodeSettings,
+  ): Promise<string>;
+  mailer: TransactionalMailer<AuthEmailTemplates>;
+}
+
+export interface EmailVerificationDependencies {
+  generateEmailVerificationLink(
     email: string,
     settings: admin.auth.ActionCodeSettings,
   ): Promise<string>;
@@ -77,6 +88,25 @@ export function applicationPasswordResetLink(firebaseLink: string, appBaseUrl: s
   return target.toString();
 }
 
+export function applicationEmailVerificationLink(
+  firebaseLink: string,
+  appBaseUrl: string,
+): string {
+  const generated = new URL(firebaseLink);
+  const mode = generated.searchParams.get("mode");
+  const oobCode = generated.searchParams.get("oobCode");
+  if (mode !== "verifyEmail" || !oobCode) {
+    throw new Error("Firebase generated an invalid email-verification action link");
+  }
+
+  const target = new URL("/auth/action", `${appBaseUrl.replace(/\/$/, "")}/`);
+  target.searchParams.set("mode", "verifyEmail");
+  target.searchParams.set("oobCode", oobCode);
+  const lang = generated.searchParams.get("lang");
+  if (lang) target.searchParams.set("lang", lang);
+  return target.toString();
+}
+
 export async function requestPasswordResetForEmail(
   email: string,
   dependencies: PasswordResetDependencies,
@@ -92,6 +122,25 @@ export async function requestPasswordResetForEmail(
     to: email,
     personalisation: { resetLink },
     reference: `PASSWORD_RESET:${randomUUID()}`,
+    requestedDeliveryMode: "LIVE",
+  });
+}
+
+export async function requestEmailVerificationForUser(
+  email: string,
+  dependencies: EmailVerificationDependencies,
+): Promise<void> {
+  const firebaseLink = await dependencies.generateEmailVerificationLink(email, {
+    url: `${APP_BASE_URL}/account`,
+    handleCodeInApp: false,
+  });
+  const verificationLink = applicationEmailVerificationLink(firebaseLink, APP_BASE_URL);
+
+  await dependencies.mailer.sendEmail({
+    templateName: "emailVerification",
+    to: email,
+    personalisation: { verificationLink },
+    reference: `EMAIL_VERIFICATION:${randomUUID()}`,
     requestedDeliveryMode: "LIVE",
   });
 }
@@ -128,6 +177,32 @@ export const requestPasswordReset = onCall(
       });
     }
 
+    return neutralResponse();
+  },
+);
+
+/**
+ * Available to signed-in onboarding users before email verification or account
+ * enablement. The recipient is always derived from Firebase Auth, never input.
+ */
+export const requestEmailVerification = onCall(
+  { region: FUNCTIONS_REGION, secrets: [...govNotifySecrets] },
+  async (request): Promise<{ success: true }> => {
+    requireAuth(request);
+    await enforceRateLimit("requestEmailVerification", request.auth!.uid);
+    const user = await admin.auth().getUser(request.auth!.uid);
+    if (!user.email) {
+      throw new Error("Authenticated user has no email address");
+    }
+    if (user.emailVerified) {
+      return neutralResponse();
+    }
+
+    await requestEmailVerificationForUser(user.email, {
+      generateEmailVerificationLink: (address, settings) =>
+        admin.auth().generateEmailVerificationLink(address, settings),
+      mailer: createAuthEmailMailer(),
+    });
     return neutralResponse();
   },
 );

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -49,6 +49,13 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     ],
     body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Updated booking (revision ((revisedRevisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nDifference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
   },
+  emailVerification: {
+    subject: "Verify your SODC email address",
+    variables: [
+    "verificationLink"
+    ],
+    body: "Welcome to SODC.\n\nUse this secure link to verify your email address:\n\n((verificationLink))\n\nIf you did not create an SODC account, you can ignore this email.\n\nFor your security, do not forward this email or share the link.\n\nSODC",
+  },
   guestTicketRequestApproved: {
     subject: "Guest ticket request approved — ((eventTitle))",
     variables: [

--- a/functions/src/rateLimiter.ts
+++ b/functions/src/rateLimiter.ts
@@ -52,6 +52,7 @@ export const CALLABLE_RATE_LIMITS = {
   cancelSectionFileReplacement: { limit: 30, windowMs: HOUR_MS },
   deleteSectionFile: { limit: 30, windowMs: HOUR_MS },
   requestPasswordReset: { limit: 5, windowMs: HOUR_MS },
+  requestEmailVerification: { limit: 5, windowMs: HOUR_MS },
 } as const satisfies Record<string, RateLimitPolicy>;
 
 export type RateLimitedCallableName = keyof typeof CALLABLE_RATE_LIMITS;

--- a/src/features/auth/components/AuthActionPage.tsx
+++ b/src/features/auth/components/AuthActionPage.tsx
@@ -11,7 +11,10 @@ import {
   Typography,
 } from "@mui/material";
 import {
+  applyActionCode,
+  checkActionCode,
   confirmPasswordReset,
+  reload,
   verifyPasswordResetCode,
 } from "firebase/auth";
 import { auth } from "../../../config/firebase";
@@ -40,6 +43,20 @@ function resetErrorMessage(error: unknown): string {
   return "The reset could not be completed. Please request a new link.";
 }
 
+function verificationErrorMessage(error: unknown): string {
+  const code =
+    typeof error === "object" && error && "code" in error
+      ? String(error.code)
+      : "";
+  if (code.includes("expired-action-code")) {
+    return "This verification link has expired. Sign in to request a new one.";
+  }
+  if (code.includes("invalid-action-code")) {
+    return "This verification link is invalid or has already been used.";
+  }
+  return "We couldn’t verify this email address. Sign in to request a new link.";
+}
+
 export default function AuthActionPage() {
   const [searchParams] = useSearchParams();
   const mode = searchParams.get("mode");
@@ -52,7 +69,7 @@ export default function AuthActionPage() {
 
   useEffect(() => {
     let active = true;
-    if (mode !== "resetPassword" || !oobCode) {
+    if (!["resetPassword", "verifyEmail"].includes(mode ?? "") || !oobCode) {
       setState("invalid");
       setError("This email action link is invalid.");
       return () => {
@@ -60,18 +77,32 @@ export default function AuthActionPage() {
       };
     }
 
-    verifyPasswordResetCode(auth, oobCode)
-      .then(() => {
-        if (active) {
-          setState("ready");
-        }
-      })
-      .catch((verificationError: unknown) => {
-        if (active) {
-          setError(resetErrorMessage(verificationError));
-          setState("invalid");
-        }
-      });
+    const completeAction = async () => {
+      if (mode === "resetPassword") {
+        await verifyPasswordResetCode(auth, oobCode);
+        if (active) setState("ready");
+        return;
+      }
+
+      await checkActionCode(auth, oobCode);
+      await applyActionCode(auth, oobCode);
+      if (auth.currentUser) {
+        await reload(auth.currentUser);
+        await auth.currentUser.getIdToken(true);
+      }
+      if (active) setState("complete");
+    };
+
+    void completeAction().catch((actionError: unknown) => {
+      if (active) {
+        setError(
+          mode === "verifyEmail"
+            ? verificationErrorMessage(actionError)
+            : resetErrorMessage(actionError),
+        );
+        setState("invalid");
+      }
+    });
 
     return () => {
       active = false;
@@ -108,7 +139,7 @@ export default function AuthActionPage() {
     <Box sx={{ maxWidth: "640px", mx: "auto", width: "100%" }}>
       <Stack spacing={2}>
         <Typography variant="h5" sx={{ color: "primary.light" }}>
-          Reset your password
+          {mode === "verifyEmail" ? "Verify your email" : "Reset your password"}
         </Typography>
 
         {state === "checking" ? (
@@ -120,7 +151,7 @@ export default function AuthActionPage() {
 
         {error ? <Alert severity="error">{error}</Alert> : null}
 
-        {state === "ready" ? (
+        {state === "ready" && mode === "resetPassword" ? (
           <form onSubmit={handleSubmit}>
             <Stack spacing={2}>
               <TextField
@@ -151,17 +182,27 @@ export default function AuthActionPage() {
           </form>
         ) : null}
 
-        {state === "invalid" ? (
+        {state === "invalid" && mode === "resetPassword" ? (
           <Button component={RouterLink} to={ROUTES.PASSWORD_RESET_REQUEST} variant="contained">
             Request a new link
           </Button>
         ) : null}
 
+        {state === "invalid" && mode === "verifyEmail" ? (
+          <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
+            Sign in to request a new link
+          </Button>
+        ) : null}
+
         {state === "complete" ? (
           <>
-            <Alert severity="success">Your password has been reset.</Alert>
+            <Alert severity="success">
+              {mode === "verifyEmail"
+                ? "Your email address has been verified."
+                : "Your password has been reset."}
+            </Alert>
             <Button component={RouterLink} to={ROUTES.ACCOUNT} variant="contained">
-              Sign in
+              {mode === "verifyEmail" && auth.currentUser ? "Continue" : "Sign in"}
             </Button>
           </>
         ) : null}

--- a/src/features/auth/components/EmailVerificationMessage.tsx
+++ b/src/features/auth/components/EmailVerificationMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import {
   Alert,
   Box,
@@ -7,7 +7,8 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import { sendEmailVerification, reload, type User } from "firebase/auth";
+import { reload, type User } from "firebase/auth";
+import { requestEmailVerification } from "../../../shared/utils/firebaseFunctions";
 
 interface EmailVerificationMessageProps {
   user: User;
@@ -27,11 +28,16 @@ export default function EmailVerificationMessage({
     setError(null);
     setSending(true);
     try {
-      await sendEmailVerification(user);
+      await requestEmailVerification();
       setSent(true);
-      setTimeout(() => setSent(false), 5000);
-    } catch (e: any) {
-      setError(e?.message || "Failed to resend verification email");
+      setTimeout(() => setSent(false), 60_000);
+    } catch (e: unknown) {
+      const code = typeof e === "object" && e && "code" in e ? String(e.code) : "";
+      setError(
+        code.includes("resource-exhausted")
+          ? "Too many verification emails requested. Please wait before trying again."
+          : "We couldn’t resend the verification email. Check your connection and try again.",
+      );
     } finally {
       setSending(false);
     }
@@ -52,33 +58,12 @@ export default function EmailVerificationMessage({
       } else {
         setError("Email not yet verified. Please check your inbox and click the verification link.");
       }
-    } catch (e: any) {
-      setError(e?.message || "Failed to check verification status");
+    } catch {
+      setError("We couldn’t check your verification status. Please try again.");
     } finally {
       setChecking(false);
     }
   };
-
-  useEffect(() => {
-    if (user?.emailVerified) {
-      return;
-    }
-
-    const interval = setInterval(async () => {
-      if (user && !user.emailVerified) {
-        try {
-          await reload(user);
-          if (user.emailVerified && onVerified) {
-            onVerified();
-          }
-        } catch {
-          // Silently fail auto-checks
-        }
-      }
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, [user, onVerified]);
 
   return (
     <Box sx={{ textAlign: "left" }}>
@@ -86,8 +71,8 @@ export default function EmailVerificationMessage({
         Verify your email
       </Typography>
       <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
-        We sent a link to <strong>{user.email}</strong>. Click the link in that email, then come
-        back here to continue.
+        We sent a link to <strong>{user.email}</strong>. Open it to verify your address
+        securely on this site.
       </Typography>
 
       <Alert severity="info" sx={{ mb: 2 }}>

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -8,9 +8,12 @@ import {
   Typography,
   Link,
 } from "@mui/material";
-import { createUserWithEmailAndPassword, sendEmailVerification } from "firebase/auth";
+import { createUserWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../../../config/firebase";
-import { syncPendingUserClaims } from "../../../shared/utils/firebaseFunctions";
+import {
+  requestEmailVerification,
+  syncPendingUserClaims,
+} from "../../../shared/utils/firebaseFunctions";
 import {
   getRegistrationPasswordHelperText,
   validateRegistrationPassword,
@@ -75,7 +78,7 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
       }
       await userCredential.user.getIdToken(true);
 
-      await sendEmailVerification(userCredential.user);
+      await requestEmailVerification();
 
       setSuccess(true);
       setPassword("");
@@ -92,6 +95,9 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
         errorMessage = "Invalid email address";
       } else if (e?.code === "auth/weak-password") {
         errorMessage = "Password is too weak";
+      } else if (String(e?.code ?? "").startsWith("functions/")) {
+        errorMessage =
+          "Your account was created, but we couldn’t send the verification email. Sign in to request another.";
       } else if (e?.message) {
         errorMessage = e.message;
       }

--- a/src/features/auth/components/__tests__/AuthActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/AuthActionPage.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  applyActionCode,
+  checkActionCode,
   confirmPasswordReset,
   verifyPasswordResetCode,
 } from "firebase/auth";
@@ -11,6 +13,8 @@ vi.mock("firebase/auth", async (importOriginal) => {
   const original = await importOriginal<typeof import("firebase/auth")>();
   return {
     ...original,
+    applyActionCode: vi.fn(),
+    checkActionCode: vi.fn(),
     verifyPasswordResetCode: vi.fn(),
     confirmPasswordReset: vi.fn(),
   };
@@ -58,7 +62,7 @@ describe("AuthActionPage", () => {
 
     expect(await screen.findByText("This email action link is invalid.")).toBeInTheDocument();
     expect(verifyPasswordResetCode).not.toHaveBeenCalled();
-    expect(screen.getByRole("link", { name: "Request a new link" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to sign in" })).toBeInTheDocument();
   });
 
   it("offers a new link when the code has expired", async () => {
@@ -70,5 +74,17 @@ describe("AuthActionPage", () => {
     expect(
       await screen.findByText("This reset link has expired. Request a new one to continue."),
     ).toBeInTheDocument();
+  });
+
+  it("checks and applies an email verification code", async () => {
+    vi.mocked(checkActionCode).mockResolvedValue({} as never);
+    vi.mocked(applyActionCode).mockResolvedValue();
+    renderAction("?mode=verifyEmail&oobCode=verification-code");
+
+    expect(
+      await screen.findByText("Your email address has been verified."),
+    ).toBeInTheDocument();
+    expect(checkActionCode).toHaveBeenCalledWith(expect.anything(), "verification-code");
+    expect(applyActionCode).toHaveBeenCalledWith(expect.anything(), "verification-code");
   });
 });

--- a/src/features/auth/components/__tests__/EmailVerificationMessage.test.tsx
+++ b/src/features/auth/components/__tests__/EmailVerificationMessage.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen, waitFor } from "../../../../test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
+import { requestEmailVerification } from "../../../../shared/utils/firebaseFunctions";
+import EmailVerificationMessage from "../EmailVerificationMessage";
+
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  requestEmailVerification: vi.fn(),
+}));
+
+describe("EmailVerificationMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests a backend-delivered verification email", async () => {
+    vi.mocked(requestEmailVerification).mockResolvedValue();
+    render(<EmailVerificationMessage user={createMockUser({ emailVerified: false })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend email" }));
+
+    await waitFor(() => expect(requestEmailVerification).toHaveBeenCalledOnce());
+    expect(screen.getByText("Verification email sent!")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resend email" })).toBeDisabled();
+  });
+
+  it("maps rate limiting to a safe message", async () => {
+    vi.mocked(requestEmailVerification).mockRejectedValue({
+      code: "functions/resource-exhausted",
+    });
+    render(<EmailVerificationMessage user={createMockUser({ emailVerified: false })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resend email" }));
+
+    expect(
+      await screen.findByText(
+        "Too many verification emails requested. Please wait before trying again.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/auth/components/__tests__/Register.test.tsx
+++ b/src/features/auth/components/__tests__/Register.test.tsx
@@ -6,11 +6,11 @@ import { REGISTRATION_MIN_PASSWORD_LENGTH } from "../../../../constants/auth";
 
 vi.mock("firebase/auth", () => ({
   createUserWithEmailAndPassword: vi.fn(),
-  sendEmailVerification: vi.fn(),
 }));
 
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   syncPendingUserClaims: vi.fn(),
+  requestEmailVerification: vi.fn(),
 }));
 
 async function fillForm(user: ReturnType<typeof userEvent.setup>, password: string) {

--- a/src/shared/utils/firebaseFunctions/authEmailActions.ts
+++ b/src/shared/utils/firebaseFunctions/authEmailActions.ts
@@ -8,3 +8,11 @@ export async function requestPasswordResetEmail(email: string): Promise<void> {
   );
   await callable({ email });
 }
+
+export async function requestEmailVerification(): Promise<void> {
+  const callable = httpsCallable<void, { success: true }>(
+    functions,
+    "requestEmailVerification",
+  );
+  await callable();
+}


### PR DESCRIPTION
## Summary

- send initial and replacement verification messages through an authenticated backend and GOV.UK Notify
- derive the recipient from Firebase Auth and allow the callable during pre-verification onboarding
- extend the shared `/auth/action` route to check and apply `verifyEmail` action codes
- refresh signed-in Auth state after completion and provide a safe signed-out continuation
- remove five-second polling and add resend cooldown/rate limiting
- add the Notify template, Dev UUID registry entry, deployment documentation, and tests

## Why

Issue #411 requires Firebase to remain the issuer and validator of verification codes while SODC owns message delivery and completion UX. The existing implementation used Firebase-hosted email delivery and continuous polling.

## User impact

New users receive a GOV.UK Notify verification email and complete verification on the SODC site. Resends are protected from accidental repetition and provider errors are mapped to safe messages.

## Security

- recipient comes from the authenticated Firebase user record
- verification links and action codes are not logged or persisted
- only `verifyEmail` and the existing `resetPassword` modes are accepted
- redirect destinations remain server-owned
- resend is limited to five requests per user per hour

## Validation

- frontend lint and production build
- frontend coverage: 74 files / 593 tests
- focused resend tests: 2 passed
- Functions lint and build
- Functions coverage: 66 files / 665 tests
- generated template manifest: 15 templates
- template registry/docs parity: 46 tests

Closes #411