### PR TITLE
Handle authentication and profile errors safely

### DIFF
--- a/functions/src/__tests__/validation.test.ts
+++ b/functions/src/__tests__/validation.test.ts
@@ -81,6 +81,7 @@ describe("validation", () => {
         const result = canUserChangeStatus("REGULAR", "PENDING", true, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe("Admins cannot have restricted membership statuses");
+        expect(result.code).toBe("ADMIN_RESTRICTED_STATUS");
       });
     });
 
@@ -94,12 +95,14 @@ describe("validation", () => {
         const result = canUserChangeStatus("REGULAR", "RETIRED", false, false, false);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe("Account must be enabled");
+        expect(result.code).toBe("ACCOUNT_NOT_ENABLED");
       });
 
       it("should not allow user to change from PENDING", () => {
         const result = canUserChangeStatus("PENDING", "REGULAR", false, false, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe("Cannot change from restricted status");
+        expect(result.code).toBe("CURRENT_STATUS_RESTRICTED");
       });
 
       it("should not allow user to self-activate from null status", () => {
@@ -118,6 +121,7 @@ describe("validation", () => {
         const result = canUserChangeStatus("REGULAR", "PENDING", false, false, true);
         expect(result.allowed).toBe(false);
         expect(result.error).toBe("Cannot change to restricted status");
+        expect(result.code).toBe("TARGET_STATUS_RESTRICTED");
       });
     });
   });
@@ -132,16 +136,21 @@ describe("validation", () => {
       const result = canUserResignMembership("REGULAR", false, false);
       expect(result.allowed).toBe(false);
       expect(result.error).toBe("Account must be enabled");
+      expect(result.code).toBe("ACCOUNT_NOT_ENABLED");
     });
 
     it("rejects admin accounts", () => {
       const result = canUserResignMembership("REGULAR", true, true);
       expect(result.allowed).toBe(false);
       expect(result.error).toBe("Admin accounts cannot resign through this flow");
+      expect(result.code).toBe("ADMIN_RESIGNATION_NOT_ALLOWED");
     });
 
     it("rejects restricted current statuses", () => {
-      expect(canUserResignMembership("PENDING", false, true).allowed).toBe(false);
+      expect(canUserResignMembership("PENDING", false, true)).toMatchObject({
+        allowed: false,
+        code: "MEMBERSHIP_RESIGNATION_NOT_ALLOWED",
+      });
       expect(canUserResignMembership("RESIGNED", false, true).allowed).toBe(false);
       expect(canUserResignMembership(null, false, true).allowed).toBe(false);
     });

--- a/functions/src/membershipStatus.ts
+++ b/functions/src/membershipStatus.ts
@@ -152,7 +152,11 @@ export const updateMembershipStatus = onCall(
     
     if (!validation.allowed) {
       logger.warn(`Invalid membership status transition attempted: userId=${userId}, current=${currentStatus || "unknown"}, new=${newStatus}, admin=${isAdmin}, targetIsAdmin=${targetUserIsAdmin}`);
-      throw new HttpsError("permission-denied", validation.error || "Invalid membership status transition");
+      throw new HttpsError(
+        "permission-denied",
+        validation.error || "Invalid membership status transition",
+        validation.code ? { code: validation.code } : undefined
+      );
     }
     
     await persistMembershipStatusWithEnabledClaim(
@@ -206,7 +210,11 @@ export const resignMembership = onCall(
         logger.warn(
           `Resign membership rejected: userId=${userId}, current=${currentStatus || "unknown"}, targetIsAdmin=${targetUserIsAdmin}`
         );
-        throw new HttpsError("permission-denied", validation.error || "Cannot resign membership");
+        throw new HttpsError(
+          "permission-denied",
+          validation.error || "Cannot resign membership",
+          validation.code ? { code: validation.code } : undefined
+        );
       }
 
       await persistMembershipStatusWithEnabledClaim(userId, newStatus);

--- a/functions/src/validation.ts
+++ b/functions/src/validation.ts
@@ -34,6 +34,21 @@ type MembershipStatus =
 /** Values from Data Connect or legacy rows (may be blank). */
 export type MembershipStatusInput = MembershipStatus | null | undefined | string;
 
+export type MembershipValidationCode =
+  | "ADMIN_RESTRICTED_STATUS"
+  | "ACCOUNT_NOT_ENABLED"
+  | "CURRENT_STATUS_RESTRICTED"
+  | "TARGET_STATUS_RESTRICTED"
+  | "MEMBERSHIP_STATUS_CHANGE_NOT_ALLOWED"
+  | "ADMIN_RESIGNATION_NOT_ALLOWED"
+  | "MEMBERSHIP_RESIGNATION_NOT_ALLOWED";
+
+interface MembershipValidationResult {
+  allowed: boolean;
+  error?: string;
+  code?: MembershipValidationCode;
+}
+
 /**
  * Checks if a membership status is restricted
  */
@@ -88,12 +103,13 @@ export function canUserChangeStatus(
   isAdmin: boolean,
   targetUserIsAdmin: boolean = false,
   callerEnabled: boolean = false
-): { allowed: boolean; error?: string } {
+): MembershipValidationResult {
   // If target user is an admin, they cannot have a restricted status
   if (targetUserIsAdmin && isRestrictedStatus(newStatus)) {
     return {
       allowed: false,
       error: "Admins cannot have restricted membership statuses",
+      code: "ADMIN_RESTRICTED_STATUS",
     };
   }
 
@@ -106,6 +122,7 @@ export function canUserChangeStatus(
     return {
       allowed: false,
       error: "Account must be enabled",
+      code: "ACCOUNT_NOT_ENABLED",
     };
   }
 
@@ -113,6 +130,7 @@ export function canUserChangeStatus(
     return {
       allowed: false,
       error: "Cannot change from restricted status",
+      code: "CURRENT_STATUS_RESTRICTED",
     };
   }
 
@@ -120,6 +138,7 @@ export function canUserChangeStatus(
     return {
       allowed: false,
       error: "Cannot change to restricted status",
+      code: "TARGET_STATUS_RESTRICTED",
     };
   }
 
@@ -130,6 +149,7 @@ export function canUserChangeStatus(
     return {
       allowed: false,
       error: "Cannot change membership status",
+      code: "MEMBERSHIP_STATUS_CHANGE_NOT_ALLOWED",
     };
   }
 
@@ -143,11 +163,12 @@ export function canUserResignMembership(
   currentStatus: MembershipStatusInput,
   targetUserIsAdmin: boolean,
   callerEnabled: boolean
-): { allowed: boolean; error?: string } {
+): MembershipValidationResult {
   if (targetUserIsAdmin) {
     return {
       allowed: false,
       error: "Admin accounts cannot resign through this flow",
+      code: "ADMIN_RESIGNATION_NOT_ALLOWED",
     };
   }
 
@@ -155,6 +176,7 @@ export function canUserResignMembership(
     return {
       allowed: false,
       error: "Account must be enabled",
+      code: "ACCOUNT_NOT_ENABLED",
     };
   }
 
@@ -162,6 +184,7 @@ export function canUserResignMembership(
     return {
       allowed: false,
       error: "Cannot resign from current membership status",
+      code: "MEMBERSHIP_RESIGNATION_NOT_ALLOWED",
     };
   }
 
@@ -172,6 +195,7 @@ export function canUserResignMembership(
     return {
       allowed: false,
       error: "Cannot resign from current membership status",
+      code: "MEMBERSHIP_RESIGNATION_NOT_ALLOWED",
     };
   }
 

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -54,6 +54,7 @@ import { getAnnouncementSections } from "../utils/announcementPreferences";
 import {
   reportError,
   toAuthUserFacingError,
+  toProfileDomainUserFacingError,
   toProfileUserFacingError,
 } from "../../../shared/errors";
 
@@ -363,7 +364,9 @@ export default function AccountSettingsPage({
       if (!result.success) {
         const error = new Error(result.error ?? "Membership resignation failed");
         reportError("account.membership-resignation", error);
-        setResignError(toProfileUserFacingError(error, "resignation").message);
+        setResignError(
+          toProfileDomainUserFacingError(result.domainCode, "resignation").message,
+        );
         return;
       }
       setResignDialogOpen(false);

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -51,6 +51,11 @@ import {
   validateNewPassword,
 } from "../../auth/utils/passwordValidation";
 import { getAnnouncementSections } from "../utils/announcementPreferences";
+import {
+  reportError,
+  toAuthUserFacingError,
+  toProfileUserFacingError,
+} from "../../../shared/errors";
 
 export interface AccountSettingsPageProps {
   user: User;
@@ -58,21 +63,6 @@ export interface AccountSettingsPageProps {
   userDataLoading?: boolean;
   isAdmin: boolean;
   onBack?: () => void;
-}
-
-function getAuthErrorMessage(error: unknown): string {
-  const code = (error as { code?: string })?.code;
-  switch (code) {
-    case "auth/wrong-password":
-    case "auth/invalid-credential":
-      return "Current password is incorrect";
-    case "auth/weak-password":
-      return "New password is too weak";
-    case "auth/requires-recent-login":
-      return "Please sign out and sign in again, then try changing your password";
-    default:
-      return (error as Error)?.message ?? "Something went wrong";
-  }
 }
 
 function usesEmailPassword(user: User): boolean {
@@ -120,7 +110,8 @@ function AnnouncementPreferencesList() {
           ? "Opted out of all announcement emails"
           : "Announcement emails enabled",
       );
-    } catch {
+    } catch (error) {
+      reportError("account.announcement-preferences.global", error);
       setGlobalOverride(null);
     } finally {
       setGlobalBusy(false);
@@ -149,7 +140,8 @@ function AnnouncementPreferencesList() {
       );
       setLocalOverrides(prev => { const m = new Map(prev); m.delete(sectionId); return m; });
       setSnackbar(newOptedOut ? "Opted out of announcements" : "Opted in to announcements");
-    } catch {
+    } catch (error) {
+      reportError("account.announcement-preferences.section", error);
       setLocalOverrides(prev => { const m = new Map(prev); m.delete(sectionId); return m; });
     } finally {
       setBusy(null);
@@ -289,7 +281,8 @@ export default function AccountSettingsPage({
       setConfirmPassword("");
       setPasswordSuccess(true);
     } catch (error) {
-      setPasswordError(getAuthErrorMessage(error));
+      reportError("account.password-change", error);
+      setPasswordError(toAuthUserFacingError(error, "password-change").message);
     } finally {
       setPasswordSubmitting(false);
     }
@@ -323,18 +316,8 @@ export default function AccountSettingsPage({
       setEmailCurrentPassword("");
       setEmailSuccess(true);
     } catch (error: unknown) {
-      const code = (error as { code?: string })?.code ?? "";
-      if (code === "auth/wrong-password" || code === "auth/invalid-credential") {
-        setEmailError("Current password is incorrect");
-      } else if (code.includes("resource-exhausted")) {
-        setEmailError("Too many email-change requests. Please wait before trying again.");
-      } else if (code.includes("already-exists")) {
-        setEmailError(
-          "This email address cannot be used. It may already be linked to another account.",
-        );
-      } else {
-        setEmailError("The email change could not be started. Check the address and try again.");
-      }
+      reportError("account.email-change", error);
+      setEmailError(toAuthUserFacingError(error, "email-change").message);
     } finally {
       setEmailSubmitting(false);
     }
@@ -364,8 +347,9 @@ export default function AccountSettingsPage({
       };
       await upsertUser(dataConnect, vars);
     } catch (error) {
+      reportError("account.privacy-setting", error);
       setShareContactInfoOverride(null);
-      setShareContactInfoError((error as Error)?.message ?? "Failed to update privacy setting");
+      setShareContactInfoError(toProfileUserFacingError(error, "privacy").message);
     } finally {
       setShareContactInfoSubmitting(false);
     }
@@ -377,13 +361,16 @@ export default function AccountSettingsPage({
     try {
       const result = await resignMembership();
       if (!result.success) {
-        setResignError(result.error ?? "Failed to resign membership");
+        const error = new Error(result.error ?? "Membership resignation failed");
+        reportError("account.membership-resignation", error);
+        setResignError(toProfileUserFacingError(error, "resignation").message);
         return;
       }
       setResignDialogOpen(false);
       await signOut(auth);
     } catch (error) {
-      setResignError(getAuthErrorMessage(error));
+      reportError("account.membership-resignation", error);
+      setResignError(toProfileUserFacingError(error, "resignation").message);
     } finally {
       setResignSubmitting(false);
     }

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -219,7 +219,9 @@ describe("AccountSettingsPage", () => {
     await user.click(toggle);
 
     await waitFor(() => {
-      expect(screen.getByText("Network error")).toBeInTheDocument();
+      expect(
+        screen.getByText("We couldn’t update your privacy setting. Check your connection and try again."),
+      ).toBeInTheDocument();
     });
     expect(toggle).toBeChecked();
   });
@@ -292,7 +294,7 @@ describe("AccountSettingsPage", () => {
 
     expect(
       await screen.findByText(
-        "This email address cannot be used. It may already be linked to another account.",
+        "That email address is already used by another account.",
       ),
     ).toBeInTheDocument();
   });
@@ -430,7 +432,10 @@ describe("AccountSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: "Confirm resign" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Membership cannot be resigned at this time")).toBeInTheDocument();
+      expect(
+        screen.getByText("We couldn’t resign your membership. Please try again or contact an administrator."),
+      ).toBeInTheDocument();
+      expect(screen.queryByText("Membership cannot be resigned at this time")).not.toBeInTheDocument();
     });
   });
 
@@ -470,7 +475,7 @@ describe("AccountSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: "Update password" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Current password is incorrect")).toBeInTheDocument();
+      expect(screen.getByText("Current password is incorrect.")).toBeInTheDocument();
     });
   });
 
@@ -493,7 +498,9 @@ describe("AccountSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: "Update password" }));
 
     await waitFor(() => {
-      expect(screen.getByText("New password is too weak")).toBeInTheDocument();
+      expect(
+        screen.getByText("Password does not meet the current account security policy."),
+      ).toBeInTheDocument();
     });
   });
 
@@ -517,7 +524,8 @@ describe("AccountSettingsPage", () => {
     await user.click(screen.getByRole("button", { name: "Update password" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Something unexpected happened")).toBeInTheDocument();
+      expect(screen.getByText("We couldn’t change your password. Please try again.")).toBeInTheDocument();
+      expect(screen.queryByText("Something unexpected happened")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -424,6 +424,7 @@ describe("AccountSettingsPage", () => {
     vi.mocked(firebaseFunctions.resignMembership).mockResolvedValue({
       success: false,
       error: "Membership cannot be resigned at this time",
+      domainCode: "MEMBERSHIP_RESIGNATION_NOT_ALLOWED",
     });
 
     renderAccountSettings({ user: mockUser, userData, isAdmin: false });
@@ -433,7 +434,9 @@ describe("AccountSettingsPage", () => {
 
     await waitFor(() => {
       expect(
-        screen.getByText("We couldn’t resign your membership. Please try again or contact an administrator."),
+        screen.getByText(
+          "You cannot resign while your membership has its current status. Contact an administrator for help.",
+        ),
       ).toBeInTheDocument();
       expect(screen.queryByText("Membership cannot be resigned at this time")).not.toBeInTheDocument();
     });

--- a/src/features/auth/components/AuthActionPage.tsx
+++ b/src/features/auth/components/AuthActionPage.tsx
@@ -24,39 +24,9 @@ import {
   validateNewPassword,
 } from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toAuthUserFacingError } from "../../../shared/errors";
 
 type ActionState = "checking" | "ready" | "invalid" | "complete";
-
-function resetErrorMessage(error: unknown): string {
-  const code =
-    typeof error === "object" && error && "code" in error
-      ? String(error.code)
-      : "";
-  if (code.includes("expired-action-code")) {
-    return "This reset link has expired. Request a new one to continue.";
-  }
-  if (code.includes("invalid-action-code")) {
-    return "This reset link is invalid or has already been used. Request a new one to continue.";
-  }
-  if (code.includes("weak-password")) {
-    return "Password does not meet the current account security policy.";
-  }
-  return "The reset could not be completed. Please request a new link.";
-}
-
-function verificationErrorMessage(error: unknown): string {
-  const code =
-    typeof error === "object" && error && "code" in error
-      ? String(error.code)
-      : "";
-  if (code.includes("expired-action-code")) {
-    return "This verification link has expired. Sign in to request a new one.";
-  }
-  if (code.includes("invalid-action-code")) {
-    return "This verification link is invalid or has already been used.";
-  }
-  return "We couldn’t verify this email address. Sign in to request a new link.";
-}
 
 function actionHeading(mode: string | null): string {
   if (mode === "verifyEmail") return "Verify your email";
@@ -102,7 +72,8 @@ export default function AuthActionPage() {
         if (mode === "verifyAndChangeEmail") {
           try {
             await reconcileMyEmail();
-          } catch {
+          } catch (reconciliationError) {
+            reportError("auth.action.reconcile-email", reconciliationError);
             // Sign-in also retries reconciliation; do not turn a successfully
             // applied one-time action into a misleading invalid-link state.
           }
@@ -112,12 +83,10 @@ export default function AuthActionPage() {
     };
 
     void completeAction().catch((actionError: unknown) => {
+      reportError("auth.action.apply", actionError, { mode: mode ?? "missing" });
       if (active) {
-        setError(
-          mode === "verifyEmail" || mode === "verifyAndChangeEmail"
-            ? verificationErrorMessage(actionError)
-            : resetErrorMessage(actionError),
-        );
+        const context = mode === "resetPassword" ? "password-reset" : "email-action";
+        setError(toAuthUserFacingError(actionError, context).message);
         setState("invalid");
       }
     });
@@ -147,7 +116,8 @@ export default function AuthActionPage() {
       setConfirmation("");
       setState("complete");
     } catch (completionError: unknown) {
-      setError(resetErrorMessage(completionError));
+      reportError("auth.password-reset.complete", completionError);
+      setError(toAuthUserFacingError(completionError, "password-reset").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/AuthGate.tsx
+++ b/src/features/auth/components/AuthGate.tsx
@@ -18,11 +18,9 @@ import type { UserData } from "../../../types";
 import EmailVerificationMessage from "./EmailVerificationMessage";
 import OnboardingShell from "./OnboardingShell";
 import { ROUTES } from "../../../constants";
-import {
-  canAttemptSignIn,
-  isPasswordPolicyAuthError,
-} from "../utils/passwordValidation";
+import { canAttemptSignIn } from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toAuthUserFacingError } from "../../../shared/errors";
 
 interface AuthGateProps {
   userData?: UserData | null;
@@ -58,7 +56,8 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
       if (userCredential.user.emailVerified) {
         try {
           await reconcileMyEmail();
-        } catch {
+        } catch (reconciliationError) {
+          reportError("auth.sign-in.reconcile-email", reconciliationError);
           // Accounts without a Data Connect profile have nothing to reconcile;
           // a later sign-in retries after profile creation.
         }
@@ -68,11 +67,8 @@ export default function AuthGate({ userData, onRegisterComplete, onProfileComple
         onRegisterComplete();
       }
     } catch (e: unknown) {
-      setError(
-        isPasswordPolicyAuthError(e)
-          ? "This password no longer meets the account security policy. Reset your password to continue."
-          : (e as { message?: string })?.message ?? "Sign-in failed",
-      );
+      reportError("auth.sign-in", e);
+      setError(toAuthUserFacingError(e, "sign-in").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/EmailVerificationMessage.tsx
+++ b/src/features/auth/components/EmailVerificationMessage.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { reload, type User } from "firebase/auth";
 import { requestEmailVerification } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toAuthUserFacingError } from "../../../shared/errors";
 
 interface EmailVerificationMessageProps {
   user: User;
@@ -32,12 +33,8 @@ export default function EmailVerificationMessage({
       setSent(true);
       setTimeout(() => setSent(false), 60_000);
     } catch (e: unknown) {
-      const code = typeof e === "object" && e && "code" in e ? String(e.code) : "";
-      setError(
-        code.includes("resource-exhausted")
-          ? "Too many verification emails requested. Please wait before trying again."
-          : "We couldn’t resend the verification email. Check your connection and try again.",
-      );
+      reportError("auth.email-verification.resend", e);
+      setError(toAuthUserFacingError(e, "email-verification").message);
     } finally {
       setSending(false);
     }
@@ -58,8 +55,9 @@ export default function EmailVerificationMessage({
       } else {
         setError("Email not yet verified. Please check your inbox and click the verification link.");
       }
-    } catch {
-      setError("We couldn’t check your verification status. Please try again.");
+    } catch (verificationError) {
+      reportError("auth.email-verification.check", verificationError);
+      setError(toAuthUserFacingError(verificationError, "email-verification").message);
     } finally {
       setChecking(false);
     }

--- a/src/features/auth/components/PasswordResetRequestPage.tsx
+++ b/src/features/auth/components/PasswordResetRequestPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import { ROUTES } from "../../../constants";
 import { requestPasswordResetEmail } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toAuthUserFacingError } from "../../../shared/errors";
 
 const NEUTRAL_CONFIRMATION =
   "If an account exists for that address, we’ll send a password reset link.";
@@ -34,15 +35,8 @@ export default function PasswordResetRequestPage() {
       await requestPasswordResetEmail(email.trim());
       setSent(true);
     } catch (requestError: unknown) {
-      const code =
-        typeof requestError === "object" && requestError && "code" in requestError
-          ? String(requestError.code)
-          : "";
-      setError(
-        code.includes("resource-exhausted")
-          ? "Too many reset requests. Please wait before trying again."
-          : "We couldn’t request a reset link. Check your connection and try again.",
-      );
+      reportError("auth.password-reset.request", requestError);
+      setError(toAuthUserFacingError(requestError, "password-reset-request").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -25,6 +25,7 @@ import { auth } from "../../../config/firebase";
 import { syncPendingUserClaims, updateDisplayName } from "../../../shared/utils/firebaseFunctions";
 import RankSelect from "../../../shared/components/RankSelect";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
+import { reportError, toProfileUserFacingError } from "../../../shared/errors";
 
 interface ProfileCompletionProps {
   userEmail: string;
@@ -107,8 +108,10 @@ export default function ProfileCompletion({
       if (displayName) {
         const displayNameResult = await updateDisplayName(displayName);
         if (!displayNameResult.success) {
-          // Log but do not block completion
-          console.warn("Failed to update display name:", displayNameResult.error);
+          reportError(
+            "profile.completion.display-name",
+            new Error(displayNameResult.error ?? "Display name update failed"),
+          );
         }
       }
 
@@ -128,8 +131,9 @@ export default function ProfileCompletion({
           onComplete();
         }, 1500);
       }
-    } catch (err: any) {
-      setError(err?.message ?? "Failed to save profile");
+    } catch (err: unknown) {
+      reportError("profile.completion", err);
+      setError(toProfileUserFacingError(err, "completion").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/auth/components/__tests__/AuthGate.test.tsx
+++ b/src/features/auth/components/__tests__/AuthGate.test.tsx
@@ -66,7 +66,8 @@ describe("AuthGate sign-in", () => {
     });
     renderGate();
     await enterCredentials("mistyped-password");
-    expect(await screen.findByText(/auth\/invalid-credential/)).toBeInTheDocument();
+    expect(await screen.findByText("Email or password is incorrect.")).toBeInTheDocument();
+    expect(screen.queryByText(/auth\/invalid-credential/)).not.toBeInTheDocument();
     expect(screen.queryByText(/password no longer meets/i)).not.toBeInTheDocument();
   });
 

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -35,7 +35,11 @@ import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import { canUserChangeStatus, membershipStatusSaveAction, NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES } from "../../users/utils/membershipStatusValidation";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
-import { reportError, toProfileUserFacingError } from "../../../shared/errors";
+import {
+  reportError,
+  toProfileDomainUserFacingError,
+  toProfileUserFacingError,
+} from "../../../shared/errors";
 
 interface EditUserDialogProps {
   open: boolean;
@@ -210,7 +214,7 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
           reportError("profile.admin-edit.membership-status", statusError);
           setUpdateMessage({
             type: "error",
-            text: toProfileUserFacingError(statusError, "update").message,
+            text: toProfileDomainUserFacingError(statusResult.domainCode, "update").message,
           });
           setSubmitting(false);
           return; // Keep dialog open on error

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -35,6 +35,7 @@ import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import { canUserChangeStatus, membershipStatusSaveAction, NON_RESTRICTED_STATUSES, RESTRICTED_STATUSES } from "../../users/utils/membershipStatusValidation";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
+import { reportError, toProfileUserFacingError } from "../../../shared/errors";
 
 interface EditUserDialogProps {
   open: boolean;
@@ -118,7 +119,8 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
         setIsCivilServant(false);
         setIsIndustry(false);
       }
-    } catch (_err) {
+    } catch (loadError) {
+      reportError("profile.admin-edit.load", loadError);
       // Fallback if getUserById fails
       const parsed = parseDisplayName(userToLoad.displayName);
       setFirstName(parsed.firstName);
@@ -204,7 +206,12 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
       if (statusSaveAction !== "none") {
         const statusResult = await updateMembershipStatus(user.uid, membershipStatus);
         if (!statusResult.success) {
-          setUpdateMessage({ type: "error", text: statusResult.error || "Failed to update membership status" });
+          const statusError = new Error(statusResult.error || "Membership status update failed");
+          reportError("profile.admin-edit.membership-status", statusError);
+          setUpdateMessage({
+            type: "error",
+            text: toProfileUserFacingError(statusError, "update").message,
+          });
           setSubmitting(false);
           return; // Keep dialog open on error
         }
@@ -215,8 +222,10 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
       if (displayName) {
         const displayNameResult = await updateUserDisplayName(user.uid, displayName);
         if (!displayNameResult.success) {
-          // Log error but don't fail the whole operation
-          console.warn("Failed to update display name:", displayNameResult.error);
+          reportError(
+            "profile.admin-edit.display-name",
+            new Error(displayNameResult.error ?? "Display name update failed"),
+          );
         }
       }
       
@@ -228,9 +237,12 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
         onSuccess(successMessage);
       }
       handleClose();
-    } catch (err: any) {
-      // Error - keep dialog open and show error message
-      setUpdateMessage({ type: "error", text: err?.message || "Failed to update user profile" });
+    } catch (err: unknown) {
+      reportError("profile.admin-edit", err);
+      setUpdateMessage({
+        type: "error",
+        text: toProfileUserFacingError(err, "update").message,
+      });
       setSubmitting(false);
     }
   };

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -33,6 +33,7 @@ import RankSelect from "../../../shared/components/RankSelect";
 import { NON_RESTRICTED_STATUSES, isRestrictedStatus } from "../../users/utils/membershipStatusValidation";
 import { auth } from "../../../config/firebase";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
+import { reportError, toProfileUserFacingError } from "../../../shared/errors";
 
 interface ProfileProps {
   userData: UserData | null;
@@ -120,7 +121,9 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
           membershipStatus as MembershipStatus
         );
         if (!statusResult.success) {
-          setError(statusResult.error || "Failed to update membership status");
+          const statusError = new Error(statusResult.error || "Membership status update failed");
+          reportError("profile.update.membership-status", statusError);
+          setError(toProfileUserFacingError(statusError, "update").message);
           setSubmitting(false);
           return;
         }
@@ -130,7 +133,10 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
       if (displayName) {
         const displayNameResult = await updateDisplayName(displayName);
         if (!displayNameResult.success) {
-          console.warn("Failed to update display name:", displayNameResult.error);
+          reportError(
+            "profile.update.display-name",
+            new Error(displayNameResult.error ?? "Display name update failed"),
+          );
         }
       }
 
@@ -138,8 +144,9 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
       if (onUpdate) {
         onUpdate();
       }
-    } catch (err: any) {
-      setError(err?.message ?? "Failed to save profile");
+    } catch (err: unknown) {
+      reportError("profile.update", err);
+      setError(toProfileUserFacingError(err, "update").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -33,7 +33,11 @@ import RankSelect from "../../../shared/components/RankSelect";
 import { NON_RESTRICTED_STATUSES, isRestrictedStatus } from "../../users/utils/membershipStatusValidation";
 import { auth } from "../../../config/firebase";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
-import { reportError, toProfileUserFacingError } from "../../../shared/errors";
+import {
+  reportError,
+  toProfileDomainUserFacingError,
+  toProfileUserFacingError,
+} from "../../../shared/errors";
 
 interface ProfileProps {
   userData: UserData | null;
@@ -123,7 +127,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
         if (!statusResult.success) {
           const statusError = new Error(statusResult.error || "Membership status update failed");
           reportError("profile.update.membership-status", statusError);
-          setError(toProfileUserFacingError(statusError, "update").message);
+          setError(toProfileDomainUserFacingError(statusResult.domainCode, "update").message);
           setSubmitting(false);
           return;
         }

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -35,6 +35,7 @@ import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
 import type { UserData } from "../../../types";
 import { getAnnouncementSections } from "../../account/utils/announcementPreferences";
+import { reportError, toProfileUserFacingError } from "../../../shared/errors";
 
 interface ProfileReviewDialogProps {
   userData: UserData;
@@ -133,18 +134,19 @@ export default function ProfileReviewDialog({
       try {
         const displayNameResult = await updateDisplayName(displayName);
         if (!displayNameResult.success) {
-          console.warn("Profile review saved, but display name sync failed:", displayNameResult.error);
+          reportError(
+            "profile.review.display-name",
+            new Error(displayNameResult.error ?? "Display name update failed"),
+          );
         }
       } catch (displayNameError) {
-        console.warn("Profile review saved, but display name sync failed:", displayNameError);
+        reportError("profile.review.display-name", displayNameError);
       }
 
       await onReviewed();
     } catch (caught) {
-      setError(
-        (caught as Error)?.message ||
-          "We could not save your profile review. Check your connection and try again.",
-      );
+      reportError("profile.review", caught);
+      setError(toProfileUserFacingError(caught, "review").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/profile/components/__tests__/Profile.test.tsx
+++ b/src/features/profile/components/__tests__/Profile.test.tsx
@@ -138,6 +138,34 @@ describe("Profile", () => {
     });
   });
 
+  it("shows trusted guidance when a membership transition is rejected", async () => {
+    vi.mocked(firebaseFunctions.updateMembershipStatus).mockResolvedValueOnce({
+      success: false,
+      error: "FirebaseError: permission denied implementation detail",
+      domainCode: "CURRENT_STATUS_RESTRICTED",
+    });
+    const user = userEvent.setup();
+    renderProfile({ userData, userEmail: userData.email });
+
+    const selectRoot = screen.getByTestId("membership-status-select");
+    const trigger =
+      selectRoot.querySelector('[role="combobox"]') ??
+      selectRoot.querySelector(".MuiSelect-select") ??
+      selectRoot;
+    fireEvent.mouseDown(trigger);
+    await user.click(await screen.findByRole("option", { name: "Reserve" }));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(
+      await screen.findByText(
+        "Membership status cannot be changed from its current restricted status.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/FirebaseError: permission denied implementation detail/),
+    ).not.toBeInTheDocument();
+  });
+
   it("includes the selected rank when saving", async () => {
     const user = userEvent.setup();
     renderProfile({ userData, userEmail: userData.email });

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -170,7 +170,10 @@ describe("ProfileReviewDialog", () => {
     await interaction.click(await screen.findByRole("checkbox", { name: "Golf" }));
     await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
 
-    expect(await screen.findByText("Preference save failed")).toBeInTheDocument();
+    expect(
+      await screen.findByText("We couldn’t save your profile review. Check your connection and try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Preference save failed")).not.toBeInTheDocument();
     expect(generated.confirmProfileReview).not.toHaveBeenCalled();
     expect(onReviewed).not.toHaveBeenCalled();
   });
@@ -251,7 +254,10 @@ describe("ProfileReviewDialog", () => {
 
     await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
 
-    expect(await screen.findByText("Network unavailable")).toBeInTheDocument();
+    expect(
+      await screen.findByText("We couldn’t save your profile review. Check your connection and try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Network unavailable")).not.toBeInTheDocument();
     expect(onReviewed).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Confirm profile" })).toBeEnabled();
   });

--- a/src/shared/errors/__tests__/errorHandling.test.ts
+++ b/src/shared/errors/__tests__/errorHandling.test.ts
@@ -5,6 +5,7 @@ import {
   extractErrorCode,
   reportError,
   toAuthUserFacingError,
+  toProfileDomainUserFacingError,
   toProfileUserFacingError,
   toUserFacingError,
 } from "../index";
@@ -138,6 +139,20 @@ describe("shared error handling", () => {
     );
     expect(mapped.message).toBe("We couldn’t save your profile. Check your connection and try again.");
     expect(mapped.message).not.toContain("SQL");
+  });
+
+  it("maps trusted membership outcome codes to specific guidance", () => {
+    expect(
+      toProfileDomainUserFacingError(
+        "ADMIN_RESIGNATION_NOT_ALLOWED",
+        "resignation",
+      ).message,
+    ).toBe(
+      "Admin accounts cannot resign through this flow. Contact another administrator for help.",
+    );
+    expect(
+      toProfileDomainUserFacingError("UNRECOGNISED_BACKEND_TEXT", "update").message,
+    ).toBe("We couldn’t save your profile. Check your connection and try again.");
   });
 
   it("reports the original failure separately from display mapping", () => {

--- a/src/shared/errors/__tests__/errorHandling.test.ts
+++ b/src/shared/errors/__tests__/errorHandling.test.ts
@@ -5,6 +5,7 @@ import {
   extractErrorCode,
   reportError,
   toAuthUserFacingError,
+  toProfileUserFacingError,
   toUserFacingError,
 } from "../index";
 
@@ -113,6 +114,30 @@ describe("shared error handling", () => {
     );
     expect(mapped.message).toBe("This email is already registered. Please sign in instead.");
     expect(mapped.message).not.toContain("Firebase");
+  });
+
+  it("maps account changes and one-time links to contextual safe messages", () => {
+    expect(
+      toAuthUserFacingError({ code: "auth/wrong-password" }, "password-change").message,
+    ).toBe("Current password is incorrect.");
+    expect(
+      toAuthUserFacingError(
+        { code: "functions/failed-precondition", details: { code: "RECENT_LOGIN_REQUIRED" } },
+        "email-change",
+      ).message,
+    ).toContain("sign out and sign in again");
+    expect(
+      toAuthUserFacingError({ code: "auth/expired-action-code" }, "email-action").message,
+    ).toContain("Sign in to request a new one");
+  });
+
+  it("does not expose raw profile service failures", () => {
+    const mapped = toProfileUserFacingError(
+      new Error("SQL constraint user_private_record leaked"),
+      "update",
+    );
+    expect(mapped.message).toBe("We couldn’t save your profile. Check your connection and try again.");
+    expect(mapped.message).not.toContain("SQL");
   });
 
   it("reports the original failure separately from display mapping", () => {

--- a/src/shared/errors/authErrors.ts
+++ b/src/shared/errors/authErrors.ts
@@ -1,5 +1,6 @@
 import {
   classifyError,
+  extractDomainErrorCode,
   extractErrorCode,
   toUserFacingError,
   type UserFacingError,
@@ -10,7 +11,10 @@ export type AuthErrorContext =
   | "sign-in"
   | "password-change"
   | "email-change"
-  | "action-link";
+  | "password-reset-request"
+  | "email-verification"
+  | "password-reset"
+  | "email-action";
 
 const INVALID_CREDENTIAL_CODES = new Set([
   "auth/invalid-credential",
@@ -33,6 +37,8 @@ export function toAuthUserFacingError(
   context: AuthErrorContext,
 ): UserFacingError {
   const code = extractErrorCode(error) ?? "";
+  const domainCode = extractDomainErrorCode(error);
+  const category = classifyError(error);
 
   if (context === "sign-in" && INVALID_CREDENTIAL_CODES.has(code)) {
     return authError(
@@ -47,6 +53,12 @@ export function toAuthUserFacingError(
       "Account unavailable",
       "This account is disabled. Contact an administrator if you need help.",
     );
+  }
+  if (
+    (context === "password-change" || context === "email-change") &&
+    INVALID_CREDENTIAL_CODES.has(code)
+  ) {
+    return authError("authentication", "Password incorrect", "Current password is incorrect.");
   }
   if (
     context === "sign-in" &&
@@ -78,25 +90,36 @@ export function toAuthUserFacingError(
       "Password does not meet the current account security policy.",
     );
   }
-  if (code === "auth/requires-recent-login") {
+  if (code === "auth/requires-recent-login" || domainCode === "RECENT_LOGIN_REQUIRED") {
     return authError(
       "authentication",
       "Sign in again",
       "Please sign out and sign in again before retrying this change.",
     );
   }
+  if (context === "email-change" && (code.includes("already-exists") || domainCode === "EMAIL_ALREADY_IN_USE")) {
+    return authError(
+      "conflict",
+      "Email already in use",
+      "That email address is already used by another account.",
+    );
+  }
   if (code === "auth/expired-action-code") {
     return authError(
       "validation",
       "Link expired",
-      "This secure link has expired. Request a new one to continue.",
+      context === "email-action"
+        ? "This verification link has expired. Sign in to request a new one."
+        : "This reset link has expired. Request a new one to continue.",
     );
   }
   if (code === "auth/invalid-action-code") {
     return authError(
       "validation",
       "Link invalid",
-      "This secure link is invalid or has already been used.",
+      context === "email-action"
+        ? "This verification link is invalid or has already been used."
+        : "This reset link is invalid or has already been used. Request a new one to continue.",
     );
   }
   if (context === "register" && code.startsWith("functions/")) {
@@ -108,13 +131,33 @@ export function toAuthUserFacingError(
     );
   }
 
+  if (category === "rate-limit") {
+    if (context === "password-reset-request") {
+      return authError(category, "Try again later", "Too many reset requests. Please wait before trying again.", true);
+    }
+    if (context === "email-verification") {
+      return authError(category, "Try again later", "Too many verification emails requested. Please wait before trying again.", true);
+    }
+    if (context === "email-change") {
+      return authError(category, "Try again later", "Too many email-change requests. Please wait before trying again.", true);
+    }
+  }
+
+  const fallbackByContext: Record<AuthErrorContext, { title: string; message: string }> = {
+    register: { title: "Account request failed", message: "The account request could not be completed. Please try again." },
+    "sign-in": { title: "Sign-in failed", message: "We couldn’t sign you in. Please try again." },
+    "password-change": { title: "Password not changed", message: "We couldn’t change your password. Please try again." },
+    "email-change": { title: "Email not changed", message: "We couldn’t request this email change. Please try again." },
+    "password-reset-request": { title: "Reset link not sent", message: "We couldn’t request a reset link. Check your connection and try again." },
+    "email-verification": { title: "Verification email not sent", message: "We couldn’t resend the verification email. Check your connection and try again." },
+    "password-reset": { title: "Password not reset", message: "The reset could not be completed. Please request a new link." },
+    "email-action": { title: "Email not verified", message: "We couldn’t verify this email address. Sign in to request a new link." },
+  };
+  const fallback = fallbackByContext[context];
+
   return toUserFacingError(error, {
     fallback: {
-      title: context === "sign-in" ? "Sign-in failed" : "Account request failed",
-      message:
-        context === "sign-in"
-          ? "We couldn’t sign you in. Please try again."
-          : "The account request could not be completed. Please try again.",
+      ...fallback,
       retryable: true,
     },
   });

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -1,2 +1,3 @@
 export * from "./errorHandling";
 export * from "./authErrors";
+export * from "./profileErrors";

--- a/src/shared/errors/profileErrors.ts
+++ b/src/shared/errors/profileErrors.ts
@@ -1,0 +1,26 @@
+import { classifyError, type UserFacingError } from "./errorHandling";
+
+export type ProfileErrorContext = "completion" | "update" | "review" | "privacy" | "resignation";
+
+const COPY: Record<ProfileErrorContext, { title: string; message: string }> = {
+  completion: { title: "Profile not saved", message: "We couldn’t complete your profile. Check your connection and try again." },
+  update: { title: "Profile not saved", message: "We couldn’t save your profile. Check your connection and try again." },
+  review: { title: "Review not saved", message: "We couldn’t save your profile review. Check your connection and try again." },
+  privacy: { title: "Privacy setting not saved", message: "We couldn’t update your privacy setting. Check your connection and try again." },
+  resignation: { title: "Membership not changed", message: "We couldn’t resign your membership. Please try again or contact an administrator." },
+};
+
+/** Maps profile service failures without exposing provider or backend messages. */
+export function toProfileUserFacingError(error: unknown, context: ProfileErrorContext): UserFacingError {
+  const category = classifyError(error);
+  if (category === "authentication" || category === "authorization") {
+    return {
+      category,
+      title: "Sign in again",
+      message: "Please sign in again before retrying this change.",
+      retryable: false,
+    };
+  }
+  const copy = COPY[context];
+  return { category, ...copy, retryable: true };
+}

--- a/src/shared/errors/profileErrors.ts
+++ b/src/shared/errors/profileErrors.ts
@@ -1,4 +1,8 @@
-import { classifyError, type UserFacingError } from "./errorHandling";
+import {
+  classifyError,
+  extractDomainErrorCode,
+  type UserFacingError,
+} from "./errorHandling";
 
 export type ProfileErrorContext = "completion" | "update" | "review" | "privacy" | "resignation";
 
@@ -10,8 +14,57 @@ const COPY: Record<ProfileErrorContext, { title: string; message: string }> = {
   resignation: { title: "Membership not changed", message: "We couldn’t resign your membership. Please try again or contact an administrator." },
 };
 
+const MEMBERSHIP_DOMAIN_ERRORS: Record<string, UserFacingError> = {
+  ADMIN_RESTRICTED_STATUS: {
+    category: "validation",
+    title: "Status not changed",
+    message: "Admin accounts cannot be assigned a restricted membership status.",
+    retryable: false,
+  },
+  ACCOUNT_NOT_ENABLED: {
+    category: "authorization",
+    title: "Account not enabled",
+    message: "This account must be enabled before its membership status can be changed.",
+    retryable: false,
+  },
+  CURRENT_STATUS_RESTRICTED: {
+    category: "precondition",
+    title: "Status not changed",
+    message: "Membership status cannot be changed from its current restricted status.",
+    retryable: false,
+  },
+  TARGET_STATUS_RESTRICTED: {
+    category: "validation",
+    title: "Status not changed",
+    message: "You cannot change your membership to a restricted status.",
+    retryable: false,
+  },
+  MEMBERSHIP_STATUS_CHANGE_NOT_ALLOWED: {
+    category: "precondition",
+    title: "Status not changed",
+    message: "Membership status cannot be changed from its current state.",
+    retryable: false,
+  },
+  ADMIN_RESIGNATION_NOT_ALLOWED: {
+    category: "precondition",
+    title: "Membership not changed",
+    message: "Admin accounts cannot resign through this flow. Contact another administrator for help.",
+    retryable: false,
+  },
+  MEMBERSHIP_RESIGNATION_NOT_ALLOWED: {
+    category: "precondition",
+    title: "Membership not changed",
+    message: "You cannot resign while your membership has its current status. Contact an administrator for help.",
+    retryable: false,
+  },
+};
+
 /** Maps profile service failures without exposing provider or backend messages. */
 export function toProfileUserFacingError(error: unknown, context: ProfileErrorContext): UserFacingError {
+  const domainCode = extractDomainErrorCode(error);
+  const domainError = domainCode ? MEMBERSHIP_DOMAIN_ERRORS[domainCode] : undefined;
+  if (domainError) return { ...domainError };
+
   const category = classifyError(error);
   if (category === "authentication" || category === "authorization") {
     return {
@@ -23,4 +76,15 @@ export function toProfileUserFacingError(error: unknown, context: ProfileErrorCo
   }
   const copy = COPY[context];
   return { category, ...copy, retryable: true };
+}
+
+/** Maps a validated domain outcome returned by a non-throwing client helper. */
+export function toProfileDomainUserFacingError(
+  domainCode: string | undefined,
+  context: ProfileErrorContext,
+): UserFacingError {
+  return toProfileUserFacingError(
+    domainCode ? { details: { code: domainCode } } : undefined,
+    context,
+  );
 }

--- a/src/shared/utils/__tests__/firebaseFunctions.test.ts
+++ b/src/shared/utils/__tests__/firebaseFunctions.test.ts
@@ -217,11 +217,17 @@ describe("updateMembershipStatus", () => {
   });
 
   it("returns success: false on error", async () => {
-    makeFailingCallable("Invalid status transition");
+    vi.mocked(httpsCallable).mockReturnValue(
+      vi.fn().mockRejectedValue({
+        message: "Invalid status transition",
+        details: { code: "CURRENT_STATUS_RESTRICTED" },
+      }) as any,
+    );
     const result = await updateMembershipStatus("user-789", "REGULAR" as MembershipStatus);
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Invalid status transition");
+    expect(result.domainCode).toBe("CURRENT_STATUS_RESTRICTED");
   });
 });
 
@@ -236,11 +242,17 @@ describe("resignMembership", () => {
   });
 
   it("returns success: false on error", async () => {
-    makeFailingCallable("Cannot resign as admin");
+    vi.mocked(httpsCallable).mockReturnValue(
+      vi.fn().mockRejectedValue({
+        message: "Cannot resign as admin",
+        details: { code: "ADMIN_RESIGNATION_NOT_ALLOWED" },
+      }) as any,
+    );
     const result = await resignMembership();
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("Cannot resign as admin");
+    expect(result.domainCode).toBe("ADMIN_RESIGNATION_NOT_ALLOWED");
   });
 });
 

--- a/src/shared/utils/firebaseFunctions/userAdmin.ts
+++ b/src/shared/utils/firebaseFunctions/userAdmin.ts
@@ -1,6 +1,7 @@
 import { httpsCallable } from "firebase/functions";
 import type { MembershipStatus } from "@dataconnect/generated";
 import { functions } from "../../../config/firebase";
+import { extractDomainErrorCode } from "../../errors";
 
 // ============================================================================
 // Admin Functions
@@ -278,7 +279,7 @@ interface UpdateMembershipStatusResponse {
 export async function updateMembershipStatus(
   userId: string,
   newStatus: MembershipStatus
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; domainCode?: string }> {
   try {
     const updateMembershipStatusCallable = httpsCallable<
       UpdateMembershipStatusRequest,
@@ -290,7 +291,8 @@ export async function updateMembershipStatus(
   } catch (error: any) {
     return {
       success: false,
-      error: error?.message || "Failed to update membership status"
+      error: error?.message || "Failed to update membership status",
+      domainCode: extractDomainErrorCode(error),
     };
   }
 }
@@ -303,7 +305,11 @@ interface ResignMembershipResponse {
 /**
  * Resigns the current user's membership (non-restricted status → RESIGNED).
  */
-export async function resignMembership(): Promise<{ success: boolean; error?: string }> {
+export async function resignMembership(): Promise<{
+  success: boolean;
+  error?: string;
+  domainCode?: string;
+}> {
   try {
     const resignMembershipCallable = httpsCallable<
       Record<string, never>,
@@ -316,6 +322,7 @@ export async function resignMembership(): Promise<{ success: boolean; error?: st
     return {
       success: false,
       error: error?.message || "Failed to resign membership",
+      domainCode: extractDomainErrorCode(error),
     };
   }
 }


### PR DESCRIPTION
## Summary

- centralise context-aware authentication, account, and profile error messages
- prevent Firebase, callable, and Data Connect diagnostics from being shown to users
- preserve neutral password-reset responses and provide recovery guidance for expired links
- report original failures separately for diagnostics
- cover the safe mappings and affected user flows with regression tests

## Why

Authentication and profile screens used a mixture of duplicated mappings and raw caught error messages. Provider and backend details could therefore leak into member-facing alerts and the recovery guidance varied between flows.

## User impact

Members now receive consistent, actionable messages for sign-in, password reset, verification, account changes, privacy, resignation, and profile operations without seeing implementation details.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:run` — 683 tests passed
- `npm run test:coverage`

Closes #464