### PR TITLE
Apply SODC tone to member-facing emails

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -1055,6 +1055,9 @@ query GetTicketOrderForWebhook($id: UUID!) @auth(level: NO_ACCESS) {
     event {
       id
       title
+      location
+      startDateTime
+      endDateTime
     }
     ticketType {
       id
@@ -1707,6 +1710,9 @@ query GetGuestTicketRequestForNotification($id: UUID!) @auth(level: NO_ACCESS) {
       event {
         id
         title
+        location
+        startDateTime
+        endDateTime
         section {
           id
           name

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/environments-dev-beta-prod.md`: Dev / Beta / Prod Firebase projects, schema-first deploy flow, smoke-test and rollback checkpoints, and local setup (cloud-backed dev; no emulators).
 - `operations/new-production-instance.md`: first-time Firebase/GCP production provisioning, integrations, administrator bootstrap, deployment, and go-live checklist.
 - `operations/transactional-email-workflows.md`: transactional email triggers by domain (payments, bookings, membership, guest tickets, ops alerts) with links to GOV.UK Notify template specs.
-- `operations/govuk-notify-template-copy.md`: draft subject/body for all Notify templates; `govuk-notify-template-registration.md`: per-environment UUID checklist.
+- `operations/govuk-notify-template-copy.md`: Notify template index and automated-email tone guide; `functions/email-templates/`: source subject/body copy; `govuk-notify-template-registration.md`: per-environment UUID checklist.
 - `operations/transactional-email-policy.md`: operational vs optional/marketing email policy (#191).
 - `operations/section-announcement-audiences.md`: explicit and membership-status-derived audience, eligibility, deduplication, and opt-out rules for section announcements.
 - `operations/firebase-hosting-security-headers.md`: production CSP and browser hardening policy, HSTS ownership, and post-deploy verification.

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -60,7 +60,7 @@ Defined via `.env*` files and read from `import.meta.env`:
 - **Transactional email overview** (triggers, idempotency, per-domain flows): [transactional-email-workflows.md](./transactional-email-workflows.md).
 - **Section file storage** (private bucket, IAM, lifecycle, CORS, and rollout): [section-file-storage.md](./section-file-storage.md).
 - **Deployment verification** (read-only Firebase/GCP configuration audit, release manifest, and smoke checks): [deployment-checks.md](./deployment-checks.md).
-- **Notify template copy and registration** (paste into dashboard, record UUIDs per env): [govuk-notify-template-copy.md](./govuk-notify-template-copy.md), [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+- **Notify source templates and registration** (paste into dashboard, record UUIDs per env): [`functions/email-templates/`](../../functions/email-templates/), [template index and tone guide](./govuk-notify-template-copy.md), [registration runbook](./govuk-notify-template-registration.md).
 - **Email policy** (operational vs optional): [transactional-email-policy.md](./transactional-email-policy.md).
 - Do not commit secret values to repo.
 - For project-specific non-secret Functions configuration, use the ignored file

--- a/docs/operations/govuk-notify-booking-templates.md
+++ b/docs/operations/govuk-notify-booking-templates.md
@@ -4,7 +4,7 @@ User-facing email after a successful **`submitEventBooking`** callable. Implemen
 
 **No email** when the callable returns **`idempotentReplay: true`**.
 
-**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (bookings section).
+**Source copy:** [`functions/email-templates/`](../../functions/email-templates/) (see the [template index](./govuk-notify-template-copy.md)).
 
 ## Configuration
 
@@ -26,15 +26,14 @@ Also required: `GOV_NOTIFY_LIVE_API_KEY` (secret), optional `GOV_NOTIFY_EMAIL_RE
 
 | Key | Semantics |
 |-----|-----------|
-| `customerFirstName` | Booker first name or `there` |
+| `firstName` | Booker first name, or `Member` if unexpectedly blank |
 | `eventTitle` | Event title |
 | `eventDateTime` | Formatted start/end (en-GB) |
-| `eventLocation` | Location or `—` |
-| `revisionNumber` | Booking revision number |
+| `eventLocation` | Location or `To be confirmed` |
 | `ticketLinesSummary` | Multiline bullet list of lines |
-| `bookerDietaryNote` | Booker dietary note or `—` |
+| `bookerDietaryNote` | Booker dietary note or `None provided` |
 | `accommodationSummary` | `Not requested` or `Requested — {note}` |
-| `bookingTotalFormatted` | Sum of line prices, e.g. `35.00 GBP` |
+| `bookingTotalFormatted` | Sum of line prices, e.g. `£35.00` |
 | `sectionBookingsUrl` | `APP_BASE_URL/sections/{sectionId}` |
 | `myPaymentsUrl` | `APP_BASE_URL/payments` |
 
@@ -44,12 +43,10 @@ All keys from **bookingConfirmation**, plus:
 
 | Key | Semantics |
 |-----|-----------|
-| `previousRevisionNumber` | Superseded booking revision |
-| `revisedRevisionNumber` | New booking revision |
 | `paymentAdjustmentStatus` | e.g. `Additional payment due`, `Refund due`, `No payment change required` |
 | `previousTotalFormatted` | Prior revision total |
 | `revisedTotalFormatted` | New revision total |
-| `deltaAmountFormatted` | Signed delta, e.g. `+15.00 GBP` |
+| `deltaAmountFormatted` | Signed delta, e.g. `+£15.00` |
 
 ## Related docs
 

--- a/docs/operations/govuk-notify-guest-ticket-request-templates.md
+++ b/docs/operations/govuk-notify-guest-ticket-request-templates.md
@@ -4,7 +4,7 @@ Emails for **additional guest ticket** moderation: notify moderators/admins when
 
 **Source of truth:** Personalisation **keys** must match Notify template placeholders.
 
-**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (guest ticket section).
+**Source copy:** [`functions/email-templates/`](../../functions/email-templates/) (see the [template index](./govuk-notify-template-copy.md)).
 
 ## Configuration
 
@@ -56,12 +56,13 @@ Client UI uses these callables instead of direct Data Connect mutations for subm
 
 | Key | Semantics |
 |-----|-----------|
-| `customerFirstName` | Booker first name or `there` |
+| `firstName` | Booker first name, or `Member` if unexpectedly blank |
 | `eventTitle` | Event title |
+| `eventDateTime` | Formatted start/end in the `Europe/London` time zone |
+| `eventLocation` | Location or `To be confirmed` |
 | `guestDisplayName` | Guest name on request |
 | `requestedGuestCount` | Number |
-| `decisionLabel` | `Approved` or `Rejected` |
-| `moderatorNote` | Note from reviewer, or `—` |
+| `moderatorNote` | Note from reviewer, or `No additional note` |
 | `myBookingsUrl` | `APP_BASE_URL` + `/sections/{sectionId}` |
 
 ## Related docs

--- a/docs/operations/govuk-notify-membership-templates.md
+++ b/docs/operations/govuk-notify-membership-templates.md
@@ -4,7 +4,7 @@ User-facing email when **membership status** changes in ways that affect app acc
 
 **Source of truth:** Personalisation **keys** must match the Notify template placeholders.
 
-**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (membership section).
+**Source copy:** [`functions/email-templates/`](../../functions/email-templates/) (see the [template index](./govuk-notify-template-copy.md)).
 
 ## Configuration
 
@@ -32,7 +32,7 @@ No email for restricted→restricted or non-restricted→non-restricted transiti
 
 | Key | Semantics |
 |-----|-----------|
-| `customerFirstName` | User first name, or `there` |
+| `firstName` | Member first name, or `Member` if unexpectedly blank |
 | `membershipStatusLabel` | Friendly label for new status, e.g. `Regular` |
 | `appUrl` | `APP_BASE_URL` (no trailing slash) |
 | `profileUrl` | `appUrl` + `/profile` |
@@ -41,12 +41,12 @@ No email for restricted→restricted or non-restricted→non-restricted transiti
 
 | Key | Semantics |
 |-----|-----------|
-| `customerFirstName` | User first name, or `there` |
+| `firstName` | Member first name, or `Member` if unexpectedly blank |
 | `membershipStatusLabel` | Friendly label for new restricted status |
 | `previousStatusLabel` | Friendly label for previous status |
 | `appUrl` | `APP_BASE_URL` |
 
-Use static template copy for “contact your administrator” — do not include admin-only notes in personalisation.
+Do not include admin-only notes in personalisation or invite replies to the automated email.
 
 ## Related docs
 

--- a/docs/operations/govuk-notify-payment-ops-internal-templates.md
+++ b/docs/operations/govuk-notify-payment-ops-internal-templates.md
@@ -6,7 +6,7 @@ Recipients are **`PAYMENT_OPS_ALERT_EMAILS`** (comma-separated). If unset or emp
 
 **Source of truth:** Personalisation **keys** in this document must match the object sent to Notify.
 
-**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (payment ops section). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+**Source copy:** [`paymentReconciliationExceptionAlert.md`](../../functions/email-templates/paymentReconciliationExceptionAlert.md) and [`paymentDisputeOpsAlert.md`](../../functions/email-templates/paymentDisputeOpsAlert.md). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
 
 ## Configuration
 

--- a/docs/operations/govuk-notify-pending-approval-templates.md
+++ b/docs/operations/govuk-notify-pending-approval-templates.md
@@ -6,7 +6,7 @@ Recipients are **all current Firebase Auth admins** (`getAdminUsers()`, same pat
 
 **Source of truth:** Personalisation **keys** in this document must match the object sent to Notify.
 
-**Draft copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
+**Source copy:** [`newUserPendingApprovalAlert.md`](../../functions/email-templates/newUserPendingApprovalAlert.md). **Registration:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
 
 ## Configuration
 

--- a/docs/operations/govuk-notify-sample-personalisation.json
+++ b/docs/operations/govuk-notify-sample-personalisation.json
@@ -1,37 +1,34 @@
 {
   "ticketOrderPaid": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
     "ticketTypeTitle": "Member ticket",
     "quantity": 2,
-    "totalFormatted": "50.00 GBP",
-    "currencyDisplay": "GBP",
-    "orderStatusLabel": "Paid",
-    "orderId": "00000000-0000-0000-0000-000000000001",
+    "totalFormatted": "£50.00",
     "myPaymentsUrl": "https://app.example/payments"
   },
   "ticketOrderFailed": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
     "ticketTypeTitle": "Member ticket",
     "quantity": 1,
-    "totalFormatted": "25.00 GBP",
-    "currencyDisplay": "GBP",
-    "orderStatusLabel": "Payment failed",
-    "orderId": "00000000-0000-0000-0000-000000000002",
+    "totalFormatted": "£25.00",
     "myPaymentsUrl": "https://app.example/payments"
   },
   "ticketOrderRefunded": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
     "ticketTypeTitle": "Member ticket",
     "quantity": 1,
-    "totalFormatted": "25.00 GBP",
-    "currencyDisplay": "GBP",
-    "orderStatusLabel": "Refunded",
-    "orderId": "00000000-0000-0000-0000-000000000003",
+    "totalFormatted": "£25.00",
     "myPaymentsUrl": "https://app.example/payments",
-    "refundFormatted": "25.00 GBP"
+    "refundFormatted": "£25.00"
   },
   "paymentReconciliationExceptionAlert": {
     "orderId": "00000000-0000-0000-0000-000000000001",
@@ -55,13 +52,13 @@
     "stripeEventId": "evt_test_dispute"
   },
   "membershipActivated": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "membershipStatusLabel": "Regular",
     "appUrl": "https://app.example",
     "profileUrl": "https://app.example/profile"
   },
   "membershipAccessRestricted": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "membershipStatusLabel": "Resigned",
     "previousStatusLabel": "Regular",
     "appUrl": "https://app.example"
@@ -77,54 +74,52 @@
     "moderationUrl": "https://app.example/admin/sections"
   },
   "guestTicketRequestApproved": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
     "guestDisplayName": "Guest Name",
     "requestedGuestCount": 2,
-    "decisionLabel": "Approved",
     "moderatorNote": "Approved for this event.",
     "myBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010"
   },
   "guestTicketRequestRejected": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
+    "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
+    "eventLocation": "Main Hall",
     "guestDisplayName": "Guest Name",
     "requestedGuestCount": 2,
-    "decisionLabel": "Rejected",
     "moderatorNote": "Capacity reached.",
     "myBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010"
   },
   "bookingConfirmation": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
     "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
     "eventLocation": "Main Hall",
-    "revisionNumber": 1,
     "ticketLinesSummary": "• Member ticket — Alex Example\n• Guest ticket — Guest Name",
     "bookerDietaryNote": "None",
     "accommodationSummary": "Not requested",
-    "bookingTotalFormatted": "35.00 GBP",
+    "bookingTotalFormatted": "£35.00",
     "sectionBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010",
     "myPaymentsUrl": "https://app.example/payments"
   },
   "bookingRevision": {
-    "customerFirstName": "Alex",
+    "firstName": "Alex",
     "eventTitle": "Summer Dinner",
     "eventDateTime": "Saturday 14 June 2025, 19:00 – 23:00",
     "eventLocation": "Main Hall",
-    "revisionNumber": 2,
     "ticketLinesSummary": "• Member ticket — Alex Example\n• Guest ticket — Guest Name",
     "bookerDietaryNote": "Vegetarian",
     "accommodationSummary": "Requested — Ground floor if possible",
-    "bookingTotalFormatted": "50.00 GBP",
+    "bookingTotalFormatted": "£50.00",
     "sectionBookingsUrl": "https://app.example/sections/00000000-0000-0000-0000-000000000010",
     "myPaymentsUrl": "https://app.example/payments",
-    "previousRevisionNumber": 1,
-    "revisedRevisionNumber": 2,
     "paymentAdjustmentStatus": "Additional payment due",
-    "previousTotalFormatted": "35.00 GBP",
-    "revisedTotalFormatted": "50.00 GBP",
-    "deltaAmountFormatted": "+15.00 GBP"
+    "previousTotalFormatted": "£35.00",
+    "revisedTotalFormatted": "£50.00",
+    "deltaAmountFormatted": "+£15.00"
   },
   "newUserPendingApprovalAlert": {
     "firstName": "Ada",

--- a/docs/operations/govuk-notify-template-copy.md
+++ b/docs/operations/govuk-notify-template-copy.md
@@ -1,453 +1,99 @@
-# GOV.UK Notify: draft template copy
+# GOV.UK Notify template copy index
 
-Ready-to-paste **subject** and **body** text for all transactional email templates. Register each template in the [GOV.UK Notify dashboard](https://www.notifications.service.gov.uk/) per Firebase environment (Dev, Beta, Prod).
+The reviewed GOV.UK Notify subjects, bodies and placeholder lists live in
+[`functions/email-templates/`](../../functions/email-templates/). Those Markdown
+files are the single source of truth used to generate the Function manifest and
+the **Admin → Email Templates** drift report. Do not maintain a second copy of
+their contents in this document.
 
-**Before publishing**
+## Automated email tone
 
-1. Follow [how to create an email template](https://www.notifications.service.gov.uk/using-notify/how-to-create-email-template) and [personalisation](https://www.notifications.service.gov.uk/using-notify/personalisation).
-2. Placeholder names must match this document **exactly** (`((customerFirstName))`, not `((first_name))`).
-3. Copy the template UUID into the matching `GOV_NOTIFY_TEMPLATE_*` env var — see [govuk-notify-template-registration.md](./govuk-notify-template-registration.md).
-4. Send a test email using sample values from [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json).
+- Use clear, concise British English with a warm club tone.
+- Use `Hello ((firstName)),` when a member name is safely available, otherwise
+  use plain `Hello,`.
+- Use member-facing terms such as member, booking, place, guest and payment.
+- Do not use customer, purchase or order in member-facing copy.
+- Automated emails must not ask recipients to reply.
+- End every automated email with these lines:
 
-Placeholder specs (keys only): `govuk-notify-*.md`. Workflow index: [transactional-email-workflows.md](./transactional-email-workflows.md).
+```text
+Kind regards,
 
----
-
-## Ticket order lifecycle
-
-### `ticketOrderPaid` — Payment confirmed
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_PAID`
-
-**Subject:** Payment confirmed for ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your payment for ((eventTitle)) is confirmed.
-
-Ticket: ((ticketTypeTitle))
-Quantity: ((quantity))
-Total: ((totalFormatted))
-Status: ((orderStatusLabel))
-Order reference: ((orderId))
-
-View your payments: ((myPaymentsUrl))
-
-If you did not make this payment, contact your section administrator.
+SODC Admin
 ```
 
-**Placeholders used:** `customerFirstName`, `eventTitle`, `ticketTypeTitle`, `quantity`, `totalFormatted`, `currencyDisplay` (optional in body), `orderStatusLabel`, `orderId`, `myPaymentsUrl`
-
----
-
-### `ticketOrderFailed` — Payment failed
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_FAILED`
-
-**Subject:** Payment could not be completed for ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-We could not complete your payment for ((eventTitle)).
-
-Ticket: ((ticketTypeTitle))
-Quantity: ((quantity))
-Amount: ((totalFormatted))
-Status: ((orderStatusLabel))
-Order reference: ((orderId))
-
-You can try again from your payments page: ((myPaymentsUrl))
-```
-
-**Placeholders used:** same as `ticketOrderPaid` (status label is sent as `Payment failed`)
-
----
-
-### `ticketOrderRefunded` — Refund processed
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_TICKET_ORDER_REFUNDED`
-
-**Subject:** Refund processed for ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-A refund has been processed for your order for ((eventTitle)).
-
-Ticket: ((ticketTypeTitle))
-Quantity: ((quantity))
-Original total: ((totalFormatted))
-Refund amount: ((refundFormatted))
-Status: ((orderStatusLabel))
-Order reference: ((orderId))
-
-View your payments: ((myPaymentsUrl))
-```
-
-**Placeholders used:** all paid/failed keys plus `refundFormatted`
-
----
-
-## Internal payment ops
-
-Set `PAYMENT_OPS_ALERT_EMAILS` before these templates will send.
-
-### `paymentReconciliationExceptionAlert`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_PAYMENT_RECONCILIATION_EXCEPTION_ALERT`
-
-**Subject:** [Payments] Reconciliation exception — ((exceptionType))
-
-**Body:**
-
-```
-A payment reconciliation exception is open.
-
-Order: ((orderId))
-Event: ((eventTitle))
-Customer: ((customerDisplay))
-Exception type: ((exceptionType))
-Note: ((exceptionNote))
-Stripe event: ((stripeEventId))
-
-Open reconciliation dashboard:
-((reconciliationDashboardUrl))
-```
-
-**Placeholders used:** `orderId`, `eventTitle`, `customerDisplay`, `exceptionType`, `exceptionNote`, `reconciliationDashboardUrl`, `stripeEventId`
-
----
-
-### `paymentDisputeOpsAlert`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_PAYMENT_DISPUTE_OPS_ALERT`
-
-**Subject:** [Payments] Stripe dispute update — ((eventTitle))
-
-**Body:**
-
-```
-Stripe dispute side-state received.
-
-Order: ((orderId))
-Event: ((eventTitle))
-Customer: ((customerDisplay))
-Local state: ((disputeLocalState))
-Stripe dispute status: ((disputeStripeStatus))
-Reason: ((disputeReason))
-Dispute ID: ((stripeDisputeId))
-Stripe event type: ((stripeEventType))
-Stripe event ID: ((stripeEventId))
-
-Open reconciliation dashboard:
-((reconciliationDashboardUrl))
-```
-
-**Placeholders used:** `orderId`, `eventTitle`, `customerDisplay`, `disputeStripeStatus`, `disputeReason`, `disputeLocalState`, `stripeDisputeId`, `stripeEventType`, `reconciliationDashboardUrl`, `stripeEventId`
-
----
-
-## Membership status
-
-### `membershipActivated`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACTIVATED`
-
-**Subject:** Your account is now active
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your membership status is now ((membershipStatusLabel)). You can sign in and use the application.
-
-Open the app: ((appUrl))
-Your profile: ((profileUrl))
-
-If you have questions, contact your section administrator.
-```
-
-**Placeholders used:** `customerFirstName`, `membershipStatusLabel`, `appUrl`, `profileUrl`
-
----
-
-### `membershipAccessRestricted`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_MEMBERSHIP_ACCESS_RESTRICTED`
-
-**Subject:** Your account access has changed
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)). You may no longer have full access to the application.
-
-If you believe this is a mistake, contact your section administrator.
-
-Application: ((appUrl))
-```
-
-**Placeholders used:** `customerFirstName`, `membershipStatusLabel`, `previousStatusLabel`, `appUrl`
-
----
-
-## Guest ticket requests
-
-### `guestTicketRequestSubmittedModerator`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_SUBMITTED_MODERATOR`
-
-**Subject:** Guest ticket request — ((eventTitle))
-
-**Body:**
-
-```
-A booker has submitted a guest ticket request that needs review.
-
-Section: ((sectionName))
-Event: ((eventTitle))
-Booker: ((bookerDisplay))
-Guest name: ((guestDisplayName))
-Ticket type: ((guestTicketTypeTitle))
-Guests requested: ((requestedGuestCount))
-Dietary note: ((dietaryNote))
-
-Review requests (Manage Sections): ((moderationUrl))
-```
-
-**Placeholders used:** `eventTitle`, `sectionName`, `bookerDisplay`, `guestDisplayName`, `requestedGuestCount`, `guestTicketTypeTitle`, `dietaryNote`, `moderationUrl`
-
----
-
-### `guestTicketRequestApproved`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_APPROVED`
-
-**Subject:** Guest ticket request approved — ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
-
-Guest: ((guestDisplayName))
-Guests requested: ((requestedGuestCount))
-Moderator note: ((moderatorNote))
-
-View your booking: ((myBookingsUrl))
-```
-
-**Placeholders used:** `customerFirstName`, `eventTitle`, `guestDisplayName`, `requestedGuestCount`, `decisionLabel`, `moderatorNote`, `myBookingsUrl`
-
----
-
-### `guestTicketRequestRejected`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_GUEST_TICKET_REQUEST_REJECTED`
-
-**Subject:** Guest ticket request not approved — ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
-
-Guest: ((guestDisplayName))
-Guests requested: ((requestedGuestCount))
-Moderator note: ((moderatorNote))
-
-View your booking: ((myBookingsUrl))
-```
-
-**Placeholders used:** same as approved (`decisionLabel` is sent as `Rejected`)
-
----
-
-## Bookings
+## Member-facing templates
 
 ### `bookingConfirmation`
 
-**Env var:** `GOV_NOTIFY_TEMPLATE_BOOKING_CONFIRMATION`
-
-**Subject:** Booking confirmed — ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your booking for ((eventTitle)) has been submitted.
-
-When: ((eventDateTime))
-Where: ((eventLocation))
-Revision: ((revisionNumber))
-
-Tickets:
-((ticketLinesSummary))
-
-Dietary requirements: ((bookerDietaryNote))
-Accommodation: ((accommodationSummary))
-Booking total: ((bookingTotalFormatted))
-
-View section bookings: ((sectionBookingsUrl))
-Payments: ((myPaymentsUrl))
-```
-
-**Placeholders used:** `customerFirstName`, `eventTitle`, `eventDateTime`, `eventLocation`, `revisionNumber`, `ticketLinesSummary`, `bookerDietaryNote`, `accommodationSummary`, `bookingTotalFormatted`, `sectionBookingsUrl`, `myPaymentsUrl`
-
----
+Source: [`bookingConfirmation.md`](../../functions/email-templates/bookingConfirmation.md)
 
 ### `bookingRevision`
 
-**Env var:** `GOV_NOTIFY_TEMPLATE_BOOKING_REVISION`
-
-**Subject:** Booking updated — ((eventTitle))
-
-**Body:**
-
-```
-Hello ((customerFirstName)),
-
-Your booking for ((eventTitle)) has been updated (revision ((revisedRevisionNumber)), previously revision ((previousRevisionNumber))).
-
-When: ((eventDateTime))
-Where: ((eventLocation))
-
-Tickets:
-((ticketLinesSummary))
-
-Dietary requirements: ((bookerDietaryNote))
-Accommodation: ((accommodationSummary))
-
-Payment adjustment: ((paymentAdjustmentStatus))
-Previous total: ((previousTotalFormatted))
-Revised total: ((revisedTotalFormatted))
-Change: ((deltaAmountFormatted))
-
-View section bookings: ((sectionBookingsUrl))
-Payments: ((myPaymentsUrl))
-```
-
-**Placeholders used:** all confirmation keys plus `previousRevisionNumber`, `revisedRevisionNumber`, `paymentAdjustmentStatus`, `previousTotalFormatted`, `revisedTotalFormatted`, `deltaAmountFormatted`
-
----
-
-## Internal approval queue
-
-### `newUserPendingApprovalAlert`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_NEW_USER_PENDING_APPROVAL_ALERT`
-
-**Subject:** [SODC] New member awaiting approval — ((firstName)) ((lastName))
-
-**Body:**
-
-```
-A new member has completed their profile and is awaiting approval.
-
-Name: ((firstName)) ((lastName))
-Email: ((email))
-Service number: ((serviceNumber))
-Service background: ((serviceBackgroundSummary))
-Requested status: ((requestedMembershipStatus))
-
-Review in Approve Users:
-((approveUsersUrl))
-```
-
-**Placeholders used:** `firstName`, `lastName`, `email`, `serviceNumber`, `serviceBackgroundSummary`, `requestedMembershipStatus`, `approveUsersUrl`
-
----
-
-## Account access
-
-### `passwordReset`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_PASSWORD_RESET`
-
-**Subject:** Reset your SODC password
-
-**Body:**
-
-```
-We received a request to reset the password for your SODC account.
-
-Use this secure link to choose a new password:
-
-((resetLink))
-
-If you did not request this, you can ignore this email. Your password will not change.
-
-For your security, do not forward this email or share the link.
-
-SODC
-```
-
-**Placeholders used:** `resetLink`
-
----
-
-### `emailVerification`
-
-**Env var:** `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION`
-
-**Subject:** Verify your SODC email address
-
-**Body:**
-
-```
-Welcome to SODC.
-
-Use this secure link to verify your email address:
-
-((verificationLink))
-
-If you did not create an SODC account, you can ignore this email.
-
-For your security, do not forward this email or share the link.
-
-SODC
-```
-
-**Placeholders used:** `verificationLink`
-
----
+Source: [`bookingRevision.md`](../../functions/email-templates/bookingRevision.md)
 
 ### `emailChangeVerification`
 
-**Env var:** `GOV_NOTIFY_TEMPLATE_EMAIL_CHANGE_VERIFICATION`
+Source: [`email-change-verification.md`](../../functions/email-templates/email-change-verification.md)
 
-**Subject:** Confirm your new SODC email address
+### `emailVerification`
 
-**Body:**
+Source: [`email-verification.md`](../../functions/email-templates/email-verification.md)
 
-```
-We received a request to change the email address used for your SODC account.
+### `guestTicketRequestApproved`
 
-Use this secure link to confirm the new address:
+Source: [`guestTicketRequestApproved.md`](../../functions/email-templates/guestTicketRequestApproved.md)
 
-((verificationLink))
+### `guestTicketRequestRejected`
 
-If you did not request this change, you can ignore this email. Your current address will remain unchanged.
+Source: [`guestTicketRequestRejected.md`](../../functions/email-templates/guestTicketRequestRejected.md)
 
-For your security, do not forward this email or share the link.
+### `membershipAccessRestricted`
 
-SODC
-```
+Source: [`membershipAccessRestricted.md`](../../functions/email-templates/membershipAccessRestricted.md)
 
-**Placeholders used:** `verificationLink`
+### `membershipActivated`
+
+Source: [`membershipActivated.md`](../../functions/email-templates/membershipActivated.md)
+
+### `passwordReset`
+
+Source: [`password-reset.md`](../../functions/email-templates/password-reset.md)
+
+### `ticketOrderFailed`
+
+Source: [`ticketOrderFailed.md`](../../functions/email-templates/ticketOrderFailed.md)
+
+### `ticketOrderPaid`
+
+Source: [`ticketOrderPaid.md`](../../functions/email-templates/ticketOrderPaid.md)
+
+### `ticketOrderRefunded`
+
+Source: [`ticketOrderRefunded.md`](../../functions/email-templates/ticketOrderRefunded.md)
+
+## Moderator and operations templates
+
+### `guestTicketRequestSubmittedModerator`
+
+Source: [`guestTicketRequestSubmittedModerator.md`](../../functions/email-templates/guestTicketRequestSubmittedModerator.md)
+
+### `newUserPendingApprovalAlert`
+
+Source: [`newUserPendingApprovalAlert.md`](../../functions/email-templates/newUserPendingApprovalAlert.md)
+
+### `paymentDisputeOpsAlert`
+
+Source: [`paymentDisputeOpsAlert.md`](../../functions/email-templates/paymentDisputeOpsAlert.md)
+
+### `paymentReconciliationExceptionAlert`
+
+Source: [`paymentReconciliationExceptionAlert.md`](../../functions/email-templates/paymentReconciliationExceptionAlert.md)
+
+## Publishing and testing
+
+Use [the template registration runbook](./govuk-notify-template-registration.md)
+and [sample personalisation](./govuk-notify-sample-personalisation.json). After
+updating a source file, regenerate the manifest with
+`npm --prefix functions run generate:templates`, deploy Functions, and use the
+Admin drift report to apply and verify the corresponding Notify dashboard change.

--- a/docs/operations/govuk-notify-template-registration.md
+++ b/docs/operations/govuk-notify-template-registration.md
@@ -2,8 +2,12 @@
 
 Use this checklist when creating templates in Notify for **Dev**, **Beta**, and **Prod**. Do **not** commit API keys or template UUIDs to the repository.
 
-**Draft copy to paste:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md)  
-**Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json)  
+**Source templates to paste:** [`functions/email-templates/`](../../functions/email-templates/)
+
+**Template index and tone guide:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md)
+
+**Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json)
+
 **Env matrix:** [environment-and-secrets.md](./environment-and-secrets.md)
 
 ## Per-environment steps
@@ -11,7 +15,7 @@ Use this checklist when creating templates in Notify for **Dev**, **Beta**, and 
 1. Sign in to [GOV.UK Notify](https://www.notifications.service.gov.uk/) for the service linked to that Firebase project.
 2. For each template below:
    - Create an **email** template ([guidance](https://www.notifications.service.gov.uk/using-notify/how-to-create-email-template)).
-   - Paste **subject** and **body** from [govuk-notify-template-copy.md](./govuk-notify-template-copy.md).
+   - Paste **subject** and **body** from the matching file in [`functions/email-templates/`](../../functions/email-templates/).
    - Add every `((placeholder))` listed for that template (Notify validates on send).
    - Send a **test email** using values from [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json) for that logical key.
    - Copy the template **UUID** into your secure ops record (table below).

--- a/docs/operations/govuk-notify-ticket-order-templates.md
+++ b/docs/operations/govuk-notify-ticket-order-templates.md
@@ -4,7 +4,7 @@ These templates send **app-owned transactional email** when a `TicketOrder` is m
 
 **Source of truth:** Personalisation **keys** in this document must match the object sent to Notify. If the dashboard placeholder names do not match the API payload, sends fail at runtime.
 
-**Draft copy for Notify dashboard:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (ticket order section). **Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json).
+**Source copy for Notify dashboard:** [`functions/email-templates/`](../../functions/email-templates/) (see the [template index](./govuk-notify-template-copy.md)). **Test payloads:** [govuk-notify-sample-personalisation.json](./govuk-notify-sample-personalisation.json).
 
 ## Configuration
 
@@ -20,7 +20,7 @@ Also required for sends: `GOV_NOTIFY_LIVE_API_KEY` (secret), optional `GOV_NOTIF
 
 ## Placeholder format
 
-GOV.UK Notify templates use double brackets. Use the **same identifier** as the JSON key sent by Functions, e.g. `((customerFirstName))`, `((eventTitle))`.
+GOV.UK Notify templates use double brackets. Use the **same identifier** as the JSON key sent by Functions, e.g. `((firstName))`, `((eventTitle))`.
 
 Numbers are sent as JSON numbers where noted (`quantity`).
 
@@ -36,14 +36,13 @@ Functions set: `PAYMENT_<TYPE>:<orderId>:<stripeEventId>` (e.g. `PAYMENT_PAID:�
 
 | Key | Type | Semantics |
 |-----|------|-----------|
-| `customerFirstName` | text | User first name, or `there` if missing/blank |
+| `firstName` | text | Member first name, or `Member` if unexpectedly blank |
 | `eventTitle` | text | Event title |
+| `eventDateTime` | text | Formatted start/end in the `Europe/London` time zone |
+| `eventLocation` | text | Location or `To be confirmed` |
 | `ticketTypeTitle` | text | Ticket type title |
 | `quantity` | number | Line quantity |
-| `totalFormatted` | text | Order total, e.g. `50.00 GBP` — `totalAmountMinor / 100` plus uppercased currency |
-| `currencyDisplay` | text | Uppercased currency code, e.g. `GBP` |
-| `orderStatusLabel` | text | Always `Paid` for this template |
-| `orderId` | text | Ticket order UUID |
+| `totalFormatted` | text | Payment total in en-GB currency format, e.g. `£50.00` |
 | `myPaymentsUrl` | text | `APP_BASE_URL` without trailing slash + `/payments` |
 
 ## Template 2: payment failed — `ticketOrderFailed`
@@ -52,13 +51,7 @@ Functions set: `PAYMENT_<TYPE>:<orderId>:<stripeEventId>` (e.g. `PAYMENT_PAID:�
 
 **Recipient:** Same as template 1.
 
-Same keys as **ticketOrderPaid**, except:
-
-| Key | Type | Semantics |
-|-----|------|-----------|
-| `orderStatusLabel` | text | `Payment failed` |
-
-All other keys: `customerFirstName`, `eventTitle`, `ticketTypeTitle`, `quantity`, `totalFormatted`, `currencyDisplay`, `orderId`, `myPaymentsUrl` — same meaning as template 1.
+Uses the same keys as **ticketOrderPaid**.
 
 ## Template 3: refund processed — `ticketOrderRefunded`
 
@@ -66,12 +59,11 @@ All other keys: `customerFirstName`, `eventTitle`, `ticketTypeTitle`, `quantity`
 
 **Recipient:** Same as template 1.
 
-Includes **all** keys from the paid/failed set, plus:
+Includes all keys from the paid/failed set, plus:
 
 | Key | Type | Semantics |
 |-----|------|-----------|
 | `refundFormatted` | text | Refund amount: uses `refundedAmountMinor` when set, otherwise `totalAmountMinor`; same display format as `totalFormatted` |
-| `orderStatusLabel` | text | `Refunded` |
 
 ## What does *not* use these templates
 

--- a/docs/operations/transactional-email-policy.md
+++ b/docs/operations/transactional-email-policy.md
@@ -2,16 +2,16 @@
 
 Defines which emails the application sends today, how they are classified, and what is deferred. Part of epic **#183**; closes **#191**.
 
-**Related:** [transactional-email-workflows.md](./transactional-email-workflows.md) (triggers and templates), [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (Notify dashboard copy).
+**Related:** [transactional-email-workflows.md](./transactional-email-workflows.md) (triggers and templates), [`functions/email-templates/`](../../functions/email-templates/) (Notify source copy), [govuk-notify-template-copy.md](./govuk-notify-template-copy.md) (template index and tone guide).
 
 ## Provider and boundaries
 
 | Channel | Provider | Used for |
 |---------|----------|----------|
-| Account verification | **Firebase Auth** | Email verification links only |
+| Account actions | **Firebase Auth + GOV.UK Notify** | Firebase creates one-time action codes; Notify sends the site-owned verification, password-reset and email-change links |
 | App-owned transactional | **GOV.UK Notify** | Payments, bookings, membership access, guest moderation, internal payment ops |
 
-We do **not** replace Firebase Auth verification emails. Stripe may send its own receipts when enabled in the Stripe dashboard; app-owned payment emails add application context and deep links.
+Firebase Auth remains the authority for one-time account action codes, but the site delivers those links using GOV.UK Notify. Stripe may send its own receipts when enabled in the Stripe dashboard; app-owned payment emails add application context and deep links.
 
 ## Email categories
 
@@ -67,12 +67,12 @@ Configuration: [environment-and-secrets.md](./environment-and-secrets.md). Regis
 ## User-facing copy expectations
 
 - Operational emails: plain language, what happened, what to do next, link placeholders only (no hardcoded environment URLs in Notify).
-- Do not include admin-only notes in customer personalisation payloads.
+- Do not include admin-only notes in member personalisation payloads.
 - Profile completion UI may state that users **will be notified by email** when an administrator activates their account (`membershipActivated`).
 
 ## Governance
 
-- New operational templates: update dispatcher, `govuk-notify-*.md`, `govuk-notify-template-copy.md`, and register in Notify per environment.
+- New operational templates: update the dispatcher, source file in `functions/email-templates/`, relevant `govuk-notify-*.md` specification, template index, and Notify registration in each environment.
 - New optional templates: new issue; reference this policy; do not merge without preferences design.
 
 ## Related issues

--- a/docs/operations/transactional-email-workflows.md
+++ b/docs/operations/transactional-email-workflows.md
@@ -2,7 +2,7 @@
 
 App-owned transactional email uses **GOV.UK Notify** via [`functions/src/mailer.ts`](../../functions/src/mailer.ts). Domain-event messages use the idempotent delivery ledger in [`functions/src/notificationDelivery.ts`](../../functions/src/notificationDelivery.ts). Password reset and email verification use one-time Firebase action codes delivered by Notify and completed on the site-owned `/auth/action` route.
 
-Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. **Draft Notify subject/body copy:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration runbook:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md). Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
+Per-template placeholder specs live in the linked `govuk-notify-*.md` files below. **Notify subject/body source:** [`functions/email-templates/`](../../functions/email-templates/). **Template index and tone guide:** [govuk-notify-template-copy.md](./govuk-notify-template-copy.md). **Registration runbook:** [govuk-notify-template-registration.md](./govuk-notify-template-registration.md). Environment variables: [environment-and-secrets.md](./environment-and-secrets.md).
 
 ## Shared delivery pattern
 

--- a/functions/email-templates/README.md
+++ b/functions/email-templates/README.md
@@ -59,6 +59,12 @@ The admin panel includes a **Template sync** page that fetches each template fro
 
 ## Relationship to `docs/operations/govuk-notify-template-copy.md`
 
-That file is a separate, hand-maintained human reference (registration runbook, sample personalisation) — it is **not** read by any code, so adding a template there does nothing on its own. This directory (`.md` files + `template-registry.json`, compiled into `generatedEmailTemplateManifest.ts`) is the actual source the Template sync page checks.
+That file is an index and tone guide linking back to this directory. It deliberately
+does not duplicate subject and body copy. This directory (`.md` files +
+`template-registry.json`, compiled into `generatedEmailTemplateManifest.ts`) is the
+source the Template sync page checks.
 
-When adding or removing a template, update both in the same PR: a `### \`templateKey\`` heading must exist in `docs/operations/govuk-notify-template-copy.md` for every template here, and vice versa. `functions/src/__tests__/emailTemplateDocsContracts.test.ts` enforces this (presence only, not that the copy text itself matches) and fails CI if either side gets a template the other doesn't — this is exactly what went wrong in #271, where the docs were updated but this directory wasn't, and the new template silently never appeared on the Template sync page (#378).
+When adding or removing a template, update the index in the same PR: a
+`### \`templateKey\`` heading must exist in
+`docs/operations/govuk-notify-template-copy.md` for every template here, and vice
+versa. `functions/src/__tests__/emailTemplateDocsContracts.test.ts` enforces this.

--- a/functions/email-templates/bookingConfirmation.md
+++ b/functions/email-templates/bookingConfirmation.md
@@ -1,12 +1,11 @@
 ---
-subject: "Your SODC booking — ((eventTitle))"
+subject: "Your booking for ((eventTitle)) is confirmed"
 templateKey: bookingConfirmation
 variables:
-  - customerFirstName
+  - firstName
   - eventTitle
   - eventDateTime
   - eventLocation
-  - revisionNumber
   - ticketLinesSummary
   - bookerDietaryNote
   - accommodationSummary
@@ -14,25 +13,25 @@ variables:
   - sectionBookingsUrl
   - myPaymentsUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your booking for ((eventTitle)) has been confirmed.
+Thank you for booking your place at ((eventTitle)). Your booking is confirmed.
 
 ---
 
 # Event details
 
-When: ((eventDateTime))
+Date and time: ((eventDateTime))
 
 Where: ((eventLocation))
 
 ---
 
-# Your booking (revision ((revisionNumber)))
+# Your booking
 
 ((ticketLinesSummary))
 
-Your dietary note: ((bookerDietaryNote))
+Dietary requirements: ((bookerDietaryNote))
 
 Accommodation: ((accommodationSummary))
 
@@ -40,12 +39,14 @@ Total: ((bookingTotalFormatted))
 
 ---
 
-You can view your booking and payment status at any time:
+View your booking:
 
 ((sectionBookingsUrl))
 
-If payment is outstanding, visit My Payments:
+If you still need to make a payment, visit My Payments:
 
 ((myPaymentsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/bookingRevision.md
+++ b/functions/email-templates/bookingRevision.md
@@ -1,44 +1,41 @@
 ---
-subject: "Your SODC booking has been updated — ((eventTitle))"
+subject: "Your booking for ((eventTitle)) has been updated"
 templateKey: bookingRevision
 variables:
-  - customerFirstName
+  - firstName
   - eventTitle
   - eventDateTime
   - eventLocation
-  - revisionNumber
   - ticketLinesSummary
   - bookerDietaryNote
   - accommodationSummary
   - bookingTotalFormatted
   - sectionBookingsUrl
   - myPaymentsUrl
-  - previousRevisionNumber
-  - revisedRevisionNumber
   - paymentAdjustmentStatus
   - previousTotalFormatted
   - revisedTotalFormatted
   - deltaAmountFormatted
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).
+Your booking for ((eventTitle)) has been updated.
 
 ---
 
 # Event details
 
-When: ((eventDateTime))
+Date and time: ((eventDateTime))
 
 Where: ((eventLocation))
 
 ---
 
-# Updated booking (revision ((revisedRevisionNumber)))
+# Your updated booking
 
 ((ticketLinesSummary))
 
-Your dietary note: ((bookerDietaryNote))
+Dietary requirements: ((bookerDietaryNote))
 
 Accommodation: ((accommodationSummary))
 
@@ -46,7 +43,7 @@ Previous total: ((previousTotalFormatted))
 
 Revised total: ((revisedTotalFormatted))
 
-Difference: ((deltaAmountFormatted))
+Payment difference: ((deltaAmountFormatted))
 
 Payment status: ((paymentAdjustmentStatus))
 
@@ -56,8 +53,10 @@ View your booking:
 
 ((sectionBookingsUrl))
 
-Manage payments:
+View your payments:
 
 ((myPaymentsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/email-change-verification.md
+++ b/functions/email-templates/email-change-verification.md
@@ -4,6 +4,8 @@ subject: Confirm your new SODC email address
 variables:
   - verificationLink
 ---
+Hello,
+
 We received a request to change the email address used for your SODC account.
 
 Use this secure link to confirm the new address:
@@ -12,6 +14,6 @@ Use this secure link to confirm the new address:
 
 If you did not request this change, you can ignore this email. Your current address will remain unchanged.
 
-For your security, do not forward this email or share the link.
+Kind regards,
 
-SODC
+SODC Admin

--- a/functions/email-templates/email-verification.md
+++ b/functions/email-templates/email-verification.md
@@ -4,7 +4,9 @@ subject: Verify your SODC email address
 variables:
   - verificationLink
 ---
-Welcome to SODC.
+Hello,
+
+Thank you for registering with SODC.
 
 Use this secure link to verify your email address:
 
@@ -12,6 +14,6 @@ Use this secure link to verify your email address:
 
 If you did not create an SODC account, you can ignore this email.
 
-For your security, do not forward this email or share the link.
+Kind regards,
 
-SODC
+SODC Admin

--- a/functions/email-templates/guestTicketRequestApproved.md
+++ b/functions/email-templates/guestTicketRequestApproved.md
@@ -2,26 +2,33 @@
 subject: "Guest ticket request approved — ((eventTitle))"
 templateKey: guestTicketRequestApproved
 variables:
-  - customerFirstName
+  - firstName
   - eventTitle
+  - eventDateTime
+  - eventLocation
   - guestDisplayName
   - requestedGuestCount
-  - decisionLabel
   - moderatorNote
   - myBookingsUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
+Your request for guest places at ((eventTitle)) has been approved.
+
+Date and time: ((eventDateTime))
+
+Location: ((eventLocation))
 
 Guest: ((guestDisplayName))
 
-Guest tickets: ((requestedGuestCount))
+Guest places: ((requestedGuestCount))
 
 Note from organiser: ((moderatorNote))
 
-You can now complete payment for your guest tickets. Visit your booking to continue:
+You can now arrange payment for the guest places. View your booking to continue:
 
 ((myBookingsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/guestTicketRequestRejected.md
+++ b/functions/email-templates/guestTicketRequestRejected.md
@@ -1,27 +1,34 @@
 ---
-subject: "Guest ticket request update — ((eventTitle))"
+subject: "Update on your guest request for ((eventTitle))"
 templateKey: guestTicketRequestRejected
 variables:
-  - customerFirstName
+  - firstName
   - eventTitle
+  - eventDateTime
+  - eventLocation
   - guestDisplayName
   - requestedGuestCount
-  - decisionLabel
   - moderatorNote
   - myBookingsUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your guest ticket request for ((eventTitle)) has been ((decisionLabel)).
+Unfortunately, your request for guest places at ((eventTitle)) was not approved.
+
+Date and time: ((eventDateTime))
+
+Location: ((eventLocation))
 
 Guest: ((guestDisplayName))
 
-Guest tickets requested: ((requestedGuestCount))
+Guest places requested: ((requestedGuestCount))
 
 Note from organiser: ((moderatorNote))
 
-If you have any questions, please contact your section organiser. You can view your booking at:
+View your booking:
 
 ((myBookingsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/membershipAccessRestricted.md
+++ b/functions/email-templates/membershipAccessRestricted.md
@@ -2,17 +2,21 @@
 subject: "Your SODC membership status has changed"
 templateKey: membershipAccessRestricted
 variables:
-  - customerFirstName
+  - firstName
   - membershipStatusLabel
   - previousStatusLabel
   - appUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
 Your SODC membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)).
 
-Your access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.
+Your access to the member area has therefore changed.
+
+View SODC online:
 
 ((appUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/membershipActivated.md
+++ b/functions/email-templates/membershipActivated.md
@@ -2,14 +2,14 @@
 subject: "Welcome to SODC — your membership is active"
 templateKey: membershipActivated
 variables:
-  - customerFirstName
+  - firstName
   - membershipStatusLabel
   - appUrl
   - profileUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your SODC membership is now active. Your membership status is ((membershipStatusLabel)).
+We are pleased to confirm that your SODC membership is now active. Your membership status is ((membershipStatusLabel)).
 
 You can now access sections, view upcoming events, and make bookings.
 
@@ -17,10 +17,12 @@ Sign in to get started:
 
 ((appUrl))
 
-We recommend completing your profile before making your first booking:
+You can review your profile and communication preferences here:
 
 ((profileUrl))
 
-Welcome aboard.
+Welcome to SODC.
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/password-reset.md
+++ b/functions/email-templates/password-reset.md
@@ -4,6 +4,8 @@ subject: Reset your SODC password
 variables:
   - resetLink
 ---
+Hello,
+
 We received a request to reset the password for your SODC account.
 
 Use this secure link to choose a new password:
@@ -12,6 +14,6 @@ Use this secure link to choose a new password:
 
 If you did not request this, you can ignore this email. Your password will not change.
 
-For your security, do not forward this email or share the link.
+Kind regards,
 
-SODC
+SODC Admin

--- a/functions/email-templates/ticketOrderFailed.md
+++ b/functions/email-templates/ticketOrderFailed.md
@@ -2,35 +2,33 @@
 subject: "Payment unsuccessful — ((eventTitle))"
 templateKey: ticketOrderFailed
 variables:
-  - customerFirstName
   - firstName
   - eventTitle
+  - eventDateTime
+  - eventLocation
   - ticketTypeTitle
   - quantity
   - totalFormatted
-  - currencyDisplay
-  - orderStatusLabel
-  - orderId
   - myPaymentsUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Unfortunately your payment for ((eventTitle)) was unsuccessful.
+We could not complete your payment for ((eventTitle)).
+
+Date and time: ((eventDateTime))
+
+Location: ((eventLocation))
 
 Ticket: ((ticketTypeTitle))
 
 Quantity: ((quantity))
 
-Amount: ((totalFormatted)) ((currencyDisplay))
-
-Status: ((orderStatusLabel))
-
-Order reference: ((orderId))
+Amount: ((totalFormatted))
 
 Your booking is still in place. You can return to My Payments to try again:
 
 ((myPaymentsUrl))
 
-If you continue to have problems, please reply to this email.
+Kind regards,
 
-SODC
+SODC Admin

--- a/functions/email-templates/ticketOrderPaid.md
+++ b/functions/email-templates/ticketOrderPaid.md
@@ -2,33 +2,33 @@
 subject: "Payment confirmed — ((eventTitle))"
 templateKey: ticketOrderPaid
 variables:
-  - customerFirstName
   - firstName
   - eventTitle
+  - eventDateTime
+  - eventLocation
   - ticketTypeTitle
   - quantity
   - totalFormatted
-  - currencyDisplay
-  - orderStatusLabel
-  - orderId
   - myPaymentsUrl
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-Your payment for ((eventTitle)) has been confirmed.
+Thank you. We have received your payment for ((eventTitle)).
+
+Date and time: ((eventDateTime))
+
+Location: ((eventLocation))
 
 Ticket: ((ticketTypeTitle))
 
 Quantity: ((quantity))
 
-Total paid: ((totalFormatted)) ((currencyDisplay))
-
-Status: ((orderStatusLabel))
-
-Order reference: ((orderId))
+Total paid: ((totalFormatted))
 
 You can view your payment history at any time:
 
 ((myPaymentsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/ticketOrderRefunded.md
+++ b/functions/email-templates/ticketOrderRefunded.md
@@ -2,31 +2,29 @@
 subject: "Refund processed — ((eventTitle))"
 templateKey: ticketOrderRefunded
 variables:
-  - customerFirstName
   - firstName
   - eventTitle
+  - eventDateTime
+  - eventLocation
   - ticketTypeTitle
   - quantity
   - totalFormatted
-  - currencyDisplay
-  - orderStatusLabel
-  - orderId
   - myPaymentsUrl
   - refundFormatted
 ---
-Dear ((customerFirstName)),
+Hello ((firstName)),
 
-A refund of ((refundFormatted)) has been processed for your payment on ((eventTitle)).
+We have processed a refund of ((refundFormatted)) for your payment for ((eventTitle)).
+
+Date and time: ((eventDateTime))
+
+Location: ((eventLocation))
 
 Ticket: ((ticketTypeTitle))
 
 Quantity: ((quantity))
 
-Original total: ((totalFormatted)) ((currencyDisplay))
-
-Status: ((orderStatusLabel))
-
-Order reference: ((orderId))
+Original payment: ((totalFormatted))
 
 Refunds typically appear in your account within 5 to 10 working days depending on your bank.
 
@@ -34,4 +32,6 @@ You can view your payment history at:
 
 ((myPaymentsUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/src/__tests__/bookingEmailDispatcher.test.ts
+++ b/functions/src/__tests__/bookingEmailDispatcher.test.ts
@@ -34,7 +34,7 @@ const sampleLines = [
 describe("bookingEmailDispatcher helpers", () => {
   it("formats event date/time for same-day events", () => {
     const formatted = formatBookingEventDateTime("2026-06-01T18:00:00.000Z", "2026-06-01T22:00:00.000Z");
-    expect(formatted).toMatch(/Jun/);
+    expect(formatted).toMatch(/June/);
     expect(formatted).toMatch(/–/);
   });
 
@@ -58,8 +58,8 @@ describe("bookingEmailDispatcher helpers", () => {
     expect(paymentAdjustmentStatusLabel(BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE)).toBe(
       "Additional payment due"
     );
-    expect(formatSignedDeltaAmount(1500)).toBe("+15.00 GBP");
-    expect(formatSignedDeltaAmount(-500)).toBe("-5.00 GBP");
+    expect(formatSignedDeltaAmount(1500)).toBe("+£15.00");
+    expect(formatSignedDeltaAmount(-500)).toBe("-£5.00");
   });
 });
 
@@ -119,6 +119,7 @@ describe("notifyBookingConfirmationEmail", () => {
         templateName: "bookingConfirmation",
         to: "sam@example.com",
         personalisation: expect.objectContaining({
+          firstName: "Sam",
           eventTitle: "Annual dinner",
           sectionBookingsUrl: "https://app.example/sections/sec-1",
           myPaymentsUrl: "https://app.example/payments",

--- a/functions/src/__tests__/emailTemplateDocsContracts.test.ts
+++ b/functions/src/__tests__/emailTemplateDocsContracts.test.ts
@@ -12,14 +12,10 @@ function readRepoFile(relativePath: string): string {
 }
 
 /**
- * functions/email-templates/*.md (compiled into EMAIL_TEMPLATE_MANIFEST) is the machine-readable
- * source consumed by getTemplateSyncStatus. docs/operations/govuk-notify-template-copy.md is a
- * separate, hand-maintained human reference with no code dependency on the source. #271 updated
- * the docs but never created the matching functions/email-templates/*.md file, so the new
- * template silently never appeared in the Email Template Sync page rather than showing as
- * unconfigured (see #378). These checks catch either direction of that drift — a template added
- * to one side without the other — even though they can't catch the docs' prose copy silently
- * diverging from the actual source content.
+ * functions/email-templates/*.md (compiled into EMAIL_TEMPLATE_MANIFEST) is the single source
+ * consumed by getTemplateSyncStatus. docs/operations/govuk-notify-template-copy.md is an index
+ * and tone guide rather than a hand-maintained duplicate. These checks catch a template added
+ * to either side without the corresponding source or index entry.
  */
 describe("GOV Notify template docs parity (#378)", () => {
   const docs = readRepoFile(DOCS_PATH);

--- a/functions/src/__tests__/emailTemplateToneContracts.test.ts
+++ b/functions/src/__tests__/emailTemplateToneContracts.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { EMAIL_TEMPLATE_MANIFEST } from "../generatedEmailTemplateManifest";
+
+const NAMED_MEMBER_TEMPLATES = [
+  "bookingConfirmation",
+  "bookingRevision",
+  "guestTicketRequestApproved",
+  "guestTicketRequestRejected",
+  "membershipActivated",
+  "membershipAccessRestricted",
+  "ticketOrderPaid",
+  "ticketOrderFailed",
+  "ticketOrderRefunded",
+] as const;
+
+const ACCOUNT_ACTION_TEMPLATES = [
+  "passwordReset",
+  "emailVerification",
+  "emailChangeVerification",
+] as const;
+
+const EVENT_TEMPLATES = [
+  "bookingConfirmation",
+  "bookingRevision",
+  "guestTicketRequestApproved",
+  "guestTicketRequestRejected",
+  "ticketOrderPaid",
+  "ticketOrderFailed",
+  "ticketOrderRefunded",
+] as const;
+
+const MEMBER_TEMPLATES = [
+  ...NAMED_MEMBER_TEMPLATES,
+  ...ACCOUNT_ACTION_TEMPLATES,
+] as const;
+
+describe("member email tone contract (#476)", () => {
+  it.each(MEMBER_TEMPLATES)("uses the automated sign-off in %s", (templateKey) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).toMatch(
+      /Kind regards,\n\nSODC Admin$/,
+    );
+  });
+
+  it.each(MEMBER_TEMPLATES)("does not use commercial or reply wording in %s", (templateKey) => {
+    const body = EMAIL_TEMPLATE_MANIFEST[templateKey].body;
+    expect(body).not.toMatch(/\b(customer|purchase|order)\b/i);
+    expect(body).not.toMatch(/\brepl(?:y|ies|ied|ying)\b/i);
+  });
+
+  it.each(NAMED_MEMBER_TEMPLATES)("greets the member by firstName in %s", (templateKey) => {
+    const template = EMAIL_TEMPLATE_MANIFEST[templateKey];
+    expect(template.body).toMatch(/^Hello \(\(firstName\)\),/);
+    expect(template.variables).toContain("firstName");
+    expect(template.variables).not.toContain("customerFirstName");
+  });
+
+  it.each(ACCOUNT_ACTION_TEMPLATES)("uses a privacy-safe generic greeting in %s", (templateKey) => {
+    const template = EMAIL_TEMPLATE_MANIFEST[templateKey];
+    expect(template.body).toMatch(/^Hello,\n/);
+    expect(template.variables).not.toContain("firstName");
+  });
+
+  it.each(EVENT_TEMPLATES)("includes useful event context in %s", (templateKey) => {
+    const variables = EMAIL_TEMPLATE_MANIFEST[templateKey].variables;
+    expect(variables).toEqual(
+      expect.arrayContaining(["eventTitle", "eventDateTime", "eventLocation"]),
+    );
+  });
+});

--- a/functions/src/__tests__/guestTicketRequestEmails.test.ts
+++ b/functions/src/__tests__/guestTicketRequestEmails.test.ts
@@ -15,7 +15,7 @@ const mockSendOnce = vi.spyOn(notificationDelivery, "sendNotificationOnce");
 
 describe("guest ticket email helpers", () => {
   it("formats moderator note", () => {
-    expect(formatModeratorNote(null)).toBe("—");
+    expect(formatModeratorNote(null)).toBe("No additional note");
     expect(formatModeratorNote("  OK  ")).toBe("OK");
   });
 
@@ -56,6 +56,9 @@ describe("notifyBookerGuestTicketRequestReviewed", () => {
             event: {
               id: "evt",
               title: "Annual dinner",
+              location: "Main Hall",
+              startDateTime: "2026-07-01T18:00:00.000Z",
+              endDateTime: "2026-07-01T22:00:00.000Z",
               section: { id: "sec-1", name: "Events" },
             },
           },
@@ -83,6 +86,9 @@ describe("notifyBookerGuestTicketRequestReviewed", () => {
         templateName: "guestTicketRequestApproved",
         to: "sam@example.com",
         personalisation: expect.objectContaining({
+          firstName: "Sam",
+          eventDateTime: expect.stringContaining("19:00 – 23:00"),
+          eventLocation: "Main Hall",
           moderatorNote: "Welcome",
           myBookingsUrl: "https://app.example/sections/sec-1",
         }),
@@ -120,6 +126,9 @@ describe("notifyModeratorsGuestTicketRequestSubmitted", () => {
             event: {
               id: "evt",
               title: "Annual dinner",
+              location: "Main Hall",
+              startDateTime: "2026-07-01T18:00:00.000Z",
+              endDateTime: "2026-07-01T22:00:00.000Z",
               section: { id: "sec-1", name: "Events" },
             },
           },

--- a/functions/src/__tests__/membershipStatusEmailDispatcher.test.ts
+++ b/functions/src/__tests__/membershipStatusEmailDispatcher.test.ts
@@ -91,7 +91,7 @@ describe("notifyMembershipStatusEmailIfNeeded", () => {
         templateName: "membershipActivated",
         to: "alex@example.com",
         personalisation: expect.objectContaining({
-          customerFirstName: "Alex",
+          firstName: "Alex",
           membershipStatusLabel: "Regular",
           appUrl: "https://app.example",
           profileUrl: "https://app.example/profile",

--- a/functions/src/__tests__/paymentLifecycleEmailDispatcher.test.ts
+++ b/functions/src/__tests__/paymentLifecycleEmailDispatcher.test.ts
@@ -4,8 +4,8 @@ import * as admin from "@dataconnect/admin-generated";
 import {
   createGovNotifyTicketOrderLifecycleDispatcher,
   formatMinorCurrency,
+  formatTransactionalEventDateTime,
   normaliseAppBaseUrl,
-  ticketOrderStatusCustomerLabel,
 } from "../paymentLifecycleEmailDispatcher";
 import type { PaymentLifecycleNotification } from "../paymentNotifications";
 
@@ -13,7 +13,7 @@ const mockGet = vi.spyOn(admin, "getTicketOrderForWebhook");
 
 describe("paymentLifecycleEmailDispatcher helpers", () => {
   it("formats minor currency", () => {
-    expect(formatMinorCurrency(1299, "gbp")).toBe("12.99 GBP");
+    expect(formatMinorCurrency(1299, "gbp")).toBe("£12.99");
   });
 
   it("normalises app base URL", () => {
@@ -22,9 +22,13 @@ describe("paymentLifecycleEmailDispatcher helpers", () => {
     expect(normaliseAppBaseUrl("https://app.example")).toBe("https://app.example");
   });
 
-  it("maps status labels", () => {
-    expect(ticketOrderStatusCustomerLabel(TicketOrderStatus.PAID)).toBe("Paid");
-    expect(ticketOrderStatusCustomerLabel(TicketOrderStatus.FAILED)).toBe("Payment failed");
+  it("formats event times in the UK time zone", () => {
+    expect(
+      formatTransactionalEventDateTime(
+        "2026-07-01T18:00:00.000Z",
+        "2026-07-01T22:00:00.000Z",
+      ),
+    ).toContain("19:00 – 23:00");
   });
 });
 
@@ -43,6 +47,9 @@ const baseOrder = {
   event: {
     id: "00000000-0000-4000-8000-00000000000e",
     title: "Annual dinner",
+    location: "Main Hall",
+    startDateTime: "2026-07-01T18:00:00.000Z",
+    endDateTime: "2026-07-01T22:00:00.000Z",
   },
   ticketType: {
     id: "00000000-0000-4000-8000-0000000000tt",
@@ -102,9 +109,10 @@ describe("createGovNotifyTicketOrderLifecycleDispatcher", () => {
         templateName: "ticketOrderPaid",
         to: "buyer@example.com",
         personalisation: expect.objectContaining({
-          customerFirstName: "Sam",
           firstName: "Sam",
           eventTitle: "Annual dinner",
+          eventDateTime: expect.stringContaining("19:00 – 23:00"),
+          eventLocation: "Main Hall",
           ticketTypeTitle: "Member ticket",
           myPaymentsUrl: "https://app.example/payments",
           quantity: 2,
@@ -146,7 +154,7 @@ describe("createGovNotifyTicketOrderLifecycleDispatcher", () => {
       expect.objectContaining({
         templateName: "ticketOrderRefunded",
         personalisation: expect.objectContaining({
-          refundFormatted: "30.00 GBP",
+          refundFormatted: "£30.00",
         }),
       })
     );

--- a/functions/src/__tests__/paymentLifecycleEmailDispatcher.test.ts
+++ b/functions/src/__tests__/paymentLifecycleEmailDispatcher.test.ts
@@ -30,6 +30,21 @@ describe("paymentLifecycleEmailDispatcher helpers", () => {
       ),
     ).toContain("19:00 – 23:00");
   });
+
+  it("formats both UK-local dates and times for a multi-day event", () => {
+    expect(
+      formatTransactionalEventDateTime(
+        "2026-07-01T18:00:00.000Z",
+        "2026-07-02T10:00:00.000Z",
+      ),
+    ).toBe("Wednesday, 1 July 2026, 19:00 – Thursday, 2 July 2026, 11:00");
+  });
+
+  it("preserves the supplied values when an event date is invalid", () => {
+    expect(
+      formatTransactionalEventDateTime("not-a-start-date", "not-an-end-date"),
+    ).toBe("not-a-start-date – not-an-end-date");
+  });
 });
 
 const baseOrder = {

--- a/functions/src/bookingEmailDispatcher.ts
+++ b/functions/src/bookingEmailDispatcher.ts
@@ -7,7 +7,11 @@ import {
 import type { UUIDString } from "@dataconnect/admin-generated";
 import { createConfiguredGovNotifyMailer, GOV_NOTIFY_PROVIDER } from "./mailer";
 import { sanitizeMailerError } from "./mailerErrors";
-import { formatMinorCurrency, normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
+import {
+  formatMinorCurrency,
+  formatTransactionalEventDateTime,
+  normaliseAppBaseUrl,
+} from "./paymentLifecycleEmailDispatcher";
 import { sendNotificationOnce } from "./notificationDelivery";
 import type { BookingPaymentDelta } from "./bookingPaymentAdjustments";
 import type { GovNotifyDeliveryMode } from "./govNotifyDeliveryMode";
@@ -48,11 +52,10 @@ type BookingNotificationRow = {
 };
 
 export type BookingEmailPersonalisation = {
-  customerFirstName: string;
+  firstName: string;
   eventTitle: string;
   eventDateTime: string;
   eventLocation: string;
-  revisionNumber: number;
   ticketLinesSummary: string;
   bookerDietaryNote: string;
   accommodationSummary: string;
@@ -62,8 +65,6 @@ export type BookingEmailPersonalisation = {
 };
 
 export type BookingRevisionEmailPersonalisation = BookingEmailPersonalisation & {
-  previousRevisionNumber: number;
-  revisedRevisionNumber: number;
   paymentAdjustmentStatus: string;
   previousTotalFormatted: string;
   revisedTotalFormatted: string;
@@ -71,23 +72,7 @@ export type BookingRevisionEmailPersonalisation = BookingEmailPersonalisation & 
 };
 
 export function formatBookingEventDateTime(startDateTime: string, endDateTime: string): string {
-  const start = new Date(startDateTime);
-  const end = new Date(endDateTime);
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-    return `${startDateTime} – ${endDateTime}`;
-  }
-  const dateFmt = new Intl.DateTimeFormat("en-GB", {
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  });
-  const timeFmt = new Intl.DateTimeFormat("en-GB", { hour: "2-digit", minute: "2-digit" });
-  const sameDay = start.toDateString() === end.toDateString();
-  if (sameDay) {
-    return `${dateFmt.format(start)}, ${timeFmt.format(start)} – ${timeFmt.format(end)}`;
-  }
-  return `${dateFmt.format(start)} ${timeFmt.format(start)} – ${dateFmt.format(end)} ${timeFmt.format(end)}`;
+  return formatTransactionalEventDateTime(startDateTime, endDateTime);
 }
 
 function linePriceMinor(price: number): number {
@@ -100,7 +85,7 @@ export function bookingTotalMinorFromLines(lines: BookingLineRow[]): number {
 
 export function buildTicketLinesSummary(lines: BookingLineRow[]): string {
   if (lines.length === 0) {
-    return "—";
+    return "No tickets recorded";
   }
   return lines
     .map((line) => {
@@ -159,13 +144,12 @@ function buildBasePersonalisation(args: {
   const fn = booking.booker.firstName?.trim();
   const totalMinor = bookingTotalMinorFromLines(booking.lines);
   return {
-    customerFirstName: fn && fn.length > 0 ? fn : "there",
+    firstName: fn && fn.length > 0 ? fn : "Member",
     eventTitle: booking.event.title ?? "—",
     eventDateTime: formatBookingEventDateTime(booking.event.startDateTime, booking.event.endDateTime),
-    eventLocation: booking.event.location?.trim() || "—",
-    revisionNumber: booking.revisionNumber,
+    eventLocation: booking.event.location?.trim() || "To be confirmed",
     ticketLinesSummary: buildTicketLinesSummary(booking.lines),
-    bookerDietaryNote: booking.bookerDietaryNote?.trim() || "—",
+    bookerDietaryNote: booking.bookerDietaryNote?.trim() || "None provided",
     accommodationSummary: buildAccommodationSummary(
       booking.accommodationRequested,
       booking.accommodationNote
@@ -277,13 +261,10 @@ export async function notifyBookingRevisionEmail(args: {
       return;
     }
 
-    const previousRevisionNumber = booking.supersedesBooking?.revisionNumber ?? booking.revisionNumber - 1;
     const mailer = (args.getMailer ?? createBookingMailer)();
     const base = buildBasePersonalisation({ booking, appBaseUrl: args.appBaseUrl });
     const personalisation: BookingRevisionEmailPersonalisation = {
       ...base,
-      previousRevisionNumber,
-      revisedRevisionNumber: booking.revisionNumber,
       paymentAdjustmentStatus: paymentAdjustmentStatusLabel(args.paymentDelta.status),
       previousTotalFormatted: formatMinorCurrency(args.paymentDelta.previousTotalMinor, "GBP"),
       revisedTotalFormatted: formatMinorCurrency(args.paymentDelta.revisedTotalMinor, "GBP"),

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -1228,6 +1228,9 @@ export interface GetGuestTicketRequestForNotificationData {
       event: {
         id: UUIDString;
         title: string;
+        location?: string | null;
+        startDateTime: TimestampString;
+        endDateTime: TimestampString;
         section: {
           id: UUIDString;
           name: string;
@@ -1784,6 +1787,9 @@ export interface GetTicketOrderForWebhookData {
     event: {
       id: UUIDString;
       title: string;
+      location?: string | null;
+      startDateTime: TimestampString;
+      endDateTime: TimestampString;
     } & Event_Key;
     ticketType: {
       id: UUIDString;

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -10,13 +10,12 @@ export interface EmailTemplateDefinition {
 
 export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = {
   bookingConfirmation: {
-    subject: "Your SODC booking — ((eventTitle))",
+    subject: "Your booking for ((eventTitle)) is confirmed",
     variables: [
-    "customerFirstName",
+    "firstName",
     "eventTitle",
     "eventDateTime",
     "eventLocation",
-    "revisionNumber",
     "ticketLinesSummary",
     "bookerDietaryNote",
     "accommodationSummary",
@@ -24,70 +23,69 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "sectionBookingsUrl",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been confirmed.\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your booking (revision ((revisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nTotal: ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nThank you for booking your place at ((eventTitle)). Your booking is confirmed.\n\n---\n\n# Event details\n\nDate and time: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your booking\n\n((ticketLinesSummary))\n\nDietary requirements: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nTotal: ((bookingTotalFormatted))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nIf you still need to make a payment, visit My Payments:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   bookingRevision: {
-    subject: "Your SODC booking has been updated — ((eventTitle))",
+    subject: "Your booking for ((eventTitle)) has been updated",
     variables: [
-    "customerFirstName",
+    "firstName",
     "eventTitle",
     "eventDateTime",
     "eventLocation",
-    "revisionNumber",
     "ticketLinesSummary",
     "bookerDietaryNote",
     "accommodationSummary",
     "bookingTotalFormatted",
     "sectionBookingsUrl",
     "myPaymentsUrl",
-    "previousRevisionNumber",
-    "revisedRevisionNumber",
     "paymentAdjustmentStatus",
     "previousTotalFormatted",
     "revisedTotalFormatted",
     "deltaAmountFormatted"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Updated booking (revision ((revisedRevisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nDifference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nYour booking for ((eventTitle)) has been updated.\n\n---\n\n# Event details\n\nDate and time: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your updated booking\n\n((ticketLinesSummary))\n\nDietary requirements: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nPayment difference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nView your payments:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   emailChangeVerification: {
     subject: "Confirm your new SODC email address",
     variables: [
     "verificationLink"
     ],
-    body: "We received a request to change the email address used for your SODC account.\n\nUse this secure link to confirm the new address:\n\n((verificationLink))\n\nIf you did not request this change, you can ignore this email. Your current address will remain unchanged.\n\nFor your security, do not forward this email or share the link.\n\nSODC",
+    body: "Hello,\n\nWe received a request to change the email address used for your SODC account.\n\nUse this secure link to confirm the new address:\n\n((verificationLink))\n\nIf you did not request this change, you can ignore this email. Your current address will remain unchanged.\n\nKind regards,\n\nSODC Admin",
   },
   emailVerification: {
     subject: "Verify your SODC email address",
     variables: [
     "verificationLink"
     ],
-    body: "Welcome to SODC.\n\nUse this secure link to verify your email address:\n\n((verificationLink))\n\nIf you did not create an SODC account, you can ignore this email.\n\nFor your security, do not forward this email or share the link.\n\nSODC",
+    body: "Hello,\n\nThank you for registering with SODC.\n\nUse this secure link to verify your email address:\n\n((verificationLink))\n\nIf you did not create an SODC account, you can ignore this email.\n\nKind regards,\n\nSODC Admin",
   },
   guestTicketRequestApproved: {
     subject: "Guest ticket request approved — ((eventTitle))",
     variables: [
-    "customerFirstName",
+    "firstName",
     "eventTitle",
+    "eventDateTime",
+    "eventLocation",
     "guestDisplayName",
     "requestedGuestCount",
-    "decisionLabel",
     "moderatorNote",
     "myBookingsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for ((eventTitle)) has been ((decisionLabel)).\n\nGuest: ((guestDisplayName))\n\nGuest tickets: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nYou can now complete payment for your guest tickets. Visit your booking to continue:\n\n((myBookingsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nYour request for guest places at ((eventTitle)) has been approved.\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nGuest: ((guestDisplayName))\n\nGuest places: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nYou can now arrange payment for the guest places. View your booking to continue:\n\n((myBookingsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   guestTicketRequestRejected: {
-    subject: "Guest ticket request update — ((eventTitle))",
+    subject: "Update on your guest request for ((eventTitle))",
     variables: [
-    "customerFirstName",
+    "firstName",
     "eventTitle",
+    "eventDateTime",
+    "eventLocation",
     "guestDisplayName",
     "requestedGuestCount",
-    "decisionLabel",
     "moderatorNote",
     "myBookingsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour guest ticket request for ((eventTitle)) has been ((decisionLabel)).\n\nGuest: ((guestDisplayName))\n\nGuest tickets requested: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nIf you have any questions, please contact your section organiser. You can view your booking at:\n\n((myBookingsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nUnfortunately, your request for guest places at ((eventTitle)) was not approved.\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nGuest: ((guestDisplayName))\n\nGuest places requested: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nView your booking:\n\n((myBookingsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   guestTicketRequestSubmittedModerator: {
     subject: "Guest ticket request — ((eventTitle))",
@@ -106,22 +104,22 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
   membershipAccessRestricted: {
     subject: "Your SODC membership status has changed",
     variables: [
-    "customerFirstName",
+    "firstName",
     "membershipStatusLabel",
     "previousStatusLabel",
     "appUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour SODC membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)).\n\nYour access to the member area has been restricted. If you think this is an error, or would like to discuss your membership, please reply to this email.\n\n((appUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nYour SODC membership status has changed from ((previousStatusLabel)) to ((membershipStatusLabel)).\n\nYour access to the member area has therefore changed.\n\nView SODC online:\n\n((appUrl))\n\nKind regards,\n\nSODC Admin",
   },
   membershipActivated: {
     subject: "Welcome to SODC — your membership is active",
     variables: [
-    "customerFirstName",
+    "firstName",
     "membershipStatusLabel",
     "appUrl",
     "profileUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour SODC membership is now active. Your membership status is ((membershipStatusLabel)).\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nWe recommend completing your profile before making your first booking:\n\n((profileUrl))\n\nWelcome aboard.\n\nSODC",
+    body: "Hello ((firstName)),\n\nWe are pleased to confirm that your SODC membership is now active. Your membership status is ((membershipStatusLabel)).\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nYou can review your profile and communication preferences here:\n\n((profileUrl))\n\nWelcome to SODC.\n\nKind regards,\n\nSODC Admin",
   },
   newUserPendingApprovalAlert: {
     subject: "[SODC] New member awaiting approval — ((firstName)) ((lastName))",
@@ -141,7 +139,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     variables: [
     "resetLink"
     ],
-    body: "We received a request to reset the password for your SODC account.\n\nUse this secure link to choose a new password:\n\n((resetLink))\n\nIf you did not request this, you can ignore this email. Your password will not change.\n\nFor your security, do not forward this email or share the link.\n\nSODC",
+    body: "Hello,\n\nWe received a request to reset the password for your SODC account.\n\nUse this secure link to choose a new password:\n\n((resetLink))\n\nIf you did not request this, you can ignore this email. Your password will not change.\n\nKind regards,\n\nSODC Admin",
   },
   paymentDisputeOpsAlert: {
     subject: "[SODC OPS] Payment dispute — ((orderId))",
@@ -175,50 +173,44 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
   ticketOrderFailed: {
     subject: "Payment unsuccessful — ((eventTitle))",
     variables: [
-    "customerFirstName",
     "firstName",
     "eventTitle",
+    "eventDateTime",
+    "eventLocation",
     "ticketTypeTitle",
     "quantity",
     "totalFormatted",
-    "currencyDisplay",
-    "orderStatusLabel",
-    "orderId",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nUnfortunately your payment for ((eventTitle)) was unsuccessful.\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nAmount: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nYour booking is still in place. You can return to My Payments to try again:\n\n((myPaymentsUrl))\n\nIf you continue to have problems, please reply to this email.\n\nSODC",
+    body: "Hello ((firstName)),\n\nWe could not complete your payment for ((eventTitle)).\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nAmount: ((totalFormatted))\n\nYour booking is still in place. You can return to My Payments to try again:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   ticketOrderPaid: {
     subject: "Payment confirmed — ((eventTitle))",
     variables: [
-    "customerFirstName",
     "firstName",
     "eventTitle",
+    "eventDateTime",
+    "eventLocation",
     "ticketTypeTitle",
     "quantity",
     "totalFormatted",
-    "currencyDisplay",
-    "orderStatusLabel",
-    "orderId",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour payment for ((eventTitle)) has been confirmed.\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nTotal paid: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nYou can view your payment history at any time:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nThank you. We have received your payment for ((eventTitle)).\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nTotal paid: ((totalFormatted))\n\nYou can view your payment history at any time:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   ticketOrderRefunded: {
     subject: "Refund processed — ((eventTitle))",
     variables: [
-    "customerFirstName",
     "firstName",
     "eventTitle",
+    "eventDateTime",
+    "eventLocation",
     "ticketTypeTitle",
     "quantity",
     "totalFormatted",
-    "currencyDisplay",
-    "orderStatusLabel",
-    "orderId",
     "myPaymentsUrl",
     "refundFormatted"
     ],
-    body: "Dear ((customerFirstName)),\n\nA refund of ((refundFormatted)) has been processed for your payment on ((eventTitle)).\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nOriginal total: ((totalFormatted)) ((currencyDisplay))\n\nStatus: ((orderStatusLabel))\n\nOrder reference: ((orderId))\n\nRefunds typically appear in your account within 5 to 10 working days depending on your bank.\n\nYou can view your payment history at:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Hello ((firstName)),\n\nWe have processed a refund of ((refundFormatted)) for your payment for ((eventTitle)).\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nTicket: ((ticketTypeTitle))\n\nQuantity: ((quantity))\n\nOriginal payment: ((totalFormatted))\n\nRefunds typically appear in your account within 5 to 10 working days depending on your bank.\n\nYou can view your payment history at:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
 };

--- a/functions/src/guestTicketRequestEmails.ts
+++ b/functions/src/guestTicketRequestEmails.ts
@@ -11,7 +11,10 @@ import {
   recipientScopedNotifyReference,
 } from "./mailer";
 import { sanitizeMailerError } from "./mailerErrors";
-import { normaliseAppBaseUrl } from "./paymentLifecycleEmailDispatcher";
+import {
+  formatTransactionalEventDateTime,
+  normaliseAppBaseUrl,
+} from "./paymentLifecycleEmailDispatcher";
 import { sendNotificationOnce } from "./notificationDelivery";
 import { resolveGuestTicketModeratorEmails } from "./guestTicketRequestModerators";
 import type { GovNotifyDeliveryMode } from "./govNotifyDeliveryMode";
@@ -34,20 +37,22 @@ export type GuestTicketEmailTemplates = {
     moderationUrl: string;
   };
   guestTicketRequestApproved: {
-    customerFirstName: string;
+    firstName: string;
     eventTitle: string;
+    eventDateTime: string;
+    eventLocation: string;
     guestDisplayName: string;
     requestedGuestCount: number;
-    decisionLabel: string;
     moderatorNote: string;
     myBookingsUrl: string;
   };
   guestTicketRequestRejected: {
-    customerFirstName: string;
+    firstName: string;
     eventTitle: string;
+    eventDateTime: string;
+    eventLocation: string;
     guestDisplayName: string;
     requestedGuestCount: number;
-    decisionLabel: string;
     moderatorNote: string;
     myBookingsUrl: string;
   };
@@ -55,7 +60,7 @@ export type GuestTicketEmailTemplates = {
 
 export function formatModeratorNote(note: string | null | undefined): string {
   const trimmed = note?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : "—";
+  return trimmed && trimmed.length > 0 ? trimmed : "No additional note";
 }
 
 export function bookerDisplayName(firstName: string, lastName: string, email: string): string {
@@ -205,8 +210,7 @@ export async function notifyBookerGuestTicketRequestReviewed(args: {
     const sectionId = request.booking.event.section.id;
     const myBookingsUrl = `${base}/sections/${sectionId}`;
     const fn = booker.firstName?.trim();
-    const customerFirstName = fn && fn.length > 0 ? fn : "there";
-    const decisionLabel = args.status === GuestTicketRequestStatus.APPROVED ? "Approved" : "Rejected";
+    const firstName = fn && fn.length > 0 ? fn : "Member";
     const notificationType =
       args.status === GuestTicketRequestStatus.APPROVED ? "GUEST_REQUEST_APPROVED" : "GUEST_REQUEST_REJECTED";
     const templateName =
@@ -220,11 +224,15 @@ export async function notifyBookerGuestTicketRequestReviewed(args: {
     const reference = `GUEST_REQUEST_${args.status}:${args.requestId}`;
 
     const personalisation = {
-      customerFirstName,
+      firstName,
       eventTitle: request.booking.event.title ?? "—",
+      eventDateTime: formatTransactionalEventDateTime(
+        request.booking.event.startDateTime,
+        request.booking.event.endDateTime,
+      ),
+      eventLocation: request.booking.event.location?.trim() || "To be confirmed",
       guestDisplayName: request.guestDisplayName ?? "—",
       requestedGuestCount: request.requestedGuestCount,
-      decisionLabel,
       moderatorNote: formatModeratorNote(request.moderatorNote),
       myBookingsUrl,
     };

--- a/functions/src/membershipStatusEmailDispatcher.ts
+++ b/functions/src/membershipStatusEmailDispatcher.ts
@@ -15,13 +15,13 @@ export const MEMBERSHIP_MAIL_TEMPLATE_KEYS = ["membershipActivated", "membership
 
 export type MembershipEmailTemplates = {
   membershipActivated: {
-    customerFirstName: string;
+    firstName: string;
     membershipStatusLabel: string;
     appUrl: string;
     profileUrl: string;
   };
   membershipAccessRestricted: {
-    customerFirstName: string;
+    firstName: string;
     membershipStatusLabel: string;
     previousStatusLabel: string;
     appUrl: string;
@@ -124,7 +124,7 @@ export async function notifyMembershipStatusEmailIfNeeded(args: {
 
     const email = user.email.trim().toLowerCase();
     const fn = user.firstName?.trim();
-    const customerFirstName = fn && fn.length > 0 ? fn : "there";
+    const firstName = fn && fn.length > 0 ? fn : "Member";
     const base = normaliseAppBaseUrl(args.appBaseUrl);
     const appUrl = base;
     const membershipStatusLabel = membershipStatusCustomerLabel(args.newStatus);
@@ -160,7 +160,7 @@ export async function notifyMembershipStatusEmailIfNeeded(args: {
       send: async (deliveryMode) => {
         if (kind === "activation") {
           const personalisation: MembershipEmailTemplates["membershipActivated"] = {
-            customerFirstName,
+            firstName,
             membershipStatusLabel,
             appUrl,
             profileUrl: `${base}/profile`,
@@ -181,7 +181,7 @@ export async function notifyMembershipStatusEmailIfNeeded(args: {
           ? membershipStatusCustomerLabel(args.previousStatus)
           : "Unknown";
         const personalisation: MembershipEmailTemplates["membershipAccessRestricted"] = {
-          customerFirstName,
+          firstName,
           membershipStatusLabel,
           previousStatusLabel,
           appUrl,

--- a/functions/src/paymentLifecycleEmailDispatcher.ts
+++ b/functions/src/paymentLifecycleEmailDispatcher.ts
@@ -1,7 +1,6 @@
 import * as logger from "firebase-functions/logger";
 import { getTicketOrderForWebhook } from "@dataconnect/admin-generated";
 import {
-  TicketOrderStatus,
   type GetTicketOrderForWebhookData,
   type UUIDString,
 } from "@dataconnect/admin-generated";
@@ -15,15 +14,13 @@ import type { GovNotifyDeliveryMode } from "./govNotifyDeliveryMode";
 export const TICKET_ORDER_MAIL_TEMPLATE_KEYS = ["ticketOrderPaid", "ticketOrderFailed", "ticketOrderRefunded"] as const;
 
 export type TicketOrderPaidPersonalisation = {
-  customerFirstName: string;
   firstName: string;
   eventTitle: string;
+  eventDateTime: string;
+  eventLocation: string;
   ticketTypeTitle: string;
   quantity: number;
   totalFormatted: string;
-  currencyDisplay: string;
-  orderStatusLabel: string;
-  orderId: string;
   myPaymentsUrl: string;
 };
 
@@ -50,45 +47,68 @@ export function normaliseAppBaseUrl(baseUrl: string): string {
 }
 
 export function formatMinorCurrency(amountMinor: number, currency: string): string {
-  const symbolOrCode = currency.trim().toUpperCase();
+  const currencyCode = currency.trim().toUpperCase();
   const major = amountMinor / 100;
-  return `${major.toFixed(2)} ${symbolOrCode}`;
+  try {
+    return new Intl.NumberFormat("en-GB", {
+      style: "currency",
+      currency: currencyCode,
+      currencyDisplay: "narrowSymbol",
+    }).format(major);
+  } catch {
+    return `${major.toFixed(2)} ${currencyCode}`;
+  }
 }
 
-export function ticketOrderStatusCustomerLabel(status: TicketOrderStatus): string {
-  switch (status) {
-    case TicketOrderStatus.PAID:
-      return "Paid";
-    case TicketOrderStatus.FAILED:
-      return "Payment failed";
-    case TicketOrderStatus.REFUNDED:
-      return "Refunded";
-    case TicketOrderStatus.PENDING:
-      return "Pending payment";
-    default:
-      return String(status);
+export function formatTransactionalEventDateTime(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${startDateTime} – ${endDateTime}`;
   }
+  const dateFormat = new Intl.DateTimeFormat("en-GB", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "Europe/London",
+  });
+  const timeFormat = new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Europe/London",
+  });
+  const dateKeyFormat = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: "Europe/London",
+  });
+  if (dateKeyFormat.format(start) === dateKeyFormat.format(end)) {
+    return `${dateFormat.format(start)}, ${timeFormat.format(start)} – ${timeFormat.format(end)}`;
+  }
+  return `${dateFormat.format(start)}, ${timeFormat.format(start)} – ${dateFormat.format(end)}, ${timeFormat.format(end)}`;
 }
 
 function buildPaidLikePersonalisation(args: {
   row: TicketOrderWebhookRow;
-  statusForEmail: TicketOrderStatus;
   appBaseUrl: string;
 }): TicketOrderPaidPersonalisation {
-  const { row, statusForEmail, appBaseUrl } = args;
+  const { row, appBaseUrl } = args;
   const base = normaliseAppBaseUrl(appBaseUrl);
   const fn = row.user.firstName?.trim();
-  const customerFirstName = fn && fn.length > 0 ? fn : "there";
+  const firstName = fn && fn.length > 0 ? fn : "Member";
   return {
-    customerFirstName,
-    firstName: customerFirstName,
+    firstName,
     eventTitle: row.event.title ?? "",
+    eventDateTime: formatTransactionalEventDateTime(
+      row.event.startDateTime,
+      row.event.endDateTime,
+    ),
+    eventLocation: row.event.location?.trim() || "To be confirmed",
     ticketTypeTitle: row.ticketType.title ?? "",
     quantity: row.quantity,
     totalFormatted: formatMinorCurrency(row.totalAmountMinor, row.currency),
-    currencyDisplay: row.currency.trim().toUpperCase(),
-    orderStatusLabel: ticketOrderStatusCustomerLabel(statusForEmail),
-    orderId: row.id,
     myPaymentsUrl: `${base}/payments`,
   };
 }
@@ -131,7 +151,6 @@ export function createGovNotifyTicketOrderLifecycleDispatcher(
       case "PAYMENT_PAID": {
         const personalisation = buildPaidLikePersonalisation({
           row,
-          statusForEmail: TicketOrderStatus.PAID,
           appBaseUrl: options.appBaseUrl,
         });
         const result = await mailer.sendEmail({
@@ -149,7 +168,6 @@ export function createGovNotifyTicketOrderLifecycleDispatcher(
       case "PAYMENT_FAILED": {
         const personalisation = buildPaidLikePersonalisation({
           row,
-          statusForEmail: TicketOrderStatus.FAILED,
           appBaseUrl: options.appBaseUrl,
         });
         const result = await mailer.sendEmail({
@@ -169,7 +187,6 @@ export function createGovNotifyTicketOrderLifecycleDispatcher(
         const personalisation: TicketOrderRefundedPersonalisation = {
           ...buildPaidLikePersonalisation({
             row,
-            statusForEmail: TicketOrderStatus.REFUNDED,
             appBaseUrl: options.appBaseUrl,
           }),
           refundFormatted: formatMinorCurrency(refundMinor, row.currency),

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -2502,6 +2502,9 @@ export interface GetTicketOrderForWebhookData {
     event: {
       id: UUIDString;
       title: string;
+      location?: string | null;
+      startDateTime: TimestampString;
+      endDateTime: TimestampString;
     } & Event_Key;
     ticketType: {
       id: UUIDString;
@@ -3911,6 +3914,9 @@ export interface GetGuestTicketRequestForNotificationData {
       event: {
         id: UUIDString;
         title: string;
+        location?: string | null;
+        startDateTime: TimestampString;
+        endDateTime: TimestampString;
         section: {
           id: UUIDString;
           name: string;

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -1247,6 +1247,9 @@ export interface GetGuestTicketRequestForNotificationData {
       event: {
         id: UUIDString;
         title: string;
+        location?: string | null;
+        startDateTime: TimestampString;
+        endDateTime: TimestampString;
         section: {
           id: UUIDString;
           name: string;
@@ -1803,6 +1806,9 @@ export interface GetTicketOrderForWebhookData {
     event: {
       id: UUIDString;
       title: string;
+      location?: string | null;
+      startDateTime: TimestampString;
+      endDateTime: TimestampString;
     } & Event_Key;
     ticketType: {
       id: UUIDString;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2048,6 +2048,9 @@ export interface GetTicketOrderForWebhookData {
     event: {
       id: UUIDString;
       title: string;
+      location?: string | null;
+      startDateTime: TimestampString;
+      endDateTime: TimestampString;
     } & Event_Key;
     ticketType: {
       id: UUIDString;
@@ -3152,6 +3155,9 @@ export interface GetGuestTicketRequestForNotificationData {
       event: {
         id: UUIDString;
         title: string;
+        location?: string | null;
+        startDateTime: TimestampString;
+        endDateTime: TimestampString;
         section: {
           id: UUIDString;
           name: string;


### PR DESCRIPTION
## Summary

- apply the agreed SODC tone and automated sign-off to all 12 member-facing GOV.UK Notify templates
- provide member names and useful event context where safely available, using British date and currency formatting
- make repository template files the single source of truth and update the related operational documentation
- add contract coverage for greetings, sign-offs, terminology and required event details

## Impact

Members receive warmer, clearer emails using consistent club language. Privacy-sensitive account actions retain a generic greeting, and automated messages no longer solicit replies.

Data Connect now supplies event date and location to ticket and guest-request dispatchers, so Data Connect must be deployed before Functions.

## Validation

- Functions lint, build and tests: 74 files / 773 tests passed
- Frontend lint, production build and tests: 88 files / 718 tests passed
- Data Connect SDK generation passed
- template terminology and `git diff --check` audits passed

Closes #476
