### PR TITLE
Add legacy migration postflight reconciliation

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -515,6 +515,7 @@ mutation CreateMigratedUserProfileAndIdentity(
   $membershipStatus: MembershipStatus!
   $shareContactInfo: Boolean!
   $announcementOptOutAll: Boolean!
+  $legacyPasswordMigrated: Boolean
   $now: Timestamp!
 ) @auth(level: NO_ACCESS) @transaction {
   user_insert(
@@ -531,6 +532,7 @@ mutation CreateMigratedUserProfileAndIdentity(
       membershipStatus: $membershipStatus
       shareContactInfo: $shareContactInfo
       announcementOptOutAll: $announcementOptOutAll
+      legacyPasswordMigrated: $legacyPasswordMigrated
       profileReviewedAt: null
       createdBy: "legacy-migration"
       updatedBy: "legacy-migration"
@@ -615,7 +617,21 @@ query ListLegacyUserIdentitiesByBatch(
     sourceSystem
     legacyUserId
     oldUid
-    user { id }
+    user {
+      id
+      firstName
+      lastName
+      email
+      serviceNumber
+      mobileNumber
+      postNominals
+      rank
+      membershipStatus
+      shareContactInfo
+      announcementOptOutAll
+      legacyPasswordMigrated
+      profileReviewedAt
+    }
     migrationBatchId
     recordSchemaVersion
     sourceChecksum

--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -28,6 +28,7 @@ query GetCurrentUser @auth(expr: "auth.token.enabled == true") {
     rank
     shareContactInfo
     announcementOptOutAll
+    legacyPasswordMigrated
     profileReviewedAt
     createdAt
     updatedAt
@@ -53,6 +54,7 @@ query GetUserById($id: String!) @auth(expr: "auth.token.admin == true && auth.to
     rank
     shareContactInfo
     announcementOptOutAll
+    legacyPasswordMigrated
     profileReviewedAt
     createdAt
     updatedAt
@@ -80,6 +82,7 @@ query ListUsers @auth(expr: "auth.token.admin == true && auth.token.enabled == t
     rank
     shareContactInfo
     announcementOptOutAll
+    legacyPasswordMigrated
     profileReviewedAt
     createdAt
     updatedAt

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -160,6 +160,10 @@ type User @table {
   # precedence over per-section preferences and applies to future sections.
   # Transactional/account-security messages are not affected.
   announcementOptOutAll: Boolean! @default(value: false)
+  # Historical migration evidence. true means the legacy bcrypt credential was
+  # imported; false means the migration-created account required password reset.
+  # Null means the account was not created by the legacy migration.
+  legacyPasswordMigrated: Boolean
   # Advanced only when the member explicitly confirms their profile.
   profileReviewedAt: Timestamp
   stripeCustomerId: String

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/firebase-hosting-security-headers.md`: production CSP and browser hardening policy, HSTS ownership, and post-deploy verification.
 - `operations/section-file-storage.md`: private section-file bucket, lifecycle states, IAM, CORS, deployment order, and verification.
 - `operations/legacy-user-migration-schema.md`: approved legacy-user field mapping, secure Data Connect write boundary, staged profile completion, and deployment order.
+- `operations/legacy-user-import.md`: guarded dry-run/apply/resume workflow and PII-minimised postflight reconciliation.
 
 ## User Guides
 

--- a/docs/operations/legacy-user-import.md
+++ b/docs/operations/legacy-user-import.md
@@ -134,6 +134,8 @@ Review:
 - `sourceChecksum` against later runs and the approval artifact;
 - create/link/already-mapped counts;
 - password-reset and compatible-bcrypt counts;
+- the persisted `legacyPasswordMigrated` outcome for migration-created
+  profiles (`true` for an imported proven-compatible hash, otherwise `false`);
 - warning and quarantine reason counts.
 
 The output deliberately contains no names, email addresses, phone numbers, or
@@ -194,9 +196,10 @@ npm run legacy-user-import -- \
 ```
 
 The state file is mode `0600` and contains only the project/batch/input binding,
-legacy UUID, canonical UID, and completed stage names. Resume rejects any
-project, checksum, schema, batch, or canonical-UID mismatch. Do not edit the
-ledger manually.
+legacy UUID, canonical UID, completed stage names, and reason codes for records
+excluded by destination reconciliation. It contains no contact details or
+password hashes. Resume rejects any project, checksum, schema, batch, or
+canonical-UID mismatch. Do not edit the ledger manually.
 
 There is no transaction spanning Firebase Auth and Data Connect. A failure
 after Auth import leaves new accounts disabled. Profile writes complete before
@@ -243,6 +246,72 @@ npm run legacy-user-import -- \
 After completion, retain the encrypted source, preflight, approval, aggregate
 output, and protected ledger according to the agreed migration retention
 policy. Run the issue #425 postflight reconciliation before cutover.
+
+## 6. Postflight reconciliation
+
+Run postflight immediately after a completed apply and before migrated members
+can sign in or edit profiles. It decrypts the same source in memory, repeats the
+same remediation questions, and first requires the resulting effective
+checksum to match the protected importer ledger. Different answers fail closed
+before destination comparison.
+
+Deploy the updated Data Connect connector before running postflight; its
+server-only batch query exposes the fields needed for read-only comparison:
+
+```bash
+npx firebase deploy --only dataconnect --project sodc-web
+```
+
+Then run from `functions`, using the same `--bcrypt-proven` choice as apply:
+
+```bash
+npm run legacy-user-postflight -- \
+  --input /secure/path/legacy-users.jsonl.gpg \
+  --preflight /secure/path/legacy-user-preflight.json \
+  --state /secure/path/sodc-web-import-state.json \
+  --project sodc-web \
+  --confirm-project sodc-web \
+  --output /secure/path/sodc-web-postflight.json \
+  --interactive-remediation \
+  --bcrypt-proven
+```
+
+For production, use the production paths/project and add `--production`:
+
+```bash
+npm run legacy-user-postflight -- \
+  --input /secure/path/legacy-users.jsonl.gpg \
+  --preflight /secure/path/legacy-user-preflight.json \
+  --state /secure/path/production-import-state.json \
+  --project sodc-web-production \
+  --confirm-project sodc-web-production \
+  --output /secure/path/production-postflight.json \
+  --interactive-remediation \
+  --bcrypt-proven \
+  --production
+```
+
+The command compares each imported identity across the ledger, immutable
+legacy mapping, Data Connect, and Firebase Auth. Profiles created by the
+migration receive an exact field comparison. Pre-existing linked profiles are
+not overwritten by the importer, so postflight checks their identity and email
+rather than treating their existing profile fields as migrated values. Planned
+reconciliation exclusions must match the ledger and must have no mapping in
+the migration batch.
+
+Success prints `outcome: "match"` and exits zero. A mismatch exits non-zero and
+reports only aggregate reason counts plus deterministic correlation IDs. The
+retained report is written atomically with mode `0600` and contains no raw
+names, emails, mobiles, source rows, or password hashes.
+
+Firebase Auth does not expose imported password hashes. Postflight therefore
+compares the persisted `legacyPasswordMigrated` evidence with the approved
+plan, records compatible-bcrypt eligibility and completed importer stages, but
+sets `credentialHashesDirectlyVerifiable` to zero and states this limitation
+in the report. Credential sign-in compatibility remains the staging proof
+required before `--bcrypt-proven` is used. The marker is historical; use it
+with Firebase Auth `lastSignInTime` when assessing whether somebody has used
+the new site.
 
 ## Recovery rules
 

--- a/docs/operations/legacy-user-migration-schema.md
+++ b/docs/operations/legacy-user-migration-schema.md
@@ -22,7 +22,7 @@ Git, GitHub, chat, normal logs, and CI artifacts.
 | `membershipStatus` | `User.membershipStatus` | Direct mapping to the existing enum |
 | `isShared` | `User.shareContactInfo` | Direct mapping; controls server-side disclosure of email and mobile number |
 | `hasSubscriptions` | `User.announcementOptOutAll` | Invert: `announcementOptOutAll = !hasSubscriptions` |
-| `passwordHash` | Firebase Authentication only | Never passed to or stored in Data Connect |
+| `passwordHash` | Firebase Authentication plus `User.legacyPasswordMigrated` evidence | The hash is never stored in Data Connect. The nullable marker is true only when a migration-created Auth account received the proven-compatible legacy bcrypt hash; false means that account required password reset; null means the migration did not create that Auth account. |
 
 ## Migration write boundary
 
@@ -39,6 +39,13 @@ Neither operation accepts `passwordHash`. Both accept nullable `oldUid` as
 provenance only. The mapping records the source system, legacy UUID, old numeric
 UID, canonical user, batch UUID, record-schema version, source checksum, and
 import timestamp.
+
+`legacyPasswordMigrated` is historical migration evidence, not a live activity
+flag. For migration-created accounts it records whether the legacy credential
+was imported successfully. It remains unchanged after a password reset or
+sign-in. To determine whether a member has subsequently used the new site,
+combine this marker with Firebase Auth's `lastSignInTime`; do not treat the
+marker alone as proof of current inactivity.
 
 ## Staged profile completion
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "dev-reset": "npm run build && node lib/scripts/cli-dev-reset.js",
-    "legacy-user-import": "ts-node --project tsconfig.scripts.json scripts/legacy-user-import.ts"
+    "legacy-user-import": "ts-node --project tsconfig.scripts.json scripts/legacy-user-import.ts",
+    "legacy-user-postflight": "ts-node --project tsconfig.scripts.json scripts/legacy-user-postflight.ts"
   },
   "engines": {
     "node": "24"

--- a/functions/scripts/legacy-user-import.ts
+++ b/functions/scripts/legacy-user-import.ts
@@ -1,10 +1,6 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import readline from "node:readline";
-import readlinePromises from "node:readline/promises";
-import { spawn } from "node:child_process";
 import * as admin from "firebase-admin";
 import type { UserImportRecord, UserRecord } from "firebase-admin/auth";
 import {
@@ -15,7 +11,6 @@ import {
   MembershipStatus as DataConnectMembershipStatus,
 } from "@dataconnect/admin-generated";
 import {
-  LEGACY_PREFLIGHT_SCHEMA_VERSION,
   LEGACY_RECORD_SCHEMA_VERSION,
   LEGACY_SOURCE_SYSTEM,
   batchesOf,
@@ -25,18 +20,22 @@ import {
   type MigrationReason,
   type NormalizedLegacyUser,
   type PlannedMigrationRecord,
-  LegacyRecordError,
-  normalizeEmail,
-  normalizeMobileNumber,
-  parseLegacyRecord,
   reconcileLegacyRecord,
-  sha256Hex,
   validateJsonLines,
 } from "../src/legacyUserMigration";
+import {
+  decryptLegacyArtifact,
+  effectiveLegacySourceChecksum,
+  emailLessLegacyUserIds,
+  readLegacyPreflight,
+  remediateLegacyContacts,
+  type ContactRemediation,
+} from "../src/legacyUserMigrationArtifact";
 import {
   createMigrationLedger,
   hasMigrationStage,
   readMigrationLedger,
+  recordMigrationExclusion,
   recordMigrationStage,
   writeMigrationLedger,
   type MigrationLedger,
@@ -64,19 +63,6 @@ interface CliOptions {
   bcryptProven: boolean;
   interactiveRemediation: boolean;
   allowQuarantineCount?: number;
-}
-
-interface ContactRemediation {
-  line: number;
-  email?: string | null;
-  mobileNumber?: string | null;
-  membershipStatus?: "LOST";
-}
-
-interface Preflight {
-  schemaVersion: string;
-  recordSchemaVersion: string;
-  overall: { recordCount: number };
 }
 
 interface ProductionApproval {
@@ -240,244 +226,6 @@ function assertProjectAllowed(options: CliOptions): boolean {
   return isProduction;
 }
 
-function readPreflight(preflightPath: string): Preflight {
-  const parsed: unknown = JSON.parse(fs.readFileSync(preflightPath, "utf8"));
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("preflight must be a JSON object");
-  }
-  const preflight = parsed as Preflight;
-  if (preflight.schemaVersion !== LEGACY_PREFLIGHT_SCHEMA_VERSION) {
-    throw new Error("unsupported preflight schema version");
-  }
-  if (preflight.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION) {
-    throw new Error("unsupported legacy record schema version");
-  }
-  if (
-    !preflight.overall ||
-    !Number.isInteger(preflight.overall.recordCount) ||
-    preflight.overall.recordCount < 0
-  ) {
-    throw new Error("preflight record count is invalid");
-  }
-  return preflight;
-}
-
-async function decryptAndValidate(inputPath: string): Promise<{
-  artifactChecksum: string;
-  plaintextLines: string[];
-}> {
-  if (!fs.statSync(inputPath).isFile()) {
-    throw new Error("encrypted input is not a file");
-  }
-  // Let GPG use its configured pinentry program. The importer never receives
-  // the passphrase; it only reads the decrypted byte stream from stdout.
-  const child = spawn("gpg", ["--quiet", "--decrypt", inputPath], {
-    // stdin must remain attached for terminal-based pinentry. Decrypted
-    // plaintext is still isolated on stdout and never reaches the terminal.
-    stdio: ["inherit", "pipe", "pipe"],
-  });
-  const exit = new Promise<number>((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (code) => resolve(code ?? 1));
-  });
-  const digest = createHash("sha256");
-  child.stdout.on("data", (chunk: Buffer) => digest.update(chunk));
-  let stderrBytes = 0;
-  child.stderr.on("data", (chunk: Buffer) => {
-    stderrBytes += chunk.length;
-  });
-
-  const lines = readline.createInterface({
-    input: child.stdout,
-    crlfDelay: Infinity,
-  });
-  const plaintextLines: string[] = [];
-  for await (const line of lines) {
-    plaintextLines.push(line);
-  }
-  const exitCode = await exit;
-  if (exitCode !== 0) {
-    throw new Error(
-      `GPG decryption failed (exit ${exitCode}, ${stderrBytes} diagnostic bytes)`
-    );
-  }
-  return {
-    artifactChecksum: digest.digest("hex"),
-    plaintextLines,
-  };
-}
-
-function terminalSafe(value: unknown): string {
-  const text = typeof value === "string" ? value : String(value ?? "");
-  return Array.from(text, (character) => {
-    const codePoint = character.codePointAt(0) ?? 0;
-    return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159)
-      ? "?"
-      : character;
-  })
-    .join("")
-    .slice(0, 200);
-}
-
-function memberLabel(record: {
-  firstName: string | null;
-  lastName: string | null;
-  serviceNumber: string | null;
-}): string {
-  const name = `${terminalSafe(record.firstName)} ${terminalSafe(
-    record.lastName
-  )}`.trim();
-  const serviceNumber = terminalSafe(record.serviceNumber) || "not supplied";
-  return `${name || "Unnamed member"} (service number: ${serviceNumber})`;
-}
-
-function isEmailRemediationError(error: unknown): boolean {
-  return (
-    error instanceof LegacyRecordError &&
-    ["invalid-email", "placeholder-email", "missing-required-value"].includes(
-      error.reason
-    )
-  );
-}
-
-async function interactivelyRemediateContacts(
-  lines: readonly string[]
-): Promise<{
-  lines: string[];
-  remediations: ContactRemediation[];
-}> {
-  if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    throw new Error(
-      "--interactive-remediation requires an interactive local terminal"
-    );
-  }
-  console.error(
-    "Interactive remediation displays member PII locally. " +
-      "Do not record, capture, or share this terminal session."
-  );
-  const prompt = readlinePromises.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-  const remediatedLines: string[] = [];
-  const remediations: ContactRemediation[] = [];
-
-  try {
-    for (let index = 0; index < lines.length; index += 1) {
-      const line = lines[index];
-      if (!line.trim()) {
-        remediatedLines.push(line);
-        continue;
-      }
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        remediatedLines.push(line);
-        continue;
-      }
-      let record;
-      try {
-        record = parseLegacyRecord(parsed);
-      } catch {
-        remediatedLines.push(line);
-        continue;
-      }
-      const remediation: ContactRemediation = { line: index + 1 };
-      try {
-        normalizeEmail(record.email);
-      } catch (error) {
-        if (!isEmailRemediationError(error)) {
-          throw error;
-        }
-        console.error(
-          `\nInvalid email for ${memberLabel(record)}: ` +
-            `"${terminalSafe(record.email)}"`
-        );
-        while (true) {
-          const replacement = await prompt.question(
-            "Replacement email, LOST for an email-less lost member, " +
-              "or SKIP to quarantine: "
-          );
-          const action = replacement.trim().toUpperCase();
-          if (action === "SKIP") {
-            break;
-          }
-          if (action === "LOST") {
-            record.email = null;
-            record.membershipStatus = "LOST";
-            remediation.email = null;
-            remediation.membershipStatus = "LOST";
-            break;
-          }
-          try {
-            record.email = normalizeEmail(replacement);
-            remediation.email = record.email;
-            break;
-          } catch {
-            console.error("That is not a valid non-placeholder email address.");
-          }
-        }
-      }
-
-      try {
-        normalizeMobileNumber(record.mobileNumber);
-      } catch (error) {
-        if (
-          !(error instanceof LegacyRecordError) ||
-          error.reason !== "invalid-mobile-number"
-        ) {
-          throw error;
-        }
-        console.error(
-          `\nInvalid mobile for ${memberLabel(record)}: ` +
-            `"${terminalSafe(record.mobileNumber)}"`
-        );
-        while (true) {
-          const replacement = await prompt.question(
-            "Replacement mobile (press Enter to clear it): "
-          );
-          try {
-            record.mobileNumber = normalizeMobileNumber(replacement);
-            remediation.mobileNumber = record.mobileNumber;
-            break;
-          } catch {
-            console.error(
-              "That number cannot be normalized to E.164; retry or press Enter."
-            );
-          }
-        }
-      }
-
-      if (
-        remediation.email !== undefined ||
-        remediation.mobileNumber !== undefined
-      ) {
-        remediations.push(remediation);
-      }
-      remediatedLines.push(JSON.stringify(record));
-    }
-  } finally {
-    prompt.close();
-  }
-  return { lines: remediatedLines, remediations };
-}
-
-function effectiveSourceChecksum(
-  artifactChecksum: string,
-  remediations: readonly ContactRemediation[]
-): string {
-  if (remediations.length === 0) {
-    return artifactChecksum;
-  }
-  return sha256Hex(
-    JSON.stringify({
-      artifactChecksum,
-      remediations,
-    })
-  );
-}
-
 function addByEmail<T extends { email: string | null }>(
   map: Map<string, T[]>,
   value: T
@@ -568,10 +316,13 @@ function planRecords(
   sourceChecksum: string
 ): {
   plans: PlannedMigrationRecord[];
-  quarantined: MigrationReason[];
+  quarantined: Array<{ legacyUserId: string; reason: MigrationReason }>;
 } {
   const plans: PlannedMigrationRecord[] = [];
-  const quarantined: MigrationReason[] = [];
+  const quarantined: Array<{
+    legacyUserId: string;
+    reason: MigrationReason;
+  }> = [];
   for (const record of records) {
     const mapping = snapshot.mappingsByLegacyId.get(record.legacyUserId) ?? null;
     const identityUid = mapping?.userId ?? record.legacyUserId;
@@ -592,7 +343,10 @@ function planRecords(
       }
     );
     if (result.outcome === "quarantined") {
-      quarantined.push(result.reason);
+      quarantined.push({
+        legacyUserId: record.legacyUserId,
+        reason: result.reason,
+      });
     } else {
       plans.push(result.plan);
     }
@@ -833,6 +587,13 @@ async function writeProfiles(
             plan.record.membershipStatus as DataConnectMembershipStatus,
           shareContactInfo: plan.record.shareContactInfo,
           announcementOptOutAll: plan.record.announcementOptOutAll,
+          legacyPasswordMigrated: plan.createAuthUser
+            ? Boolean(
+                options.bcryptProven &&
+                  plan.record.email &&
+                  plan.record.passwordDisposition === "compatible-bcrypt"
+              )
+            : null,
         });
       } else {
         await linkLegacyIdentityToExistingUser(provenance);
@@ -884,26 +645,20 @@ async function reconcileAccess(
 async function main(): Promise<void> {
   const options = parseArguments(process.argv.slice(2));
   const isProduction = assertProjectAllowed(options);
-  const preflight = readPreflight(options.preflightPath);
+  const preflight = readLegacyPreflight(options.preflightPath);
   console.log("Decrypting and validating the canonical artifact in memory...");
-  const decrypted = await decryptAndValidate(options.inputPath);
+  const decrypted = await decryptLegacyArtifact(options.inputPath);
   const remediated = options.interactiveRemediation
-    ? await interactivelyRemediateContacts(decrypted.plaintextLines)
+    ? await remediateLegacyContacts(decrypted.plaintextLines)
     : { lines: decrypted.plaintextLines, remediations: [] };
-  const emailLessLegacyUserIds = new Set(
+  const allowedEmailLessLegacyUserIds = emailLessLegacyUserIds(
+    remediated.lines,
     remediated.remediations
-      .filter(({ email, membershipStatus }) =>
-        email === null && membershipStatus === "LOST"
-      )
-      .map(({ line }) => {
-        const parsed: unknown = JSON.parse(remediated.lines[line - 1]);
-        return parseLegacyRecord(parsed).legacyUserId;
-      })
   );
   const validation = validateJsonLines(remediated.lines, {
-    allowEmailLessLegacyUserIds: emailLessLegacyUserIds,
+    allowEmailLessLegacyUserIds: allowedEmailLessLegacyUserIds,
   });
-  const sourceChecksum = effectiveSourceChecksum(
+  const sourceChecksum = effectiveLegacySourceChecksum(
     decrypted.artifactChecksum,
     remediated.remediations
   );
@@ -927,7 +682,7 @@ async function main(): Promise<void> {
     sourceChecksum,
     planned.plans,
     inputReasons,
-    planned.quarantined,
+    planned.quarantined.map(({ reason }) => reason),
     remediated.remediations
   );
   const quarantineCount =
@@ -960,7 +715,31 @@ async function main(): Promise<void> {
   const ledger = options.resume
     ? readMigrationLedger(options.statePath, binding)
     : createMigrationLedger(binding);
-  if (!options.resume) {
+  if (options.resume) {
+    const plannedExclusions = new Map(
+      planned.quarantined.map(({ legacyUserId, reason }) => [
+        legacyUserId,
+        reason,
+      ])
+    );
+    const ledgerExclusions = Object.entries(ledger.excludedRecords);
+    if (
+      ledgerExclusions.length !== plannedExclusions.size ||
+      ledgerExclusions.some(
+        ([legacyUserId, { reason }]) =>
+          plannedExclusions.get(legacyUserId) !== reason
+      )
+    ) {
+      throw new Error("resume reconciliation exclusions do not match the ledger");
+    }
+  } else {
+    for (const exclusion of planned.quarantined) {
+      recordMigrationExclusion(
+        ledger,
+        exclusion.legacyUserId,
+        exclusion.reason
+      );
+    }
     writeMigrationLedger(options.statePath, ledger);
   }
 

--- a/functions/scripts/legacy-user-postflight.ts
+++ b/functions/scripts/legacy-user-postflight.ts
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import * as admin from "firebase-admin";
+import type { UserRecord } from "firebase-admin/auth";
+import { listLegacyUserIdentitiesByBatch } from "@dataconnect/admin-generated";
+import {
+  LEGACY_RECORD_SCHEMA_VERSION,
+  batchesOf,
+  validateJsonLines,
+} from "../src/legacyUserMigration";
+import {
+  decryptLegacyArtifact,
+  effectiveLegacySourceChecksum,
+  emailLessLegacyUserIds,
+  readLegacyPreflight,
+  remediateLegacyContacts,
+} from "../src/legacyUserMigrationArtifact";
+import {
+  readMigrationLedger,
+  type MigrationLedgerBinding,
+} from "../src/legacyUserMigrationLedger";
+import {
+  buildLegacyUserPostflightReport,
+  type PostflightIdentity,
+} from "../src/legacyUserPostflight";
+
+const MAX_MIGRATION_RECORDS = 10_000;
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+interface CliOptions {
+  inputPath: string;
+  preflightPath: string;
+  statePath: string;
+  projectId: string;
+  confirmProject: string;
+  outputPath?: string;
+  production: boolean;
+  bcryptProven: boolean;
+  interactiveRemediation: boolean;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  npm run legacy-user-postflight -- \\
+    --input ../secure/legacy-users.jsonl.gpg \\
+    --preflight ../secure/preflight.json \\
+    --state ../secure/import-ledger.json \\
+    --project sodc-web \\
+    --confirm-project sodc-web \\
+    --output ../secure/postflight.json \\
+    --interactive-remediation
+
+Use the same remediation answers and --bcrypt-proven choice as the import.
+Add --production when the selected .firebaserc project uses the prod alias.`);
+  process.exit(2);
+}
+
+function parseArguments(argv: string[]): CliOptions {
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueOptions = new Set([
+    "--input",
+    "--preflight",
+    "--state",
+    "--project",
+    "--confirm-project",
+    "--output",
+  ]);
+  const flagOptions = new Set([
+    "--production",
+    "--bcrypt-proven",
+    "--interactive-remediation",
+    "--help",
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (valueOptions.has(argument)) {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) usage();
+      values.set(argument, value);
+      index += 1;
+    } else if (flagOptions.has(argument)) {
+      flags.add(argument);
+    } else usage();
+  }
+  if (flags.has("--help")) usage();
+  const inputPath = values.get("--input");
+  const preflightPath = values.get("--preflight");
+  const statePath = values.get("--state");
+  const projectId = values.get("--project");
+  const confirmProject = values.get("--confirm-project");
+  if (!inputPath || !preflightPath || !statePath || !projectId) usage();
+  if (confirmProject !== projectId) {
+    throw new Error("--confirm-project must exactly match the target project");
+  }
+  return {
+    inputPath,
+    preflightPath,
+    statePath,
+    projectId,
+    confirmProject,
+    outputPath: values.get("--output"),
+    production: flags.has("--production"),
+    bcryptProven: flags.has("--bcrypt-proven"),
+    interactiveRemediation: flags.has("--interactive-remediation"),
+  };
+}
+
+function firebasercPath(): string {
+  const candidates = [
+    path.resolve(process.cwd(), ".firebaserc"),
+    path.resolve(process.cwd(), "../.firebaserc"),
+    path.resolve(__dirname, "../../.firebaserc"),
+  ];
+  const existing = candidates.find((candidate) => fs.existsSync(candidate));
+  if (!existing) throw new Error("could not find .firebaserc");
+  return existing;
+}
+
+function assertProjectAllowed(options: CliOptions): void {
+  const parsed = JSON.parse(fs.readFileSync(firebasercPath(), "utf8")) as {
+    projects?: Record<string, unknown>;
+  };
+  const entries = Object.entries(parsed.projects ?? {}).filter(
+    (entry): entry is [string, string] => typeof entry[1] === "string"
+  );
+  if (!entries.some(([, projectId]) => projectId === options.projectId)) {
+    throw new Error("target project is not declared in .firebaserc");
+  }
+  const isProduction = entries.some(
+    ([alias, projectId]) =>
+      alias.toLowerCase() === "prod" && projectId === options.projectId
+  );
+  if (options.production !== isProduction) {
+    throw new Error(
+      isProduction
+        ? "production target requires --production"
+        : "--production was supplied for a non-production target"
+    );
+  }
+}
+
+function readLedgerBinding(
+  statePath: string,
+  projectId: string,
+  sourceChecksum: string
+): MigrationLedgerBinding {
+  const parsed = JSON.parse(fs.readFileSync(statePath, "utf8")) as {
+    projectId?: unknown;
+    migrationBatchId?: unknown;
+    recordSchemaVersion?: unknown;
+    sourceChecksum?: unknown;
+  };
+  if (
+    parsed.projectId !== projectId ||
+    typeof parsed.migrationBatchId !== "string" ||
+    !UUID_PATTERN.test(parsed.migrationBatchId) ||
+    parsed.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION ||
+    parsed.sourceChecksum !== sourceChecksum ||
+    !SHA256_PATTERN.test(sourceChecksum)
+  ) {
+    throw new Error("import ledger is not bound to this effective migration plan");
+  }
+  return {
+    projectId,
+    migrationBatchId: parsed.migrationBatchId,
+    recordSchemaVersion: LEGACY_RECORD_SCHEMA_VERSION,
+    sourceChecksum,
+  };
+}
+
+async function snapshotAuthUsers(
+  canonicalUids: readonly string[]
+): Promise<Map<string, UserRecord>> {
+  const users = new Map<string, UserRecord>();
+  for (const batch of batchesOf(canonicalUids, 100)) {
+    const result = await admin.auth().getUsers(batch.map((uid) => ({ uid })));
+    for (const user of result.users) users.set(user.uid, user);
+  }
+  return users;
+}
+
+function writeReport(outputPath: string, report: unknown): void {
+  const directory = path.dirname(outputPath);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = `${outputPath}.tmp`;
+  fs.writeFileSync(temporaryPath, `${JSON.stringify(report, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.chmodSync(temporaryPath, 0o600);
+  fs.renameSync(temporaryPath, outputPath);
+  fs.chmodSync(outputPath, 0o600);
+}
+
+async function main(): Promise<void> {
+  const options = parseArguments(process.argv.slice(2));
+  assertProjectAllowed(options);
+  const preflight = readLegacyPreflight(options.preflightPath);
+  console.log("Decrypting and reconstructing the effective migration plan...");
+  const decrypted = await decryptLegacyArtifact(options.inputPath);
+  const remediated = options.interactiveRemediation
+    ? await remediateLegacyContacts(decrypted.plaintextLines)
+    : { lines: decrypted.plaintextLines, remediations: [] };
+  const validation = validateJsonLines(remediated.lines, {
+    allowEmailLessLegacyUserIds: emailLessLegacyUserIds(
+      remediated.lines,
+      remediated.remediations
+    ),
+  });
+  if (validation.recordCount !== preflight.overall.recordCount) {
+    throw new Error("decrypted record count does not match preflight");
+  }
+  const sourceChecksum = effectiveLegacySourceChecksum(
+    decrypted.artifactChecksum,
+    remediated.remediations
+  );
+  const binding = readLedgerBinding(
+    options.statePath,
+    options.projectId,
+    sourceChecksum
+  );
+  const ledger = readMigrationLedger(options.statePath, binding);
+
+  if (!admin.apps.length) admin.initializeApp({ projectId: options.projectId });
+  console.log("Taking read-only Auth and Data Connect postflight snapshots...");
+  const [identityResult, authUsers] = await Promise.all([
+    listLegacyUserIdentitiesByBatch({
+      migrationBatchId: binding.migrationBatchId,
+      limit: MAX_MIGRATION_RECORDS + 1,
+    }),
+    snapshotAuthUsers(
+      Object.values(ledger.records).map(({ canonicalUid }) => canonicalUid)
+    ),
+  ]);
+  const identities = identityResult.data.legacyUserIdentities;
+  if (identities.length > MAX_MIGRATION_RECORDS) {
+    throw new Error("postflight identity snapshot exceeds the safe CLI ceiling");
+  }
+  const report = buildLegacyUserPostflightReport({
+    projectId: options.projectId,
+    rawSourceRecords: validation.recordCount,
+    normalizedRecords: validation.records,
+    sourceQuarantined: new Set(
+      validation.quarantined.map(({ line }) => line)
+    ).size,
+    ledger,
+    identities: identities as PostflightIdentity[],
+    authUsers,
+    bcryptProven: options.bcryptProven,
+  });
+  console.log(JSON.stringify(report, null, 2));
+  if (options.outputPath) writeReport(options.outputPath, report);
+  if (report.outcome !== "match") process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(
+    `Legacy user postflight stopped: ${
+      error instanceof Error ? error.message : "unknown error"
+    }`
+  );
+  process.exitCode = 1;
+});

--- a/functions/src/__tests__/legacyMigrationSchemaContracts.test.ts
+++ b/functions/src/__tests__/legacyMigrationSchemaContracts.test.ts
@@ -24,6 +24,7 @@ describe("legacy migration Data Connect contracts", () => {
     expect(schema).toContain("mobileNumber: String");
     expect(schema).toContain("postNominals: String");
     expect(schema).toContain("announcementOptOutAll: Boolean! @default(value: false)");
+    expect(schema).toContain("legacyPasswordMigrated: Boolean");
     expect(schema).toContain("profileReviewedAt: Timestamp");
   });
 
@@ -50,6 +51,9 @@ describe("legacy migration Data Connect contracts", () => {
     expect(create).toContain("$oldUid: Int");
     expect(create).toContain("oldUid: $oldUid");
     expect(create).toContain("profileReviewedAt: null");
+    expect(create).toContain(
+      "legacyPasswordMigrated: $legacyPasswordMigrated"
+    );
     expect(create).not.toContain("passwordHash");
   });
 

--- a/functions/src/__tests__/legacyUserImportCliContracts.test.ts
+++ b/functions/src/__tests__/legacyUserImportCliContracts.test.ts
@@ -6,6 +6,11 @@ const cli = fs.readFileSync(
   path.resolve(process.cwd(), "scripts/legacy-user-import.ts"),
   "utf8"
 );
+const artifact = fs.readFileSync(
+  path.resolve(process.cwd(), "src/legacyUserMigrationArtifact.ts"),
+  "utf8"
+);
+const safetyCode = `${cli}\n${artifact}`;
 
 describe("legacy user import CLI safety contracts", () => {
   it("defaults to dry-run and requires explicit apply guards", () => {
@@ -17,22 +22,22 @@ describe("legacy user import CLI safety contracts", () => {
   });
 
   it("stream-decrypts with GPG and never writes plaintext", () => {
-    expect(cli).toContain("spawn(\"gpg\"");
-    expect(cli).toContain("\"--decrypt\"");
-    expect(cli).not.toContain("[\"--batch\", \"--quiet\", \"--decrypt\"");
-    expect(cli).toContain("input: child.stdout");
-    expect(cli).toContain("stdio: [\"inherit\", \"pipe\", \"pipe\"]");
-    expect(cli).not.toMatch(/writeFileSync\([^)]*plaintext/i);
+    expect(safetyCode).toContain("spawn(\"gpg\"");
+    expect(safetyCode).toContain("\"--decrypt\"");
+    expect(safetyCode).not.toContain("[\"--batch\", \"--quiet\", \"--decrypt\"");
+    expect(safetyCode).toContain("input: child.stdout");
+    expect(safetyCode).toContain("stdio: [\"inherit\", \"pipe\", \"pipe\"]");
+    expect(safetyCode).not.toMatch(/writeFileSync\([^)]*plaintext/i);
   });
 
   it("requires an explicit local TTY for PII contact remediation", () => {
     expect(cli).toContain("--interactive-remediation");
-    expect(cli).toContain("process.stdin.isTTY");
-    expect(cli).toContain("Do not record, capture, or share this terminal");
-    expect(cli).toContain("press Enter to clear it");
-    expect(cli).toContain("LOST for an email-less lost member");
-    expect(cli).toContain("emailLessLegacyUserIds");
-    expect(cli).toContain("effectiveSourceChecksum");
+    expect(safetyCode).toContain("process.stdin.isTTY");
+    expect(safetyCode).toContain("Do not record, capture, or share this terminal");
+    expect(safetyCode).toContain("press Enter to clear it");
+    expect(safetyCode).toContain("LOST for an email-less lost member");
+    expect(safetyCode).toContain("emailLessLegacyUserIds");
+    expect(safetyCode).toContain("effectiveLegacySourceChecksum");
   });
 
   it("stages new Auth users disabled and unverified in bounded batches", () => {

--- a/functions/src/__tests__/legacyUserMigrationArtifact.test.ts
+++ b/functions/src/__tests__/legacyUserMigrationArtifact.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  effectiveLegacySourceChecksum,
+  emailLessLegacyUserIds,
+  readLegacyPreflight,
+} from "../legacyUserMigrationArtifact";
+import { sha256Hex } from "../legacyUserMigration";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("legacy migration artifact helpers", () => {
+  it("validates the preflight contract", () => {
+    const directory = fs.mkdtempSync(
+      path.join(os.tmpdir(), "sodc-preflight-")
+    );
+    temporaryDirectories.push(directory);
+    const preflightPath = path.join(directory, "preflight.json");
+    fs.writeFileSync(
+      preflightPath,
+      JSON.stringify({
+        schemaVersion: "sodc-legacy-user-preflight/v2",
+        recordSchemaVersion: "sodc-legacy-user/v1",
+        overall: { recordCount: 918 },
+      })
+    );
+
+    expect(readLegacyPreflight(preflightPath).overall.recordCount).toBe(918);
+  });
+
+  it("binds remediation decisions into the effective checksum", () => {
+    const artifactChecksum = "a".repeat(64);
+    const remediations = [{ line: 3, mobileNumber: null }];
+
+    expect(effectiveLegacySourceChecksum(artifactChecksum, [])).toBe(
+      artifactChecksum
+    );
+    expect(
+      effectiveLegacySourceChecksum(artifactChecksum, remediations)
+    ).toBe(sha256Hex(JSON.stringify({ artifactChecksum, remediations })));
+  });
+
+  it("derives only explicitly remediated email-less LOST identities", () => {
+    const record = {
+      legacyUserId: "19eb78b8-d258-46f0-a3b7-d01a44a86bd9",
+      oldUid: null,
+      email: null,
+      firstName: "Lost",
+      lastName: "Member",
+      mobileNumber: null,
+      postNominals: null,
+      serviceNumber: null,
+      rank: null,
+      membershipStatus: "LOST",
+      isShared: null,
+      hasSubscriptions: false,
+      passwordHash: null,
+    };
+    const lines = [JSON.stringify(record)];
+
+    expect(
+      emailLessLegacyUserIds(lines, [
+        { line: 1, email: null, membershipStatus: "LOST" },
+      ])
+    ).toEqual(new Set([record.legacyUserId]));
+    expect(emailLessLegacyUserIds(lines, [{ line: 1, mobileNumber: null }])).toEqual(
+      new Set()
+    );
+  });
+});

--- a/functions/src/__tests__/legacyUserMigrationLedger.test.ts
+++ b/functions/src/__tests__/legacyUserMigrationLedger.test.ts
@@ -7,6 +7,7 @@ import {
   createMigrationLedger,
   hasMigrationStage,
   readMigrationLedger,
+  recordMigrationExclusion,
   recordMigrationStage,
   writeMigrationLedger,
 } from "../legacyUserMigrationLedger";
@@ -36,6 +37,22 @@ describe("legacy migration resume ledger", () => {
     expect(() =>
       recordMigrationStage(ledger, "legacy-id", "different", "profile-created")
     ).toThrow(/canonical UID conflict/);
+  });
+
+  it("records non-PII reconciliation exclusions separately", () => {
+    const ledger = createMigrationLedger(binding);
+    recordMigrationExclusion(
+      ledger,
+      "legacy-id",
+      "identity-mapping-conflict"
+    );
+
+    expect(ledger.excludedRecords).toEqual({
+      "legacy-id": { reason: "identity-mapping-conflict" },
+    });
+    expect(() =>
+      recordMigrationStage(ledger, "legacy-id", "canonical-id", "auth-created")
+    ).toThrow(/cannot receive a stage/);
   });
 
   it("binds resume to the exact project, batch, schema, and source", () => {

--- a/functions/src/__tests__/legacyUserPostflight.test.ts
+++ b/functions/src/__tests__/legacyUserPostflight.test.ts
@@ -1,0 +1,155 @@
+import type { UserRecord } from "firebase-admin/auth";
+import { describe, expect, it } from "vitest";
+import type { NormalizedLegacyUser } from "../legacyUserMigration";
+import {
+  createMigrationLedger,
+  recordMigrationExclusion,
+  recordMigrationStage,
+} from "../legacyUserMigrationLedger";
+import {
+  buildLegacyUserPostflightReport,
+  type PostflightIdentity,
+} from "../legacyUserPostflight";
+
+const legacyUserId = "19eb78b8-d258-46f0-a3b7-d01a44a86bd9";
+const binding = {
+  projectId: "sodc-web",
+  migrationBatchId: "f3b47f8e-91d2-449f-a1cd-8545a705b423",
+  recordSchemaVersion: "sodc-legacy-user/v1",
+  sourceChecksum: "a".repeat(64),
+};
+const record: NormalizedLegacyUser = {
+  legacyUserId,
+  oldUid: 123,
+  email: "member@example.test",
+  firstName: "Test",
+  lastName: "Member",
+  mobileNumber: "+447700900123",
+  postNominals: null,
+  serviceNumber: "A123",
+  rank: "Squadron Leader",
+  membershipStatus: "REGULAR",
+  shareContactInfo: true,
+  announcementOptOutAll: false,
+  passwordHash: "$2b$10$" + "a".repeat(53),
+  passwordDisposition: "compatible-bcrypt",
+  warnings: [],
+};
+
+function identity(overrides: Partial<PostflightIdentity> = {}): PostflightIdentity {
+  return {
+    sourceSystem: "sodc-legacy",
+    legacyUserId,
+    oldUid: 123,
+    migrationBatchId: binding.migrationBatchId,
+    recordSchemaVersion: binding.recordSchemaVersion,
+    sourceChecksum: binding.sourceChecksum,
+    user: {
+      id: legacyUserId,
+      firstName: "Test",
+      lastName: "Member",
+      email: "member@example.test",
+      serviceNumber: "A123",
+      mobileNumber: "+447700900123",
+      postNominals: null,
+      rank: "Squadron Leader",
+      membershipStatus: "REGULAR",
+      shareContactInfo: true,
+      announcementOptOutAll: false,
+      legacyPasswordMigrated: true,
+      profileReviewedAt: null,
+    },
+    ...overrides,
+  };
+}
+
+function auth(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    uid: legacyUserId,
+    email: "member@example.test",
+    emailVerified: false,
+    disabled: false,
+    customClaims: { enabled: true },
+    ...overrides,
+  } as UserRecord;
+}
+
+function completedLedger() {
+  const ledger = createMigrationLedger(binding);
+  for (const stage of [
+    "auth-created",
+    "profile-created",
+    "access-reconciled",
+  ] as const) {
+    recordMigrationStage(ledger, legacyUserId, legacyUserId, stage);
+  }
+  return ledger;
+}
+
+describe("legacy user postflight reconciliation", () => {
+  it("reports a complete migration as a match without emitting PII", () => {
+    const report = buildLegacyUserPostflightReport({
+      projectId: binding.projectId,
+      rawSourceRecords: 1,
+      normalizedRecords: [record],
+      sourceQuarantined: 0,
+      ledger: completedLedger(),
+      identities: [identity()],
+      authUsers: new Map([[legacyUserId, auth()]]),
+      bcryptProven: true,
+    });
+
+    expect(report.outcome).toBe("match");
+    expect(report.counts.compatibleBcryptPlanned).toBe(1);
+    expect(report.counts.credentialHashesDirectlyVerifiable).toBe(0);
+    expect(JSON.stringify(report)).not.toContain(record.email);
+    expect(JSON.stringify(report)).not.toContain(record.mobileNumber!);
+  });
+
+  it("reports field, access, provenance, and missing-state differences", () => {
+    const report = buildLegacyUserPostflightReport({
+      projectId: binding.projectId,
+      rawSourceRecords: 1,
+      normalizedRecords: [record],
+      sourceQuarantined: 0,
+      ledger: completedLedger(),
+      identities: [
+        identity({
+          sourceChecksum: "b".repeat(64),
+          user: { ...identity().user, firstName: "Wrong" },
+        }),
+      ],
+      authUsers: new Map([
+        [legacyUserId, auth({ disabled: true, customClaims: { enabled: false } })],
+      ]),
+      bcryptProven: false,
+    });
+
+    expect(report.outcome).toBe("mismatch");
+    expect(report.reasonCounts).toMatchObject({
+      "identity-provenance-mismatch": 1,
+      "profile-field-mismatch": 1,
+      "auth-access-claim-mismatch": 1,
+      "auth-disabled-state-mismatch": 1,
+    });
+    expect(report.differences[0].correlationId).toHaveLength(20);
+  });
+
+  it("accepts a planned reconciliation exclusion without a destination record", () => {
+    const ledger = createMigrationLedger(binding);
+    recordMigrationExclusion(ledger, legacyUserId, "identity-mapping-conflict");
+    const report = buildLegacyUserPostflightReport({
+      projectId: binding.projectId,
+      rawSourceRecords: 1,
+      normalizedRecords: [record],
+      sourceQuarantined: 0,
+      ledger,
+      identities: [],
+      authUsers: new Map(),
+      bcryptProven: false,
+    });
+
+    expect(report.outcome).toBe("match");
+    expect(report.counts.excludedRecords).toBe(1);
+  });
+});

--- a/functions/src/__tests__/legacyUserPostflightCliContracts.test.ts
+++ b/functions/src/__tests__/legacyUserPostflightCliContracts.test.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const cli = fs.readFileSync(
+  path.resolve(process.cwd(), "scripts/legacy-user-postflight.ts"),
+  "utf8"
+);
+
+describe("legacy user postflight CLI safety contracts", () => {
+  it("requires an exact declared project and production-mode agreement", () => {
+    expect(cli).toContain("--confirm-project must exactly match");
+    expect(cli).toContain("target project is not declared in .firebaserc");
+    expect(cli).toContain("production target requires --production");
+  });
+
+  it("binds the effective source to the protected import ledger", () => {
+    expect(cli).toContain("effectiveLegacySourceChecksum");
+    expect(cli).toContain("readMigrationLedger(options.statePath, binding)");
+    expect(cli).toContain("import ledger is not bound");
+  });
+
+  it("uses read-only snapshots and returns non-zero on mismatch", () => {
+    expect(cli).toContain("listLegacyUserIdentitiesByBatch");
+    expect(cli).toContain("admin.auth().getUsers");
+    expect(cli).toContain("report.outcome !== \"match\"");
+    expect(cli).not.toContain("updateUser(");
+    expect(cli).not.toContain("importUsers(");
+  });
+
+  it("writes an optional owner-only report atomically", () => {
+    expect(cli).toContain("mode: 0o600");
+    expect(cli).toContain("fs.renameSync(temporaryPath, outputPath)");
+  });
+});

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -550,6 +550,7 @@ export interface CreateMigratedUserProfileAndIdentityVariables {
   membershipStatus: MembershipStatus;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  legacyPasswordMigrated?: boolean | null;
   now: TimestampString;
 }
 
@@ -1098,6 +1099,7 @@ export interface GetCurrentUserData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -1935,6 +1937,7 @@ export interface GetUserByIdData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -2294,6 +2297,18 @@ export interface ListLegacyUserIdentitiesByBatchData {
     oldUid?: number | null;
     user: {
       id: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      serviceNumber: string;
+      mobileNumber?: string | null;
+      postNominals?: string | null;
+      rank?: string | null;
+      membershipStatus: MembershipStatus;
+      shareContactInfo?: boolean | null;
+      announcementOptOutAll: boolean;
+      legacyPasswordMigrated?: boolean | null;
+      profileReviewedAt?: TimestampString | null;
     } & User_Key;
     migrationBatchId: UUIDString;
     recordSchemaVersion: string;
@@ -2559,6 +2574,7 @@ export interface ListUsersData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;

--- a/functions/src/legacyUserMigrationArtifact.ts
+++ b/functions/src/legacyUserMigrationArtifact.ts
@@ -1,0 +1,260 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import readline from "node:readline";
+import readlinePromises from "node:readline/promises";
+import { spawn } from "node:child_process";
+import {
+  LEGACY_PREFLIGHT_SCHEMA_VERSION,
+  LEGACY_RECORD_SCHEMA_VERSION,
+  LegacyRecordError,
+  normalizeEmail,
+  normalizeMobileNumber,
+  parseLegacyRecord,
+  sha256Hex,
+} from "./legacyUserMigration";
+
+export interface LegacyPreflight {
+  schemaVersion: string;
+  recordSchemaVersion: string;
+  overall: { recordCount: number };
+}
+
+export interface ContactRemediation {
+  line: number;
+  email?: string | null;
+  mobileNumber?: string | null;
+  membershipStatus?: "LOST";
+}
+
+export function readLegacyPreflight(preflightPath: string): LegacyPreflight {
+  const parsed: unknown = JSON.parse(fs.readFileSync(preflightPath, "utf8"));
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("preflight must be a JSON object");
+  }
+  const preflight = parsed as LegacyPreflight;
+  if (preflight.schemaVersion !== LEGACY_PREFLIGHT_SCHEMA_VERSION) {
+    throw new Error("unsupported preflight schema version");
+  }
+  if (preflight.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION) {
+    throw new Error("unsupported legacy record schema version");
+  }
+  if (
+    !preflight.overall ||
+    !Number.isInteger(preflight.overall.recordCount) ||
+    preflight.overall.recordCount < 0
+  ) {
+    throw new Error("preflight record count is invalid");
+  }
+  return preflight;
+}
+
+export async function decryptLegacyArtifact(inputPath: string): Promise<{
+  artifactChecksum: string;
+  plaintextLines: string[];
+}> {
+  if (!fs.statSync(inputPath).isFile()) {
+    throw new Error("encrypted input is not a file");
+  }
+  // GPG owns passphrase handling through its configured pinentry program. The
+  // process reads decrypted bytes only from stdout and never persists them.
+  const child = spawn("gpg", ["--quiet", "--decrypt", inputPath], {
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+  const exit = new Promise<number>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code) => resolve(code ?? 1));
+  });
+  const digest = createHash("sha256");
+  child.stdout.on("data", (chunk: Buffer) => digest.update(chunk));
+  let stderrBytes = 0;
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderrBytes += chunk.length;
+  });
+
+  const lines = readline.createInterface({
+    input: child.stdout,
+    crlfDelay: Infinity,
+  });
+  const plaintextLines: string[] = [];
+  for await (const line of lines) {
+    plaintextLines.push(line);
+  }
+  const exitCode = await exit;
+  if (exitCode !== 0) {
+    throw new Error(
+      `GPG decryption failed (exit ${exitCode}, ${stderrBytes} diagnostic bytes)`
+    );
+  }
+  return { artifactChecksum: digest.digest("hex"), plaintextLines };
+}
+
+function terminalSafe(value: unknown): string {
+  const text = typeof value === "string" ? value : String(value ?? "");
+  return Array.from(text, (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159)
+      ? "?"
+      : character;
+  })
+    .join("")
+    .slice(0, 200);
+}
+
+function memberLabel(record: {
+  firstName: string | null;
+  lastName: string | null;
+  serviceNumber: string | null;
+}): string {
+  const name = `${terminalSafe(record.firstName)} ${terminalSafe(
+    record.lastName
+  )}`.trim();
+  const serviceNumber = terminalSafe(record.serviceNumber) || "not supplied";
+  return `${name || "Unnamed member"} (service number: ${serviceNumber})`;
+}
+
+function isEmailRemediationError(error: unknown): boolean {
+  return (
+    error instanceof LegacyRecordError &&
+    ["invalid-email", "placeholder-email", "missing-required-value"].includes(
+      error.reason
+    )
+  );
+}
+
+export async function remediateLegacyContacts(
+  lines: readonly string[]
+): Promise<{ lines: string[]; remediations: ContactRemediation[] }> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      "--interactive-remediation requires an interactive local terminal"
+    );
+  }
+  console.error(
+    "Interactive remediation displays member PII locally. " +
+      "Do not record, capture, or share this terminal session."
+  );
+  const prompt = readlinePromises.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const remediatedLines: string[] = [];
+  const remediations: ContactRemediation[] = [];
+
+  try {
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      if (!line.trim()) {
+        remediatedLines.push(line);
+        continue;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        remediatedLines.push(line);
+        continue;
+      }
+      let record;
+      try {
+        record = parseLegacyRecord(parsed);
+      } catch {
+        remediatedLines.push(line);
+        continue;
+      }
+      const remediation: ContactRemediation = { line: index + 1 };
+      try {
+        normalizeEmail(record.email);
+      } catch (error) {
+        if (!isEmailRemediationError(error)) throw error;
+        console.error(
+          `\nInvalid email for ${memberLabel(record)}: ` +
+            `"${terminalSafe(record.email)}"`
+        );
+        while (true) {
+          const replacement = await prompt.question(
+            "Replacement email, LOST for an email-less lost member, " +
+              "or SKIP to quarantine: "
+          );
+          const action = replacement.trim().toUpperCase();
+          if (action === "SKIP") break;
+          if (action === "LOST") {
+            record.email = null;
+            record.membershipStatus = "LOST";
+            remediation.email = null;
+            remediation.membershipStatus = "LOST";
+            break;
+          }
+          try {
+            record.email = normalizeEmail(replacement);
+            remediation.email = record.email;
+            break;
+          } catch {
+            console.error("That is not a valid non-placeholder email address.");
+          }
+        }
+      }
+
+      try {
+        normalizeMobileNumber(record.mobileNumber);
+      } catch (error) {
+        if (
+          !(error instanceof LegacyRecordError) ||
+          error.reason !== "invalid-mobile-number"
+        ) throw error;
+        console.error(
+          `\nInvalid mobile for ${memberLabel(record)}: ` +
+            `"${terminalSafe(record.mobileNumber)}"`
+        );
+        while (true) {
+          const replacement = await prompt.question(
+            "Replacement mobile (press Enter to clear it): "
+          );
+          try {
+            record.mobileNumber = normalizeMobileNumber(replacement);
+            remediation.mobileNumber = record.mobileNumber;
+            break;
+          } catch {
+            console.error(
+              "That number cannot be normalized to E.164; retry or press Enter."
+            );
+          }
+        }
+      }
+
+      if (
+        remediation.email !== undefined ||
+        remediation.mobileNumber !== undefined
+      ) remediations.push(remediation);
+      remediatedLines.push(JSON.stringify(record));
+    }
+  } finally {
+    prompt.close();
+  }
+  return { lines: remediatedLines, remediations };
+}
+
+export function effectiveLegacySourceChecksum(
+  artifactChecksum: string,
+  remediations: readonly ContactRemediation[]
+): string {
+  return remediations.length === 0
+    ? artifactChecksum
+    : sha256Hex(JSON.stringify({ artifactChecksum, remediations }));
+}
+
+export function emailLessLegacyUserIds(
+  lines: readonly string[],
+  remediations: readonly ContactRemediation[]
+): Set<string> {
+  return new Set(
+    remediations
+      .filter(
+        ({ email, membershipStatus }) =>
+          email === null && membershipStatus === "LOST"
+      )
+      .map(({ line }) => {
+        const parsed: unknown = JSON.parse(lines[line - 1]);
+        return parseLegacyRecord(parsed).legacyUserId;
+      })
+  );
+}

--- a/functions/src/legacyUserMigrationLedger.ts
+++ b/functions/src/legacyUserMigrationLedger.ts
@@ -22,6 +22,7 @@ export interface MigrationLedgerRecord {
 export interface MigrationLedger extends MigrationLedgerBinding {
   ledgerSchemaVersion: "sodc-legacy-user-import-ledger/v1";
   records: Record<string, MigrationLedgerRecord>;
+  excludedRecords: Record<string, { reason: string }>;
 }
 
 export function createMigrationLedger(
@@ -31,6 +32,7 @@ export function createMigrationLedger(
     ledgerSchemaVersion: "sodc-legacy-user-import-ledger/v1",
     ...binding,
     records: {},
+    excludedRecords: {},
   };
 }
 
@@ -64,6 +66,9 @@ export function recordMigrationStage(
   canonicalUid: string,
   stage: MigrationStage
 ): void {
+  if (ledger.excludedRecords[legacyUserId]) {
+    throw new Error("excluded migration record cannot receive a stage");
+  }
   const existing = ledger.records[legacyUserId];
   if (existing && existing.canonicalUid !== canonicalUid) {
     throw new Error("resume ledger canonical UID conflict");
@@ -97,6 +102,13 @@ export function readMigrationLedger(
   ) {
     throw new Error("resume ledger records are invalid");
   }
+  if (
+    !ledger.excludedRecords ||
+    typeof ledger.excludedRecords !== "object" ||
+    Array.isArray(ledger.excludedRecords)
+  ) {
+    throw new Error("resume ledger excluded records are invalid");
+  }
   const validStages = new Set<MigrationStage>([
     "auth-created",
     "profile-created",
@@ -119,12 +131,37 @@ export function readMigrationLedger(
       throw new Error("resume ledger record is invalid");
     }
   }
+  for (const [legacyUserId, exclusion] of Object.entries(
+    ledger.excludedRecords
+  )) {
+    if (
+      !legacyUserId ||
+      ledger.records[legacyUserId] ||
+      !exclusion ||
+      typeof exclusion !== "object" ||
+      typeof exclusion.reason !== "string" ||
+      !exclusion.reason
+    ) {
+      throw new Error("resume ledger excluded record is invalid");
+    }
+  }
   return ledger;
 }
 
+export function recordMigrationExclusion(
+  ledger: MigrationLedger,
+  legacyUserId: string,
+  reason: string
+): void {
+  if (ledger.records[legacyUserId]) {
+    throw new Error("migration ledger record cannot also be excluded");
+  }
+  ledger.excludedRecords[legacyUserId] = { reason };
+}
+
 /**
- * Persists only migration IDs and stage names. The temporary file is created
- * with owner-only permissions and atomically renamed over the prior checkpoint.
+ * Persists only migration IDs, stage names, and non-PII exclusion reason codes.
+ * The temporary file is owner-only and atomically replaces the checkpoint.
  */
 export function writeMigrationLedger(
   ledgerPath: string,

--- a/functions/src/legacyUserPostflight.ts
+++ b/functions/src/legacyUserPostflight.ts
@@ -1,0 +1,313 @@
+import type { UserRecord } from "firebase-admin/auth";
+import {
+  hasMigrationStage,
+  type MigrationLedger,
+} from "./legacyUserMigrationLedger";
+import {
+  LEGACY_RECORD_SCHEMA_VERSION,
+  LEGACY_SOURCE_SYSTEM,
+  sha256Hex,
+  type NormalizedLegacyUser,
+} from "./legacyUserMigration";
+import { isNonRestrictedStatus } from "./validation";
+
+export const LEGACY_POSTFLIGHT_SCHEMA_VERSION =
+  "sodc-legacy-user-postflight/v1";
+
+export interface PostflightIdentity {
+  sourceSystem: string;
+  legacyUserId: string;
+  oldUid?: number | null;
+  migrationBatchId: string;
+  recordSchemaVersion: string;
+  sourceChecksum: string;
+  user: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    serviceNumber: string;
+    mobileNumber?: string | null;
+    postNominals?: string | null;
+    rank?: string | null;
+    membershipStatus: string;
+    shareContactInfo?: boolean | null;
+    announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
+    profileReviewedAt?: string | null;
+  };
+}
+
+export type PostflightReason =
+  | "source-record-missing-from-ledger"
+  | "ledger-record-missing-from-source"
+  | "ledger-stage-incomplete"
+  | "identity-mapping-missing"
+  | "identity-mapping-additional"
+  | "identity-provenance-mismatch"
+  | "canonical-uid-mismatch"
+  | "auth-user-missing"
+  | "auth-email-mismatch"
+  | "auth-access-claim-mismatch"
+  | "auth-disabled-state-mismatch"
+  | "auth-email-verification-mismatch"
+  | "profile-field-mismatch";
+
+export interface PostflightDifference {
+  correlationId: string;
+  reasons: PostflightReason[];
+}
+
+export interface PostflightReport {
+  schemaVersion: typeof LEGACY_POSTFLIGHT_SCHEMA_VERSION;
+  outcome: "match" | "mismatch";
+  projectId: string;
+  migrationBatchId: string;
+  recordSchemaVersion: string;
+  sourceChecksum: string;
+  counts: {
+    rawSourceRecords: number;
+    normalizedSourceRecords: number;
+    sourceQuarantined: number;
+    ledgerRecords: number;
+    excludedRecords: number;
+    identityMappings: number;
+    authUsersMatched: number;
+    profilesCreated: number;
+    profilesLinked: number;
+    compatibleBcryptPlanned: number;
+    passwordResetRequired: number;
+    credentialHashesDirectlyVerifiable: 0;
+    differences: number;
+  };
+  reasonCounts: Partial<Record<PostflightReason, number>>;
+  differences: PostflightDifference[];
+  limitations: string[];
+}
+
+function correlationId(sourceChecksum: string, legacyUserId: string): string {
+  return sha256Hex(`${sourceChecksum}:${legacyUserId}`).slice(0, 20);
+}
+
+function sameNullable(left: unknown, right: unknown): boolean {
+  return (left ?? null) === (right ?? null);
+}
+
+function expectedProfile(
+  record: NormalizedLegacyUser,
+  legacyPasswordMigrated: boolean | null
+): Record<string, unknown> {
+  return {
+    firstName: record.firstName,
+    lastName: record.lastName,
+    email: record.email,
+    serviceNumber: record.serviceNumber,
+    mobileNumber: record.mobileNumber,
+    postNominals: record.postNominals,
+    rank: record.rank,
+    membershipStatus: record.membershipStatus,
+    shareContactInfo: record.shareContactInfo,
+    announcementOptOutAll: record.announcementOptOutAll,
+    legacyPasswordMigrated,
+    profileReviewedAt: null,
+  };
+}
+
+function profileMatches(
+  actual: PostflightIdentity["user"],
+  expected: NormalizedLegacyUser,
+  legacyPasswordMigrated: boolean | null
+): boolean {
+  return Object.entries(
+    expectedProfile(expected, legacyPasswordMigrated)
+  ).every(([field, value]) =>
+      sameNullable(actual[field as keyof typeof actual], value)
+    );
+}
+
+export function buildLegacyUserPostflightReport(input: {
+  projectId: string;
+  rawSourceRecords: number;
+  normalizedRecords: readonly NormalizedLegacyUser[];
+  sourceQuarantined: number;
+  ledger: MigrationLedger;
+  identities: readonly PostflightIdentity[];
+  authUsers: ReadonlyMap<string, UserRecord>;
+  bcryptProven: boolean;
+}): PostflightReport {
+  const differences = new Map<string, Set<PostflightReason>>();
+  const add = (legacyUserId: string, reason: PostflightReason): void => {
+    const existing = differences.get(legacyUserId) ?? new Set();
+    existing.add(reason);
+    differences.set(legacyUserId, existing);
+  };
+  const sourceById = new Map(
+    input.normalizedRecords.map((record) => [record.legacyUserId, record])
+  );
+  const identityById = new Map<string, PostflightIdentity>();
+  for (const identity of input.identities) {
+    if (identityById.has(identity.legacyUserId)) {
+      add(identity.legacyUserId, "identity-provenance-mismatch");
+    }
+    identityById.set(identity.legacyUserId, identity);
+  }
+
+  for (const legacyUserId of sourceById.keys()) {
+    if (
+      !input.ledger.records[legacyUserId] &&
+      !input.ledger.excludedRecords[legacyUserId]
+    ) {
+      add(legacyUserId, "source-record-missing-from-ledger");
+    }
+  }
+  for (const legacyUserId of Object.keys(input.ledger.excludedRecords)) {
+    if (!sourceById.has(legacyUserId)) {
+      add(legacyUserId, "ledger-record-missing-from-source");
+    }
+  }
+  for (const [legacyUserId, ledgerRecord] of Object.entries(
+    input.ledger.records
+  )) {
+    const source = sourceById.get(legacyUserId);
+    if (!source) {
+      add(legacyUserId, "ledger-record-missing-from-source");
+      continue;
+    }
+    if (!hasMigrationStage(input.ledger, legacyUserId, "access-reconciled")) {
+      add(legacyUserId, "ledger-stage-incomplete");
+    }
+    const identity = identityById.get(legacyUserId);
+    if (!identity) {
+      add(legacyUserId, "identity-mapping-missing");
+      continue;
+    }
+    if (
+      identity.sourceSystem !== LEGACY_SOURCE_SYSTEM ||
+      identity.migrationBatchId !== input.ledger.migrationBatchId ||
+      identity.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION ||
+      identity.sourceChecksum !== input.ledger.sourceChecksum ||
+      !sameNullable(identity.oldUid, source.oldUid)
+    ) add(legacyUserId, "identity-provenance-mismatch");
+    if (
+      identity.user.id !== ledgerRecord.canonicalUid
+    ) add(legacyUserId, "canonical-uid-mismatch");
+
+    const auth = input.authUsers.get(ledgerRecord.canonicalUid);
+    if (!auth) {
+      add(legacyUserId, "auth-user-missing");
+    } else {
+      if ((auth.email ?? "").toLowerCase() !== source.email) {
+        add(legacyUserId, "auth-email-mismatch");
+      }
+      const shouldBeEnabled = isNonRestrictedStatus(source.membershipStatus);
+      if (auth.customClaims?.enabled !== shouldBeEnabled) {
+        add(legacyUserId, "auth-access-claim-mismatch");
+      }
+      if (
+        hasMigrationStage(input.ledger, legacyUserId, "auth-created") &&
+        auth.disabled === shouldBeEnabled
+      ) add(legacyUserId, "auth-disabled-state-mismatch");
+      if (
+        hasMigrationStage(input.ledger, legacyUserId, "auth-created") &&
+        source.email &&
+        auth.emailVerified
+      ) add(legacyUserId, "auth-email-verification-mismatch");
+    }
+
+    if (hasMigrationStage(input.ledger, legacyUserId, "profile-created")) {
+      const migrationCreatedAuth = hasMigrationStage(
+        input.ledger,
+        legacyUserId,
+        "auth-created"
+      );
+      const legacyPasswordMigrated = migrationCreatedAuth
+        ? Boolean(
+            input.bcryptProven &&
+              source.email &&
+              source.passwordDisposition === "compatible-bcrypt"
+          )
+        : null;
+      if (!profileMatches(identity.user, source, legacyPasswordMigrated)) {
+        add(legacyUserId, "profile-field-mismatch");
+      }
+    } else if (identity.user.email.toLowerCase() !== source.email) {
+      // Linked pre-existing profiles are deliberately not overwritten, but the
+      // importer required their identity email to match before linking.
+      add(legacyUserId, "profile-field-mismatch");
+    }
+  }
+  for (const identity of input.identities) {
+    if (!input.ledger.records[identity.legacyUserId]) {
+      add(identity.legacyUserId, "identity-mapping-additional");
+    }
+  }
+
+  const reportDifferences = [...differences.entries()]
+    .map(([legacyUserId, reasons]) => ({
+      correlationId: correlationId(input.ledger.sourceChecksum, legacyUserId),
+      reasons: [...reasons].sort(),
+    }))
+    .sort((left, right) => left.correlationId.localeCompare(right.correlationId));
+  const reasonCounts: Partial<Record<PostflightReason, number>> = {};
+  for (const difference of reportDifferences) {
+    for (const reason of difference.reasons) {
+      reasonCounts[reason] = (reasonCounts[reason] ?? 0) + 1;
+    }
+  }
+  const ledgerEntries = Object.entries(input.ledger.records);
+  const authCreatedRecords = ledgerEntries.flatMap(([legacyUserId]) => {
+    const source = sourceById.get(legacyUserId);
+    return source &&
+      hasMigrationStage(input.ledger, legacyUserId, "auth-created")
+      ? [source]
+      : [];
+  });
+  const authUsersMatched = ledgerEntries.filter(([, record]) =>
+    input.authUsers.has(record.canonicalUid)
+  ).length;
+
+  return {
+    schemaVersion: LEGACY_POSTFLIGHT_SCHEMA_VERSION,
+    outcome: reportDifferences.length === 0 ? "match" : "mismatch",
+    projectId: input.projectId,
+    migrationBatchId: input.ledger.migrationBatchId,
+    recordSchemaVersion: input.ledger.recordSchemaVersion,
+    sourceChecksum: input.ledger.sourceChecksum,
+    counts: {
+      rawSourceRecords: input.rawSourceRecords,
+      normalizedSourceRecords: input.normalizedRecords.length,
+      sourceQuarantined: input.sourceQuarantined,
+      ledgerRecords: ledgerEntries.length,
+      excludedRecords: Object.keys(input.ledger.excludedRecords).length,
+      identityMappings: input.identities.length,
+      authUsersMatched,
+      profilesCreated: ledgerEntries.filter(([id]) =>
+        hasMigrationStage(input.ledger, id, "profile-created")
+      ).length,
+      profilesLinked: ledgerEntries.filter(([id]) =>
+        hasMigrationStage(input.ledger, id, "identity-linked")
+      ).length,
+      compatibleBcryptPlanned: input.bcryptProven
+        ? authCreatedRecords.filter(
+            (record) =>
+              Boolean(record.email) &&
+              record.passwordDisposition === "compatible-bcrypt"
+          ).length
+        : 0,
+      passwordResetRequired: authCreatedRecords.filter(
+        (record) =>
+          Boolean(record.email) &&
+          (!input.bcryptProven ||
+            record.passwordDisposition !== "compatible-bcrypt")
+      ).length,
+      credentialHashesDirectlyVerifiable: 0,
+      differences: reportDifferences.length,
+    },
+    reasonCounts,
+    differences: reportDifferences,
+    limitations: [
+      "Firebase Authentication does not expose imported password hashes; credential hash presence cannot be directly re-read.",
+      "Fields on linked pre-existing profiles are not compared because the importer deliberately does not overwrite them.",
+    ],
+  };
+}

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -1109,6 +1109,18 @@ export interface ListLegacyUserIdentitiesByBatchData {
     oldUid?: number | null;
     user: {
       id: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      serviceNumber: string;
+      mobileNumber?: string | null;
+      postNominals?: string | null;
+      rank?: string | null;
+      membershipStatus: MembershipStatus;
+      shareContactInfo?: boolean | null;
+      announcementOptOutAll: boolean;
+      legacyPasswordMigrated?: boolean | null;
+      profileReviewedAt?: TimestampString | null;
     } & User_Key;
     migrationBatchId: UUIDString;
     recordSchemaVersion: string;
@@ -5548,6 +5560,7 @@ export interface GetCurrentUserData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -5665,6 +5678,7 @@ export interface GetUserByIdData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -5790,6 +5804,7 @@ export interface ListUsersData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -11052,6 +11067,7 @@ export interface CreateMigratedUserProfileAndIdentityVariables {
   membershipStatus: MembershipStatus;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  legacyPasswordMigrated?: boolean | null;
   now: TimestampString;
 }
 ```
@@ -11090,6 +11106,7 @@ const createMigratedUserProfileAndIdentityVars: CreateMigratedUserProfileAndIden
   membershipStatus: ..., 
   shareContactInfo: ..., 
   announcementOptOutAll: ..., 
+  legacyPasswordMigrated: ..., // optional
   now: ..., 
 };
 
@@ -11097,7 +11114,7 @@ const createMigratedUserProfileAndIdentityVars: CreateMigratedUserProfileAndIden
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await createMigratedUserProfileAndIdentity(createMigratedUserProfileAndIdentityVars);
 // Variables can be defined inline as well.
-const { data } = await createMigratedUserProfileAndIdentity({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., now: ..., });
+const { data } = await createMigratedUserProfileAndIdentity({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., legacyPasswordMigrated: ..., now: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -11139,13 +11156,14 @@ const createMigratedUserProfileAndIdentityVars: CreateMigratedUserProfileAndIden
   membershipStatus: ..., 
   shareContactInfo: ..., 
   announcementOptOutAll: ..., 
+  legacyPasswordMigrated: ..., // optional
   now: ..., 
 };
 
 // Call the `createMigratedUserProfileAndIdentityRef()` function to get a reference to the mutation.
 const ref = createMigratedUserProfileAndIdentityRef(createMigratedUserProfileAndIdentityVars);
 // Variables can be defined inline as well.
-const ref = createMigratedUserProfileAndIdentityRef({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., now: ..., });
+const ref = createMigratedUserProfileAndIdentityRef({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., legacyPasswordMigrated: ..., now: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -569,6 +569,7 @@ export interface CreateMigratedUserProfileAndIdentityVariables {
   membershipStatus: MembershipStatus;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  legacyPasswordMigrated?: boolean | null;
   now: TimestampString;
 }
 
@@ -1117,6 +1118,7 @@ export interface GetCurrentUserData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -1954,6 +1956,7 @@ export interface GetUserByIdData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -2313,6 +2316,18 @@ export interface ListLegacyUserIdentitiesByBatchData {
     oldUid?: number | null;
     user: {
       id: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      serviceNumber: string;
+      mobileNumber?: string | null;
+      postNominals?: string | null;
+      rank?: string | null;
+      membershipStatus: MembershipStatus;
+      shareContactInfo?: boolean | null;
+      announcementOptOutAll: boolean;
+      legacyPasswordMigrated?: boolean | null;
+      profileReviewedAt?: TimestampString | null;
     } & User_Key;
     migrationBatchId: UUIDString;
     recordSchemaVersion: string;
@@ -2578,6 +2593,7 @@ export interface ListUsersData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -956,6 +956,18 @@ export interface ListLegacyUserIdentitiesByBatchData {
     oldUid?: number | null;
     user: {
       id: string;
+      firstName: string;
+      lastName: string;
+      email: string;
+      serviceNumber: string;
+      mobileNumber?: string | null;
+      postNominals?: string | null;
+      rank?: string | null;
+      membershipStatus: MembershipStatus;
+      shareContactInfo?: boolean | null;
+      announcementOptOutAll: boolean;
+      legacyPasswordMigrated?: boolean | null;
+      profileReviewedAt?: TimestampString | null;
     } & User_Key;
     migrationBatchId: UUIDString;
     recordSchemaVersion: string;
@@ -4409,6 +4421,7 @@ export interface GetCurrentUserData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -4504,6 +4517,7 @@ export interface GetUserByIdData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -4602,6 +4616,7 @@ export interface ListUsersData {
     rank?: string | null;
     shareContactInfo?: boolean | null;
     announcementOptOutAll: boolean;
+    legacyPasswordMigrated?: boolean | null;
     profileReviewedAt?: TimestampString | null;
     createdAt: TimestampString;
     updatedAt: TimestampString;
@@ -8898,6 +8913,7 @@ export interface CreateMigratedUserProfileAndIdentityVariables {
   membershipStatus: MembershipStatus;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  legacyPasswordMigrated?: boolean | null;
   now: TimestampString;
 }
 ```
@@ -8966,11 +8982,12 @@ export default function CreateMigratedUserProfileAndIdentityComponent() {
     membershipStatus: ..., 
     shareContactInfo: ..., 
     announcementOptOutAll: ..., 
+    legacyPasswordMigrated: ..., // optional
     now: ..., 
   };
   mutation.mutate(createMigratedUserProfileAndIdentityVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., now: ..., });
+  mutation.mutate({ userId: ..., legacyUserId: ..., oldUid: ..., sourceSystem: ..., migrationBatchId: ..., recordSchemaVersion: ..., sourceChecksum: ..., firstName: ..., lastName: ..., email: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., membershipStatus: ..., shareContactInfo: ..., announcementOptOutAll: ..., legacyPasswordMigrated: ..., now: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -20,6 +20,7 @@ export interface UserData {
   rank?: string | null;
   shareContactInfo?: boolean | null;
   announcementOptOutAll?: boolean;
+  legacyPasswordMigrated?: boolean | null;
   profileReviewedAt?: string | null;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Closes #425.

## What changed

- add a guarded, read-only legacy-user postflight CLI that reconstructs the approved remediated plan and verifies its checksum against the import ledger
- reconcile migration records across Firebase Auth, Data Connect profiles, immutable legacy identity mappings, access claims, and importer stages
- emit PII-minimised machine-readable reports using aggregate reason counts and deterministic correlation IDs
- persist planned reconciliation exclusions in the resume ledger so intentional quarantines can be distinguished from incomplete imports
- record `User.legacyPasswordMigrated` for migration-created accounts and verify it during postflight without storing or re-exporting password hashes
- add the required server-only Data Connect fields, regenerate SDKs, and document development and production procedures

## Why

The migration needs a retained, fail-closed proof that the destination matches the exact effective import plan after interactive remediation. Raw preflight totals alone cannot prove this because remediation may replace contact data, clear mobiles, exclude records, or create email-less LOST members.

The password marker also preserves whether a migration-created member can use their legacy credential or must reset it. It remains historical evidence; Firebase Auth `lastSignInTime` is the source for subsequent site usage.

## Validation

- frontend lint and production build
- 622 frontend tests
- Functions lint and TypeScript build
- 729 Functions tests
- Functions coverage
- generated Data Connect SDKs
- `git diff --check`

