### PR TITLE
Sanitise administration failure states

### DIFF
--- a/docs/architecture/error-handling.md
+++ b/docs/architecture/error-handling.md
@@ -101,3 +101,28 @@ same sign-in response.
 - Always retain the safe unknown fallback.
 - Test the known code, malformed/unknown input, raw-message non-disclosure, and
   retryability or privacy behaviour.
+
+## Administration audit (#467)
+
+The administration audit completed on 3 August 2026 covers user and approval
+management, groups, sections, events, tickets and guest moderation, section
+files, announcements and delivery settings, payment reconciliation, and audit
+logs. These surfaces map failures through `toAdminUserFacingError`, report the
+original error separately, and do not display arbitrary provider messages.
+
+The following cases are intentionally retained:
+
+- Application-owned validation copy, such as required-field and date-order
+  messages, is displayed directly because it is reviewed UI text rather than
+  exception content.
+- Stable application domain codes may select reviewed feature-specific copy;
+  the associated server message is never displayed.
+- Announcement delivery failure reasons remain available in controlled logs and
+  persisted operational records, while the UI displays only a safe summary.
+- `useUserData` still inspects a caught message to classify a missing profile,
+  but that message is not rendered. Replacing this internal compatibility check
+  with a stable Data Connect code is deferred until that API exposes one.
+
+Any newly added administration workflow must follow the map, report, display
+contract above and include a regression assertion that an arbitrary technical
+message is absent from rendered output.

--- a/src/features/admin/components/AnnouncementSendHistory.tsx
+++ b/src/features/admin/components/AnnouncementSendHistory.tsx
@@ -23,6 +23,7 @@ import {
   type AnnouncementSend,
   type AnnouncementRecipient,
 } from "../../../shared/utils/firebaseFunctions";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface Props {
   sectionId: string;
@@ -58,6 +59,16 @@ function formatDate(iso: string) {
   });
 }
 
+function recipientDetail(recipient: AnnouncementRecipient): string {
+  if (recipient.status === "skipped" && recipient.skippedReason === "opted_out") {
+    return "Recipient opted out";
+  }
+  if (recipient.status === "failed" || recipient.status === "enqueue_failed" || recipient.status === "bounced") {
+    return "Delivery failed; diagnostic detail is available in secure logs.";
+  }
+  return "";
+}
+
 function SendRow({ send, sectionId }: { send: AnnouncementSend; sectionId: string }) {
   const [open, setOpen] = useState(false);
   const [recipients, setRecipients] = useState<AnnouncementRecipient[] | null>(null);
@@ -71,8 +82,9 @@ function SendRow({ send, sectionId }: { send: AnnouncementSend; sectionId: strin
     try {
       const data = await getAnnouncementSendRecipients(send.id, sectionId);
       setRecipients(data);
-    } catch {
-      setError("Failed to load recipients");
+    } catch (caught) {
+      reportError("admin.announcements.recipients", caught, { sendId: send.id });
+      setError(toAdminUserFacingError(caught, "announcements").message);
     } finally {
       setLoading(false);
     }
@@ -169,7 +181,7 @@ function SendRow({ send, sectionId }: { send: AnnouncementSend; sectionId: strin
                         <TableCell>{r.effectiveDeliveryMode.replace("_", " ")}</TableCell>
                         <TableCell>
                           <Typography variant="caption" color="text.secondary">
-                            {r.skippedReason ?? r.failureReason ?? ""}
+                            {recipientDetail(r)}
                           </Typography>
                         </TableCell>
                       </TableRow>
@@ -195,11 +207,9 @@ export default function AnnouncementSendHistory({ sectionId, refreshTrigger }: P
     setError(null);
     getAnnouncementSendHistory(sectionId)
       .then(setSends)
-      .catch((err: unknown) => {
-        const msg = err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Unknown error";
-        setError(`Failed to load send history: ${msg}`);
+      .catch((caught: unknown) => {
+        reportError("admin.announcements.history", caught, { sectionId });
+        setError(toAdminUserFacingError(caught, "announcements").message);
       })
       .finally(() => setLoading(false));
   }, [sectionId, refreshTrigger]);

--- a/src/features/admin/components/ApproveUsers.tsx
+++ b/src/features/admin/components/ApproveUsers.tsx
@@ -28,6 +28,11 @@ import {
   type UserWithoutDataConnectProfileRow,
 } from "../../../shared/utils/firebaseFunctions";
 import "../../../shared/components/PageContainer.css";
+import {
+  reportError,
+  toAdminUserFacingError,
+  toProfileDomainUserFacingError,
+} from "../../../shared/errors";
 
 interface ApproveUsersProps {
   onBack: () => void;
@@ -63,7 +68,7 @@ export default function ApproveUsers({ onBack }: ApproveUsersProps) {
       ]);
 
       if (!withoutProfileResult.success || !withoutProfileResult.users) {
-        throw new Error(withoutProfileResult.error || "Failed to load users without profile");
+        throw new Error("Users without profiles could not be loaded");
       }
       setUsersWithoutProfile(withoutProfileResult.users);
 
@@ -72,12 +77,9 @@ export default function ApproveUsers({ onBack }: ApproveUsersProps) {
       } else {
         setPendingUsers([]);
       }
-    } catch (err: unknown) {
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Failed to load users";
-      setError(message);
+    } catch (caught) {
+      reportError("admin.user-approval.load", caught);
+      setError(toAdminUserFacingError(caught, "user-approval").message);
       setUsersWithoutProfile([]);
       setPendingUsers([]);
     } finally {
@@ -142,14 +144,15 @@ export default function ApproveUsers({ onBack }: ApproveUsersProps) {
         );
         await fetchData();
       } else {
-        setErrorMessage(result.error || "Failed to approve user");
+        setErrorMessage(
+          result.domainCode
+            ? toProfileDomainUserFacingError(result.domainCode, "update").message
+            : "The user could not be approved. Please refresh and try again.",
+        );
       }
-    } catch (err: unknown) {
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Failed to approve user";
-      setErrorMessage(message);
+    } catch (caught) {
+      reportError("admin.user-approval.approve", caught, { userId: user.id });
+      setErrorMessage(toAdminUserFacingError(caught, "user-approval").message);
     } finally {
       setApprovingUserId(null);
     }

--- a/src/features/admin/components/AuditLogs.tsx
+++ b/src/features/admin/components/AuditLogs.tsx
@@ -28,6 +28,7 @@ import {
 } from "@dataconnect/generated";
 import PageHeader from "../../../shared/components/PageHeader";
 import "../../../shared/components/PageContainer.css";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface AuditLogsProps {
   onBack: () => void;
@@ -47,8 +48,8 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
       const ref = listUsersRef(dataConnect);
       const result = await executeQuery(ref);
       setAllUsers(result.data?.users || []);
-    } catch (err: any) {
-      console.error("Failed to fetch users for audit log lookup:", err);
+    } catch (error) {
+      reportError("admin.audit-logs.user-lookup", error);
     }
   }, []);
 
@@ -69,8 +70,9 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
         const result = await executeQuery(ref);
         setSections(result.data?.sections || []);
       }
-    } catch (err: any) {
-      setError(err?.message || "Failed to load audit logs");
+    } catch (caught) {
+      reportError("admin.audit-logs.load", caught, { tab: tabValue });
+      setError(toAdminUserFacingError(caught, "audit-logs").message);
     } finally {
       setLoading(false);
     }

--- a/src/features/admin/components/EmailDeliverySettingsPage.tsx
+++ b/src/features/admin/components/EmailDeliverySettingsPage.tsx
@@ -26,6 +26,7 @@ import {
   type GovNotifyDeliveryAdminConfiguration,
 } from "../../../shared/utils/firebaseFunctions/govNotifyDeliveryConfiguration";
 import "../../../shared/components/PageContainer.css";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 const MODES: GovNotifyDeliveryMode[] = ["SIMULATION", "TEAM_TEST", "LIVE"];
 const RANK: Record<GovNotifyDeliveryMode, number> = {
@@ -48,10 +49,6 @@ interface Props {
   onBack: () => void;
 }
 
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : "The operation could not be completed.";
-}
-
 export default function EmailDeliverySettingsPage({ onBack }: Props) {
   const [configuration, setConfiguration] =
     useState<GovNotifyDeliveryAdminConfiguration | null>(null);
@@ -70,7 +67,8 @@ export default function EmailDeliverySettingsPage({ onBack }: Props) {
       setConfiguration(result);
       setSelectedMode(result.runtimeMode);
     } catch (loadError) {
-      setError(errorMessage(loadError));
+      reportError("admin.email-delivery.load", loadError);
+      setError(toAdminUserFacingError(loadError, "email-configuration").message);
     } finally {
       setLoading(false);
     }
@@ -106,7 +104,8 @@ export default function EmailDeliverySettingsPage({ onBack }: Props) {
       setReason("");
       setConfirmOpen(false);
     } catch (saveError) {
-      setError(errorMessage(saveError));
+      reportError("admin.email-delivery.save", saveError, { selectedMode });
+      setError(toAdminUserFacingError(saveError, "email-configuration").message);
       setConfirmOpen(false);
     } finally {
       setSaving(false);

--- a/src/features/admin/components/EmailTemplateSyncPage.tsx
+++ b/src/features/admin/components/EmailTemplateSyncPage.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import { CheckCircle, ContentCopy, Error, ExpandLess, ExpandMore, OpenInNew, Warning } from "@mui/icons-material";
 import PageHeader from "../../../shared/components/PageHeader";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 import {
   getTemplateSyncStatus,
   type TemplateSyncResult,
@@ -299,8 +300,9 @@ export default function EmailTemplateSyncPage({ onBack }: EmailTemplateSyncPageP
     try {
       const data = await getTemplateSyncStatus();
       setResults(data.results);
-    } catch {
-      setError("Failed to fetch template sync status");
+    } catch (caught) {
+      reportError("admin.email-templates.sync-status", caught);
+      setError(toAdminUserFacingError(caught, "email-configuration").message);
     } finally {
       setLoading(false);
     }

--- a/src/features/admin/components/ManageSectionFiles.tsx
+++ b/src/features/admin/components/ManageSectionFiles.tsx
@@ -28,6 +28,7 @@ import {
   type SectionFile,
 } from "../../../shared/utils/firebaseFunctions";
 import PageHeader from "../../../shared/components/PageHeader";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 const MAX_BYTES = 25 * 1024 * 1024;
 const ALLOWED_TYPES = [
@@ -49,17 +50,6 @@ function validateFile(file: File): string | null {
   if (file.size > MAX_BYTES) return "Files must be 25 MB or smaller.";
   if (!ALLOWED_TYPES.includes(file.type)) return "This file type is not supported.";
   return null;
-}
-
-function errorMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : "";
-  if (/permission|unauth|denied/i.test(message)) {
-    return "You no longer have permission to manage files for this section.";
-  }
-  if (/precondition|changed|current state/i.test(message)) {
-    return "The file changed. Refresh the list and try again.";
-  }
-  return "The operation could not be completed. Please try again.";
 }
 
 export default function ManageSectionFiles({
@@ -89,8 +79,9 @@ export default function ManageSectionFiles({
     try {
       setFiles(await listSectionFiles(sectionId));
     } catch (error) {
+      reportError("admin.section-files.load", error, { sectionId });
       setFiles([]);
-      setNotice({ severity: "error", text: errorMessage(error) });
+      setNotice({ severity: "error", text: toAdminUserFacingError(error, "files").message });
     } finally {
       setLoading(false);
     }
@@ -108,7 +99,8 @@ export default function ManageSectionFiles({
       setNotice({ severity: "success", text: success });
       await load();
     } catch (error) {
-      setNotice({ severity: "error", text: errorMessage(error) });
+      reportError("admin.section-files.operation", error, { sectionId });
+      setNotice({ severity: "error", text: toAdminUserFacingError(error, "files").message });
     } finally {
       setBusy(false);
       setStage(null);
@@ -170,7 +162,8 @@ export default function ManageSectionFiles({
     try {
       await navigator.clipboard.writeText(file.canonicalUrl);
       setNotice({ severity: "success", text: "Stable file link copied." });
-    } catch {
+    } catch (error) {
+      reportError("admin.section-files.copy-link", error, { sectionId, fileId: file.id });
       setNotice({ severity: "error", text: "The link could not be copied. Try again." });
     }
   };

--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -32,6 +32,7 @@ import {
   SectionEditorDialogSurface,
 } from "./ManageSectionsSurfaces";
 import type { SectionUserGroupRow, SectionWithDetails } from "./manageSectionsTypes";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface ManageSectionsProps {
   onBack: () => void;
@@ -120,8 +121,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       existingSections.sort((a, b) => a.name.localeCompare(b.name));
       
       setSections(existingSections);
-    } catch (err: any) {
-      setError(err?.message || "Failed to fetch sections");
+    } catch (caught) {
+      reportError("admin.sections.load", caught);
+      setError(toAdminUserFacingError(caught, "sections").message);
     } finally {
       setLoading(false);
     }
@@ -136,8 +138,8 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       const ref = listUserGroupsRef(dataConnect);
       const result = await executeQuery(ref);
       setAllUserGroups(result.data?.userGroups || []);
-    } catch (err: any) {
-      console.error("Failed to fetch user groups:", err);
+    } catch (caught) {
+      reportError("admin.sections.available-groups", caught);
     }
   }, []);
 
@@ -167,8 +169,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       } else {
         setSectionUserGroups([]);
       }
-    } catch (err: any) {
-      console.error("Failed to fetch section user groups:", err);
+    } catch (caught) {
+      reportError("admin.sections.assigned-groups", caught, { sectionId });
+      setError(toAdminUserFacingError(caught, "sections").message);
       setSectionUserGroups([]);
     } finally {
       setLoadingUserGroups(false);
@@ -223,8 +226,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       await executeMutation(ref);
       await fetchSections();
       showSuccess(`Section "${section.name}" deleted`);
-    } catch (err: any) {
-      setError(err?.message || "Failed to delete section");
+    } catch (caught) {
+      reportError("admin.sections.delete", caught, { sectionId: section.id });
+      setError(toAdminUserFacingError(caught, "sections").message);
     }
   };
 
@@ -257,8 +261,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       setDialogOpen(false);
       await fetchSections();
       showSuccess(`Section ${editingSection ? "updated" : "created"}`);
-    } catch (err: any) {
-      setError(err?.message || `Failed to ${editingSection ? "update" : "create"} section`);
+    } catch (caught) {
+      reportError("admin.sections.save", caught, { editing: Boolean(editingSection) });
+      setError(toAdminUserFacingError(caught, "sections").message);
     } finally {
       setSubmitting(false);
     }
@@ -292,8 +297,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       setSelectedPurpose(SectionUserGroupPurpose.ACCESS);
       setAddUserGroupDialogOpen(false);
       showSuccess("User group added to section");
-    } catch (err: any) {
-      setError(err?.message || "Failed to add user group");
+    } catch (caught) {
+      reportError("admin.sections.add-group", caught, { sectionId: editingSection.id });
+      setError(toAdminUserFacingError(caught, "sections").message);
     } finally {
       setAddingUserGroup(false);
     }
@@ -335,8 +341,9 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       // Refresh section user groups
       await fetchSectionUserGroups(editingSection.id);
       showSuccess("User group removed from section");
-    } catch (err: any) {
-      setError(err?.message || "Failed to remove user group");
+    } catch (caught) {
+      reportError("admin.sections.remove-group", caught, { sectionId: editingSection.id, userGroupId });
+      setError(toAdminUserFacingError(caught, "sections").message);
     } finally {
       setRemovingUserGroupId(null);
     }

--- a/src/features/admin/components/ManageUsers.tsx
+++ b/src/features/admin/components/ManageUsers.tsx
@@ -27,6 +27,7 @@ import { grantAdminClaim, revokeAdminClaim } from "../../../shared/utils/firebas
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
 import "../../../shared/components/PageContainer.css";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface ManageUsersProps {
   onBack: () => void;
@@ -80,16 +81,13 @@ export default function ManageUsers({ onBack }: ManageUsersProps) {
         setAdminUsers(result.users);
         setAdminCount(result.users.length);
       } else {
-        setAdminListError(result.error || "Failed to fetch admin users");
+        setAdminListError("Administrator accounts could not be loaded. Please try again.");
         setAdminUsers([]);
         setAdminCount(0);
       }
-    } catch (err: unknown) {
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Failed to fetch admin users";
-      setAdminListError(message);
+    } catch (caught) {
+      reportError("admin.users.list-admins", caught);
+      setAdminListError(toAdminUserFacingError(caught, "users").message);
       setAdminUsers([]);
       setAdminCount(0);
     } finally {
@@ -151,15 +149,12 @@ export default function ManageUsers({ onBack }: ManageUsersProps) {
       } else {
         setUpdateMessage({
           type: "error",
-          text: result.error || "Failed to grant admin claim",
+          text: "Administrator access could not be granted. Please try again.",
         });
       }
-    } catch (err: unknown) {
-      const message =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Failed to grant admin claim";
-      setUpdateMessage({ type: "error", text: message });
+    } catch (caught) {
+      reportError("admin.users.grant-admin", caught, { userId: uid });
+      setUpdateMessage({ type: "error", text: toAdminUserFacingError(caught, "admin-claims").message });
     } finally {
       setUpdatingUserId(null);
       setTimeout(() => setUpdateMessage(null), ERROR_MESSAGE_TIMEOUT);
@@ -192,15 +187,12 @@ export default function ManageUsers({ onBack }: ManageUsersProps) {
       } else {
         setUpdateMessage({
           type: "error",
-          text: result.error || "Failed to revoke admin claim",
+          text: "Administrator access could not be revoked. Please try again.",
         });
       }
-    } catch (err: unknown) {
-      const errorMessage =
-        err && typeof (err as { message?: string }).message === "string"
-          ? (err as { message: string }).message
-          : "Failed to revoke admin claim";
-      setUpdateMessage({ type: "error", text: errorMessage });
+    } catch (caught) {
+      reportError("admin.users.revoke-admin", caught, { userId: uid });
+      setUpdateMessage({ type: "error", text: toAdminUserFacingError(caught, "admin-claims").message });
     } finally {
       setUpdatingUserId(null);
       setTimeout(() => setUpdateMessage(null), ERROR_MESSAGE_TIMEOUT);

--- a/src/features/admin/components/PaymentReconciliationDashboard.tsx
+++ b/src/features/admin/components/PaymentReconciliationDashboard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Alert,
   Box,
@@ -30,18 +30,24 @@ import PageHeader from "../../../shared/components/PageHeader";
 import SnackbarAlert from "../../../shared/components/SnackbarAlert";
 import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import "../../../shared/components/PageContainer.css";
+import FailureState from "../../../shared/components/FailureState";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface PaymentReconciliationDashboardProps {
   onBack: () => void;
 }
 
 export default function PaymentReconciliationDashboard({ onBack }: PaymentReconciliationDashboardProps) {
-  const { data, isLoading, refetch } = useListOpenPaymentReconciliationExceptions(dataConnect);
+  const { data, isLoading, isError, error: queryError, refetch } = useListOpenPaymentReconciliationExceptions(dataConnect);
   const [typeFilter, setTypeFilter] = useState<"ALL" | PaymentReconciliationExceptionType>("ALL");
   const [eventSearch, setEventSearch] = useState("");
   const [resolvingId, setResolvingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
+
+  useEffect(() => {
+    if (isError) reportError("admin.payment-reconciliation.load", queryError);
+  }, [isError, queryError]);
 
   const filteredRows = useMemo(() => {
     const rows = data?.paymentReconciliationExceptions ?? [];
@@ -66,7 +72,8 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
       await refetch();
       showSuccess("Exception marked reviewed");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to mark exception reviewed");
+      reportError("admin.payment-reconciliation.resolve", err, { exceptionId: id });
+      setError(toAdminUserFacingError(err, "payment-reconciliation").message);
     } finally {
       setResolvingId(null);
     }
@@ -109,6 +116,12 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
 
       {isLoading ? (
         <CircularProgress size={24} />
+      ) : isError ? (
+        <FailureState
+          title={toAdminUserFacingError(queryError, "payment-reconciliation").title}
+          message={toAdminUserFacingError(queryError, "payment-reconciliation").message}
+          onRetry={() => void refetch()}
+        />
       ) : filteredRows.length === 0 ? (
         <Alert severity="info">No open reconciliation exceptions match current filters.</Alert>
       ) : (

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { Box } from "@mui/material";
 import { executeQuery, executeMutation } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
@@ -48,6 +48,7 @@ import SendAnnouncementPage from "./SendAnnouncementPage";
 import SnackbarAlert from "../../../shared/components/SnackbarAlert";
 import { useSnackbar } from "../../../shared/hooks/useSnackbar";
 import "../../../shared/components/PageContainer.css";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface SectionEventsManagerProps {
   sectionId: string;
@@ -57,7 +58,13 @@ interface SectionEventsManagerProps {
 }
 
 export default function SectionEventsManager({ sectionId, sectionName, initialEventId, onBack }: SectionEventsManagerProps) {
-  const { data: eventsData, isLoading: loadingEvents, isError: errorEvents, refetch: refetchEvents } = useGetEventsForSection(
+  const {
+    data: eventsData,
+    isLoading: loadingEvents,
+    isError: errorEvents,
+    error: eventsQueryError,
+    refetch: refetchEvents,
+  } = useGetEventsForSection(
     dataConnect,
     { sectionId: sectionId as UUIDString }
   );
@@ -78,7 +85,13 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
 
   // Ticket types: which event we're managing ticket types for
   const [ticketTypesEventId, setTicketTypesEventId] = useState<string | null>(initialEventId ?? null);
-  const { data: eventDetailData, isLoading: loadingEventDetail, refetch: refetchEventDetail } = useGetEventById(
+  const {
+    data: eventDetailData,
+    isLoading: loadingEventDetail,
+    isError: eventDetailFailed,
+    error: eventDetailError,
+    refetch: refetchEventDetail,
+  } = useGetEventById(
     dataConnect,
     { id: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
     { enabled: !!ticketTypesEventId }
@@ -102,27 +115,82 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
   const {
     data: guestRequestsData,
     isLoading: loadingGuestRequests,
+    isError: guestRequestsFailed,
+    error: guestRequestsError,
     refetch: refetchGuestRequests,
   } = useListGuestTicketRequestsForAdmin(
     dataConnect,
     { eventId: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
     { enabled: !!ticketTypesEventId }
   );
-  const { data: eventBookingsData, isLoading: loadingEventBookings } = useListEventBookingsForAdmin(
+  const {
+    data: eventBookingsData,
+    isLoading: loadingEventBookings,
+    isError: eventBookingsFailed,
+    error: eventBookingsError,
+  } = useListEventBookingsForAdmin(
     dataConnect,
     { eventId: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
     { enabled: !!ticketTypesEventId }
   );
-  const { data: ticketOrdersData, isLoading: loadingTicketOrders } = useListTicketOrdersForAdmin(
+  const {
+    data: ticketOrdersData,
+    isLoading: loadingTicketOrders,
+    isError: ticketOrdersFailed,
+    error: ticketOrdersError,
+  } = useListTicketOrdersForAdmin(
     dataConnect,
     { eventId: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
     { enabled: !!ticketTypesEventId }
   );
-  const { data: paymentAdjustmentsData, isLoading: loadingPaymentAdjustments } = useListBookingPaymentAdjustmentsForAdmin(
+  const {
+    data: paymentAdjustmentsData,
+    isLoading: loadingPaymentAdjustments,
+    isError: paymentAdjustmentsFailed,
+    error: paymentAdjustmentsError,
+  } = useListBookingPaymentAdjustmentsForAdmin(
     dataConnect,
     { eventId: (ticketTypesEventId ?? "00000000-0000-0000-0000-000000000000") as UUIDString },
     { enabled: !!ticketTypesEventId }
   );
+
+  useEffect(() => {
+    if (!errorEvents) return;
+    reportError("admin.events.list", eventsQueryError, { sectionId });
+  }, [errorEvents, eventsQueryError, sectionId]);
+
+  useEffect(() => {
+    const failures = [
+      { failed: eventDetailFailed, error: eventDetailError, operation: "detail", context: "events" as const },
+      { failed: guestRequestsFailed, error: guestRequestsError, operation: "guest-requests", context: "guest-moderation" as const },
+      { failed: eventBookingsFailed, error: eventBookingsError, operation: "bookings", context: "tickets" as const },
+      { failed: ticketOrdersFailed, error: ticketOrdersError, operation: "orders", context: "tickets" as const },
+      { failed: paymentAdjustmentsFailed, error: paymentAdjustmentsError, operation: "adjustments", context: "payment-reconciliation" as const },
+    ].filter((failure) => failure.failed);
+
+    if (failures.length === 0) return;
+
+    for (const failure of failures) {
+      reportError(`admin.events.${failure.operation}`, failure.error, {
+        sectionId,
+        eventId: ticketTypesEventId,
+      });
+    }
+    setError(toAdminUserFacingError(failures[0].error, failures[0].context).message);
+  }, [
+    eventBookingsError,
+    eventBookingsFailed,
+    eventDetailError,
+    eventDetailFailed,
+    guestRequestsError,
+    guestRequestsFailed,
+    paymentAdjustmentsError,
+    paymentAdjustmentsFailed,
+    sectionId,
+    ticketOrdersError,
+    ticketOrdersFailed,
+    ticketTypesEventId,
+  ]);
 
   const fetchUserGroups = useCallback(async () => {
     setLoadingUserGroups(true);
@@ -130,12 +198,13 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       const ref = listUserGroupsRef(dataConnect);
       const result = await executeQuery(ref);
       setAllUserGroups((result.data?.userGroups ?? []).map((ug) => ({ id: ug.id, name: ug.name })));
-    } catch {
+    } catch (caught) {
+      reportError("admin.events.user-groups", caught, { sectionId });
       setAllUserGroups([]);
     } finally {
       setLoadingUserGroups(false);
     }
-  }, []);
+  }, [sectionId]);
 
   const openEventDialog = (event?: EventRow | null) => {
     if (event) {
@@ -218,7 +287,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       setEventDialogOpen(false);
       showSuccess(`Event ${editingEvent ? "updated" : "created"}`);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save event");
+      reportError("admin.events.save", err, { sectionId, editing: Boolean(editingEvent) });
+      setError(toAdminUserFacingError(err, "events").message);
     } finally {
       setSubmitting(false);
     }
@@ -250,7 +320,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       if (ticketTypesEventId === event.id) setTicketTypesEventId(null);
       showSuccess(`Event "${event.title}" deleted`);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to delete event");
+      reportError("admin.events.delete", err, { sectionId, eventId: event.id });
+      setError(toAdminUserFacingError(err, "events").message);
     } finally {
       setDeletingEventId(null);
     }
@@ -322,7 +393,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       setTicketTypeDialogOpen(false);
       showSuccess(`Ticket type ${editingTicketType ? "updated" : "created"}`);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to save ticket type");
+      reportError("admin.tickets.save", err, { eventId: ticketTypesEventId, editing: Boolean(editingTicketType) });
+      setError(toAdminUserFacingError(err, "tickets").message);
     } finally {
       setSubmittingTicketType(false);
     }
@@ -338,7 +410,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       refetchEvents();
       showSuccess("Ticket type deleted");
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to delete ticket type");
+      reportError("admin.tickets.delete", err, { ticketTypeId: id });
+      setError(toAdminUserFacingError(err, "tickets").message);
     } finally {
       setDeletingTicketTypeId(null);
     }
@@ -374,7 +447,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       refetchGuestRequests();
       showSuccess(`Guest ticket request ${status === GuestTicketRequestStatus.APPROVED ? "approved" : "rejected"}`);
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to review guest ticket request");
+      reportError("admin.guest-moderation.review", err, { requestId: request.id, status });
+      setError(toAdminUserFacingError(err, "guest-moderation").message);
     } finally {
       setReviewingRequestId(null);
     }

--- a/src/features/admin/components/SendAnnouncementPage.tsx
+++ b/src/features/admin/components/SendAnnouncementPage.tsx
@@ -28,6 +28,7 @@ import {
 } from "../../../shared/utils/firebaseFunctions";
 import TemplateEditor from "./TemplateEditor";
 import AnnouncementSendHistory from "./AnnouncementSendHistory";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface SendAnnouncementPageProps {
   sectionId: string;
@@ -73,7 +74,10 @@ export default function SendAnnouncementPage({
     setTemplatesError(null);
     getAnnouncementTemplates(sectionId)
       .then(setTemplates)
-      .catch(() => setTemplatesError("Failed to load templates from GOV Notify"))
+      .catch((caught) => {
+        reportError("admin.announcements.templates", caught, { sectionId });
+        setTemplatesError(toAdminUserFacingError(caught, "announcements").message);
+      })
       .finally(() => setLoadingTemplates(false));
   }, [sectionId, templatesTrigger]);
 
@@ -84,7 +88,10 @@ export default function SendAnnouncementPage({
         setSiteDeliveryMode(configuredMode);
         setDeliveryMode(configuredMode === "SIMULATION" ? "SIMULATION" : configuredMode);
       })
-      .catch(() => setDeliveryModeError("The site-wide email delivery mode is unavailable."));
+      .catch((caught) => {
+        reportError("admin.announcements.delivery-mode", caught, { sectionId });
+        setDeliveryModeError(toAdminUserFacingError(caught, "email-configuration").message);
+      });
   }, [sectionId]);
 
   const handleTemplateChange = async (e: SelectChangeEvent) => {
@@ -103,7 +110,8 @@ export default function SendAnnouncementPage({
       setPreviewHtml(html);
       setPreviewSubject(subject);
     } catch (err) {
-      setPreviewError(err instanceof Error ? err.message : "Failed to load preview");
+      reportError("admin.announcements.preview", err, { sectionId, templateId: id });
+      setPreviewError(toAdminUserFacingError(err, "announcements").message);
     } finally {
       setLoadingPreview(false);
     }
@@ -127,8 +135,9 @@ export default function SendAnnouncementPage({
       );
       setSendResult(result);
       setHistoryTrigger((n) => n + 1);
-    } catch {
-      setSendError("Failed to send announcement. Please try again.");
+    } catch (caught) {
+      reportError("admin.announcements.send", caught, { sectionId, templateId: selectedId });
+      setSendError(toAdminUserFacingError(caught, "announcements").message);
     } finally {
       setSending(false);
     }

--- a/src/features/admin/components/UserGroupMemberships.tsx
+++ b/src/features/admin/components/UserGroupMemberships.tsx
@@ -39,6 +39,7 @@ import {
 import { MembershipStatus } from "@dataconnect/generated";
 import SnackbarAlert from "../../../shared/components/SnackbarAlert";
 import { useSnackbar } from "../../../shared/hooks/useSnackbar";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface UserGroupMembershipsProps {
   userId: string;
@@ -68,8 +69,9 @@ export default function UserGroupMemberships({
       const ref = getUserWithAccessGroupsRef(dataConnect, { id: userId });
       const result = await executeQuery(ref);
       setUserData(result.data?.user || null);
-    } catch (err: any) {
-      setError(err?.message || "Failed to fetch user user groups");
+    } catch (caught) {
+      reportError("admin.user-memberships.load", caught, { userId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setLoading(false);
     }
@@ -80,10 +82,10 @@ export default function UserGroupMemberships({
       const ref = listUserGroupsRef(dataConnect);
       const result = await executeQuery(ref);
       setAllGroups(result.data?.userGroups || []);
-    } catch (err: any) {
-      console.error("Failed to fetch user groups:", err);
+    } catch (caught) {
+      reportError("admin.user-memberships.available-groups", caught, { userId });
     }
-  }, []);
+  }, [userId]);
 
   useEffect(() => {
     fetchUserData();
@@ -109,8 +111,9 @@ export default function UserGroupMemberships({
       }
       setAddDialogOpen(false);
       showSuccess(`Added to "${allGroups.find((g) => g.id === groupId)?.name ?? "group"}"`);
-    } catch (err: any) {
-      setError(err?.message || "Failed to add user to user group");
+    } catch (caught) {
+      reportError("admin.user-memberships.add", caught, { userId, groupId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setAddingGroupId(null);
     }
@@ -135,8 +138,9 @@ export default function UserGroupMemberships({
         onUpdate();
       }
       showSuccess(`Removed from "${groupName}"`);
-    } catch (err: any) {
-      setError(err?.message || "Failed to remove user from user group");
+    } catch (caught) {
+      reportError("admin.user-memberships.remove", caught, { userId, groupId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setRemovingGroupId(null);
     }

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -39,6 +39,7 @@ import type {
   UserSearchResult,
   UserSummary,
 } from "./userGroupsTypes";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface UserGroupsProps {
   onBack: () => void;
@@ -101,8 +102,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       existingGroups.sort((a, b) => a.name.localeCompare(b.name));
       
       setUserGroups(existingGroups);
-    } catch (err: any) {
-      setError(err?.message || "Failed to fetch user groups");
+    } catch (caught) {
+      reportError("admin.user-groups.load", caught);
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setLoading(false);
     }
@@ -124,8 +126,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
           [groupId]: result.data.userGroup!,
         }));
       }
-    } catch (err: any) {
-      console.error(`Failed to fetch details for group ${groupId}:`, err);
+    } catch (caught) {
+      reportError("admin.user-groups.details", caught, { groupId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setLoadingDetails((prev) => ({ ...prev, [groupId]: false }));
     }
@@ -164,8 +167,12 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
             }))
           );
         }
-      } catch {
-        if (!cancelled) setAllUsers([]);
+      } catch (caught) {
+        reportError("admin.user-groups.members", caught);
+        if (!cancelled) {
+          setAllUsers([]);
+          setError(toAdminUserFacingError(caught, "user-groups").message);
+        }
       } finally {
         if (!cancelled) setLoadingAllUsers(false);
       }
@@ -231,7 +238,8 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
                   membershipStatus: userResult.data.user.membershipStatus,
                 };
               }
-            } catch (_err) {
+            } catch (caught) {
+              reportError("admin.user-groups.user-detail", caught, { userId: user.uid });
               // If we can't fetch user data, use display name from search
               const nameParts = user.displayName?.split(", ") || [];
               return {
@@ -247,8 +255,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         );
         setSearchResults(usersWithData.filter((u): u is NonNullable<typeof u> => u !== null));
       }
-    } catch (err: any) {
-      console.error("Failed to search users:", err);
+    } catch (caught) {
+      reportError("admin.user-groups.search", caught);
+      setError(toAdminUserFacingError(caught, "users").message);
       setSearchResults([]);
     } finally {
       setSearchingUsers(false);
@@ -293,8 +302,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       setUserSearchTerm("");
       setSearchResults([]);
       showSuccess("User added to group");
-    } catch (err: any) {
-      setError(err?.message || "Failed to add user to group");
+    } catch (caught) {
+      reportError("admin.user-groups.add-user", caught, { groupId: addingToGroupId, userId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setAddingUserId(null);
     }
@@ -317,8 +327,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       setGroupDetails({ ...groupDetails });
       await fetchGroupDetails(groupId);
       showSuccess("User removed from group");
-    } catch (err: any) {
-      setError(err?.message || "Failed to remove user from group");
+    } catch (caught) {
+      reportError("admin.user-groups.remove-user", caught, { groupId, userId });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     }
   };
 
@@ -353,8 +364,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       delete groupDetails[group.id];
       setGroupDetails({ ...groupDetails });
       showSuccess(`User group "${group.name}" deleted`);
-    } catch (err: any) {
-      setError(err?.message || "Failed to delete user group");
+    } catch (caught) {
+      reportError("admin.user-groups.delete", caught, { groupId: group.id });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     }
   };
 
@@ -388,8 +400,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       setDialogOpen(false);
       await fetchUserGroupsList();
       showSuccess(`User group ${editingGroup ? "updated" : "created"}`);
-    } catch (err: any) {
-      setError(err?.message || `Failed to ${editingGroup ? "update" : "create"} user group`);
+    } catch (caught) {
+      reportError("admin.user-groups.save", caught, { editing: Boolean(editingGroup) });
+      setError(toAdminUserFacingError(caught, "user-groups").message);
     } finally {
       setSubmitting(false);
     }

--- a/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
+++ b/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
@@ -145,8 +145,9 @@ describe("AnnouncementSendHistory", () => {
     render(<AnnouncementSendHistory sectionId={SECTION_ID} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to load send history: network")).toBeInTheDocument();
+      expect(screen.getByText("We could not complete the announcement operation. Please try again.")).toBeInTheDocument();
     });
+    expect(screen.queryByText(/network/i)).not.toBeInTheDocument();
   });
 
   it("renders send rows with date, template name, and counts", async () => {
@@ -190,9 +191,10 @@ describe("AnnouncementSendHistory", () => {
     expect(screen.getByText("Eve Black")).toBeInTheDocument();
     expect(screen.getByText("Frank Green")).toBeInTheDocument();
     expect(screen.getByText("Grace Blue")).toBeInTheDocument();
-    expect(screen.getByText("opted_out")).toBeInTheDocument();
-    expect(screen.getByText("GOV Notify rejected")).toBeInTheDocument();
-    expect(screen.getByText("GOV Notify reported permanent-failure")).toBeInTheDocument();
+    expect(screen.getByText("Recipient opted out")).toBeInTheDocument();
+    expect(screen.getAllByText("Delivery failed; diagnostic detail is available in secure logs.")).toHaveLength(2);
+    expect(screen.queryByText("GOV Notify rejected")).not.toBeInTheDocument();
+    expect(screen.queryByText("GOV Notify reported permanent-failure")).not.toBeInTheDocument();
 
     // Status chips — "Sent"/"Skipped"/"Failed" also appear as column headers, so use getAllByText
     expect(screen.getAllByText("Sent").length).toBeGreaterThanOrEqual(1);
@@ -218,8 +220,9 @@ describe("AnnouncementSendHistory", () => {
     await user.click(screen.getAllByRole("button", { name: "Expand" })[0]);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed to load recipients")).toBeInTheDocument();
+      expect(screen.getByText("We could not complete the announcement operation. Please try again.")).toBeInTheDocument();
     });
+    expect(screen.queryByText(/network/i)).not.toBeInTheDocument();
   });
 
   it("collapses an expanded row on second click", async () => {

--- a/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
+++ b/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
@@ -111,7 +111,8 @@ describe("ManageSectionFiles", () => {
   it("shows a permission-safe error when the list cannot be loaded", async () => {
     vi.mocked(listSectionFiles).mockRejectedValue(new Error("permission-denied"));
     render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
-    expect(await screen.findByText(/no longer have permission/i)).toBeInTheDocument();
+    expect(await screen.findByText(/could not complete the file operation/i)).toBeInTheDocument();
+    expect(screen.queryByText(/permission-denied/i)).not.toBeInTheDocument();
   });
 
   it("clears previously loaded metadata when a refresh loses access", async () => {
@@ -126,7 +127,8 @@ describe("ManageSectionFiles", () => {
     await user.click(screen.getByRole("button", { name: "Edit Joining instructions" }));
     await user.click(screen.getByRole("button", { name: "Save" }));
 
-    expect(await screen.findByText(/no longer have permission/i)).toBeInTheDocument();
+    expect(await screen.findByText(/could not complete the file operation/i)).toBeInTheDocument();
+    expect(screen.queryByText(/permission-denied/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Joining instructions")).not.toBeInTheDocument();
   });
 });

--- a/src/features/admin/components/listAdminUsers.ts
+++ b/src/features/admin/components/listAdminUsers.ts
@@ -1,6 +1,7 @@
 import { getFunctions, httpsCallable } from "firebase/functions";
 import { firebaseApp } from "../../../config/firebase";
 import type { AdminUser } from "../../../types";
+import { reportError } from "../../../shared/errors";
 
 export type { AdminUser };
 
@@ -20,11 +21,11 @@ export async function listAdminUsers(): Promise<{ success: boolean; users?: Admi
     const result = await listAdminUsersCallable();
     const data = result.data as ListAdminUsersResponse;
     return { success: true, users: data.users };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("admin.users.list-admins", error);
     return { 
       success: false, 
-      error: error?.message || "Failed to list admin users" 
+      error: "Administrator accounts could not be loaded. Please try again."
     };
   }
 }
-

--- a/src/features/users/hooks/__tests__/useUserSearch.test.ts
+++ b/src/features/users/hooks/__tests__/useUserSearch.test.ts
@@ -122,7 +122,7 @@ describe("useUserSearch", () => {
 
     const { result } = renderHook(() => useUserSearch("test", 0));
 
-    await waitFor(() => expect(result.current.error).toBe("Search failed"));
+    await waitFor(() => expect(result.current.error).toBe("Users could not be searched. Please try again."));
 
     expect(result.current.users).toEqual([]);
     expect(result.current.loading).toBe(false);
@@ -134,7 +134,8 @@ describe("useUserSearch", () => {
 
     const { result } = renderHook(() => useUserSearch("test", 0));
 
-    await waitFor(() => expect(result.current.error).toBe("Network error"));
+    await waitFor(() => expect(result.current.error).toBe("We could not complete the user operation. Please try again."));
+    expect(result.current.error).not.toContain("Network error");
   });
 
   it("clears results when search term is cleared", async () => {

--- a/src/features/users/hooks/useUserSearch.ts
+++ b/src/features/users/hooks/useUserSearch.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { searchUsers } from "../utils/searchUsers";
 import type { SearchUser } from "../../../types";
 import { ITEMS_PER_PAGE } from "../../../constants";
+import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface UseUserSearchResult {
   users: SearchUser[];
@@ -53,13 +54,14 @@ export function useUserSearch(
         setTotalPages(result.data.totalPages);
         setTotal(result.data.total);
       } else {
-        setError(result.error || "Failed to search users");
+        setError("Users could not be searched. Please try again.");
         setUsers([]);
         setTotalPages(1);
         setTotal(0);
       }
-    } catch (err: any) {
-      setError(err?.message || "Failed to search users");
+    } catch (caught) {
+      reportError("admin.users.search", caught);
+      setError(toAdminUserFacingError(caught, "users").message);
       setUsers([]);
       setTotalPages(1);
       setTotal(0);
@@ -118,4 +120,3 @@ export function useUserSearch(
     refetch,
   };
 }
-

--- a/src/features/users/utils/searchUsers.ts
+++ b/src/features/users/utils/searchUsers.ts
@@ -2,6 +2,7 @@ import { getFunctions, httpsCallable } from "firebase/functions";
 import { firebaseApp } from "../../../config/firebase";
 import type { SearchUsersRequest, SearchUsersResponse } from "../../../types";
 import { ITEMS_PER_PAGE } from "../../../constants";
+import { reportError } from "../../../shared/errors";
 
 /**
  * Searches for users by email or display name
@@ -24,11 +25,11 @@ export async function searchUsers(
     
     const result = await searchUsersCallable({ searchTerm, page, pageSize });
     return { success: true, data: result.data };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("admin.users.search-callable", error);
     return { 
       success: false, 
-      error: error?.message || "Failed to search users" 
+      error: "Users could not be searched. Please try again."
     };
   }
 }
-

--- a/src/shared/errors/__tests__/adminErrors.test.ts
+++ b/src/shared/errors/__tests__/adminErrors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { toAdminUserFacingError } from "../adminErrors";
+
+describe("toAdminUserFacingError", () => {
+  it("uses contextual copy without exposing an unknown provider message", () => {
+    const mapped = toAdminUserFacingError(
+      new Error("relation users_secret does not exist"),
+      "users",
+    );
+
+    expect(mapped.message).toBe("We could not complete the user operation. Please try again.");
+    expect(mapped.message).not.toContain("users_secret");
+    expect(mapped.retryable).toBe(true);
+  });
+
+  it("preserves distinct authorization handling", () => {
+    const mapped = toAdminUserFacingError(
+      { code: "permission-denied", message: "internal policy details" },
+      "sections",
+    );
+
+    expect(mapped.title).toBe("Access denied");
+    expect(mapped.message).not.toContain("internal policy details");
+    expect(mapped.retryable).toBe(false);
+  });
+
+  it("preserves configuration guidance", () => {
+    const mapped = toAdminUserFacingError(
+      { code: "configuration", message: "secret name" },
+      "email-configuration",
+    );
+
+    expect(mapped.message).not.toContain("secret name");
+  });
+});

--- a/src/shared/errors/adminErrors.ts
+++ b/src/shared/errors/adminErrors.ts
@@ -1,0 +1,43 @@
+import { toUserFacingError, type UserFacingError } from "./errorHandling";
+
+export type AdminErrorContext =
+  | "users"
+  | "user-approval"
+  | "admin-claims"
+  | "user-groups"
+  | "sections"
+  | "events"
+  | "tickets"
+  | "guest-moderation"
+  | "files"
+  | "announcements"
+  | "email-configuration"
+  | "payment-reconciliation"
+  | "audit-logs";
+
+const CONTEXT_MESSAGES: Record<AdminErrorContext, string> = {
+  users: "We could not complete the user operation. Please try again.",
+  "user-approval": "We could not complete the approval operation. Please refresh and try again.",
+  "admin-claims": "We could not update administrator access. Please refresh and try again.",
+  "user-groups": "We could not complete the user group operation. Please refresh and try again.",
+  sections: "We could not complete the section operation. Please refresh and try again.",
+  events: "We could not complete the event operation. Please refresh and try again.",
+  tickets: "We could not complete the ticket operation. Please refresh and try again.",
+  "guest-moderation": "We could not review the guest request. Please refresh and try again.",
+  files: "We could not complete the file operation. Please refresh and try again.",
+  announcements: "We could not complete the announcement operation. Please try again.",
+  "email-configuration": "We could not complete the email configuration operation. Please try again.",
+  "payment-reconciliation": "We could not complete the payment reconciliation operation. Please refresh and try again.",
+  "audit-logs": "We could not load the audit logs. Please try again.",
+};
+
+/** Maps an administration failure without exposing provider or server messages. */
+export function toAdminUserFacingError(error: unknown, context: AdminErrorContext): UserFacingError {
+  const mapped = toUserFacingError(error);
+  if (mapped.category !== "unknown") return mapped;
+  return {
+    ...mapped,
+    title: "Administration operation failed",
+    message: CONTEXT_MESSAGES[context],
+  };
+}

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -3,3 +3,4 @@ export * from "./authErrors";
 export * from "./profileErrors";
 export * from "./bookingErrors";
 export * from "./memberDataErrors";
+export * from "./adminErrors";

--- a/src/shared/utils/__tests__/firebaseFunctions.test.ts
+++ b/src/shared/utils/__tests__/firebaseFunctions.test.ts
@@ -72,7 +72,8 @@ describe("grantAdminClaim", () => {
     const result = await grantAdminClaim("uid-123");
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Permission denied");
+    expect(result.error).toBe("Administrator access could not be granted. Please try again.");
+    expect(result.error).not.toContain("Permission denied");
   });
 });
 
@@ -91,7 +92,8 @@ describe("revokeAdminClaim", () => {
     const result = await revokeAdminClaim("uid-456");
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain("Last admin");
+    expect(result.error).toBe("Administrator access could not be revoked. Please try again.");
+    expect(result.error).not.toContain("Last admin");
   });
 });
 
@@ -114,7 +116,7 @@ describe("updateDisplayName", () => {
     const result = await updateDisplayName("New Name");
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Update failed");
+    expect(result.error).toBe("The display name could not be updated. Please try again.");
   });
 });
 
@@ -133,7 +135,7 @@ describe("updateUserDisplayName", () => {
     const result = await updateUserDisplayName("user-123", "Admin Name");
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Not found");
+    expect(result.error).toBe("The display name could not be updated. Please try again.");
   });
 });
 
@@ -160,7 +162,7 @@ describe("listUsersWithoutDataConnectProfile", () => {
     const result = await listUsersWithoutDataConnectProfile();
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Unauthorized");
+    expect(result.error).toBe("Users without profiles could not be loaded. Please try again.");
   });
 });
 
@@ -180,7 +182,7 @@ describe("listUsersPendingApproval", () => {
     const result = await listUsersPendingApproval();
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Service unavailable");
+    expect(result.error).toBe("Pending users could not be loaded. Please try again.");
   });
 });
 
@@ -198,7 +200,7 @@ describe("syncPendingUserClaims", () => {
     const result = await syncPendingUserClaims();
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Claims sync failed");
+    expect(result.error).toBe("The account status could not be synchronised. Please try again.");
   });
 });
 
@@ -226,7 +228,8 @@ describe("updateMembershipStatus", () => {
     const result = await updateMembershipStatus("user-789", "REGULAR" as MembershipStatus);
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Invalid status transition");
+    expect(result.error).toBe("The membership status could not be updated. Please try again.");
+    expect(result.error).not.toContain("Invalid status transition");
     expect(result.domainCode).toBe("CURRENT_STATUS_RESTRICTED");
   });
 });
@@ -251,7 +254,8 @@ describe("resignMembership", () => {
     const result = await resignMembership();
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("Cannot resign as admin");
+    expect(result.error).toBe("The membership could not be resigned. Please try again.");
+    expect(result.error).not.toContain("Cannot resign as admin");
     expect(result.domainCode).toBe("ADMIN_RESIGNATION_NOT_ALLOWED");
   });
 });

--- a/src/shared/utils/firebaseFunctions/userAdmin.ts
+++ b/src/shared/utils/firebaseFunctions/userAdmin.ts
@@ -1,7 +1,7 @@
 import { httpsCallable } from "firebase/functions";
 import type { MembershipStatus } from "@dataconnect/generated";
 import { functions } from "../../../config/firebase";
-import { extractDomainErrorCode } from "../../errors";
+import { extractDomainErrorCode, reportError } from "../../errors";
 
 // ============================================================================
 // Admin Functions
@@ -32,10 +32,11 @@ export async function grantAdminClaim(
 
     const result = await grantAdminCallable({ uid });
     return { success: true, message: result.data.message };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.grant-admin", error);
     return {
       success: false,
-      error: error?.message || "Failed to grant admin claim"
+      error: "Administrator access could not be granted. Please try again."
     };
   }
 }
@@ -65,10 +66,11 @@ export async function revokeAdminClaim(
 
     const result = await revokeAdminCallable({ uid });
     return { success: true, message: result.data.message };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.revoke-admin", error);
     return {
       success: false,
-      error: error?.message || "Failed to revoke admin claim"
+      error: "Administrator access could not be revoked. Please try again."
     };
   }
 }
@@ -102,10 +104,11 @@ export async function updateDisplayName(
 
     const result = await updateDisplayNameCallable({ displayName });
     return { success: result.data.success };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.update-display-name", error);
     return {
       success: false,
-      error: error?.message || "Failed to update display name"
+      error: "The display name could not be updated. Please try again."
     };
   }
 }
@@ -138,10 +141,11 @@ export async function updateUserDisplayName(
 
     const result = await updateUserDisplayNameCallable({ userId, displayName });
     return { success: result.data.success };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.update-user-display-name", error, { userId });
     return {
       success: false,
-      error: error?.message || "Failed to update user display name"
+      error: "The display name could not be updated. Please try again."
     };
   }
 }
@@ -196,11 +200,8 @@ export async function listUsersWithoutDataConnectProfile(): Promise<{
     const result = await callable();
     return { success: true, users: result.data.users };
   } catch (error: unknown) {
-    const message =
-      error && typeof (error as { message?: string }).message === "string"
-        ? (error as { message: string }).message
-        : "Failed to load users without profile";
-    return { success: false, error: message };
+    reportError("callable.list-users-without-profile", error);
+    return { success: false, error: "Users without profiles could not be loaded. Please try again." };
   }
 }
 
@@ -220,11 +221,8 @@ export async function listUsersPendingApproval(): Promise<{
     const result = await callable();
     return { success: true, users: result.data.users };
   } catch (error: unknown) {
-    const message =
-      error && typeof (error as { message?: string }).message === "string"
-        ? (error as { message: string }).message
-        : "Failed to load pending users";
-    return { success: false, error: message };
+    reportError("callable.list-pending-users", error);
+    return { success: false, error: "Pending users could not be loaded. Please try again." };
   }
 }
 
@@ -247,11 +245,8 @@ export async function syncPendingUserClaims(): Promise<{
     const result = await callable();
     return { success: result.data.success };
   } catch (error: unknown) {
-    const message =
-      error && typeof (error as { message?: string }).message === "string"
-        ? (error as { message: string }).message
-        : "Failed to sync account status";
-    return { success: false, error: message };
+    reportError("callable.sync-pending-user-claims", error);
+    return { success: false, error: "The account status could not be synchronised. Please try again." };
   }
 }
 
@@ -288,10 +283,11 @@ export async function updateMembershipStatus(
 
     const result = await updateMembershipStatusCallable({ userId, newStatus });
     return { success: result.data.success };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.update-membership-status", error, { userId, newStatus });
     return {
       success: false,
-      error: error?.message || "Failed to update membership status",
+      error: "The membership status could not be updated. Please try again.",
       domainCode: extractDomainErrorCode(error),
     };
   }
@@ -318,10 +314,11 @@ export async function resignMembership(): Promise<{
 
     const result = await resignMembershipCallable({});
     return { success: result.data.success };
-  } catch (error: any) {
+  } catch (error: unknown) {
+    reportError("callable.resign-membership", error);
     return {
       success: false,
-      error: error?.message || "Failed to resign membership",
+      error: "The membership could not be resigned. Please try again.",
       domainCode: extractDomainErrorCode(error),
     };
   }


### PR DESCRIPTION
## Summary

- add a shared administration error mapper with safe, context-specific copy
- sanitise failure states across user, section, event, file, announcement, payment, email configuration, and audit workflows
- retain technical details in controlled reporting while preventing provider messages from reaching the UI
- add regression coverage and record the final administration audit

## Impact

Moderators and administrators receive consistent, actionable failure guidance without exposing Data Connect, callable, GOV.UK Notify, Stripe, storage, or other service internals.

## Validation

- `npm test -- --run` — 88 files, 718 tests passed
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #467
