### PR TITLE
Standardise member loading, empty, and retry states

### DIFF
--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -56,7 +56,9 @@ import {
   toAuthUserFacingError,
   toProfileDomainUserFacingError,
   toProfileUserFacingError,
+  toMemberDataError,
 } from "../../../shared/errors";
+import FailureState from "../../../shared/components/FailureState";
 
 export interface AccountSettingsPageProps {
   user: User;
@@ -72,7 +74,7 @@ function usesEmailPassword(user: User): boolean {
 
 function AnnouncementPreferencesList() {
   const queryClient = useQueryClient();
-  const { data, isLoading } = useGetMyAnnouncementPreferences({ staleTime: Infinity });
+  const { data, isLoading, isError, error, refetch } = useGetMyAnnouncementPreferences({ staleTime: Infinity });
   const optOut = useOptOutSectionAnnouncement();
   const optIn = useOptInSectionAnnouncement();
   const updateGlobalOptOut = useUpdateAnnouncementOptOutAll();
@@ -173,7 +175,13 @@ function AnnouncementPreferencesList() {
         choices are preserved.
       </Typography>
       {isLoading ? (
-        <CircularProgress size={20} />
+        <CircularProgress size={20} aria-label="Loading communication preferences" />
+      ) : isError ? (
+        <FailureState
+          title={toMemberDataError(error, "preferences").title}
+          message={toMemberDataError(error, "preferences").message}
+          onRetry={() => void refetch()}
+        />
       ) : sections.length === 0 ? (
         <Typography variant="body2" color="text.secondary">
           You are not a member of any sections.

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -36,6 +36,7 @@ import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
 import type { UserData } from "../../../types";
 import { getAnnouncementSections } from "../../account/utils/announcementPreferences";
 import { reportError, toProfileUserFacingError } from "../../../shared/errors";
+import FailureState from "../../../shared/components/FailureState";
 
 interface ProfileReviewDialogProps {
   userData: UserData;
@@ -266,9 +267,15 @@ export default function ProfileReviewDialog({
               <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
                 Account-security, booking and payment messages are always sent when required.
               </Typography>
-              {preferences.isLoading ? <CircularProgress size={20} /> : null}
+              {preferences.isLoading ? (
+                <CircularProgress size={20} aria-label="Loading communication preferences" />
+              ) : null}
               {preferences.isError ? (
-                <Alert severity="error">We could not load your communication preferences.</Alert>
+                <FailureState
+                  title="Communication preferences are unavailable"
+                  message="We could not load your communication preferences. Please try again."
+                  onRetry={() => void preferences.refetch()}
+                />
               ) : null}
               {preferencesInitialised ? (
                 <FormGroup>

--- a/src/features/sections/components/MyBookings.tsx
+++ b/src/features/sections/components/MyBookings.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -28,6 +27,9 @@ import {
   formatBookingEventWhen,
   getMyBookingActionLabel,
 } from "../utils/myBookingsDisplay";
+import FailureState from "../../../shared/components/FailureState";
+import { reportError, toMemberDataError } from "../../../shared/errors";
+import { useEffect } from "react";
 
 interface MyBookingsProps {
   onBack: () => void;
@@ -52,6 +54,12 @@ export default function MyBookings({ onBack }: MyBookingsProps) {
   const bookings = data?.user?.bookings ?? [];
   const ticketOrders = ticketOrdersData?.user?.ticketOrders ?? [];
 
+  useEffect(() => {
+    if (isError) reportError("bookings.history", error);
+  }, [error, isError]);
+
+  const loadError = toMemberDataError(error, "bookings");
+
   return (
     <Box className="page-container">
       <PageHeader title="My Bookings" onBack={onBack} />
@@ -64,16 +72,11 @@ export default function MyBookings({ onBack }: MyBookingsProps) {
           <CircularProgress size={28} aria-label="Loading bookings" />
         </Box>
       ) : isError ? (
-        <Alert
-          severity="error"
-          action={
-            <Button color="inherit" size="small" onClick={() => refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          {error instanceof Error ? error.message : "We could not load your bookings. Please try again."}
-        </Alert>
+        <FailureState
+          title={loadError.title}
+          message={loadError.message}
+          onRetry={loadError.retryable ? () => void refetch() : undefined}
+        />
       ) : bookings.length === 0 ? (
         <Typography variant="body1" color="text.secondary">
           No bookings yet — head to a section to find an upcoming event.

--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -33,6 +33,7 @@ import {
   ticketOrderStatusChipColor,
 } from "../utils/myPaymentsDisplay";
 import { reportError, toBookingUserFacingError } from "../../../shared/errors";
+import FailureState from "../../../shared/components/FailureState";
 
 interface MyPaymentsProps {
   onBack: () => void;
@@ -141,16 +142,11 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
           <CircularProgress size={28} aria-label="Loading payments" />
         </Box>
       ) : isError ? (
-        <Alert
-          severity="error"
-          action={
-            <Button color="inherit" size="small" onClick={() => refetch()}>
-              Retry
-            </Button>
-          }
-        >
-          {toBookingUserFacingError(error, "payment-history").message}
-        </Alert>
+        <FailureState
+          title={toBookingUserFacingError(error, "payment-history").title}
+          message={toBookingUserFacingError(error, "payment-history").message}
+          onRetry={() => void refetch()}
+        />
       ) : paymentGroups.length === 0 ? (
         <Alert severity="info">
           You have not made any ticket payments yet. After you pay for an event, your receipts will appear here.

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -3,13 +3,14 @@ import {
   Box,
   Alert,
   CircularProgress,
-  Button,
   Snackbar,
 } from "@mui/material";
 import { useGetUserAccessGroups, useGetSectionsForUser } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
 import { executeMutation } from "firebase/data-connect";
 import PageHeader from "../../../shared/components/PageHeader";
+import FailureState from "../../../shared/components/FailureState";
+import { reportError } from "../../../shared/errors";
 import {
   getMemberGroups,
   canUserSubscribe,
@@ -67,7 +68,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [subscribing, setSubscribing] = useState(false);
   const [sectionMembers, setSectionMembers] = useState<SectionMember[]>([]);
   const [loadingMembers, setLoadingMembers] = useState(true);
-  const [errorMembers, setErrorMembers] = useState<string | null>(null);
+  const [errorMembers, setErrorMembers] = useState(false);
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null);
 
   const currentUser = auth.currentUser;
@@ -113,7 +114,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const fetchMembers = useCallback(async () => {
     const requestId = ++membersRequestIdRef.current;
     setLoadingMembers(true);
-    setErrorMembers(null);
+    setErrorMembers(false);
     try {
       const res = await getSectionMembersMerged(sectionId);
       if (membersRequestIdRef.current !== requestId) return;
@@ -130,10 +131,8 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       setSectionMembers(members);
     } catch (err: unknown) {
       if (membersRequestIdRef.current !== requestId) return;
-      const message = err && typeof (err as { message?: string }).message === "string"
-        ? (err as { message: string }).message
-        : "Failed to load section members";
-      setErrorMembers(message);
+      reportError("sections.members", err);
+      setErrorMembers(true);
       setSectionMembers([]);
     } finally {
       if (membersRequestIdRef.current === requestId) {
@@ -455,7 +454,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       <Box className="page-container" sx={{ backgroundColor: "background.default" }}>
         <PageHeader title="Section Details" onBack={onBack} />
         <Box className="loading-container">
-          <CircularProgress />
+          <CircularProgress aria-label="Loading section details" />
         </Box>
       </Box>
     );
@@ -465,19 +464,16 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     return (
       <Box className="page-container" sx={{ backgroundColor: "background.default" }}>
         <PageHeader title="Section Details" onBack={onBack} />
-        <Alert severity="error" sx={{ mt: 2 }}>
-          {errorMembers && !errorSection ? errorMembers : "Failed to load section details. Please try again."}
-        </Alert>
-        <Button
-          variant="outlined"
-          onClick={() => {
-            refetchSection();
-            refetchMembers();
-          }}
-          sx={{ mt: 2 }}
-        >
-          Retry
-        </Button>
+        <Box sx={{ mt: 2 }}>
+          <FailureState
+            title="Section unavailable"
+            message="We could not load this section. Please try again."
+            onRetry={() => {
+              void refetchSection();
+              void refetchMembers();
+            }}
+          />
+        </Box>
       </Box>
     );
   }

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -95,8 +95,9 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       const result = await getSectionForUser(sectionId);
       if (sectionRequestIdRef.current !== requestId) return;
       setSectionData({ section: result.section });
-    } catch {
+    } catch (error) {
       if (sectionRequestIdRef.current !== requestId) return;
+      reportError("sections.detail", error);
       setSectionData(undefined);
       setErrorSection(true);
     } finally {
@@ -172,8 +173,9 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       const result = await getSectionEventsForUser(sectionId);
       if (eventsRequestIdRef.current !== requestId) return;
       setEventsData({ section: { events: result.events } });
-    } catch {
+    } catch (error) {
       if (eventsRequestIdRef.current !== requestId) return;
+      reportError("sections.events", error);
       setEventsData(undefined);
       setErrorEvents(true);
     } finally {
@@ -200,7 +202,8 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     try {
       const result = await getEventForUser(selectedEventId);
       setEventDetailData({ event: result.event });
-    } catch {
+    } catch (error) {
+      reportError("sections.event-detail", error);
       setEventDetailData(undefined);
       setErrorEventDetail(true);
     } finally {

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -33,6 +33,7 @@ import EventDetailHero from "./EventDetailHero";
 import SectionEventCard from "./SectionEventCard";
 import SectionMemberCard from "./SectionMemberCard";
 import SectionMemberListItem from "./SectionMemberListItem";
+import FailureState from "../../../shared/components/FailureState";
 
 type MemberViewMode = "card" | "list";
 
@@ -283,15 +284,14 @@ export function SectionEventsListView({
 
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-          <CircularProgress />
+          <CircularProgress aria-label="Loading events" />
         </Box>
       ) : isError ? (
-        <Alert severity="error" sx={{ mt: 2 }}>
-          Failed to load events.{" "}
-          <Button size="small" onClick={onRetry}>
-            Retry
-          </Button>
-        </Alert>
+        <FailureState
+          title="Events are unavailable"
+          message="We could not load the events for this section. Please try again."
+          onRetry={onRetry}
+        />
       ) : listMode === "upcoming" && upcoming.length === 0 ? (
         <Alert severity="info">
           {past.length > 0
@@ -360,15 +360,14 @@ export function SectionEventDetailView({
       </Button>
       {loading ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-          <CircularProgress />
+          <CircularProgress aria-label="Loading event" />
         </Box>
       ) : isError ? (
-        <Alert severity="error" sx={{ mt: 2 }}>
-          Failed to load event.{" "}
-          <Button size="small" onClick={onRetry}>
-            Retry
-          </Button>
-        </Alert>
+        <FailureState
+          title="Event unavailable"
+          message="We could not load this event. Please try again."
+          onRetry={onRetry}
+        />
       ) : !event ? (
         <Alert severity="info">Event not found.</Alert>
       ) : (

--- a/src/features/sections/components/SectionFilesList.tsx
+++ b/src/features/sections/components/SectionFilesList.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import DownloadIcon from "@mui/icons-material/Download";
 import FailureState from "../../../shared/components/FailureState";
+import { reportError } from "../../../shared/errors";
 import {
   listSectionFiles,
   requestSectionFileDownload,
@@ -44,7 +45,8 @@ export default function SectionFilesList({ sectionId }: { sectionId: string }) {
     setDownloadError(false);
     try {
       setFiles(await listSectionFiles(sectionId));
-    } catch {
+    } catch (error) {
+      reportError("sections.files.list", error);
       setFiles([]);
       setLoadError(true);
     } finally {
@@ -62,7 +64,8 @@ export default function SectionFilesList({ sectionId }: { sectionId: string }) {
     try {
       const result = await requestSectionFileDownload(sectionId, file.id);
       window.location.assign(result.downloadUrl);
-    } catch {
+    } catch (error) {
+      reportError("sections.files.download", error);
       setDownloadError(true);
     } finally {
       setDownloadingId(null);

--- a/src/features/sections/components/SectionFilesList.tsx
+++ b/src/features/sections/components/SectionFilesList.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import DownloadIcon from "@mui/icons-material/Download";
+import FailureState from "../../../shared/components/FailureState";
 import {
   listSectionFiles,
   requestSectionFileDownload,
@@ -80,17 +81,17 @@ export default function SectionFilesList({ sectionId }: { sectionId: string }) {
       )}
       {loading ? (
         <Stack direction="row" spacing={1} alignItems="center" sx={{ py: 2 }}>
-          <CircularProgress size={22} />
+          <CircularProgress size={22} aria-label="Loading section files" />
           <Typography>Loading files…</Typography>
         </Stack>
       ) : loadError ? (
-        <Alert
-          severity="error"
-          action={<Button color="inherit" onClick={() => void load()}>Reload files</Button>}
-          sx={{ mt: 1 }}
-        >
-          Files could not be loaded. Your access may have changed.
-        </Alert>
+        <Box sx={{ mt: 1 }}>
+          <FailureState
+            title="Files are unavailable"
+            message="We could not load the files for this section. Your access may have changed."
+            onRetry={() => void load()}
+          />
+        </Box>
       ) : files.length === 0 ? (
         <Typography color="text.secondary" sx={{ mt: 1 }}>
           No files are available for this section.

--- a/src/features/sections/components/SectionsList.tsx
+++ b/src/features/sections/components/SectionsList.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Alert,
   CircularProgress,
-  Button,
 } from "@mui/material";
 import { useGetSectionsForUser, useListSections } from "@dataconnect/generated/react";
 import { dataConnect } from "../../../config/firebase";
@@ -15,6 +14,8 @@ import type { SectionType, SectionUserGroupPurpose } from "@dataconnect/generate
 import { SectionUserGroupPurpose as SectionPurpose } from "@dataconnect/generated";
 import SectionListCard from "./SectionListCard";
 import "../../../shared/components/PageContainer.css";
+import FailureState from "../../../shared/components/FailureState";
+import { reportError, toMemberDataError } from "../../../shared/errors";
 
 interface SectionsListProps {
   onBack: () => void;
@@ -59,12 +60,12 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
   // Surface query errors without logging successful query state on every render.
   useEffect(() => {
     if (userSectionsError) {
-      console.error('GetSectionsForUser error:', userSectionsError);
-      setErrorMessage(userSectionsError instanceof Error ? userSectionsError.message : 'Failed to load sections');
+      reportError("sections.member-list", userSectionsError);
+      setErrorMessage("query");
     }
     if (allSectionsError) {
-      console.error('ListSections error:', allSectionsError);
-      setErrorMessage(allSectionsError instanceof Error ? allSectionsError.message : 'Failed to load sections');
+      reportError("sections.admin-list", allSectionsError);
+      setErrorMessage("query");
     }
   }, [userSectionsError, allSectionsError]);
 
@@ -125,8 +126,7 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
         return [];
       }
     } catch (error) {
-      console.error('Error extracting sections:', error);
-      setErrorMessage(error instanceof Error ? error.message : 'Unknown error occurred');
+      reportError("sections.list-display", error);
       return [];
     }
   }, [isAdmin, allSectionsData, userSectionsData]);
@@ -159,7 +159,7 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
       <Box className="page-container" sx={{ backgroundColor: "background.default" }}>
         <PageHeader title="Sections" onBack={onBack} />
         <Box className="loading-container">
-          <CircularProgress />
+          <CircularProgress aria-label="Loading sections" />
         </Box>
       </Box>
     );
@@ -167,15 +167,20 @@ function SectionsListComponent({ onBack, onSelectSection }: SectionsListProps) {
 
   // Early return for error state
   if (error || errorMessage) {
+    const userFacingError = toMemberDataError(
+      isAdmin ? allSectionsError : userSectionsError,
+      "sections",
+    );
     return (
       <Box className="page-container" sx={{ backgroundColor: "background.default" }}>
         <PageHeader title="Sections" onBack={onBack} />
-        <Alert severity="error" sx={{ mt: 2 }}>
-          {errorMessage || "Failed to load sections. Please try again."}
-        </Alert>
-        <Button variant="outlined" onClick={handleRefresh} sx={{ mt: 2 }}>
-          Retry
-        </Button>
+        <Box sx={{ mt: 2 }}>
+          <FailureState
+            title={userFacingError.title}
+            message={userFacingError.message}
+            onRetry={userFacingError.retryable ? handleRefresh : undefined}
+          />
+        </Box>
       </Box>
     );
   }
@@ -225,13 +230,13 @@ export default function SectionsList(props: SectionsListProps) {
   try {
     return <SectionsListComponent {...props} />;
   } catch (error) {
-    console.error('SectionsList render error:', error);
+    reportError("sections.list-render", error);
     return (
       <Box className="page-container" sx={{ backgroundColor: "background.default" }}>
         <PageHeader title="Sections" onBack={props.onBack} />
-        <Alert severity="error" sx={{ mt: 2 }}>
-          An error occurred while loading sections. Please refresh the page.
-        </Alert>
+        <Box sx={{ mt: 2 }}>
+          <FailureState message="We could not display your sections. Please reload the page." />
+        </Box>
       </Box>
     );
   }

--- a/src/features/sections/components/__tests__/MyBookings.test.tsx
+++ b/src/features/sections/components/__tests__/MyBookings.test.tsx
@@ -5,6 +5,7 @@ import MyBookings from "../MyBookings";
 import * as reactGenerated from "@dataconnect/generated/react";
 import { BookingStatus } from "@dataconnect/generated";
 import { dataConnectQueryResult } from "../../../../test-utils/dataConnectMocks";
+import userEvent from "@testing-library/user-event";
 
 vi.mock("@dataconnect/generated/react", () => ({
   useGetMyBookings: vi.fn(),
@@ -221,5 +222,48 @@ describe("MyBookings", () => {
     );
 
     expect(screen.getByText(/no bookings yet/i)).toBeInTheDocument();
+  });
+
+  it("shows a safe failure and retries without exposing query details", async () => {
+    const refetch = vi.fn();
+    vi.mocked(reactGenerated.useGetMyBookings).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyBookings>({
+        isLoading: false,
+        isError: true,
+        error: new Error("booking_rows database failure"),
+        refetch,
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <MyBookings onBack={() => undefined} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText(/could not load your bookings/i)).toBeInTheDocument();
+    expect(screen.queryByText(/booking_rows/)).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes access denied from a retryable failure", () => {
+    vi.mocked(reactGenerated.useGetMyBookings).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyBookings>({
+        isLoading: false,
+        isError: true,
+        error: { code: "permission-denied", message: "internal policy name" },
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <MyBookings onBack={() => undefined} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole("heading", { name: "Access denied" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/internal policy name/i)).not.toBeInTheDocument();
   });
 });

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -282,7 +282,7 @@ describe("MyPayments", () => {
       screen.getByText("We couldn’t load your payment history. Please try again."),
     ).toBeInTheDocument();
     expect(screen.queryByText(/Postgres ticket_orders/)).not.toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await user.click(screen.getByRole("button", { name: "Try again" }));
     expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '../../../../test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import SectionDetail from '../SectionDetail';
@@ -225,6 +225,10 @@ describe('SectionDetail', () => {
     });
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should render loading state', () => {
     vi.mocked(getSectionMembersMerged).mockReturnValue(new Promise(() => undefined));
 
@@ -247,6 +251,7 @@ describe('SectionDetail', () => {
   });
 
   it('should render error state', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     mockGetSectionById({
       data: undefined,
       isLoading: false,
@@ -265,6 +270,7 @@ describe('SectionDetail', () => {
       expect(screen.getByText(/could not load this section/i)).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith('[sections.detail]', expect.any(Error), {});
   });
 
   it('should render section description above the members list', async () => {
@@ -1497,6 +1503,7 @@ describe('SectionDetail', () => {
   });
 
   it('shows events list retry button when events fail to load', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const mockSectionData = {
       section: {
         id: sectionId,
@@ -1520,6 +1527,52 @@ describe('SectionDetail', () => {
       expect(screen.getByText(/could not load the events for this section/i)).toBeInTheDocument();
     });
     expect(screen.getAllByRole('button', { name: /try again/i })).not.toHaveLength(0);
+    expect(consoleError).toHaveBeenCalledWith('[sections.events]', expect.any(Error), {});
+  });
+
+  it('reports an event-detail failure', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const eventId = 'event-1';
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        purposeLinks: [],
+      },
+    };
+    const mockEventsData = {
+      section: {
+        id: sectionId,
+        events: [
+          {
+            id: eventId,
+            title: 'Annual Dinner',
+            ...upcomingEventTimes,
+            location: 'Main Hall',
+            guestOfHonour: null,
+          },
+        ],
+      },
+    };
+
+    mockGetSectionById({ data: mockSectionData, isLoading: false, isError: false });
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetEventsForSection({ data: mockEventsData, isLoading: false, isError: false });
+    mockGetEventById({ data: undefined, isLoading: false, isError: true });
+
+    renderSectionDetail();
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /annual dinner/i }));
+
+    expect(await screen.findByText(/could not load this event/i)).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith('[sections.event-detail]', expect.any(Error), {});
   });
 
   it('shows members refresh button and calls refetch when clicked', async () => {

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -262,9 +262,9 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByText(/failed to load section details/i)).toBeInTheDocument();
+      expect(screen.getByText(/could not load this section/i)).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
 
   it('should render section description above the members list', async () => {
@@ -1517,9 +1517,9 @@ describe('SectionDetail', () => {
     renderSectionDetail();
 
     await waitFor(() => {
-      expect(screen.getByText(/failed to load events/i)).toBeInTheDocument();
+      expect(screen.getByText(/could not load the events for this section/i)).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /try again/i })).not.toHaveLength(0);
   });
 
   it('shows members refresh button and calls refetch when clicked', async () => {

--- a/src/features/sections/components/__tests__/SectionFilesList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionFilesList.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "../../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import SectionFilesList from "../SectionFilesList";
@@ -15,6 +15,10 @@ vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
 describe("SectionFilesList", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("shows safe member-facing file metadata", async () => {
@@ -50,8 +54,10 @@ describe("SectionFilesList", () => {
   });
 
   it("uses a non-enumerating error and supports retry", async () => {
+    const failure = new Error("permission denied");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(listSectionFiles)
-      .mockRejectedValueOnce(new Error("permission denied"))
+      .mockRejectedValueOnce(failure)
       .mockResolvedValueOnce([]);
     render(<SectionFilesList sectionId="section-1" />);
 
@@ -59,10 +65,14 @@ describe("SectionFilesList", () => {
     reload.click();
     await waitFor(() => expect(listSectionFiles).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("No files are available for this section.")).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith("[sections.files.list]", failure, {});
+    consoleError.mockRestore();
   });
 
   it("keeps the file list visible and shows a download-specific error", async () => {
     const user = userEvent.setup();
+    const failure = new Error("permission denied");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(listSectionFiles).mockResolvedValue([
       {
         id: "file-1",
@@ -78,7 +88,7 @@ describe("SectionFilesList", () => {
         canonicalUrl: "https://members.example.org/sections/section-1/files/file-1",
       },
     ]);
-    vi.mocked(requestSectionFileDownload).mockRejectedValue(new Error("permission denied"));
+    vi.mocked(requestSectionFileDownload).mockRejectedValue(failure);
     render(<SectionFilesList sectionId="section-1" />);
 
     await user.click(
@@ -88,5 +98,7 @@ describe("SectionFilesList", () => {
     expect(await screen.findByText(/could not be downloaded/i)).toBeInTheDocument();
     expect(screen.getByText("Joining instructions")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith("[sections.files.download]", failure, {});
+    consoleError.mockRestore();
   });
 });

--- a/src/features/sections/components/__tests__/SectionFilesList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionFilesList.test.tsx
@@ -55,7 +55,7 @@ describe("SectionFilesList", () => {
       .mockResolvedValueOnce([]);
     render(<SectionFilesList sectionId="section-1" />);
 
-    const reload = await screen.findByRole("button", { name: "Reload files" });
+    const reload = await screen.findByRole("button", { name: "Try again" });
     reload.click();
     await waitFor(() => expect(listSectionFiles).toHaveBeenCalledTimes(2));
     expect(await screen.findByText("No files are available for this section.")).toBeInTheDocument();
@@ -87,6 +87,6 @@ describe("SectionFilesList", () => {
 
     expect(await screen.findByText(/could not be downloaded/i)).toBeInTheDocument();
     expect(screen.getByText("Joining instructions")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Reload files" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Try again" })).not.toBeInTheDocument();
   });
 });

--- a/src/features/sections/components/__tests__/SectionsList.test.tsx
+++ b/src/features/sections/components/__tests__/SectionsList.test.tsx
@@ -85,8 +85,8 @@ describe('SectionsList', () => {
 
     render(<SectionsList onBack={mockOnBack} onSelectSection={mockOnSelectSection} />);
 
-    expect(screen.getByText(/failed to load sections/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByText(/could not load your sections/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
   });
 
   it('should render sections list for regular users', async () => {

--- a/src/features/welcome/components/MemberWelcomePage.tsx
+++ b/src/features/welcome/components/MemberWelcomePage.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 import {
-  Alert,
   Box,
   Button,
   Card,
@@ -19,6 +18,7 @@ import type { UserData } from "../../../types";
 import { extractAccessibleSections } from "../../../shared/navigation/extractAccessibleSections";
 import { getMemberDisplayName } from "../../../shared/utils/userDisplayName";
 import { useUpcomingEventsForUser } from "../hooks/useUpcomingEventsForUser";
+import FailureState from "../../../shared/components/FailureState";
 
 export interface MemberWelcomePageProps {
   userData: UserData | null;
@@ -33,7 +33,12 @@ export default function MemberWelcomePage({
 }: MemberWelcomePageProps) {
   const displayName = getMemberDisplayName(userData, userEmail);
   const sections = useMemo(() => extractAccessibleSections(sectionsData), [sectionsData]);
-  const { events, loading: loadingEvents, isError: errorEvents } = useUpcomingEventsForUser(sections);
+  const {
+    events,
+    loading: loadingEvents,
+    isError: errorEvents,
+    retry: retryEvents,
+  } = useUpcomingEventsForUser(sections);
 
   return (
     <Box sx={{ maxWidth: "900px", mx: "auto", px: { xs: 2, sm: 3 }, py: 2 }}>
@@ -53,17 +58,24 @@ export default function MemberWelcomePage({
       </Typography>
       {loadingEvents ? (
         <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-          <CircularProgress size={28} />
+          <CircularProgress size={28} aria-label="Loading upcoming events" />
         </Box>
-      ) : errorEvents ? (
-        <Alert severity="error" sx={{ mb: 3 }}>
-          Failed to load upcoming events. Please try again later.
-        </Alert>
-      ) : events.length === 0 ? (
+      ) : null}
+      {errorEvents ? (
+        <Box sx={{ mb: 3 }}>
+          <FailureState
+            title="Upcoming events are unavailable"
+            message="We could not refresh upcoming events. Your sections are still available below."
+            onRetry={retryEvents}
+          />
+        </Box>
+      ) : null}
+      {!loadingEvents && !errorEvents && events.length === 0 ? (
         <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
           Nothing in the diary yet — check back soon or browse your sections below.
         </Typography>
-      ) : (
+      ) : null}
+      {!loadingEvents && events.length > 0 ? (
         <Box
           component="ul"
           sx={{
@@ -101,7 +113,7 @@ export default function MemberWelcomePage({
             </Box>
           ))}
         </Box>
-      )}
+      ) : null}
 
       <Typography variant="h6" component="h2" sx={{ mb: 2 }}>
         Your sections

--- a/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
+++ b/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { SectionType } from "@dataconnect/generated";
 import { getEventsForSection } from "@dataconnect/generated";
@@ -53,6 +53,10 @@ describe("useUpcomingEventsForUser", () => {
     } as unknown as Awaited<ReturnType<typeof getEventsForSection>>);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("does not refetch when the sections array reference changes but content is the same", async () => {
     const { result, rerender } = renderHook(
       ({ sections }) => useUpcomingEventsForUser(sections),
@@ -69,8 +73,10 @@ describe("useUpcomingEventsForUser", () => {
   });
 
   it("can retry a failed request and recover", async () => {
+    const failure = new Error("temporary network failure");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     vi.mocked(getEventsForSection)
-      .mockRejectedValueOnce(new Error("temporary network failure"))
+      .mockRejectedValueOnce(failure)
       .mockResolvedValueOnce({
         data: {
           section: {
@@ -87,5 +93,7 @@ describe("useUpcomingEventsForUser", () => {
 
     await waitFor(() => expect(result.current.isError).toBe(false));
     expect(getEventsForSection).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith("[welcome.upcoming-events]", failure, {});
+    consoleError.mockRestore();
   });
 });

--- a/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
+++ b/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { SectionType } from "@dataconnect/generated";
 import { getEventsForSection } from "@dataconnect/generated";
 import { sectionsFingerprint, useUpcomingEventsForUser } from "../useUpcomingEventsForUser";
@@ -66,5 +66,26 @@ describe("useUpcomingEventsForUser", () => {
 
     await waitFor(() => expect(result.current.events).toHaveLength(1));
     expect(getEventsForSection).toHaveBeenCalledTimes(1);
+  });
+
+  it("can retry a failed request and recover", async () => {
+    vi.mocked(getEventsForSection)
+      .mockRejectedValueOnce(new Error("temporary network failure"))
+      .mockResolvedValueOnce({
+        data: {
+          section: {
+            id: "section-1",
+            events: [],
+          },
+        },
+      } as unknown as Awaited<ReturnType<typeof getEventsForSection>>);
+
+    const { result } = renderHook(() => useUpcomingEventsForUser([eventSection]));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(result.current.isError).toBe(false));
+    expect(getEventsForSection).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -49,6 +49,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
   const [events, setEvents] = useState<UpcomingEventRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [isError, setIsError] = useState(false);
+  const [retryAttempt, setRetryAttempt] = useState(0);
   const lastFetchedKeyRef = useRef<string | null>(null);
 
   useEffect(() => {
@@ -104,7 +105,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
       } catch {
         if (alive) {
           setIsError(true);
-          setEvents([]);
+          // Keep any previously loaded events visible while the retry option is shown.
         }
       } finally {
         if (alive) {
@@ -116,7 +117,12 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
     return () => {
       alive = false;
     };
-  }, [eventSectionIdsKey, sectionNameById]);
+  }, [eventSectionIdsKey, sectionNameById, retryAttempt]);
 
-  return { events, loading, isError };
+  return {
+    events,
+    loading,
+    isError,
+    retry: () => setRetryAttempt((attempt) => attempt + 1),
+  };
 }

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -4,6 +4,7 @@ import type { UUIDString } from "@dataconnect/generated";
 import { SectionType } from "@dataconnect/generated";
 import { dataConnect } from "../../../config/firebase";
 import type { AccessibleSection } from "../../../shared/navigation/extractAccessibleSections";
+import { reportError } from "../../../shared/errors";
 import {
   isUpcomingSectionEvent,
   sortUpcomingSectionEvents,
@@ -102,8 +103,9 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
           setEvents(upcoming);
           setIsError(false);
         }
-      } catch {
+      } catch (error) {
         if (alive) {
+          reportError("welcome.upcoming-events", error);
           setIsError(true);
           // Keep any previously loaded events visible while the retry option is shown.
         }

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -2,3 +2,4 @@ export * from "./errorHandling";
 export * from "./authErrors";
 export * from "./profileErrors";
 export * from "./bookingErrors";
+export * from "./memberDataErrors";

--- a/src/shared/errors/memberDataErrors.ts
+++ b/src/shared/errors/memberDataErrors.ts
@@ -1,0 +1,33 @@
+import { toUserFacingError, type UserFacingError } from "./errorHandling";
+
+export type MemberDataContext =
+  | "sections"
+  | "events"
+  | "event"
+  | "files"
+  | "bookings"
+  | "payments"
+  | "profile"
+  | "preferences";
+
+const CONTEXT_MESSAGES: Record<MemberDataContext, string> = {
+  sections: "We could not load your sections. Please try again.",
+  events: "We could not load the events. Please try again.",
+  event: "We could not load this event. Please try again.",
+  files: "We could not load the files for this section. Please try again.",
+  bookings: "We could not load your bookings. Please try again.",
+  payments: "We could not load your payments. Please try again.",
+  profile: "We could not load your profile. Please try again.",
+  preferences: "We could not load your communication preferences. Please try again.",
+};
+
+/** Maps member-data failures without ever displaying provider or query messages. */
+export function toMemberDataError(error: unknown, context: MemberDataContext): UserFacingError {
+  const mapped = toUserFacingError(error);
+  if (mapped.category !== "unknown") return mapped;
+  return {
+    ...mapped,
+    title: "Unable to load information",
+    message: CONTEXT_MESSAGES[context],
+  };
+}


### PR DESCRIPTION
## Summary

- add a shared safe mapper for member-data failures, including distinct access-denied handling
- standardise loading, empty, failure, and retry states across sections, events, files, bookings, payments, the member dashboard, profile review, and communication preferences
- retain useful dashboard and section content when a secondary request fails
- remove raw query and provider error text from member-facing screens
- add accessible labels to loading indicators and focused retry/access-denied coverage

## User impact

Members now see consistent, actionable messages instead of technical errors. Independent failures, such as an unavailable events or files request, no longer discard other useful page content.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --run` — 87 files, 714 tests passed

Closes #466