### PR TITLE
Standardise booking and payment failure handling

### DIFF
--- a/src/features/sections/components/AdditionalGuestRequestSection.tsx
+++ b/src/features/sections/components/AdditionalGuestRequestSection.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import type { GetMyBookingsForEventData } from "@dataconnect/generated";
 import { submitGuestTicketRequest } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toBookingUserFacingError } from "../../../shared/errors";
 import { formatGbpMajorAmount } from "../../../shared/utils/currencyDisplay";
 
 type BookingList = NonNullable<GetMyBookingsForEventData["user"]>["bookings"];
@@ -126,11 +127,8 @@ export default function AdditionalGuestRequestSection({
       setDietaryNote("");
       await onRequestCreated();
     } catch (e: unknown) {
-      const msg =
-        e && typeof (e as { message?: string }).message === "string"
-          ? (e as { message: string }).message
-          : "Could not submit request. Please try again.";
-      setError(msg);
+      reportError("booking.guest-request", e);
+      setError(toBookingUserFacingError(e, "guest-request").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/sections/components/CheckoutStatusNotice.tsx
+++ b/src/features/sections/components/CheckoutStatusNotice.tsx
@@ -5,6 +5,7 @@ import { useGetMyTicketOrderById } from "@dataconnect/generated/react";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
 import { formatPaymentAmount } from "../../../shared/utils/currencyDisplay";
 import { reconcileMyCheckoutSessionOrders } from "../../../shared/utils/firebaseFunctions";
+import { reportError } from "../../../shared/errors";
 
 type CheckoutState = "success" | "cancel";
 
@@ -35,7 +36,7 @@ export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss
   }, [orderId]);
 
   const shouldQuery = checkoutState === "success" && Boolean(canonicalOrderId);
-  const { data, isLoading, isError, refetch } = useGetMyTicketOrderById(
+  const { data, isLoading, isError, error, refetch } = useGetMyTicketOrderById(
     dataConnect,
     { id: canonicalOrderId ?? "00000000-0000-0000-0000-000000000000" },
     { enabled: shouldQuery },
@@ -46,10 +47,16 @@ export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss
   const shouldPoll = shouldQuery && status === "PENDING" && pollCount < MAX_POLLS;
 
   useEffect(() => {
+    if (isError) reportError("payments.checkout-status", error);
+  }, [error, isError]);
+
+  useEffect(() => {
     if (!shouldQuery || !canonicalOrderId) {
       return;
     }
-    void reconcileMyCheckoutSessionOrders({ orderId: canonicalOrderId }).catch(() => undefined);
+    void reconcileMyCheckoutSessionOrders({ orderId: canonicalOrderId }).catch(
+      (reconciliationError) => reportError("payments.checkout-reconciliation", reconciliationError),
+    );
   }, [shouldQuery, canonicalOrderId]);
 
   useEffect(() => {
@@ -92,7 +99,28 @@ export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss
     return (
       <Alert severity="error" onClose={onDismiss} sx={{ mb: 2 }}>
         <AlertTitle>Unable to load order status</AlertTitle>
-        Please refresh the page in a moment, or contact support if this continues.
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="body2">We couldn’t load the latest payment status.</Typography>
+          <Button color="inherit" size="small" onClick={() => void refetch()}>
+            Retry
+          </Button>
+        </Stack>
+      </Alert>
+    );
+  }
+
+  if (status === "PENDING" && pollCount >= MAX_POLLS) {
+    return (
+      <Alert severity="warning" onClose={onDismiss} sx={{ mb: 2 }}>
+        <AlertTitle>Payment confirmation is taking longer than expected</AlertTitle>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="body2">
+            Your payment may still be processing. Refresh the status before trying to pay again.
+          </Typography>
+          <Button color="inherit" size="small" onClick={() => void refetch()}>
+            Refresh status
+          </Button>
+        </Stack>
       </Alert>
     );
   }
@@ -136,12 +164,30 @@ export default function CheckoutStatusNotice({ checkoutState, orderId, onDismiss
     );
   }
 
+  if (status === "FAILED") {
+    return (
+      <Alert severity="warning" onClose={onDismiss} sx={{ mb: 2 }}>
+        <AlertTitle>Payment not completed</AlertTitle>
+        This payment was not confirmed. Review your booking before starting checkout again.
+      </Alert>
+    );
+  }
+
+  if (status === "REFUNDED") {
+    return (
+      <Alert severity="info" onClose={onDismiss} sx={{ mb: 2 }}>
+        <AlertTitle>Payment refunded</AlertTitle>
+        This ticket payment has been refunded. Your payment history contains the latest details.
+      </Alert>
+    );
+  }
+
   return (
     <Alert severity="warning" onClose={onDismiss} sx={{ mb: 2 }}>
       <AlertTitle>Payment update required</AlertTitle>
       <Box>
         <Typography variant="body2" sx={{ mb: 1 }}>
-          Current order status: {status}.
+          We received an unexpected payment status. Refresh before trying to pay again, or contact support if this continues.
         </Typography>
         <Button size="small" onClick={() => void refetch()}>
           Refresh status

--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -32,6 +32,7 @@ import {
   groupTicketOrdersForDisplay,
   ticketOrderStatusChipColor,
 } from "../utils/myPaymentsDisplay";
+import { reportError, toBookingUserFacingError } from "../../../shared/errors";
 
 interface MyPaymentsProps {
   onBack: () => void;
@@ -65,6 +66,10 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
   );
 
   useEffect(() => {
+    if (isError) reportError("payments.history", error);
+  }, [error, isError]);
+
+  useEffect(() => {
     if (isLoading || paymentGroups.length === 0) {
       return;
     }
@@ -84,7 +89,8 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
           Object.entries(artifacts.artifactsByOrderId).map(([orderId, value]) => [artifactKey(orderId), value])
         );
         setStripeArtifactsByOrderId((prev) => ({ ...prev, ...normalizedArtifacts }));
-      } catch {
+      } catch (artifactError) {
+        reportError("payments.receipts", artifactError);
         // Receipt links are optional; fail silently on the member UI.
       }
     };
@@ -117,7 +123,8 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
     attemptedReconcileSessions.current.add(sessionKey);
     void reconcileMyCheckoutSessionOrders({ orderId: reconcileAnchor.id })
       .then(() => refetch())
-      .catch(() => {
+      .catch((reconciliationError) => {
+        reportError("payments.reconciliation", reconciliationError);
         attemptedReconcileSessions.current.delete(sessionKey);
       });
   }, [isLoading, orders, refetch]);
@@ -142,7 +149,7 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
             </Button>
           }
         >
-          {error instanceof Error ? error.message : "We could not load your payment history. Please try again."}
+          {toBookingUserFacingError(error, "payment-history").message}
         </Alert>
       ) : paymentGroups.length === 0 ? (
         <Alert severity="info">

--- a/src/features/sections/components/__tests__/AdditionalGuestRequestSection.test.tsx
+++ b/src/features/sections/components/__tests__/AdditionalGuestRequestSection.test.tsx
@@ -101,4 +101,20 @@ describe("AdditionalGuestRequestSection", () => {
     expect(screen.getByText("Vegan")).toBeInTheDocument();
     expect(screen.getByText("OK")).toBeInTheDocument();
   });
+
+  it("does not expose a raw callable error", async () => {
+    vi.mocked(firebaseFunctions.submitGuestTicketRequest).mockRejectedValueOnce(
+      new Error("FirebaseError: SQL guest_ticket_requests failed"),
+    );
+    const user = userEvent.setup();
+    render(<AdditionalGuestRequestSection {...baseProps} requests={[]} />);
+
+    await user.type(screen.getByLabelText(/^guest name/i), "Alex Patron");
+    await user.click(screen.getByRole("button", { name: /submit request/i }));
+
+    expect(
+      await screen.findByText("We couldn’t submit the guest request. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/SQL guest_ticket_requests/)).not.toBeInTheDocument();
+  });
 });

--- a/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
+++ b/src/features/sections/components/__tests__/CheckoutStatusNotice.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "../../../../test-utils";
+import userEvent from "@testing-library/user-event";
 import CheckoutStatusNotice from "../CheckoutStatusNotice";
 import * as dcReact from "@dataconnect/generated/react";
 
@@ -114,6 +115,97 @@ describe("CheckoutStatusNotice", () => {
       vi.advanceTimersByTime(2500);
     });
     expect(refetch).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("offers a safe retry when the order query fails", async () => {
+    const refetch = vi.fn();
+    vi.mocked(dcReact.useGetMyTicketOrderById).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("Postgres order lookup failed"),
+      refetch,
+    } as never);
+    const user = userEvent.setup();
+    render(
+      <CheckoutStatusNotice
+        checkoutState="success"
+        orderId="11111111-1111-1111-1111-111111111111"
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText(/couldn’t load the latest payment status/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Postgres order lookup/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not expose an unexpected stored order status", () => {
+    vi.mocked(dcReact.useGetMyTicketOrderById).mockReturnValue({
+      data: { user: { ticketOrders: [{ id: "abc", status: "STRIPE_INTERNAL_STATE" }] } },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+
+    render(
+      <CheckoutStatusNotice
+        checkoutState="success"
+        orderId="11111111-1111-1111-1111-111111111111"
+        onDismiss={onDismiss}
+      />,
+    );
+    expect(screen.getByText(/unexpected payment status/i)).toBeInTheDocument();
+    expect(screen.queryByText(/STRIPE_INTERNAL_STATE/)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ["FAILED", "Payment not completed"],
+    ["REFUNDED", "Payment refunded"],
+  ])("renders the explicit %s order state", (status, heading) => {
+    vi.mocked(dcReact.useGetMyTicketOrderById).mockReturnValue({
+      data: { user: { ticketOrders: [{ id: "abc", status }] } },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as never);
+    render(
+      <CheckoutStatusNotice
+        checkoutState="success"
+        orderId="11111111-1111-1111-1111-111111111111"
+        onDismiss={onDismiss}
+      />,
+    );
+    expect(screen.getByText(heading)).toBeInTheDocument();
+  });
+
+  it("stops polling and advises refresh before another payment", () => {
+    vi.useFakeTimers();
+    const refetch = vi.fn();
+    vi.mocked(dcReact.useGetMyTicketOrderById).mockReturnValue({
+      data: { user: { ticketOrders: [{ id: "abc", status: "PENDING" }] } },
+      isLoading: false,
+      isError: false,
+      refetch,
+    } as never);
+    render(
+      <CheckoutStatusNotice
+        checkoutState="success"
+        orderId="11111111-1111-1111-1111-111111111111"
+        onDismiss={onDismiss}
+      />,
+    );
+
+    for (let poll = 0; poll < 8; poll += 1) {
+      act(() => vi.advanceTimersByTime(2500));
+    }
+    expect(
+      screen.getByText(/payment confirmation is taking longer than expected/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/before trying to pay again/i)).toBeInTheDocument();
+    expect(refetch).toHaveBeenCalledTimes(8);
     vi.useRealTimers();
   });
 });

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -222,7 +222,7 @@ describe("EventBookingWizard", () => {
     expect(screen.queryByText(/Your booking is confirmed/i)).not.toBeInTheDocument();
   });
 
-  it("submits booking edits with base revision metadata", async () => {
+  it("retries booking edits with the same idempotency key and safe error copy", async () => {
     vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue({
       data: {
         user: {
@@ -237,6 +237,9 @@ describe("EventBookingWizard", () => {
       },
       isLoading: false,
     } as never);
+    vi.mocked(firebaseFunctions.submitEventBooking)
+      .mockRejectedValueOnce(new Error("SQL booking revision implementation detail"))
+      .mockResolvedValueOnce({ bookingId: "booking-new", status: "SUBMITTED" });
 
     const user = userEvent.setup();
     render(
@@ -289,8 +292,17 @@ describe("EventBookingWizard", () => {
     await user.click(screen.getByRole("button", { name: "Next" }));
     await user.click(screen.getByRole("button", { name: "Save booking changes" }));
 
+    expect(
+      await screen.findByText("We couldn’t submit your booking. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/SQL booking revision/)).not.toBeInTheDocument();
+
+    const firstSubmission = vi.mocked(firebaseFunctions.submitEventBooking).mock.calls[0]?.[0];
+    await user.click(screen.getByRole("button", { name: "Save booking changes" }));
+
     await waitFor(() => {
-      expect(firebaseFunctions.submitEventBooking).toHaveBeenCalledWith(
+      expect(firebaseFunctions.submitEventBooking).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           eventId: "event-1",
           baseBookingId: "booking-1",
@@ -298,6 +310,8 @@ describe("EventBookingWizard", () => {
         })
       );
     });
+    const retrySubmission = vi.mocked(firebaseFunctions.submitEventBooking).mock.calls[1]?.[0];
+    expect(retrySubmission?.idempotencyKey).toBe(firstSubmission?.idempotencyKey);
   });
 
   it("shows moderation notice when guest count exceeds policy on review step", async () => {

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -264,4 +264,25 @@ describe("MyPayments", () => {
 
     expect(screen.getByText(/you have not made any ticket payments yet/i)).toBeInTheDocument();
   });
+
+  it("shows a safe retryable error without exposing query details", async () => {
+    const refetch = vi.fn();
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
+        isLoading: false,
+        isError: true,
+        error: new Error("Postgres ticket_orders relation failed"),
+        refetch,
+      }),
+    );
+    const user = userEvent.setup();
+    render(<MyPayments onBack={() => undefined} />);
+
+    expect(
+      screen.getByText("We couldn’t load your payment history. Please try again."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Postgres ticket_orders/)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
+++ b/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   buildBookingSubmissionLines,
   EMPTY_GUEST_DETAIL,
-  extractCallableErrorCode,
   guestCountValidationError,
   guestDetailsValidationError,
   resizeExtraGuestDetails,
@@ -78,11 +77,5 @@ describe("bookingWizardModel", () => {
         dietaryNote: "Vegan",
       },
     ]);
-  });
-
-  it("reads callable error codes from either supported Firebase shape", () => {
-    expect(extractCallableErrorCode({ details: { code: "DETAILS" } })).toBe("DETAILS");
-    expect(extractCallableErrorCode({ customData: { code: "CUSTOM" } })).toBe("CUSTOM");
-    expect(extractCallableErrorCode(new Error("none"))).toBeUndefined();
   });
 });

--- a/src/features/sections/hooks/bookingWizardModel.ts
+++ b/src/features/sections/hooks/bookingWizardModel.ts
@@ -118,11 +118,3 @@ export function buildBookingSubmissionLines(args: {
   }
   return lines;
 }
-
-export function extractCallableErrorCode(error: unknown): string | undefined {
-  const callableError = error as {
-    details?: { code?: string };
-    customData?: { code?: string };
-  };
-  return callableError?.details?.code ?? callableError?.customData?.code;
-}

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -14,13 +14,17 @@ import {
   BOOKING_STEPS,
   buildBookingSubmissionLines,
   EMPTY_GUEST_DETAIL,
-  extractCallableErrorCode,
   guestCountValidationError,
   guestDetailsValidationError,
   resizeExtraGuestDetails,
   type ExtraGuestDetailRow,
   type WizardMode,
 } from "./bookingWizardModel";
+import {
+  extractDomainErrorCode,
+  reportError,
+  toBookingUserFacingError,
+} from "../../../shared/errors";
 import { useBookingWizardData } from "./useBookingWizardData";
 import { useSectionMemberSeatingOptions } from "./useSectionMemberSeatingOptions";
 
@@ -319,9 +323,7 @@ export function useBookingWizardState({
 
       if (!memberTicketTypeId || !membershipStatus || gate.ok !== true) return;
 
-      if (isEditingBooking && existingTerminalBooking) {
-        idempotencyKeyRef.current = crypto.randomUUID();
-      } else if (!idempotencyKeyRef.current) {
+      if (!idempotencyKeyRef.current) {
         const fromDraft = existingDraft?.clientSubmissionKey?.trim();
         if (fromDraft) {
           try {
@@ -365,11 +367,8 @@ export function useBookingWizardState({
       setActiveStep(3);
       onBookingComplete?.();
     } catch (err: unknown) {
-      const code = extractCallableErrorCode(err);
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Booking failed. Please try again.";
+      reportError("booking.submit", err);
+      const code = extractDomainErrorCode(err);
       if (code === "BOOKING_ALREADY_SUBMITTED") {
         setSubmitError("You already have a submitted booking for this event.");
         await refetchMyBookings();
@@ -397,7 +396,7 @@ export function useBookingWizardState({
           );
         }
       } else {
-        setSubmitError(message);
+        setSubmitError(toBookingUserFacingError(err, "booking-submit").message);
       }
     } finally {
       setSubmitting(false);
@@ -411,11 +410,8 @@ export function useBookingWizardState({
       const { url } = await createEventBookingCheckoutSession({ eventId: event.id });
       window.location.assign(url);
     } catch (err: unknown) {
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Could not start checkout. Please try again.";
-      setSubmitError(message);
+      reportError("booking.checkout-start", err);
+      setSubmitError(toBookingUserFacingError(err, "checkout-start").message);
     } finally {
       setPayingAllTickets(false);
     }

--- a/src/shared/errors/__tests__/bookingErrors.test.ts
+++ b/src/shared/errors/__tests__/bookingErrors.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { toBookingUserFacingError } from "../bookingErrors";
+
+describe("booking and payment error mapping", () => {
+  it.each([
+    ["INVALID_LINES", "Add at least one valid ticket"],
+    ["NO_SECTION_ACCESS", "do not have access"],
+    ["NO_BOOKER_PURPOSE", "not available to your membership group"],
+    ["NOT_AUTHORIZED_BOOKER", "not eligible to book"],
+    ["OUTSIDE_BOOKING_WINDOW", "booking window is closed"],
+    ["TICKET_TYPE_NOT_FOUND", "no longer available"],
+    ["INELIGIBLE_TICKET_TYPE", "not eligible for one of the selected"],
+    ["SELF_TICKET_REQUIRED", "ticket for yourself"],
+    ["GUEST_BEFORE_SELF", "member ticket before"],
+    ["TOO_MANY_GUEST_LINES", "additional guest request"],
+    ["INVALID_GUEST_FIELDS", "Review the guest names"],
+    ["GUEST_APPROVAL_REQUIRED", "need moderator approval"],
+    ["BOOKING_ALREADY_SUBMITTED", "already have a submitted booking"],
+    ["BOOKING_REVISION_BASE_REQUIRED", "Refresh your booking"],
+    ["BOOKING_REVISION_BASE_NOT_FOUND", "no longer current"],
+    ["BOOKING_REVISION_CONFLICT", "changed while you were editing"],
+  ])("maps %s without exposing callable text", (code, expected) => {
+    const mapped = toBookingUserFacingError(
+      {
+        code: "functions/failed-precondition",
+        details: { code },
+        message: "SQL booking_revision internal detail",
+      },
+      "booking-submit",
+    );
+    expect(mapped.message).toContain(expected);
+    expect(mapped.message).not.toContain("SQL");
+  });
+
+  it.each([
+    ["booking-submit", "We couldn’t submit your booking."],
+    ["checkout-start", "We couldn’t start checkout."],
+    ["guest-request", "We couldn’t submit the guest request."],
+    ["payment-history", "We couldn’t load your payment history."],
+  ] as const)("uses a safe %s fallback", (context, expected) => {
+    const mapped = toBookingUserFacingError(
+      new Error("Stripe secret and internal server detail"),
+      context,
+    );
+    expect(mapped.message).toContain(expected);
+    expect(mapped.message).not.toContain("Stripe");
+  });
+});

--- a/src/shared/errors/bookingErrors.ts
+++ b/src/shared/errors/bookingErrors.ts
@@ -1,0 +1,136 @@
+import { toUserFacingError, type UserFacingErrorInput } from "./errorHandling";
+
+export type BookingErrorContext =
+  | "booking-submit"
+  | "checkout-start"
+  | "guest-request"
+  | "payment-history";
+
+const BOOKING_DOMAIN_ERRORS: Record<string, UserFacingErrorInput> = {
+  INVALID_LINES: {
+    category: "validation",
+    title: "Check your booking",
+    message: "Add at least one valid ticket and review the booking details.",
+    retryable: false,
+  },
+  NO_SECTION_ACCESS: {
+    category: "authorization",
+    title: "Booking unavailable",
+    message: "You do not have access to book this section’s events.",
+    retryable: false,
+  },
+  NO_BOOKER_PURPOSE: {
+    category: "authorization",
+    title: "Booking unavailable",
+    message: "Online booking is not available to your membership group for this event.",
+    retryable: false,
+  },
+  NOT_AUTHORIZED_BOOKER: {
+    category: "authorization",
+    title: "Booking unavailable",
+    message: "You are not eligible to book this event.",
+    retryable: false,
+  },
+  OUTSIDE_BOOKING_WINDOW: {
+    category: "precondition",
+    title: "Booking closed",
+    message: "The booking window is closed.",
+    retryable: false,
+  },
+  TICKET_TYPE_NOT_FOUND: {
+    category: "not-found",
+    title: "Ticket unavailable",
+    message: "A selected ticket is no longer available. Refresh and choose another ticket.",
+    retryable: true,
+  },
+  INELIGIBLE_TICKET_TYPE: {
+    category: "authorization",
+    title: "Ticket unavailable",
+    message: "You are not eligible for one of the selected ticket types.",
+    retryable: false,
+  },
+  SELF_TICKET_REQUIRED: {
+    category: "validation",
+    title: "Member ticket required",
+    message: "Choose a ticket for yourself before adding guests.",
+    retryable: false,
+  },
+  GUEST_BEFORE_SELF: {
+    category: "validation",
+    title: "Check your booking",
+    message: "Choose your member ticket before adding a guest ticket.",
+    retryable: false,
+  },
+  TOO_MANY_GUEST_LINES: {
+    category: "validation",
+    title: "Too many guests",
+    message: "Use the additional guest request option for extra guest places.",
+    retryable: false,
+  },
+  INVALID_GUEST_FIELDS: {
+    category: "validation",
+    title: "Check guest details",
+    message: "Review the guest names and ticket types, then try again.",
+    retryable: false,
+  },
+  GUEST_APPROVAL_REQUIRED: {
+    category: "precondition",
+    title: "Guest approval required",
+    message: "One or more guest places need moderator approval before you can continue.",
+    retryable: false,
+  },
+  BOOKING_ALREADY_SUBMITTED: {
+    category: "conflict",
+    title: "Already booked",
+    message: "You already have a submitted booking for this event.",
+    retryable: false,
+  },
+  BOOKING_REVISION_BASE_REQUIRED: {
+    category: "conflict",
+    title: "Booking changed",
+    message: "Refresh your booking before making further changes.",
+    retryable: true,
+  },
+  BOOKING_REVISION_BASE_NOT_FOUND: {
+    category: "conflict",
+    title: "Booking changed",
+    message: "The booking you tried to update is no longer current. Refresh and review the latest booking.",
+    retryable: true,
+  },
+  BOOKING_REVISION_CONFLICT: {
+    category: "conflict",
+    title: "Booking changed",
+    message: "Your booking changed while you were editing it. Refresh and review the latest version.",
+    retryable: true,
+  },
+};
+
+const FALLBACKS: Record<BookingErrorContext, UserFacingErrorInput> = {
+  "booking-submit": {
+    title: "Booking not submitted",
+    message: "We couldn’t submit your booking. Please try again.",
+    retryable: true,
+  },
+  "checkout-start": {
+    title: "Checkout not started",
+    message: "We couldn’t start checkout. Please try again.",
+    retryable: true,
+  },
+  "guest-request": {
+    title: "Request not submitted",
+    message: "We couldn’t submit the guest request. Please try again.",
+    retryable: true,
+  },
+  "payment-history": {
+    title: "Payments unavailable",
+    message: "We couldn’t load your payment history. Please try again.",
+    retryable: true,
+  },
+};
+
+export function toBookingUserFacingError(error: unknown, context: BookingErrorContext) {
+  return toUserFacingError(error, {
+    domainErrors: BOOKING_DOMAIN_ERRORS,
+    fallback: FALLBACKS[context],
+  });
+}

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -1,3 +1,4 @@
 export * from "./errorHandling";
 export * from "./authErrors";
 export * from "./profileErrors";
+export * from "./bookingErrors";

--- a/src/test-utils/dataConnectMocks.ts
+++ b/src/test-utils/dataConnectMocks.ts
@@ -4,6 +4,7 @@ export interface DataConnectQueryResultOverrides {
   data?: unknown;
   isLoading?: boolean;
   isError?: boolean;
+  error?: unknown;
   refetch?: ReturnType<typeof vi.fn>;
 }
 


### PR DESCRIPTION
## Summary

- add central, reviewed mappings for all stable booking and revision error codes
- replace raw callable, guest-request, checkout, and payment-query messages with safe contextual guidance
- preserve booking idempotency keys across retries
- make checkout return states explicit for cancelled, missing or invalid references, query failure, pending timeout, paid, failed, refunded, not found, and unexpected states
- add safe Retry or Refresh actions where the operation is idempotent
- report original failures separately for diagnostics

## Why

Booking and payment flows mixed stable domain-code handling with raw callable and query messages. Edited-booking retries also generated a new idempotency key, which weakened duplicate protection after a transient failure.

## User impact

Members now receive consistent, actionable booking and payment guidance without Firebase, Data Connect, or Stripe implementation details. Retrying a failed booking edit reuses the same idempotency key, and payment-status failures provide safe recovery actions.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:coverage` — 87 files and 711 tests passed

Closes #465