### PR TITLE
Establish shared safe error handling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `architecture/booking-data-model.md`: booking entities, relationships, and issue cross-links.
 - `architecture/booking-submission-api.md`: callable contract for `submitEventBooking`.
 - `architecture/security-and-permissions.md`: auth model across Data Connect and Cloud Functions.
+- `architecture/error-handling.md`: shared safe error contract, provider/domain-code mapping, diagnostic reporting, and privacy rules.
 - `operations/environment-and-secrets.md`: environment variables and secrets matrix.
 - `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, schema-first deploy flow, smoke-test and rollback checkpoints, and local setup (cloud-backed dev; no emulators).
 - `operations/new-production-instance.md`: first-time Firebase/GCP production provisioning, integrations, administrator bootstrap, deployment, and go-live checklist.

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -58,6 +58,20 @@ Do not build a single global map of server message strings. Server copy is not a
 stable API and may expose implementation details. Add stable domain codes to the
 callable contract where they are missing.
 
+### Ambiguous failed preconditions
+
+The Firebase/gRPC `failed-precondition` transport code does not identify one
+user-facing category. This codebase uses it for both state conflicts (for example,
+an object changed and must be refreshed) and deployment configuration failures
+(for example, a provider is not configured). The shared classifier therefore
+maps an unqualified `failed-precondition` to neutral `precondition` guidance.
+
+Before adopting `toUserFacingError` for a callable that can return
+`failed-precondition`, add an application-owned `details.code` and a reviewed
+feature mapping whenever the UI must distinguish `conflict`, `configuration`,
+validation, or another outcome. Never infer that distinction from the callable's
+message text.
+
 ## Authentication and privacy
 
 `toAuthUserFacingError` centralises Firebase Auth mapping and takes a context so

--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -1,0 +1,76 @@
+# Safe error handling
+
+Issue #463 establishes the shared client-side contract for turning technical
+failures into safe, useful display content. The broader #302 epic migrates each
+application surface to this contract.
+
+## Rule: map, report, display
+
+Treat caught values as `unknown` and keep these operations separate:
+
+1. **Map** the technical error with `toUserFacingError` or
+   `toAuthUserFacingError` from `src/shared/errors`.
+2. **Report** the original value with `reportError`, using a stable context name
+   that contains no personal data or secrets.
+3. **Display** only fields from the resulting `UserFacingError`.
+
+Never render an arbitrary `error.message`, Firebase/provider code, stack trace,
+SQL or Data Connect detail, Stripe response, storage detail, or callable message.
+The raw exception belongs only in controlled logs or telemetry.
+
+```ts
+try {
+  await performOperation();
+} catch (error: unknown) {
+  reportError("perform-operation", error);
+  const displayError = toUserFacingError(error);
+  setError(displayError);
+}
+```
+
+`UserFacingError` provides a category, title, message, retryability flag, and an
+optional recommended action. UI components should use `retryable` only when the
+operation itself is safe to repeat.
+
+## Provider and domain codes
+
+`extractErrorCode` reads provider codes such as `functions/unavailable` and uses
+them only for broad classification. `extractDomainErrorCode` reads a restricted,
+application-owned code from callable `details.code` (or `customData.code` for
+Firebase compatibility).
+
+Domain features should provide their own reviewed code map:
+
+```ts
+const displayError = toUserFacingError(error, {
+  domainErrors: {
+    BOOKING_ALREADY_SUBMITTED: {
+      category: "conflict",
+      title: "Already booked",
+      message: "You already have a booking for this event.",
+      retryable: false,
+    },
+  },
+});
+```
+
+Do not build a single global map of server message strings. Server copy is not a
+stable API and may expose implementation details. Add stable domain codes to the
+callable contract where they are missing.
+
+## Authentication and privacy
+
+`toAuthUserFacingError` centralises Firebase Auth mapping and takes a context so
+registration, sign-in, account changes, and action links can give appropriate
+guidance. Flows that could reveal whether an account exists must use neutral copy;
+for example, invalid credentials, unknown users, and wrong passwords map to the
+same sign-in response.
+
+## Adding a mapping
+
+- Prefer an existing category when only generic guidance is required.
+- Add contextual Auth wording to `authErrors.ts`.
+- Add business-rule wording in the owning feature, keyed by a stable domain code.
+- Always retain the safe unknown fallback.
+- Test the known code, malformed/unknown input, raw-message non-disclosure, and
+  retryability or privacy behaviour.

--- a/src/features/auth/components/Register.tsx
+++ b/src/features/auth/components/Register.tsx
@@ -18,6 +18,10 @@ import {
   PASSWORD_POLICY_HELPER_TEXT,
   validateNewPassword,
 } from "../utils/passwordValidation";
+import {
+  reportError,
+  toAuthUserFacingError,
+} from "../../../shared/errors";
 
 interface RegisterProps {
   onSuccess?: () => void;
@@ -88,21 +92,9 @@ export default function Register({ onSuccess, onSignInClick }: RegisterProps) {
       if (onSuccess) {
         onSuccess();
       }
-    } catch (e: any) {
-      let errorMessage = "Registration failed";
-      if (e?.code === "auth/email-already-in-use") {
-        errorMessage = "This email is already registered. Please sign in instead.";
-      } else if (e?.code === "auth/invalid-email") {
-        errorMessage = "Invalid email address";
-      } else if (e?.code === "auth/weak-password") {
-        errorMessage = "Password is too weak";
-      } else if (String(e?.code ?? "").startsWith("functions/")) {
-        errorMessage =
-          "Your account was created, but we couldn’t send the verification email. Sign in to request another.";
-      } else if (e?.message) {
-        errorMessage = e.message;
-      }
-      setError(errorMessage);
+    } catch (error: unknown) {
+      reportError("registration", error);
+      setError(toAuthUserFacingError(error, "register").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/__tests__/Register.test.tsx
+++ b/src/features/auth/components/__tests__/Register.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "../../../../test-utils";
 import Register from "../Register";
@@ -28,6 +28,10 @@ async function fillForm(user: ReturnType<typeof userEvent.setup>, password: stri
 }
 
 describe("Register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("explains that password requirements come from the current policy", () => {
     render(<Register />);
     expect(
@@ -57,5 +61,27 @@ describe("Register", () => {
     expect(await screen.findByText("Password must be at least 12 characters.")).toBeInTheDocument();
     expect(validatePassword).toHaveBeenCalled();
     expect(createUserWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  it("uses the shared safe fallback instead of rendering an unknown technical message", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const user = userEvent.setup();
+    vi.mocked(validatePassword).mockResolvedValue({
+      isValid: true,
+      passwordPolicy: policy,
+    });
+    vi.mocked(createUserWithEmailAndPassword).mockRejectedValue(
+      new Error("SQL user insert failed with internal identifier 42"),
+    );
+
+    render(<Register />);
+    await fillForm(user, "compliant-password");
+    await user.click(screen.getByRole("button", { name: "Create account" }));
+
+    expect(
+      await screen.findByText("The account request could not be completed. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/SQL user insert/)).not.toBeInTheDocument();
+    consoleSpy.mockRestore();
   });
 });

--- a/src/shared/errors/__tests__/errorHandling.test.ts
+++ b/src/shared/errors/__tests__/errorHandling.test.ts
@@ -34,7 +34,7 @@ describe("shared error handling", () => {
     ["functions/not-found", "not-found"],
     ["functions/resource-exhausted", "rate-limit"],
     ["auth/network-request-failed", "network"],
-    ["functions/failed-precondition", "configuration"],
+    ["functions/failed-precondition", "precondition"],
     ["functions/internal", "unknown"],
   ] as const)("classifies %s as %s", (code, category) => {
     expect(classifyError({ code })).toBe(category);
@@ -65,6 +65,21 @@ describe("shared error handling", () => {
       message: "You already have a booking for this event.",
       retryable: false,
     });
+  });
+
+  it("uses neutral guidance when failed-precondition has no stable domain code", () => {
+    const mapped = toUserFacingError({
+      code: "functions/failed-precondition",
+      message: "Stripe is not configured on the server",
+    });
+    expect(mapped).toEqual({
+      category: "precondition",
+      title: "The operation cannot be completed",
+      message:
+        "The operation cannot be completed in its current state. Refresh and try again. If the problem continues, contact an administrator.",
+      retryable: true,
+    });
+    expect(mapped.message).not.toContain("Stripe");
   });
 
   it("never exposes an unknown error message", () => {

--- a/src/shared/errors/__tests__/errorHandling.test.ts
+++ b/src/shared/errors/__tests__/errorHandling.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyError,
+  extractDomainErrorCode,
+  extractErrorCode,
+  reportError,
+  toAuthUserFacingError,
+  toUserFacingError,
+} from "../index";
+
+describe("shared error handling", () => {
+  it("extracts and normalises provider codes without reading messages", () => {
+    expect(extractErrorCode({ code: " Functions/Unavailable " })).toBe(
+      "functions/unavailable",
+    );
+    expect(extractErrorCode(new Error("functions/unavailable"))).toBeUndefined();
+  });
+
+  it("accepts stable callable detail codes and rejects arbitrary detail", () => {
+    expect(extractDomainErrorCode({ details: { code: "booking_already_submitted" } })).toBe(
+      "BOOKING_ALREADY_SUBMITTED",
+    );
+    expect(extractDomainErrorCode({ customData: { code: "RECENT_LOGIN_REQUIRED" } })).toBe(
+      "RECENT_LOGIN_REQUIRED",
+    );
+    expect(extractDomainErrorCode({ details: { code: "Not safe to display." } })).toBeUndefined();
+  });
+
+  it.each([
+    ["functions/permission-denied", "authorization"],
+    ["auth/requires-recent-login", "authentication"],
+    ["functions/invalid-argument", "validation"],
+    ["functions/already-exists", "conflict"],
+    ["functions/not-found", "not-found"],
+    ["functions/resource-exhausted", "rate-limit"],
+    ["auth/network-request-failed", "network"],
+    ["functions/failed-precondition", "configuration"],
+    ["functions/internal", "unknown"],
+  ] as const)("classifies %s as %s", (code, category) => {
+    expect(classifyError({ code })).toBe(category);
+  });
+
+  it("maps application-owned domain codes before generic provider categories", () => {
+    expect(
+      toUserFacingError(
+        {
+          code: "functions/failed-precondition",
+          details: { code: "BOOKING_ALREADY_SUBMITTED" },
+          message: "Internal booking revision 42 failed",
+        },
+        {
+          domainErrors: {
+            BOOKING_ALREADY_SUBMITTED: {
+              category: "conflict",
+              title: "Already booked",
+              message: "You already have a booking for this event.",
+              retryable: false,
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      category: "conflict",
+      title: "Already booked",
+      message: "You already have a booking for this event.",
+      retryable: false,
+    });
+  });
+
+  it("never exposes an unknown error message", () => {
+    const technicalMessage = "SQL SELECT users password_hash failed";
+    const mapped = toUserFacingError(new Error(technicalMessage));
+    expect(mapped.category).toBe("unknown");
+    expect(mapped.message).not.toContain(technicalMessage);
+    expect(mapped.message).toBe("The operation could not be completed. Please try again.");
+  });
+
+  it("uses a neutral sign-in message for account-enumerating Auth failures", () => {
+    const missingUser = toAuthUserFacingError(
+      { code: "auth/user-not-found", message: "No user record" },
+      "sign-in",
+    );
+    const wrongPassword = toAuthUserFacingError(
+      { code: "auth/wrong-password", message: "Wrong password" },
+      "sign-in",
+    );
+    expect(missingUser.message).toBe("Email or password is incorrect.");
+    expect(wrongPassword.message).toBe(missingUser.message);
+  });
+
+  it("maps registration errors without exposing Firebase messages", () => {
+    const mapped = toAuthUserFacingError(
+      {
+        code: "auth/email-already-in-use",
+        message: "Firebase: Error (auth/email-already-in-use).",
+      },
+      "register",
+    );
+    expect(mapped.message).toBe("This email is already registered. Please sign in instead.");
+    expect(mapped.message).not.toContain("Firebase");
+  });
+
+  it("reports the original failure separately from display mapping", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const original = new Error("diagnostic detail");
+    reportError("registration", original, { attempt: 1 });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[registration]",
+      original,
+      { attempt: 1 },
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/shared/errors/authErrors.ts
+++ b/src/shared/errors/authErrors.ts
@@ -1,0 +1,121 @@
+import {
+  classifyError,
+  extractErrorCode,
+  toUserFacingError,
+  type UserFacingError,
+} from "./errorHandling";
+
+export type AuthErrorContext =
+  | "register"
+  | "sign-in"
+  | "password-change"
+  | "email-change"
+  | "action-link";
+
+const INVALID_CREDENTIAL_CODES = new Set([
+  "auth/invalid-credential",
+  "auth/user-not-found",
+  "auth/wrong-password",
+]);
+
+function authError(
+  category: UserFacingError["category"],
+  title: string,
+  message: string,
+  retryable = false,
+): UserFacingError {
+  return { category, title, message, retryable };
+}
+
+/** Central, context-aware Firebase Auth mapping. */
+export function toAuthUserFacingError(
+  error: unknown,
+  context: AuthErrorContext,
+): UserFacingError {
+  const code = extractErrorCode(error) ?? "";
+
+  if (context === "sign-in" && INVALID_CREDENTIAL_CODES.has(code)) {
+    return authError(
+      "authentication",
+      "Sign-in failed",
+      "Email or password is incorrect.",
+    );
+  }
+  if (code === "auth/user-disabled") {
+    return authError(
+      "authorization",
+      "Account unavailable",
+      "This account is disabled. Contact an administrator if you need help.",
+    );
+  }
+  if (
+    context === "sign-in" &&
+    (code === "auth/password-does-not-meet-requirements" || code === "auth/weak-password")
+  ) {
+    return authError(
+      "validation",
+      "Password update required",
+      "This password no longer meets the account security policy. Reset your password to continue.",
+    );
+  }
+  if (context === "register" && code === "auth/email-already-in-use") {
+    return authError(
+      "conflict",
+      "Account already exists",
+      "This email is already registered. Please sign in instead.",
+    );
+  }
+  if (code === "auth/invalid-email") {
+    return authError("validation", "Invalid email", "Enter a valid email address.");
+  }
+  if (
+    code === "auth/weak-password" ||
+    code === "auth/password-does-not-meet-requirements"
+  ) {
+    return authError(
+      "validation",
+      "Password requirements not met",
+      "Password does not meet the current account security policy.",
+    );
+  }
+  if (code === "auth/requires-recent-login") {
+    return authError(
+      "authentication",
+      "Sign in again",
+      "Please sign out and sign in again before retrying this change.",
+    );
+  }
+  if (code === "auth/expired-action-code") {
+    return authError(
+      "validation",
+      "Link expired",
+      "This secure link has expired. Request a new one to continue.",
+    );
+  }
+  if (code === "auth/invalid-action-code") {
+    return authError(
+      "validation",
+      "Link invalid",
+      "This secure link is invalid or has already been used.",
+    );
+  }
+  if (context === "register" && code.startsWith("functions/")) {
+    return authError(
+      classifyError(error),
+      "Verification email not sent",
+      "Your account was created, but we couldn’t send the verification email. Sign in to request another.",
+      true,
+    );
+  }
+
+  return toUserFacingError(error, {
+    fallback: {
+      title: context === "sign-in" ? "Sign-in failed" : "Account request failed",
+      message:
+        context === "sign-in"
+          ? "We couldn’t sign you in. Please try again."
+          : "The account request could not be completed. Please try again.",
+      retryable: true,
+    },
+  });
+}

--- a/src/shared/errors/errorHandling.ts
+++ b/src/shared/errors/errorHandling.ts
@@ -3,6 +3,7 @@ export type ErrorCategory =
   | "authorization"
   | "validation"
   | "conflict"
+  | "precondition"
   | "not-found"
   | "rate-limit"
   | "network"
@@ -56,6 +57,13 @@ const DEFAULT_ERRORS: Record<ErrorCategory, UserFacingError> = {
     category: "conflict",
     title: "The information has changed",
     message: "Refresh the page, check the latest information, and try again.",
+    retryable: true,
+  },
+  precondition: {
+    category: "precondition",
+    title: "The operation cannot be completed",
+    message:
+      "The operation cannot be completed in its current state. Refresh and try again. If the problem continues, contact an administrator.",
     retryable: true,
   },
   "not-found": {
@@ -169,7 +177,10 @@ export function classifyError(error: unknown): ErrorCategory {
   ) {
     return "validation";
   }
-  if (code.includes("failed-precondition")) return "configuration";
+  // Firebase/gRPC failed-precondition is used for both state conflicts and
+  // deployment configuration in this codebase. It cannot safely distinguish
+  // those outcomes without an application-owned details.code mapping.
+  if (code.includes("failed-precondition")) return "precondition";
   if (code.startsWith("auth/")) return "authentication";
   return "unknown";
 }

--- a/src/shared/errors/errorHandling.ts
+++ b/src/shared/errors/errorHandling.ts
@@ -1,0 +1,207 @@
+export type ErrorCategory =
+  | "authentication"
+  | "authorization"
+  | "validation"
+  | "conflict"
+  | "not-found"
+  | "rate-limit"
+  | "network"
+  | "configuration"
+  | "unknown";
+
+export interface ErrorAction {
+  label: string;
+  href?: string;
+}
+
+export interface UserFacingError {
+  category: ErrorCategory;
+  title: string;
+  message: string;
+  retryable: boolean;
+  action?: ErrorAction;
+}
+
+export type UserFacingErrorInput = Omit<UserFacingError, "category"> & {
+  category?: ErrorCategory;
+};
+
+export interface UserFacingErrorOptions {
+  domainErrors?: Readonly<Record<string, UserFacingErrorInput>>;
+  fallback?: UserFacingErrorInput;
+}
+
+type ErrorRecord = Record<string, unknown>;
+
+const DEFAULT_ERRORS: Record<ErrorCategory, UserFacingError> = {
+  authentication: {
+    category: "authentication",
+    title: "Sign in required",
+    message: "Please sign in again and retry the operation.",
+    retryable: false,
+  },
+  authorization: {
+    category: "authorization",
+    title: "Access denied",
+    message: "You do not have permission to complete this operation.",
+    retryable: false,
+  },
+  validation: {
+    category: "validation",
+    title: "Check the information",
+    message: "Check the information you entered and try again.",
+    retryable: false,
+  },
+  conflict: {
+    category: "conflict",
+    title: "The information has changed",
+    message: "Refresh the page, check the latest information, and try again.",
+    retryable: true,
+  },
+  "not-found": {
+    category: "not-found",
+    title: "Not found",
+    message: "The requested information could not be found.",
+    retryable: false,
+  },
+  "rate-limit": {
+    category: "rate-limit",
+    title: "Try again later",
+    message: "Too many requests have been made. Please wait before trying again.",
+    retryable: true,
+  },
+  network: {
+    category: "network",
+    title: "Connection problem",
+    message: "Check your connection and try again.",
+    retryable: true,
+  },
+  configuration: {
+    category: "configuration",
+    title: "Service unavailable",
+    message: "This service is not available at the moment. Please contact an administrator.",
+    retryable: false,
+  },
+  unknown: {
+    category: "unknown",
+    title: "Something went wrong",
+    message: "The operation could not be completed. Please try again.",
+    retryable: true,
+  },
+};
+
+function asRecord(value: unknown): ErrorRecord | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as ErrorRecord)
+    : undefined;
+}
+
+function stringProperty(value: unknown, property: string): string | undefined {
+  const candidate = asRecord(value)?.[property];
+  return typeof candidate === "string" && candidate.trim()
+    ? candidate.trim()
+    : undefined;
+}
+
+function normaliseProviderCode(code: string): string {
+  return code.trim().toLowerCase();
+}
+
+/** Extracts a provider error code without consulting its untrusted message. */
+export function extractErrorCode(error: unknown): string | undefined {
+  const code = stringProperty(error, "code");
+  return code ? normaliseProviderCode(code) : undefined;
+}
+
+/**
+ * Extracts an application-owned code returned in callable error details.
+ * Only a restricted code shape is accepted so arbitrary detail is never treated
+ * as display content.
+ */
+export function extractDomainErrorCode(error: unknown): string | undefined {
+  const record = asRecord(error);
+  const detailsCode = stringProperty(record?.details, "code");
+  const customDataCode = stringProperty(record?.customData, "code");
+  const code = detailsCode ?? customDataCode;
+  if (!code || !/^[A-Za-z][A-Za-z0-9_-]{0,79}$/.test(code)) return undefined;
+  return code.toUpperCase();
+}
+
+export function classifyError(error: unknown): ErrorCategory {
+  const code = extractErrorCode(error) ?? "";
+
+  if (
+    code.includes("network-request-failed") ||
+    code.endsWith("/unavailable") ||
+    code === "unavailable" ||
+    code.endsWith("/deadline-exceeded") ||
+    code === "deadline-exceeded" ||
+    code.endsWith("/aborted") ||
+    code === "aborted"
+  ) {
+    return "network";
+  }
+  if (code.includes("too-many-requests") || code.includes("resource-exhausted")) {
+    return "rate-limit";
+  }
+  if (code.includes("permission-denied")) return "authorization";
+  if (
+    code.includes("unauthenticated") ||
+    code.includes("requires-recent-login") ||
+    code.includes("user-token-expired") ||
+    code.includes("invalid-user-token")
+  ) {
+    return "authentication";
+  }
+  if (code.includes("not-found") || code.includes("user-not-found")) return "not-found";
+  if (
+    code.includes("already-exists") ||
+    code.includes("email-already-in-use") ||
+    code.includes("operation-not-allowed")
+  ) {
+    return "conflict";
+  }
+  if (
+    code.includes("invalid-argument") ||
+    code.includes("invalid-email") ||
+    code.includes("weak-password") ||
+    code.includes("password-does-not-meet-requirements")
+  ) {
+    return "validation";
+  }
+  if (code.includes("failed-precondition")) return "configuration";
+  if (code.startsWith("auth/")) return "authentication";
+  return "unknown";
+}
+
+function withCategory(
+  input: UserFacingErrorInput,
+  category: ErrorCategory,
+): UserFacingError {
+  return { ...input, category: input.category ?? category };
+}
+
+/** Maps an unknown technical failure to safe, deterministic display content. */
+export function toUserFacingError(
+  error: unknown,
+  options: UserFacingErrorOptions = {},
+): UserFacingError {
+  const category = classifyError(error);
+  const domainCode = extractDomainErrorCode(error);
+  const domainError = domainCode ? options.domainErrors?.[domainCode] : undefined;
+  if (domainError) return withCategory(domainError, category);
+  if (options.fallback) return withCategory(options.fallback, category);
+  return { ...DEFAULT_ERRORS[category] };
+}
+
+/**
+ * Reports the original failure separately from user-facing mapping. Do not put
+ * secrets or personal data in the context string or metadata.
+ */
+export function reportError(
+  context: string,
+  error: unknown,
+  metadata?: Readonly<Record<string, string | number | boolean | null>>,
+): void {
+  console.error(`[${context}]`, error, metadata ?? {});
+}

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -1,0 +1,2 @@
+export * from "./errorHandling";
+export * from "./authErrors";


### PR DESCRIPTION
## Summary

- add a shared user-facing error contract and deterministic provider classification
- support reviewed callable domain-code mappings without trusting server messages
- centralise context-aware Firebase Auth error mappings
- separate diagnostic reporting from display mapping
- migrate registration as the first consumer and document the contributor pattern

## Why

Issue #463 provides the foundation for the error-handling epic. Member and administrator surfaces need a consistent way to turn unknown Firebase, callable, Data Connect, and network failures into safe copy while retaining the original error for diagnostics.

The implementation deliberately does not perform the broader UI sweep owned by the remaining sub-epics.

## Impact

Registration no longer renders arbitrary Firebase or internal error messages. Future screens can reuse the shared contract, domain-code mapping, Auth mapping, retryability metadata, and safe fallback.

Part of #302.
Implements #463.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:run` — 85 files, 673 tests
- `npm run test:coverage` — thresholds passed