### PR TITLE
Redact deployment check error output

### DIFF
--- a/scripts/deployment-check-lib.mjs
+++ b/scripts/deployment-check-lib.mjs
@@ -76,14 +76,27 @@ export function redact(value) {
   if (typeof value !== "string") return value;
   return value
     .replace(/Bearer\s+[A-Za-z0-9._~-]+/gi, "Bearer [REDACTED]")
-    .replace(/([?&](?:key|token|code|signature)=)[^&\s]+/gi, "$1[REDACTED]");
+    .replace(
+      /([?&](?:key|token|code|signature|credential|x-goog-(?:signature|credential|security-token)|x-amz-(?:signature|credential|security-token))=)[^&\s]+/gi,
+      "$1[REDACTED]"
+    );
+}
+
+export function safeErrorMessage(error) {
+  const message =
+    typeof error === "string"
+      ? error
+      : error && typeof error === "object" && typeof error.message === "string"
+        ? error.message
+        : "Unknown error";
+  return redact(message);
 }
 
 export function result(id, status, summary, details) {
   return {
     id,
     status,
-    summary,
+    summary: redact(summary),
     ...(details === undefined ? {} : { details: redact(details) }),
   };
 }

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -18,6 +18,7 @@ import {
   parseJsonOutput,
   resolveTarget,
   result,
+  safeErrorMessage,
   unwrapFirebaseResult,
 } from "./deployment-check-lib.mjs";
 
@@ -98,7 +99,7 @@ async function commandCheck(results, definition) {
   } catch (error) {
     const status = definition.optional ? RESULT_STATUS.WARN : RESULT_STATUS.FAIL;
     results.push(
-      result(definition.id, status, `${definition.label}: ${error.message}`, {
+      result(definition.id, status, `${definition.label}: ${safeErrorMessage(error)}`, {
         command: [definition.command, ...definition.args].join(" "),
       })
     );
@@ -135,7 +136,7 @@ async function main() {
   try {
     options = parseArguments(process.argv.slice(2));
   } catch (error) {
-    console.error(error.message);
+    console.error(safeErrorMessage(error));
     console.error(help);
     process.exitCode = 2;
     return;
@@ -437,7 +438,7 @@ async function main() {
             publiclyInvokable: isPublicInvokerPolicy(policy),
           };
         } catch (error) {
-          return { functionName, serviceName, error: error.message };
+          return { functionName, serviceName, error: safeErrorMessage(error) };
         }
       }
     );
@@ -709,7 +710,13 @@ async function main() {
       })
     );
   } catch (error) {
-    results.push(result("hosting-runtime", RESULT_STATUS.FAIL, `Hosting runtime audit failed: ${error.message}`));
+    results.push(
+      result(
+        "hosting-runtime",
+        RESULT_STATUS.FAIL,
+        `Hosting runtime audit failed: ${safeErrorMessage(error)}`
+      )
+    );
   }
 
   if (options.authenticated) {
@@ -728,7 +735,13 @@ async function main() {
       if (!response.ok) throw new Error(`callable returned HTTP ${response.status}`);
       results.push(result("authenticated-callable", RESULT_STATUS.PASS, "Authenticated callable smoke check passed."));
     } catch (error) {
-      results.push(result("authenticated-callable", RESULT_STATUS.FAIL, `Authenticated smoke check failed: ${error.message}`));
+      results.push(
+        result(
+          "authenticated-callable",
+          RESULT_STATUS.FAIL,
+          `Authenticated smoke check failed: ${safeErrorMessage(error)}`
+        )
+      );
     }
   } else {
     results.push(

--- a/scripts/deployment-check.test.mjs
+++ b/scripts/deployment-check.test.mjs
@@ -14,6 +14,8 @@ import {
   parseJsonOutput,
   redact,
   resolveTarget,
+  result,
+  safeErrorMessage,
   unwrapFirebaseResult,
 } from "./deployment-check-lib.mjs";
 
@@ -87,6 +89,29 @@ describe("deployment check parsing and comparison", () => {
       accessToken: "[REDACTED]",
       message: "Authorization: Bearer [REDACTED] and ?code=[REDACTED]",
     });
+
+    expect(
+      redact(
+        "https://storage.example/object?X-Goog-Credential=service%40example&X-Goog-Signature=signature-value&X-Amz-Security-Token=session-value"
+      )
+    ).toBe(
+      "https://storage.example/object?X-Goog-Credential=[REDACTED]&X-Goog-Signature=[REDACTED]&X-Amz-Security-Token=[REDACTED]"
+    );
+  });
+
+  it("normalises thrown values and redacts summaries as defence in depth", () => {
+    expect(safeErrorMessage(new Error("Bearer secret-token"))).toBe("Bearer [REDACTED]");
+    expect(safeErrorMessage("request failed?signature=private-value")).toBe(
+      "request failed?signature=[REDACTED]"
+    );
+    expect(safeErrorMessage({ reason: "no message" })).toBe("Unknown error");
+    expect(
+      result(
+        "safe-summary",
+        RESULT_STATUS.FAIL,
+        "request failed with Bearer secret-token"
+      ).summary
+    ).toBe("request failed with Bearer [REDACTED]");
   });
 
   it("discovers deployed Function and Secret contracts from source fixtures", async () => {


### PR DESCRIPTION
## Summary

- normalise unknown thrown values before including them in deployment-check output
- redact every result summary as a defence-in-depth boundary
- redact Google Cloud and AWS signed-URL credentials, signatures, and security tokens
- cover Bearer tokens, signed URLs, string throws, non-Error objects, and result summaries with regression tests

## Why

The deployment checker previously interpolated `error.message` directly into human and JSON summaries. A command error containing a token or signed URL could therefore bypass the existing detail-field redaction, while non-Error thrown values could produce an unhelpful `undefined` message.

This is the follow-up to the final Copilot review comment on merged PR #455.

## Validation

- `npm run test:run -- scripts/deployment-check.test.mjs` — 12 tests passed
- `npm run lint`
- `node --check scripts/deployment-check.mjs`
- `node --check scripts/deployment-check-lib.mjs`
- `git diff main...HEAD --check`
- full root coverage — 80 files / 636 tests passed before carrying the identical commit onto updated `main`
- full Functions coverage — 73 files / 730 tests passed before carrying the identical commit onto updated `main`
