### PR TITLE
Add migrated member password and profile review flow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# The Data Connect SDK generator emits example placeholders with trailing spaces.
+# Keep generated documentation reproducible while excluding that generator-owned
+# formatting from Git's whitespace error checks.
+src/dataconnect-generated/README.md whitespace=-trailing-space
+src/dataconnect-generated/react/README.md whitespace=-trailing-space

--- a/dataconnect/api/user-mutations.gql
+++ b/dataconnect/api/user-mutations.gql
@@ -219,6 +219,7 @@ mutation ConfirmProfileReview(
   $postNominals: String
   $rank: String!
   $shareContactInfo: Boolean!
+  $announcementOptOutAll: Boolean!
 ) @auth(expr: "auth.token.enabled == true") {
   user_update(
     id_expr: "auth.uid"
@@ -230,6 +231,7 @@ mutation ConfirmProfileReview(
       postNominals: $postNominals
       rank: $rank
       shareContactInfo: $shareContactInfo
+      announcementOptOutAll: $announcementOptOutAll
       profileReviewedAt_expr: "request.time"
       updatedAt_expr: "request.time"
       updatedBy_expr: "auth.uid"

--- a/docs/operations/environments-dev-beta-prod.md
+++ b/docs/operations/environments-dev-beta-prod.md
@@ -23,6 +23,10 @@ before using the promotion process below.
 3. **Secrets and Stripe differ per project** — Use separate webhook endpoints, Stripe secrets, and Firebase secrets per environment (see [environment-and-secrets.md](./environment-and-secrets.md)).
 4. **Backend dependencies deploy schema-first** — For a full-stack release, verify generated Data Connect SDKs locally, deploy and validate Data Connect and Storage rules, deploy and validate Functions, then deploy Hosting. Do not use one unscoped `firebase deploy` command for a release that changes these dependencies.
 
+Firebase Authentication password policy is also project-specific. Follow
+[firebase-password-policy.md](./firebase-password-policy.md) in every
+environment; Dev configuration is not inherited by Beta or Prod.
+
 ## Firebase CLI aliases
 
 Aliases live in `.firebaserc` at the repo root. Typical mapping:

--- a/docs/operations/firebase-password-policy.md
+++ b/docs/operations/firebase-password-policy.md
@@ -1,0 +1,45 @@
+# Firebase Authentication password policy
+
+The application treats each environment's Firebase Authentication password
+policy as the authoritative source for registration, sign-in upgrade checks,
+password reset, and password change. The browser calls Firebase
+`validatePassword()`; it does not reproduce complexity rules in application
+code and never sends a password to Functions or Data Connect.
+
+## Required environment setup
+
+Repeat these steps independently in **Dev**, **Beta**, and **Prod**. Configuring
+one Firebase project does not configure the others.
+
+1. Open Firebase Console → Authentication → Settings → Password policy for the
+   exact target project.
+2. Set a minimum length of **12 characters**. Do not add composition rules
+   unless they have been separately approved and tested with the member UX.
+3. During rollout, use the policy's notification/monitoring mode and exercise
+   registration, reset, change-password, and representative migrated-password
+   sign-ins.
+4. After the environment passes those checks, enable enforcement and
+   **force upgrade on sign-in**. A member whose submitted password is no longer
+   compliant must use the site's GOV.UK Notify-backed reset journey.
+5. Record the target project, operator, date, policy requirements, enforcement
+   state, and test evidence in the release record.
+
+The application check improves the member-facing explanation, but Firebase
+enforcement is the security boundary for clients that bypass the UI. Do not
+enable forced upgrade in Prod until Beta proves compatible imported passwords
+continue to sign in and non-compliant passwords reach the reset journey.
+
+## Verification
+
+For each environment, confirm:
+
+- a compliant migrated credential signs in without an unnecessary reset;
+- a non-compliant credential is directed to reset before normal site access;
+- a passwordless migrated identity can set a compliant password from the
+  in-app reset email;
+- registration, reset, and Account settings display requirements returned by
+  Firebase and reject a non-compliant password; and
+- email verification still precedes the six-month details review.
+
+Never place real passwords, reset links, action codes, or member email
+addresses in screenshots, logs, issues, or CI artifacts.

--- a/docs/operations/firebase-password-policy.md
+++ b/docs/operations/firebase-password-policy.md
@@ -1,10 +1,12 @@
 # Firebase Authentication password policy
 
 The application treats each environment's Firebase Authentication password
-policy as the authoritative source for registration, sign-in upgrade checks,
-password reset, and password change. The browser calls Firebase
-`validatePassword()`; it does not reproduce complexity rules in application
-code and never sends a password to Functions or Data Connect.
+policy as authoritative. The browser calls Firebase `validatePassword()` for
+new passwords during registration, password reset, and password change; it does
+not reproduce complexity rules in application code. Sign-in credentials go
+directly to Firebase Authentication, which applies the configured enforcement
+state and force-upgrade setting. Passwords are never sent to Functions or Data
+Connect.
 
 ## Required environment setup
 
@@ -19,15 +21,19 @@ one Firebase project does not configure the others.
    registration, reset, change-password, and representative migrated-password
    sign-ins.
 4. After the environment passes those checks, enable enforcement and
-   **force upgrade on sign-in**. A member whose submitted password is no longer
-   compliant must use the site's GOV.UK Notify-backed reset journey.
+   **force upgrade on sign-in**. When Firebase rejects an otherwise valid
+   credential because its password is no longer compliant, the site directs
+   the member to the GOV.UK Notify-backed reset journey.
 5. Record the target project, operator, date, policy requirements, enforcement
    state, and test evidence in the release record.
 
-The application check improves the member-facing explanation, but Firebase
-enforcement is the security boundary for clients that bypass the UI. Do not
-enable forced upgrade in Prod until Beta proves compatible imported passwords
-continue to sign in and non-compliant passwords reach the reset journey.
+The new-password check improves the member-facing explanation. For sign-in,
+Firebase's policy error triggers the reset explanation; the application does
+not pre-check the submitted credential because doing so would bypass monitoring
+mode and could misreport an ordinary typo as a policy failure. Firebase
+enforcement is the security boundary. Do not enable forced upgrade in Prod
+until Beta proves compatible imported passwords continue to sign in and
+non-compliant passwords reach the reset journey.
 
 ## Verification
 

--- a/docs/operations/legacy-user-import.md
+++ b/docs/operations/legacy-user-import.md
@@ -255,6 +255,14 @@ same remediation questions, and first requires the resulting effective
 checksum to match the protected importer ledger. Different answers fail closed
 before destination comparison.
 
+Before enabling migrated members, complete the target environment's
+[Firebase password-policy setup](./firebase-password-policy.md). Rehearsal must
+prove that a compatible imported password passes the deployed policy, while a
+missing or non-compliant password reaches the in-app reset journey. It must also
+exercise email verification followed by the combined profile and communication
+review; migrated profiles retain a null `profileReviewedAt` until that complete
+review succeeds.
+
 Deploy the updated Data Connect connector before running postflight; its
 server-only batch query exposes the fields needed for read-only comparison:
 

--- a/docs/user-guide/member-getting-started.md
+++ b/docs/user-guide/member-getting-started.md
@@ -62,8 +62,11 @@ After approval you have access to:
 
 The site asks you to review your profile when it has never been confirmed and
 again when the last confirmation is more than six calendar months old. Check
-your name, service number, mobile number, post-nominals, rank or title, and
-contact-sharing choice, then select **Confirm profile**.
+your name, service number, mobile number, post-nominals, rank or title,
+contact-sharing choice, and announcement-email preferences, then select
+**Confirm profile**. Individual section choices are preserved when the master
+announcement switch is off, and account-security, booking, and payment messages
+are always sent when required.
 
 Your verified sign-in email is shown read-only in the review. To change it, use
 **Account settings**, complete the verification link sent to the new address,
@@ -72,6 +75,11 @@ email address.
 
 If saving fails, your review date is not changed. Check your connection and try
 again.
+
+Passwords are checked against the current Firebase security policy whenever
+they are submitted for sign-in. If an older migrated password no longer meets
+the policy, use **Forgot password?** to set a compliant password through the
+site's secure email flow.
 
 ---
 

--- a/docs/user-guide/member-getting-started.md
+++ b/docs/user-guide/member-getting-started.md
@@ -76,10 +76,10 @@ email address.
 If saving fails, your review date is not changed. Check your connection and try
 again.
 
-Passwords are checked against the current Firebase security policy whenever
-they are submitted for sign-in. If an older migrated password no longer meets
-the policy, use **Forgot password?** to set a compliant password through the
-site's secure email flow.
+Firebase Authentication applies the current security policy when you sign in.
+If it requires an older migrated password to be upgraded, the site directs you
+to **Forgot password?** so you can set a compliant password through the secure
+email flow.
 
 ---
 

--- a/functions/src/__tests__/dataconnectAuthContracts.test.ts
+++ b/functions/src/__tests__/dataconnectAuthContracts.test.ts
@@ -87,6 +87,7 @@ describe("Data Connect auth contracts", () => {
     );
     expect(profileReview).toContain("id_expr: \"auth.uid\"");
     expect(profileReview).toContain("profileReviewedAt_expr: \"request.time\"");
+    expect(profileReview).toContain("announcementOptOutAll: $announcementOptOutAll");
 
     const ordinaryProfileUpdate = extractOperationBlock(
       userMutations,

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -354,6 +354,7 @@ export interface ConfirmProfileReviewVariables {
   postNominals?: string | null;
   rank: string;
   shareContactInfo: boolean;
+  announcementOptOutAll: boolean;
 }
 
 export interface ConsumeCallableRateLimitData {

--- a/src/constants/__tests__/auth.test.ts
+++ b/src/constants/__tests__/auth.test.ts
@@ -2,14 +2,12 @@ import { describe, it, expect } from 'vitest';
 import {
   AUTH_EXPRESSIONS,
   FIREBASE_MIN_PASSWORD_LENGTH,
-  REGISTRATION_MIN_PASSWORD_LENGTH,
   type AuthExpression,
 } from '../auth';
 
 describe('auth constants', () => {
-  it('should export password length constants for onboarding', () => {
+  it('should export the minimum length needed before attempting Firebase sign-in', () => {
     expect(FIREBASE_MIN_PASSWORD_LENGTH).toBe(6);
-    expect(REGISTRATION_MIN_PASSWORD_LENGTH).toBe(12);
   });
   it('should export USER_ACCESS expression', () => {
     expect(AUTH_EXPRESSIONS.USER_ACCESS).toBe('auth.token.enabled == true');
@@ -36,4 +34,3 @@ describe('auth constants', () => {
     });
   });
 });
-

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -36,10 +36,3 @@ export type AuthExpression = typeof AUTH_EXPRESSIONS[keyof typeof AUTH_EXPRESSIO
 /** Firebase Auth floor — sign-in accepts this minimum so existing accounts are not locked out. */
 export const FIREBASE_MIN_PASSWORD_LENGTH = 6;
 
-/**
- * Minimum length for new registrations, and for any newly-set password (e.g. Account Settings'
- * change-password flow). Existing accounts created before this was raised are not affected —
- * sign-in still only requires FIREBASE_MIN_PASSWORD_LENGTH. See #208.
- */
-export const REGISTRATION_MIN_PASSWORD_LENGTH = 12;
-

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -20835,6 +20835,7 @@ export interface ConfirmProfileReviewVariables {
   postNominals?: string | null;
   rank: string;
   shareContactInfo: boolean;
+  announcementOptOutAll: boolean;
 }
 ```
 ### Return Type
@@ -20861,13 +20862,14 @@ const confirmProfileReviewVars: ConfirmProfileReviewVariables = {
   postNominals: ..., // optional
   rank: ..., 
   shareContactInfo: ..., 
+  announcementOptOutAll: ..., 
 };
 
 // Call the `confirmProfileReview()` function to execute the mutation.
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await confirmProfileReview(confirmProfileReviewVars);
 // Variables can be defined inline as well.
-const { data } = await confirmProfileReview({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., });
+const { data } = await confirmProfileReview({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -20897,12 +20899,13 @@ const confirmProfileReviewVars: ConfirmProfileReviewVariables = {
   postNominals: ..., // optional
   rank: ..., 
   shareContactInfo: ..., 
+  announcementOptOutAll: ..., 
 };
 
 // Call the `confirmProfileReviewRef()` function to get a reference to the mutation.
 const ref = confirmProfileReviewRef(confirmProfileReviewVars);
 // Variables can be defined inline as well.
-const ref = confirmProfileReviewRef({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., });
+const ref = confirmProfileReviewRef({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -373,6 +373,7 @@ export interface ConfirmProfileReviewVariables {
   postNominals?: string | null;
   rank: string;
   shareContactInfo: boolean;
+  announcementOptOutAll: boolean;
 }
 
 export interface ConsumeCallableRateLimitData {

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -17147,6 +17147,7 @@ export interface ConfirmProfileReviewVariables {
   postNominals?: string | null;
   rank: string;
   shareContactInfo: boolean;
+  announcementOptOutAll: boolean;
 }
 ```
 ### Return Type
@@ -17203,10 +17204,11 @@ export default function ConfirmProfileReviewComponent() {
     postNominals: ..., // optional
     rank: ..., 
     shareContactInfo: ..., 
+    announcementOptOutAll: ..., 
   };
   mutation.mutate(confirmProfileReviewVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., });
+  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -26,7 +26,7 @@ import {
   useOptInSectionAnnouncement,
   useUpdateAnnouncementOptOutAll,
 } from "@dataconnect/generated/react";
-import { MembershipStatus, SectionUserGroupPurpose, upsertUser, type UpsertUserVariables } from "@dataconnect/generated";
+import { upsertUser, type UpsertUserVariables } from "@dataconnect/generated";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link as RouterLink } from "react-router-dom";
 import {
@@ -47,9 +47,10 @@ import { getMembershipStatusLabel } from "../../../shared/utils/membershipStatus
 import { canUserResignMembership } from "../../users/utils/membershipStatusValidation";
 import { useColorMode, type ColorModePreference } from "../../../shared/appShell/ColorModeContext";
 import {
-  getRegistrationPasswordHelperText,
-  validateRegistrationPassword,
+  PASSWORD_POLICY_HELPER_TEXT,
+  validateNewPassword,
 } from "../../auth/utils/passwordValidation";
+import { getAnnouncementSections } from "../utils/announcementPreferences";
 
 export interface AccountSettingsPageProps {
   user: User;
@@ -91,32 +92,7 @@ function AnnouncementPreferencesList() {
   const [snackbar, setSnackbar] = useState<string | null>(null);
 
   const sections = useMemo(() => {
-    const grantsAccess = (purposes?: string[] | null) =>
-      purposes?.includes(SectionUserGroupPurpose.ACCESS) ||
-      purposes?.includes(SectionUserGroupPurpose.MODERATOR);
-
-    const sectionMap = new Map<string, { id: string; name: string }>();
-    const addSection = (s: { id: string; name: string }) => {
-      if (!sectionMap.has(s.id)) sectionMap.set(s.id, s);
-    };
-
-    // Explicit group memberships
-    for (const ug of data?.user?.userGroups ?? []) {
-      for (const pl of ug.userGroup.purposeLinks) {
-        if (grantsAccess(pl.purposes) && pl.section) addSection(pl.section);
-      }
-    }
-
-    // Status-based group memberships
-    const userStatus = data?.user?.membershipStatus;
-    for (const ug of data?.allUserGroups ?? []) {
-      if (!ug.membershipStatuses?.includes(userStatus as MembershipStatus)) continue;
-      for (const pl of ug.purposeLinks) {
-        if (grantsAccess(pl.purposes) && pl.section) addSection(pl.section);
-      }
-    }
-
-    return Array.from(sectionMap.values()).sort((a, b) => a.name.localeCompare(b.name));
+    return getAnnouncementSections(data);
   }, [data]);
 
   const optOutIds = useMemo(
@@ -287,11 +263,6 @@ export default function AccountSettingsPage({
     setPasswordError(null);
     setPasswordSuccess(false);
 
-    const passwordValidation = validateRegistrationPassword(newPassword);
-    if (!passwordValidation.isValid) {
-      setPasswordError(passwordValidation.error ?? "Password does not meet the minimum requirements");
-      return;
-    }
     if (newPassword !== confirmPassword) {
       setPasswordError("New passwords do not match");
       return;
@@ -303,6 +274,13 @@ export default function AccountSettingsPage({
 
     setPasswordSubmitting(true);
     try {
+      const passwordValidation = await validateNewPassword(auth, newPassword);
+      if (!passwordValidation.isValid) {
+        setPasswordError(
+          passwordValidation.error ?? "Password does not meet the current requirements",
+        );
+        return;
+      }
       const credential = EmailAuthProvider.credential(user.email, currentPassword);
       await reauthenticateWithCredential(user, credential);
       await updatePassword(user, newPassword);
@@ -593,7 +571,7 @@ export default function AccountSettingsPage({
                     required
                     fullWidth
                     disabled={passwordSubmitting}
-                    helperText={getRegistrationPasswordHelperText()}
+                    helperText={PASSWORD_POLICY_HELPER_TEXT}
                   />
                   <TextField
                     label="Confirm new password"
@@ -612,7 +590,7 @@ export default function AccountSettingsPage({
                       disabled={
                         passwordSubmitting ||
                         !currentPassword ||
-                        !validateRegistrationPassword(newPassword).isValid ||
+                        !newPassword ||
                         newPassword !== confirmPassword
                       }
                       sx={{

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -17,6 +17,15 @@ vi.mock("firebase/auth", () => ({
   reauthenticateWithCredential: vi.fn().mockResolvedValue(undefined),
   updatePassword: vi.fn().mockResolvedValue(undefined),
   signOut: vi.fn().mockResolvedValue(undefined),
+  validatePassword: vi.fn().mockResolvedValue({
+    isValid: true,
+    passwordPolicy: {
+      customStrengthOptions: { minPasswordLength: 12 },
+      enforcementState: "ENFORCE",
+      forceUpgradeOnSignin: true,
+      allowedNonAlphanumericCharacters: "",
+    },
+  }),
 }));
 
 const mockUpsertUser = vi.fn().mockResolvedValue({ data: {} });
@@ -288,9 +297,19 @@ describe("AccountSettingsPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("rejects a new password below the shared minimum length (#208)", async () => {
+  it("rejects a new password when the deployed Firebase policy rejects it", async () => {
     const user = userEvent.setup();
-    const { updatePassword } = await import("firebase/auth");
+    const { updatePassword, validatePassword } = await import("firebase/auth");
+    vi.mocked(validatePassword).mockResolvedValueOnce({
+      isValid: false,
+      meetsMinPasswordLength: false,
+      passwordPolicy: {
+        customStrengthOptions: { minPasswordLength: 12 },
+        enforcementState: "ENFORCE",
+        forceUpgradeOnSignin: true,
+        allowedNonAlphanumericCharacters: "",
+      },
+    });
 
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
@@ -303,14 +322,17 @@ describe("AccountSettingsPage", () => {
     await user.type(newPasswordInputs[0]!, "short12345");
     await user.type(newPasswordInputs[1]!, "short12345");
 
-    expect(screen.getByRole("button", { name: "Update password" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Update password" }));
+    expect(await screen.findByText("Password must be at least 12 characters.")).toBeInTheDocument();
     expect(updatePassword).not.toHaveBeenCalled();
   });
 
-  it("shows the shared minimum length in the new password helper text", () => {
+  it("explains that the current policy is used for a new password", () => {
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
 
-    expect(screen.getByText("Must be at least 12 characters")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Requirements are checked against the current account security policy/),
+    ).toBeInTheDocument();
   });
 
   it("resigns membership and signs out", async () => {

--- a/src/features/account/utils/__tests__/announcementPreferences.test.ts
+++ b/src/features/account/utils/__tests__/announcementPreferences.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getAnnouncementSections } from "../announcementPreferences";
+
+describe("getAnnouncementSections", () => {
+  it("combines explicit and status-based access, removes duplicates, and sorts names", () => {
+    expect(
+      getAnnouncementSections({
+        user: {
+          membershipStatus: "REGULAR",
+          userGroups: [
+            {
+              userGroup: {
+                purposeLinks: [
+                  { purposes: ["ACCESS"], section: { id: "two", name: "Zulu" } },
+                  { purposes: ["ANNOUNCEMENTS"], section: { id: "ignored", name: "Ignored" } },
+                ],
+              },
+            },
+          ],
+        },
+        allUserGroups: [
+          {
+            membershipStatuses: ["REGULAR"],
+            purposeLinks: [
+              { purposes: ["MODERATOR"], section: { id: "one", name: "Alpha" } },
+              { purposes: ["ACCESS"], section: { id: "two", name: "Zulu" } },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([
+      { id: "one", name: "Alpha" },
+      { id: "two", name: "Zulu" },
+    ]);
+  });
+});

--- a/src/features/account/utils/__tests__/announcementPreferences.test.ts
+++ b/src/features/account/utils/__tests__/announcementPreferences.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { MembershipStatus, SectionUserGroupPurpose } from "@dataconnect/generated";
 import { getAnnouncementSections } from "../announcementPreferences";
 
 describe("getAnnouncementSections", () => {
@@ -6,13 +7,21 @@ describe("getAnnouncementSections", () => {
     expect(
       getAnnouncementSections({
         user: {
-          membershipStatus: "REGULAR",
+          membershipStatus: MembershipStatus.REGULAR,
+          announcementOptOutAll: false,
+          optOuts: [],
           userGroups: [
             {
               userGroup: {
                 purposeLinks: [
-                  { purposes: ["ACCESS"], section: { id: "two", name: "Zulu" } },
-                  { purposes: ["ANNOUNCEMENTS"], section: { id: "ignored", name: "Ignored" } },
+                  {
+                    purposes: [SectionUserGroupPurpose.ACCESS],
+                    section: { id: "two", name: "Zulu" },
+                  },
+                  {
+                    purposes: [SectionUserGroupPurpose.MESSAGE],
+                    section: { id: "ignored", name: "Ignored" },
+                  },
                 ],
               },
             },
@@ -20,10 +29,16 @@ describe("getAnnouncementSections", () => {
         },
         allUserGroups: [
           {
-            membershipStatuses: ["REGULAR"],
+            membershipStatuses: [MembershipStatus.REGULAR],
             purposeLinks: [
-              { purposes: ["MODERATOR"], section: { id: "one", name: "Alpha" } },
-              { purposes: ["ACCESS"], section: { id: "two", name: "Zulu" } },
+              {
+                purposes: [SectionUserGroupPurpose.MODERATOR],
+                section: { id: "one", name: "Alpha" },
+              },
+              {
+                purposes: [SectionUserGroupPurpose.ACCESS],
+                section: { id: "two", name: "Zulu" },
+              },
             ],
           },
         ],

--- a/src/features/account/utils/announcementPreferences.ts
+++ b/src/features/account/utils/announcementPreferences.ts
@@ -1,35 +1,28 @@
+import type {
+  GetMyAnnouncementPreferencesData,
+  SectionUserGroupPurpose,
+} from "@dataconnect/generated";
+import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
+
 interface AnnouncementSection {
   id: string;
   name: string;
 }
 
-interface PurposeLink {
-  purposes?: string[] | null;
-  section?: AnnouncementSection | null;
-}
-
-interface PreferenceGroup {
-  membershipStatuses?: string[] | null;
-  purposeLinks?: PurposeLink[] | null;
-}
-
-export interface AnnouncementPreferenceData {
-  user?: {
-    membershipStatus?: string | null;
-    userGroups?: Array<{ userGroup: PreferenceGroup }> | null;
-  } | null;
-  allUserGroups?: PreferenceGroup[] | null;
-}
-
-function grantsSectionAccess(purposes?: string[] | null) {
-  return purposes?.includes("ACCESS") || purposes?.includes("MODERATOR");
+function grantsSectionAccess(purposes?: SectionUserGroupPurpose[] | null) {
+  return (
+    purposes?.includes(SectionPurpose.ACCESS) ||
+    purposes?.includes(SectionPurpose.MODERATOR)
+  );
 }
 
 export function getAnnouncementSections(
-  data: AnnouncementPreferenceData | null | undefined,
+  data: GetMyAnnouncementPreferencesData | null | undefined,
 ): AnnouncementSection[] {
   const sections = new Map<string, AnnouncementSection>();
-  const addLinks = (links?: PurposeLink[] | null) => {
+  const addLinks = (
+    links?: GetMyAnnouncementPreferencesData["allUserGroups"][number]["purposeLinks"] | null,
+  ) => {
     for (const link of links ?? []) {
       if (grantsSectionAccess(link.purposes) && link.section && !sections.has(link.section.id)) {
         sections.set(link.section.id, link.section);

--- a/src/features/account/utils/announcementPreferences.ts
+++ b/src/features/account/utils/announcementPreferences.ts
@@ -1,0 +1,52 @@
+interface AnnouncementSection {
+  id: string;
+  name: string;
+}
+
+interface PurposeLink {
+  purposes?: string[] | null;
+  section?: AnnouncementSection | null;
+}
+
+interface PreferenceGroup {
+  membershipStatuses?: string[] | null;
+  purposeLinks?: PurposeLink[] | null;
+}
+
+export interface AnnouncementPreferenceData {
+  user?: {
+    membershipStatus?: string | null;
+    userGroups?: Array<{ userGroup: PreferenceGroup }> | null;
+  } | null;
+  allUserGroups?: PreferenceGroup[] | null;
+}
+
+function grantsSectionAccess(purposes?: string[] | null) {
+  return purposes?.includes("ACCESS") || purposes?.includes("MODERATOR");
+}
+
+export function getAnnouncementSections(
+  data: AnnouncementPreferenceData | null | undefined,
+): AnnouncementSection[] {
+  const sections = new Map<string, AnnouncementSection>();
+  const addLinks = (links?: PurposeLink[] | null) => {
+    for (const link of links ?? []) {
+      if (grantsSectionAccess(link.purposes) && link.section && !sections.has(link.section.id)) {
+        sections.set(link.section.id, link.section);
+      }
+    }
+  };
+
+  for (const membership of data?.user?.userGroups ?? []) {
+    addLinks(membership.userGroup.purposeLinks);
+  }
+
+  const membershipStatus = data?.user?.membershipStatus;
+  for (const group of data?.allUserGroups ?? []) {
+    if (membershipStatus && group.membershipStatuses?.includes(membershipStatus)) {
+      addLinks(group.purposeLinks);
+    }
+  }
+
+  return [...sections.values()].sort((left, right) => left.name.localeCompare(right.name));
+}

--- a/src/features/auth/components/AuthActionPage.tsx
+++ b/src/features/auth/components/AuthActionPage.tsx
@@ -20,8 +20,8 @@ import {
 import { auth } from "../../../config/firebase";
 import { ROUTES } from "../../../constants";
 import {
-  getRegistrationPasswordHelperText,
-  validateRegistrationPassword,
+  PASSWORD_POLICY_HELPER_TEXT,
+  validateNewPassword,
 } from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
 
@@ -39,7 +39,7 @@ function resetErrorMessage(error: unknown): string {
     return "This reset link is invalid or has already been used. Request a new one to continue.";
   }
   if (code.includes("weak-password")) {
-    return getRegistrationPasswordHelperText();
+    return "Password does not meet the current account security policy.";
   }
   return "The reset could not be completed. Please request a new link.";
 }
@@ -130,11 +130,6 @@ export default function AuthActionPage() {
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     setError(null);
-    const validation = validateRegistrationPassword(password);
-    if (!validation.isValid) {
-      setError(validation.error ?? "Choose a stronger password.");
-      return;
-    }
     if (password !== confirmation) {
       setError("Passwords do not match.");
       return;
@@ -142,6 +137,11 @@ export default function AuthActionPage() {
 
     setSubmitting(true);
     try {
+      const validation = await validateNewPassword(auth, password);
+      if (!validation.isValid) {
+        setError(validation.error ?? "Choose a stronger password.");
+        return;
+      }
       await confirmPasswordReset(auth, oobCode, password);
       setPassword("");
       setConfirmation("");
@@ -178,7 +178,7 @@ export default function AuthActionPage() {
                 value={password}
                 onChange={(event) => setPassword(event.target.value)}
                 autoComplete="new-password"
-                helperText={getRegistrationPasswordHelperText()}
+                helperText={PASSWORD_POLICY_HELPER_TEXT}
                 disabled={submitting}
                 required
                 fullWidth

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -18,7 +18,11 @@ import type { UserData } from "../../../types";
 import EmailVerificationMessage from "./EmailVerificationMessage";
 import OnboardingShell from "./OnboardingShell";
 import { ROUTES } from "../../../constants";
-import { canAttemptSignIn } from "../utils/passwordValidation";
+import {
+  canAttemptSignIn,
+  isPasswordPolicyAuthError,
+  validateNewPassword,
+} from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
 
 interface AuthGateProps {
@@ -50,6 +54,11 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
     setError(null);
     setSubmitting(true);
     try {
+      const policyValidation = await validateNewPassword(auth, password);
+      if (!policyValidation.isValid) {
+        setError(`${policyValidation.error} Reset your password to continue.`);
+        return;
+      }
       const userCredential = await signInWithEmailAndPassword(auth, email.trim(), password);
       await userCredential.user.getIdToken(true);
       if (userCredential.user.emailVerified) {
@@ -64,8 +73,12 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
       if (onRegisterComplete) {
         onRegisterComplete();
       }
-    } catch (e: any) {
-      setError(e?.message ?? "Sign-in failed");
+    } catch (e: unknown) {
+      setError(
+        isPasswordPolicyAuthError(e)
+          ? "This password no longer meets the account security policy. Reset your password to continue."
+          : (e as { message?: string })?.message ?? "Sign-in failed",
+      );
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -21,7 +21,6 @@ import { ROUTES } from "../../../constants";
 import {
   canAttemptSignIn,
   isPasswordPolicyAuthError,
-  validateNewPassword,
 } from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
 
@@ -54,11 +53,6 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
     setError(null);
     setSubmitting(true);
     try {
-      const policyValidation = await validateNewPassword(auth, password);
-      if (!policyValidation.isValid) {
-        setError(`${policyValidation.error} Reset your password to continue.`);
-        return;
-      }
       const userCredential = await signInWithEmailAndPassword(auth, email.trim(), password);
       await userCredential.user.getIdToken(true);
       if (userCredential.user.emailVerified) {

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -15,10 +15,9 @@ import {
   syncPendingUserClaims,
 } from "../../../shared/utils/firebaseFunctions";
 import {
-  getRegistrationPasswordHelperText,
-  validateRegistrationPassword,
+  PASSWORD_POLICY_HELPER_TEXT,
+  validateNewPassword,
 } from "../utils/passwordValidation";
-import { REGISTRATION_MIN_PASSWORD_LENGTH } from "../../../constants/auth";
 
 interface RegisterProps {
   onSuccess?: () => void;
@@ -40,10 +39,7 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim())) {
       return { isValid: false, error: "Invalid email format" };
     }
-    const passwordValidation = validateRegistrationPassword(password);
-    if (!passwordValidation.isValid) {
-      return { isValid: false, error: passwordValidation.error };
-    }
+    if (!password) return { isValid: false, error: "Password is required" };
     if (password !== confirmPassword) {
       return { isValid: false, error: "Passwords do not match" };
     }
@@ -63,6 +59,11 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
 
     setSubmitting(true);
     try {
+      const passwordValidation = await validateNewPassword(auth, password);
+      if (!passwordValidation.isValid) {
+        setError(passwordValidation.error ?? "Choose a stronger password");
+        return;
+      }
       const userCredential = await createUserWithEmailAndPassword(
         auth,
         email.trim(),
@@ -158,7 +159,7 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
             fullWidth
             required
             disabled={submitting}
-            helperText={getRegistrationPasswordHelperText()}
+            helperText={PASSWORD_POLICY_HELPER_TEXT}
           />
           <TextField
             label="Confirm Password"
@@ -177,7 +178,7 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
             disabled={
               submitting ||
               !email.trim() ||
-              password.length < REGISTRATION_MIN_PASSWORD_LENGTH ||
+              !password ||
               password !== confirmPassword
             }
             sx={{

--- a/src/features/auth/components/__tests__/AuthActionPage.test.tsx
+++ b/src/features/auth/components/__tests__/AuthActionPage.test.tsx
@@ -7,6 +7,7 @@ import {
   confirmPasswordReset,
   reload,
   verifyPasswordResetCode,
+  validatePassword,
 } from "firebase/auth";
 import AuthActionPage from "../AuthActionPage";
 import { reconcileMyEmail } from "../../../../shared/utils/firebaseFunctions";
@@ -26,6 +27,7 @@ vi.mock("firebase/auth", async (importOriginal) => {
     reload: vi.fn(),
     verifyPasswordResetCode: vi.fn(),
     confirmPasswordReset: vi.fn(),
+    validatePassword: vi.fn(),
   };
 });
 
@@ -37,6 +39,15 @@ describe("AuthActionPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mutableAuth.currentUser = null;
+    vi.mocked(validatePassword).mockResolvedValue({
+      isValid: true,
+      passwordPolicy: {
+        customStrengthOptions: { minPasswordLength: 12 },
+        enforcementState: "ENFORCE",
+        forceUpgradeOnSignin: true,
+        allowedNonAlphanumericCharacters: "",
+      },
+    });
   });
 
   function renderAction(search: string) {

--- a/src/features/auth/components/__tests__/AuthGate.test.tsx
+++ b/src/features/auth/components/__tests__/AuthGate.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { onAuthStateChanged, signInWithEmailAndPassword, validatePassword } from "firebase/auth";
+import { render, screen } from "../../../../test-utils";
+import AuthGate from "../AuthGate";
+
+vi.mock("firebase/auth", () => ({
+  onAuthStateChanged: vi.fn(),
+  signInWithEmailAndPassword: vi.fn(),
+  validatePassword: vi.fn(),
+}));
+
+vi.mock("../../../../config/firebase", () => ({ auth: {} }));
+vi.mock("../../../users/hooks/useEnabledClaim", () => ({
+  useEnabledClaim: () => ({ isEnabled: false, isEnabledClaimResolved: true }),
+}));
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({ reconcileMyEmail: vi.fn() }));
+
+const policy = {
+  customStrengthOptions: { minPasswordLength: 12 },
+  enforcementState: "ENFORCE",
+  forceUpgradeOnSignin: true,
+  allowedNonAlphanumericCharacters: "",
+};
+
+function renderGate() {
+  return render(
+    <MemoryRouter>
+      <AuthGate />
+    </MemoryRouter>,
+  );
+}
+
+async function enterCredentials(password: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Email"), "member@example.org");
+  await user.type(screen.getByLabelText("Password"), password);
+  await user.click(screen.getByRole("button", { name: "Sign in" }));
+}
+
+describe("AuthGate password policy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(onAuthStateChanged).mockImplementation((_auth, observer) => {
+      if (typeof observer === "function") observer(null);
+      return vi.fn();
+    });
+  });
+
+  it("checks every submitted password and routes a non-compliant member to reset", async () => {
+    vi.mocked(validatePassword).mockResolvedValue({
+      isValid: false,
+      meetsMinPasswordLength: false,
+      passwordPolicy: policy,
+    });
+    renderGate();
+    await enterCredentials("legacy-password");
+    expect(await screen.findByText(/Reset your password to continue/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Forgot password?" })).toHaveAttribute(
+      "href",
+      "/account/reset-password",
+    );
+    expect(signInWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  it("signs in when the submitted password meets the deployed policy", async () => {
+    vi.mocked(validatePassword).mockResolvedValue({ isValid: true, passwordPolicy: policy });
+    vi.mocked(signInWithEmailAndPassword).mockResolvedValue({
+      user: {
+        emailVerified: false,
+        getIdToken: vi.fn().mockResolvedValue("token"),
+      },
+    } as never);
+    renderGate();
+    await enterCredentials("compliant-password");
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
+      {},
+      "member@example.org",
+      "compliant-password",
+    );
+  });
+});

--- a/src/features/auth/components/__tests__/AuthGate.test.tsx
+++ b/src/features/auth/components/__tests__/AuthGate.test.tsx
@@ -1,14 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { onAuthStateChanged, signInWithEmailAndPassword, validatePassword } from "firebase/auth";
+import { onAuthStateChanged, signInWithEmailAndPassword } from "firebase/auth";
 import { render, screen } from "../../../../test-utils";
 import AuthGate from "../AuthGate";
 
 vi.mock("firebase/auth", () => ({
   onAuthStateChanged: vi.fn(),
   signInWithEmailAndPassword: vi.fn(),
-  validatePassword: vi.fn(),
 }));
 
 vi.mock("../../../../config/firebase", () => ({ auth: {} }));
@@ -16,13 +15,6 @@ vi.mock("../../../users/hooks/useEnabledClaim", () => ({
   useEnabledClaim: () => ({ isEnabled: false, isEnabledClaimResolved: true }),
 }));
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({ reconcileMyEmail: vi.fn() }));
-
-const policy = {
-  customStrengthOptions: { minPasswordLength: 12 },
-  enforcementState: "ENFORCE",
-  forceUpgradeOnSignin: true,
-  allowedNonAlphanumericCharacters: "",
-};
 
 function renderGate() {
   return render(
@@ -39,7 +31,7 @@ async function enterCredentials(password: string) {
   await user.click(screen.getByRole("button", { name: "Sign in" }));
 }
 
-describe("AuthGate password policy", () => {
+describe("AuthGate sign-in", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(onAuthStateChanged).mockImplementation((_auth, observer) => {
@@ -48,11 +40,10 @@ describe("AuthGate password policy", () => {
     });
   });
 
-  it("checks every submitted password and routes a non-compliant member to reset", async () => {
-    vi.mocked(validatePassword).mockResolvedValue({
-      isValid: false,
-      meetsMinPasswordLength: false,
-      passwordPolicy: policy,
+  it("routes a member to reset when Firebase rejects their password under the policy", async () => {
+    vi.mocked(signInWithEmailAndPassword).mockRejectedValue({
+      code: "auth/password-does-not-meet-requirements",
+      message: "Password does not meet requirements",
     });
     renderGate();
     await enterCredentials("legacy-password");
@@ -61,11 +52,25 @@ describe("AuthGate password policy", () => {
       "href",
       "/account/reset-password",
     );
-    expect(signInWithEmailAndPassword).not.toHaveBeenCalled();
+    expect(signInWithEmailAndPassword).toHaveBeenCalledWith(
+      {},
+      "member@example.org",
+      "legacy-password",
+    );
   });
 
-  it("signs in when the submitted password meets the deployed policy", async () => {
-    vi.mocked(validatePassword).mockResolvedValue({ isValid: true, passwordPolicy: policy });
+  it("does not misreport an ordinary invalid credential as a policy failure", async () => {
+    vi.mocked(signInWithEmailAndPassword).mockRejectedValue({
+      code: "auth/invalid-credential",
+      message: "Firebase: Error (auth/invalid-credential).",
+    });
+    renderGate();
+    await enterCredentials("mistyped-password");
+    expect(await screen.findByText(/auth\/invalid-credential/)).toBeInTheDocument();
+    expect(screen.queryByText(/password no longer meets/i)).not.toBeInTheDocument();
+  });
+
+  it("signs in when Firebase accepts the submitted password", async () => {
     vi.mocked(signInWithEmailAndPassword).mockResolvedValue({
       user: {
         emailVerified: false,

--- a/src/features/auth/components/__tests__/Register.test.tsx
+++ b/src/features/auth/components/__tests__/Register.test.tsx
@@ -1,17 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { render, screen, fireEvent } from "../../../../test-utils";
+import { render, screen } from "../../../../test-utils";
 import Register from "../Register";
-import { REGISTRATION_MIN_PASSWORD_LENGTH } from "../../../../constants/auth";
+import { createUserWithEmailAndPassword, validatePassword } from "firebase/auth";
 
 vi.mock("firebase/auth", () => ({
   createUserWithEmailAndPassword: vi.fn(),
+  validatePassword: vi.fn(),
 }));
 
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   syncPendingUserClaims: vi.fn(),
   requestEmailVerification: vi.fn(),
 }));
+
+const policy = {
+  customStrengthOptions: { minPasswordLength: 12 },
+  enforcementState: "ENFORCE",
+  forceUpgradeOnSignin: true,
+  allowedNonAlphanumericCharacters: "",
+};
 
 async function fillForm(user: ReturnType<typeof userEvent.setup>, password: string) {
   await user.type(screen.getByLabelText(/email/i), "new@example.com");
@@ -20,43 +28,34 @@ async function fillForm(user: ReturnType<typeof userEvent.setup>, password: stri
 }
 
 describe("Register", () => {
-  it(`shows the ${REGISTRATION_MIN_PASSWORD_LENGTH}-character minimum in the password helper text`, () => {
+  it("explains that password requirements come from the current policy", () => {
     render(<Register />);
-
     expect(
-      screen.getByText(`Must be at least ${REGISTRATION_MIN_PASSWORD_LENGTH} characters`)
+      screen.getByText(/Requirements are checked against the current account security policy/),
     ).toBeInTheDocument();
   });
 
-  it("keeps Create account disabled when the password is below the minimum", async () => {
+  it("keeps Create account disabled when the confirmation differs", async () => {
     const user = userEvent.setup();
     render(<Register />);
-
-    await fillForm(user, "a".repeat(REGISTRATION_MIN_PASSWORD_LENGTH - 1));
-
+    await user.type(screen.getByLabelText(/email/i), "new@example.com");
+    await user.type(screen.getByLabelText(/^password/i), "one-password");
+    await user.type(screen.getByLabelText(/confirm password/i), "another-password");
     expect(screen.getByRole("button", { name: "Create account" })).toBeDisabled();
   });
 
-  it("enables Create account once the password meets the minimum and matches confirmation", async () => {
+  it("asks Firebase to validate before creating an account", async () => {
     const user = userEvent.setup();
+    vi.mocked(validatePassword).mockResolvedValue({
+      isValid: false,
+      meetsMinPasswordLength: false,
+      passwordPolicy: policy,
+    });
     render(<Register />);
-
-    await fillForm(user, "a".repeat(REGISTRATION_MIN_PASSWORD_LENGTH));
-
-    expect(screen.getByRole("button", { name: "Create account" })).toBeEnabled();
-  });
-
-  it("shows validateForm's own rejection message when the form is submitted directly with a too-short password", async () => {
-    const user = userEvent.setup();
-    render(<Register />);
-
     await fillForm(user, "short");
-    // The submit button is disabled at this password length, but the form's own onSubmit
-    // validation (validateForm) is a second line of defense — exercise it directly.
-    fireEvent.submit(screen.getByRole("button", { name: "Create account" }).closest("form")!);
-
-    expect(
-      await screen.findByText(`Password must be at least ${REGISTRATION_MIN_PASSWORD_LENGTH} characters`)
-    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+    expect(await screen.findByText("Password must be at least 12 characters.")).toBeInTheDocument();
+    expect(validatePassword).toHaveBeenCalled();
+    expect(createUserWithEmailAndPassword).not.toHaveBeenCalled();
   });
 });

--- a/src/features/auth/utils/__tests__/passwordValidation.test.ts
+++ b/src/features/auth/utils/__tests__/passwordValidation.test.ts
@@ -1,29 +1,53 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { validatePassword } from "firebase/auth";
 import {
   canAttemptSignIn,
-  getRegistrationPasswordHelperText,
-  validateRegistrationPassword,
+  passwordPolicyError,
+  validateNewPassword,
 } from "../passwordValidation";
-import {
-  FIREBASE_MIN_PASSWORD_LENGTH,
-  REGISTRATION_MIN_PASSWORD_LENGTH,
-} from "../../../../constants/auth";
+import { FIREBASE_MIN_PASSWORD_LENGTH } from "../../../../constants/auth";
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const original = await importOriginal<typeof import("firebase/auth")>();
+  return { ...original, validatePassword: vi.fn() };
+});
+
+const policy = {
+  customStrengthOptions: { minPasswordLength: 12 },
+  enforcementState: "ENFORCE",
+  forceUpgradeOnSignin: true,
+  allowedNonAlphanumericCharacters: "",
+};
 
 describe("passwordValidation", () => {
-  it("uses shared registration minimum length", () => {
-    expect(REGISTRATION_MIN_PASSWORD_LENGTH).toBe(12);
-    expect(getRegistrationPasswordHelperText()).toBe("Must be at least 12 characters");
+  beforeEach(() => vi.clearAllMocks());
+
+  it("describes requirements reported by Firebase", () => {
+    expect(
+      passwordPolicyError({
+        isValid: false,
+        meetsMinPasswordLength: false,
+        containsUppercaseLetter: false,
+        containsNumericCharacter: false,
+        passwordPolicy: policy,
+      }),
+    ).toBe("Password must be at least 12 characters, include an uppercase letter, include a number.");
   });
 
-  it("rejects registration passwords below the minimum", () => {
-    expect(validateRegistrationPassword("123456789012").isValid).toBe(true);
-    expect(validateRegistrationPassword("12345678901")).toEqual({
+  it("uses the deployed Firebase policy as the validation source", async () => {
+    vi.mocked(validatePassword).mockResolvedValue({
       isValid: false,
-      error: "Password must be at least 12 characters",
+      meetsMinPasswordLength: false,
+      passwordPolicy: policy,
     });
+    await expect(validateNewPassword({} as never, "short")).resolves.toMatchObject({
+      isValid: false,
+      error: "Password must be at least 12 characters.",
+    });
+    expect(validatePassword).toHaveBeenCalledWith({}, "short");
   });
 
-  it("allows sign-in at the Firebase minimum length", () => {
+  it("allows sign-in attempts at the Firebase credential floor", () => {
     expect(FIREBASE_MIN_PASSWORD_LENGTH).toBe(6);
     expect(canAttemptSignIn("12345")).toBe(false);
     expect(canAttemptSignIn("123456")).toBe(true);

--- a/src/features/auth/utils/passwordValidation.ts
+++ b/src/features/auth/utils/passwordValidation.ts
@@ -1,22 +1,48 @@
 import {
-  FIREBASE_MIN_PASSWORD_LENGTH,
-  REGISTRATION_MIN_PASSWORD_LENGTH,
-} from "../../../constants/auth";
+  validatePassword as validateFirebasePassword,
+  type Auth,
+  type PasswordValidationStatus,
+} from "firebase/auth";
+import { FIREBASE_MIN_PASSWORD_LENGTH } from "../../../constants/auth";
 
-export function validateRegistrationPassword(password: string): { isValid: boolean; error?: string } {
-  if (password.length < REGISTRATION_MIN_PASSWORD_LENGTH) {
-    return {
-      isValid: false,
-      error: `Password must be at least ${REGISTRATION_MIN_PASSWORD_LENGTH} characters`,
-    };
+export const PASSWORD_POLICY_HELPER_TEXT =
+  "Requirements are checked against the current account security policy.";
+
+export function passwordPolicyError(status: PasswordValidationStatus): string {
+  const requirements: string[] = [];
+  const options = status.passwordPolicy.customStrengthOptions;
+  if (status.meetsMinPasswordLength === false && options.minPasswordLength) {
+    requirements.push(`be at least ${options.minPasswordLength} characters`);
   }
-  return { isValid: true };
+  if (status.meetsMaxPasswordLength === false && options.maxPasswordLength) {
+    requirements.push(`be no more than ${options.maxPasswordLength} characters`);
+  }
+  if (status.containsLowercaseLetter === false) requirements.push("include a lowercase letter");
+  if (status.containsUppercaseLetter === false) requirements.push("include an uppercase letter");
+  if (status.containsNumericCharacter === false) requirements.push("include a number");
+  if (status.containsNonAlphanumericCharacter === false) {
+    requirements.push("include a non-alphanumeric character");
+  }
+  return requirements.length
+    ? `Password must ${requirements.join(", ")}.`
+    : "Password does not meet the current account security policy.";
 }
 
-export function getRegistrationPasswordHelperText(): string {
-  return `Must be at least ${REGISTRATION_MIN_PASSWORD_LENGTH} characters`;
+export async function validateNewPassword(auth: Auth, password: string) {
+  const status = await validateFirebasePassword(auth, password);
+  return {
+    isValid: status.isValid,
+    error: status.isValid ? undefined : passwordPolicyError(status),
+    status,
+  };
 }
 
 export function canAttemptSignIn(password: string): boolean {
   return password.length >= FIREBASE_MIN_PASSWORD_LENGTH;
+}
+
+export function isPasswordPolicyAuthError(error: unknown): boolean {
+  const code =
+    error && typeof error === "object" && "code" in error ? String(error.code) : "";
+  return code.includes("password-does-not-meet-requirements") || code.includes("weak-password");
 }

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogContent,
   DialogTitle,
   FormControlLabel,
+  FormGroup,
   Stack,
   TextField,
   Typography,
@@ -17,6 +18,11 @@ import {
   useTheme,
 } from "@mui/material";
 import { confirmProfileReview } from "@dataconnect/generated";
+import {
+  useGetMyAnnouncementPreferences,
+  useOptInSectionAnnouncement,
+  useOptOutSectionAnnouncement,
+} from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import {
   MAX_MOBILE_NUMBER_LENGTH,
@@ -28,6 +34,7 @@ import RankSelect from "../../../shared/components/RankSelect";
 import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
 import type { UserData } from "../../../types";
+import { getAnnouncementSections } from "../../account/utils/announcementPreferences";
 
 interface ProfileReviewDialogProps {
   userData: UserData;
@@ -49,9 +56,16 @@ export default function ProfileReviewDialog({
   const [postNominals, setPostNominals] = useState("");
   const [rank, setRank] = useState("");
   const [shareContactInfo, setShareContactInfo] = useState(true);
+  const [announcementOptOutAll, setAnnouncementOptOutAll] = useState(false);
+  const [sectionOptOutIds, setSectionOptOutIds] = useState<Set<string>>(new Set());
+  const [preferencesInitialised, setPreferencesInitialised] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [rankError, setRankError] = useState(false);
+  const preferences = useGetMyAnnouncementPreferences({ staleTime: 0 });
+  const optOutSection = useOptOutSectionAnnouncement();
+  const optInSection = useOptInSectionAnnouncement();
+  const announcementSections = getAnnouncementSections(preferences.data);
 
   useEffect(() => {
     setFirstName(userData.firstName || "");
@@ -62,6 +76,15 @@ export default function ProfileReviewDialog({
     setRank(userData.rank || "");
     setShareContactInfo(userData.shareContactInfo ?? true);
   }, [userData]);
+
+  useEffect(() => {
+    if (!preferences.data?.user || preferencesInitialised) return;
+    setAnnouncementOptOutAll(preferences.data.user.announcementOptOutAll ?? false);
+    setSectionOptOutIds(
+      new Set((preferences.data.user.optOuts ?? []).map((optOut) => optOut.section.id)),
+    );
+    setPreferencesInitialised(true);
+  }, [preferences.data, preferencesInitialised]);
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -81,6 +104,20 @@ export default function ProfileReviewDialog({
     setRankError(false);
     setSubmitting(true);
     try {
+      if (!preferences.data?.user || !preferencesInitialised) {
+        throw new Error("Communication preferences are still loading. Please try again.");
+      }
+      const storedOptOutIds = new Set(
+        (preferences.data.user.optOuts ?? []).map((optOut) => optOut.section.id),
+      );
+      for (const section of announcementSections) {
+        const stored = storedOptOutIds.has(section.id);
+        const requested = sectionOptOutIds.has(section.id);
+        if (stored === requested) continue;
+        if (requested) await optOutSection.mutateAsync({ sectionId: section.id });
+        else await optInSection.mutateAsync({ sectionId: section.id });
+      }
+
       await confirmProfileReview(dataConnect, {
         firstName: firstName.trim(),
         lastName: lastName.trim(),
@@ -89,6 +126,7 @@ export default function ProfileReviewDialog({
         postNominals: postNominals.trim() || null,
         rank,
         shareContactInfo,
+        announcementOptOutAll,
       });
 
       const displayName = `${lastName.trim()}, ${firstName.trim()}`;
@@ -133,8 +171,8 @@ export default function ProfileReviewDialog({
         <DialogTitle id="profile-review-title">Please review your profile</DialogTitle>
         <DialogContent dividers>
           <Typography id="profile-review-description" variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-            Please check these details are still correct. We ask every six months so membership and
-            contact information stays current.
+            Please check these details and communication choices are still correct. We ask every six
+            months so membership and contact information stays current.
           </Typography>
 
           {error && (
@@ -219,10 +257,62 @@ export default function ProfileReviewDialog({
               }
               label="Share my email address and mobile number with members in my sections"
             />
+            <Box component="section" aria-labelledby="review-announcements-heading">
+              <Typography id="review-announcements-heading" variant="h6" component="h2">
+                Announcement emails
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Account-security, booking and payment messages are always sent when required.
+              </Typography>
+              {preferences.isLoading ? <CircularProgress size={20} /> : null}
+              {preferences.isError ? (
+                <Alert severity="error">We could not load your communication preferences.</Alert>
+              ) : null}
+              {preferencesInitialised ? (
+                <FormGroup>
+                  <FormControlLabel
+                    control={
+                      <Checkbox
+                        checked={!announcementOptOutAll}
+                        onChange={(event) => setAnnouncementOptOutAll(!event.target.checked)}
+                        disabled={submitting}
+                      />
+                    }
+                    label="Receive announcement emails"
+                  />
+                  {announcementSections.map((section) => (
+                    <FormControlLabel
+                      key={section.id}
+                      control={
+                        <Checkbox
+                          checked={!sectionOptOutIds.has(section.id)}
+                          onChange={(event) => {
+                            setSectionOptOutIds((current) => {
+                              const next = new Set(current);
+                              if (event.target.checked) next.delete(section.id);
+                              else next.add(section.id);
+                              return next;
+                            });
+                          }}
+                          disabled={submitting || announcementOptOutAll}
+                        />
+                      }
+                      label={section.name}
+                    />
+                  ))}
+                </FormGroup>
+              ) : null}
+            </Box>
           </Stack>
         </DialogContent>
         <DialogActions sx={{ px: 3, py: 2 }}>
-          <Button type="submit" variant="contained" disabled={submitting || missingRequiredField}>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={
+              submitting || missingRequiredField || !preferencesInitialised || preferences.isError
+            }
+          >
             {submitting ? <CircularProgress size={24} /> : "Confirm profile"}
           </Button>
         </DialogActions>

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { fireEvent, render, screen, waitFor } from "../../../../test-utils";
 import { MembershipStatus } from "@dataconnect/generated";
 import * as generated from "@dataconnect/generated";
+import * as generatedReact from "@dataconnect/generated/react";
 import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 import type { UserData } from "../../../../types";
 import ProfileReviewDialog from "../ProfileReviewDialog";
@@ -12,6 +13,27 @@ vi.mock("@dataconnect/generated", () => ({
   MembershipStatus: {
     REGULAR: "REGULAR",
   },
+}));
+
+const mockOptOut = vi.fn().mockResolvedValue(undefined);
+const mockOptIn = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@dataconnect/generated/react", () => ({
+  useGetMyAnnouncementPreferences: vi.fn(() => ({
+    data: {
+      user: {
+        membershipStatus: "REGULAR",
+        announcementOptOutAll: false,
+        userGroups: [],
+        optOuts: [],
+      },
+      allUserGroups: [],
+    },
+    isLoading: false,
+    isError: false,
+  })),
+  useOptOutSectionAnnouncement: vi.fn(() => ({ mutateAsync: mockOptOut })),
+  useOptInSectionAnnouncement: vi.fn(() => ({ mutateAsync: mockOptIn })),
 }));
 
 vi.mock("../../../../config/firebase", () => ({
@@ -43,6 +65,110 @@ describe("ProfileReviewDialog", () => {
     vi.clearAllMocks();
     vi.mocked(generated.confirmProfileReview).mockResolvedValue({ data: {} } as never);
     vi.mocked(firebaseFunctions.updateDisplayName).mockResolvedValue({ success: true });
+    mockOptOut.mockResolvedValue(undefined);
+    mockOptIn.mockResolvedValue(undefined);
+    vi.mocked(generatedReact.useGetMyAnnouncementPreferences).mockReturnValue({
+      data: {
+        user: {
+          membershipStatus: "REGULAR",
+          announcementOptOutAll: false,
+          userGroups: [],
+          optOuts: [],
+        },
+        allUserGroups: [],
+      },
+      isLoading: false,
+      isError: false,
+    } as never);
+  });
+
+  it("reviews per-section preferences before advancing the profile timestamp", async () => {
+    vi.mocked(generatedReact.useGetMyAnnouncementPreferences).mockReturnValue({
+      data: {
+        user: {
+          membershipStatus: "REGULAR",
+          announcementOptOutAll: false,
+          userGroups: [
+            {
+              userGroup: {
+                membershipStatuses: [],
+                purposeLinks: [
+                  {
+                    purposes: ["ACCESS"],
+                    section: { id: "section-1", name: "Golf" },
+                  },
+                ],
+              },
+            },
+          ],
+          optOuts: [],
+        },
+        allUserGroups: [],
+      },
+      isLoading: false,
+      isError: false,
+    } as never);
+    const interaction = userEvent.setup();
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={vi.fn()}
+      />,
+    );
+
+    await interaction.click(await screen.findByRole("checkbox", { name: "Golf" }));
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    await waitFor(() => expect(mockOptOut).toHaveBeenCalledWith({ sectionId: "section-1" }));
+    expect(mockOptOut.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(generated.confirmProfileReview).mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("does not advance the profile timestamp when a preference save fails", async () => {
+    vi.mocked(generatedReact.useGetMyAnnouncementPreferences).mockReturnValue({
+      data: {
+        user: {
+          membershipStatus: "REGULAR",
+          announcementOptOutAll: false,
+          userGroups: [
+            {
+              userGroup: {
+                membershipStatuses: [],
+                purposeLinks: [
+                  {
+                    purposes: ["ACCESS"],
+                    section: { id: "section-1", name: "Golf" },
+                  },
+                ],
+              },
+            },
+          ],
+          optOuts: [],
+        },
+        allUserGroups: [],
+      },
+      isLoading: false,
+      isError: false,
+    } as never);
+    mockOptOut.mockRejectedValueOnce(new Error("Preference save failed"));
+    const interaction = userEvent.setup();
+    const onReviewed = vi.fn();
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={onReviewed}
+      />,
+    );
+
+    await interaction.click(await screen.findByRole("checkbox", { name: "Golf" }));
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    expect(await screen.findByText("Preference save failed")).toBeInTheDocument();
+    expect(generated.confirmProfileReview).not.toHaveBeenCalled();
+    expect(onReviewed).not.toHaveBeenCalled();
   });
 
   it("shows all review fields and sources the read-only email from Firebase Auth", () => {
@@ -72,6 +198,7 @@ describe("ProfileReviewDialog", () => {
         name: "Share my email address and mobile number with members in my sections",
       }),
     ).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Receive announcement emails" })).toBeChecked();
   });
 
   it("normalises and atomically submits the reviewed fields before completing", async () => {
@@ -98,6 +225,7 @@ describe("ProfileReviewDialog", () => {
           postNominals: "MRAeS",
           rank: "Wing Commander",
           shareContactInfo: true,
+          announcementOptOutAll: false,
         },
       );
     });

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -13,6 +13,10 @@ vi.mock("@dataconnect/generated", () => ({
   MembershipStatus: {
     REGULAR: "REGULAR",
   },
+  SectionUserGroupPurpose: {
+    ACCESS: "ACCESS",
+    MODERATOR: "MODERATOR",
+  },
 }));
 
 const mockOptOut = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- use each Firebase project's configured password policy for registration, password reset, and password changes, and handle Firebase's force-upgrade response during sign-in
- direct members with non-compliant passwords to the existing reset flow
- combine the six-month profile review with global and per-section announcement preferences
- prevent the review timestamp advancing when a preference update fails
- document password-policy configuration and migration verification for Dev, Beta, and Prod

## Impact

Migrated members are guided through password compliance, email verification, account access checks, and the combined profile/comms review in a consistent order. Password requirements follow Firebase configuration rather than an application or environment-variable constant.

## Operator action

Configure and verify the recommended Firebase password policy independently in Dev, Beta, and Prod using the new runbook. New-password validation improves guidance; sign-in relies on Firebase's policy response so monitoring mode and ordinary invalid credentials behave correctly. Firebase Auth remains the enforcement boundary.

## Validation

- frontend lint and production build
- Functions lint and build
- frontend coverage: 82 files, 641 tests
- Functions coverage: 73 files, 730 tests
- focused profile-review regression test: 6 tests
- Data Connect SDK generation and generated-output checks
- `git diff --check`

Closes #456
