### PR TITLE
Refine moderator and operations email tone

### DIFF
--- a/docs/operations/govuk-notify-guest-ticket-request-templates.md
+++ b/docs/operations/govuk-notify-guest-ticket-request-templates.md
@@ -41,6 +41,9 @@ Client UI uses these callables instead of direct Data Connect mutations for subm
 
 ## Template 1: moderator alert — `guestTicketRequestSubmittedModerator`
 
+The subject uses the common `[SODC]` internal prefix. The body uses concise
+review labels and the standard automated `Kind regards, SODC Admin` sign-off.
+
 | Key | Semantics |
 |-----|-----------|
 | `eventTitle` | Event title |

--- a/docs/operations/govuk-notify-payment-ops-internal-templates.md
+++ b/docs/operations/govuk-notify-payment-ops-internal-templates.md
@@ -25,13 +25,18 @@ Functions set short references for Notify logs, e.g. `reconciliation-ops:<orderI
 
 ## Template 1: reconciliation exception — `paymentReconciliationExceptionAlert`
 
+Both payment-operations subjects use the common `[SODC]` internal prefix. The
+body labels the account holder as the member while retaining Stripe and ticket
+order identifiers required for investigation, and uses the standard automated
+`Kind regards, SODC Admin` sign-off.
+
 **Trigger:** A reconciliation exception row becomes **OPEN** (new row or reopened from **RESOLVED**). For **`ACTIVE_DISPUTE`**, the reconciliation-path alert is skipped when the snapshot upsert runs on the **dispute webhook** path (the dispute-specific template covers that case).
 
 | Key | Semantics |
 |-----|-----------|
 | `orderId` | Ticket order UUID |
 | `eventTitle` | Event title from order |
-| `customerDisplay` | Booker display, e.g. `Name <email>` |
+| `customerDisplay` | Member/booker display, e.g. `Name <email>` (historical payload key) |
 | `exceptionType` | Enum string, e.g. `ACTIVE_DISPUTE`, `MISSING_PAYMENT_INTENT`, `REFUND_AMOUNT_MISMATCH` |
 | `exceptionNote` | Stored exception note |
 | `reconciliationDashboardUrl` | `APP_BASE_URL` (normalised) + `/admin/payments/reconciliation` |
@@ -45,7 +50,7 @@ Functions set short references for Notify logs, e.g. `reconciliation-ops:<orderI
 |-----|-----------|
 | `orderId` | Ticket order UUID |
 | `eventTitle` | Event title |
-| `customerDisplay` | Booker display |
+| `customerDisplay` | Member/booker display (historical payload key) |
 | `disputeStripeStatus` | Stripe dispute `status` |
 | `disputeReason` | Stripe dispute `reason` |
 | `disputeLocalState` | Normalised dispute state label from webhook routing |

--- a/docs/operations/govuk-notify-pending-approval-templates.md
+++ b/docs/operations/govuk-notify-pending-approval-templates.md
@@ -34,6 +34,10 @@ Also required for sends: `GOV_NOTIFY_LIVE_API_KEY` (secret), optional `GOV_NOTIF
 
 ## Template: `newUserPendingApprovalAlert`
 
+The subject deliberately omits the member's name and email address. Those details
+remain in the body for authorised administrators reviewing the account. The body
+uses the standard automated `Kind regards, SODC Admin` sign-off.
+
 | Key | Semantics |
 |-----|-----------|
 | `firstName` | User's first name |

--- a/functions/email-templates/guestTicketRequestSubmittedModerator.md
+++ b/functions/email-templates/guestTicketRequestSubmittedModerator.md
@@ -1,5 +1,5 @@
 ---
-subject: "Guest ticket request — ((eventTitle))"
+subject: "[SODC] Guest ticket request — ((eventTitle))"
 templateKey: guestTicketRequestSubmittedModerator
 variables:
   - eventTitle
@@ -11,7 +11,7 @@ variables:
   - dietaryNote
   - moderationUrl
 ---
-A guest ticket request has been submitted for your review.
+A guest ticket request is ready for review.
 
 Event: ((eventTitle))
 
@@ -19,18 +19,20 @@ Section: ((sectionName))
 
 Requested by: ((bookerDisplay))
 
-Guest name: ((guestDisplayName))
+Guest: ((guestDisplayName))
 
-Guest count: ((requestedGuestCount))
+Places requested: ((requestedGuestCount))
 
 Ticket type: ((guestTicketTypeTitle))
 
-Dietary note: ((dietaryNote))
+Dietary requirements: ((dietaryNote))
 
 ---
 
-Review and approve or decline this request in the admin panel:
+Review the request in SODC:
 
 ((moderationUrl))
 
-SODC
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/newUserPendingApprovalAlert.md
+++ b/functions/email-templates/newUserPendingApprovalAlert.md
@@ -1,5 +1,5 @@
 ---
-subject: "[SODC] New member awaiting approval — ((firstName)) ((lastName))"
+subject: "[SODC] New member awaiting approval"
 templateKey: newUserPendingApprovalAlert
 variables:
   - firstName
@@ -10,13 +10,24 @@ variables:
   - requestedMembershipStatus
   - approveUsersUrl
 ---
-A new member has completed their profile and is awaiting approval.
+A new member has completed their profile and is ready for review.
 
 Name: ((firstName)) ((lastName))
+
 Email: ((email))
+
 Service number: ((serviceNumber))
+
 Service background: ((serviceBackgroundSummary))
+
 Requested status: ((requestedMembershipStatus))
 
-Review in Approve Users:
+---
+
+Review the member in Approve Users:
+
 ((approveUsersUrl))
+
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/paymentDisputeOpsAlert.md
+++ b/functions/email-templates/paymentDisputeOpsAlert.md
@@ -1,5 +1,5 @@
 ---
-subject: "[SODC OPS] Payment dispute — ((orderId))"
+subject: "[SODC] Payment dispute — ((orderId))"
 templateKey: paymentDisputeOpsAlert
 variables:
   - orderId
@@ -13,21 +13,21 @@ variables:
   - reconciliationDashboardUrl
   - stripeEventId
 ---
-A payment dispute event has been received.
+A Stripe payment dispute needs review.
 
-Order ID: ((orderId))
+Ticket order ID: ((orderId))
 
 Event: ((eventTitle))
 
-Customer: ((customerDisplay))
+Member: ((customerDisplay))
 
-Dispute ID: ((stripeDisputeId))
+Stripe dispute ID: ((stripeDisputeId))
 
-Stripe status: ((disputeStripeStatus))
+Stripe dispute status: ((disputeStripeStatus))
 
-Reason: ((disputeReason))
+Stripe dispute reason: ((disputeReason))
 
-Local state: ((disputeLocalState))
+SODC dispute state: ((disputeLocalState))
 
 Stripe event type: ((stripeEventType))
 
@@ -35,8 +35,10 @@ Stripe event ID: ((stripeEventId))
 
 ---
 
-Review in the reconciliation dashboard:
+Review the dispute in the reconciliation dashboard:
 
 ((reconciliationDashboardUrl))
 
-SODC Ops
+Kind regards,
+
+SODC Admin

--- a/functions/email-templates/paymentReconciliationExceptionAlert.md
+++ b/functions/email-templates/paymentReconciliationExceptionAlert.md
@@ -1,5 +1,5 @@
 ---
-subject: "[SODC OPS] Reconciliation exception — ((orderId))"
+subject: "[SODC] Payment reconciliation exception — ((orderId))"
 templateKey: paymentReconciliationExceptionAlert
 variables:
   - orderId
@@ -10,24 +10,26 @@ variables:
   - reconciliationDashboardUrl
   - stripeEventId
 ---
-A payment reconciliation exception requires your attention.
+A payment reconciliation exception needs review.
 
-Order ID: ((orderId))
+Ticket order ID: ((orderId))
 
 Event: ((eventTitle))
 
-Customer: ((customerDisplay))
+Member: ((customerDisplay))
 
 Exception type: ((exceptionType))
 
-Note: ((exceptionNote))
+Recorded note: ((exceptionNote))
 
 Stripe event ID: ((stripeEventId))
 
 ---
 
-Review in the reconciliation dashboard:
+Review the exception in the reconciliation dashboard:
 
 ((reconciliationDashboardUrl))
 
-SODC Ops
+Kind regards,
+
+SODC Admin

--- a/functions/src/__tests__/emailTemplateToneContracts.test.ts
+++ b/functions/src/__tests__/emailTemplateToneContracts.test.ts
@@ -34,6 +34,13 @@ const MEMBER_TEMPLATES = [
   ...ACCOUNT_ACTION_TEMPLATES,
 ] as const;
 
+const INTERNAL_TEMPLATES = [
+  "guestTicketRequestSubmittedModerator",
+  "newUserPendingApprovalAlert",
+  "paymentReconciliationExceptionAlert",
+  "paymentDisputeOpsAlert",
+] as const;
+
 describe("member email tone contract (#476)", () => {
   it.each(MEMBER_TEMPLATES)("uses the automated sign-off in %s", (templateKey) => {
     expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).toMatch(
@@ -65,5 +72,45 @@ describe("member email tone contract (#476)", () => {
     expect(variables).toEqual(
       expect.arrayContaining(["eventTitle", "eventDateTime", "eventLocation"]),
     );
+  });
+});
+
+describe("internal email tone contract (#477)", () => {
+  it.each(INTERNAL_TEMPLATES)("uses the common subject prefix in %s", (templateKey) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].subject).toMatch(/^\[SODC\] /);
+  });
+
+  it.each(INTERNAL_TEMPLATES)("uses the automated sign-off in %s", (templateKey) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).toMatch(
+      /Kind regards,\n\nSODC Admin$/,
+    );
+  });
+
+  it.each(INTERNAL_TEMPLATES)("does not invite a reply in %s", (templateKey) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).not.toMatch(
+      /\brepl(?:y|ies|ied|ying)\b/i,
+    );
+  });
+
+  it("keeps member personal data out of the pending-approval subject", () => {
+    const subject = EMAIL_TEMPLATE_MANIFEST.newUserPendingApprovalAlert.subject;
+    expect(subject).not.toMatch(/\(\((firstName|lastName|email)\)\)/);
+  });
+
+  it.each([
+    ["guestTicketRequestSubmittedModerator", "moderationUrl"],
+    ["newUserPendingApprovalAlert", "approveUsersUrl"],
+    ["paymentReconciliationExceptionAlert", "reconciliationDashboardUrl"],
+    ["paymentDisputeOpsAlert", "reconciliationDashboardUrl"],
+  ] as const)("retains the remediation link in %s", (templateKey, linkVariable) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].variables).toContain(linkVariable);
+  });
+
+  it.each([
+    "paymentReconciliationExceptionAlert",
+    "paymentDisputeOpsAlert",
+  ] as const)("uses member rather than customer wording in %s", (templateKey) => {
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).toContain("Member: ((customerDisplay))");
+    expect(EMAIL_TEMPLATE_MANIFEST[templateKey].body).not.toContain("Customer:");
   });
 });

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -88,7 +88,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     body: "Hello ((firstName)),\n\nUnfortunately, your request for guest places at ((eventTitle)) was not approved.\n\nDate and time: ((eventDateTime))\n\nLocation: ((eventLocation))\n\nGuest: ((guestDisplayName))\n\nGuest places requested: ((requestedGuestCount))\n\nNote from organiser: ((moderatorNote))\n\nView your booking:\n\n((myBookingsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   guestTicketRequestSubmittedModerator: {
-    subject: "Guest ticket request — ((eventTitle))",
+    subject: "[SODC] Guest ticket request — ((eventTitle))",
     variables: [
     "eventTitle",
     "sectionName",
@@ -99,7 +99,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "dietaryNote",
     "moderationUrl"
     ],
-    body: "A guest ticket request has been submitted for your review.\n\nEvent: ((eventTitle))\n\nSection: ((sectionName))\n\nRequested by: ((bookerDisplay))\n\nGuest name: ((guestDisplayName))\n\nGuest count: ((requestedGuestCount))\n\nTicket type: ((guestTicketTypeTitle))\n\nDietary note: ((dietaryNote))\n\n---\n\nReview and approve or decline this request in the admin panel:\n\n((moderationUrl))\n\nSODC",
+    body: "A guest ticket request is ready for review.\n\nEvent: ((eventTitle))\n\nSection: ((sectionName))\n\nRequested by: ((bookerDisplay))\n\nGuest: ((guestDisplayName))\n\nPlaces requested: ((requestedGuestCount))\n\nTicket type: ((guestTicketTypeTitle))\n\nDietary requirements: ((dietaryNote))\n\n---\n\nReview the request in SODC:\n\n((moderationUrl))\n\nKind regards,\n\nSODC Admin",
   },
   membershipAccessRestricted: {
     subject: "Your SODC membership status has changed",
@@ -122,7 +122,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     body: "Hello ((firstName)),\n\nWe are pleased to confirm that your SODC membership is now active. Your membership status is ((membershipStatusLabel)).\n\nYou can now access sections, view upcoming events, and make bookings.\n\nSign in to get started:\n\n((appUrl))\n\nYou can review your profile and communication preferences here:\n\n((profileUrl))\n\nWelcome to SODC.\n\nKind regards,\n\nSODC Admin",
   },
   newUserPendingApprovalAlert: {
-    subject: "[SODC] New member awaiting approval — ((firstName)) ((lastName))",
+    subject: "[SODC] New member awaiting approval",
     variables: [
     "firstName",
     "lastName",
@@ -132,7 +132,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "requestedMembershipStatus",
     "approveUsersUrl"
     ],
-    body: "A new member has completed their profile and is awaiting approval.\n\nName: ((firstName)) ((lastName))\nEmail: ((email))\nService number: ((serviceNumber))\nService background: ((serviceBackgroundSummary))\nRequested status: ((requestedMembershipStatus))\n\nReview in Approve Users:\n((approveUsersUrl))",
+    body: "A new member has completed their profile and is ready for review.\n\nName: ((firstName)) ((lastName))\n\nEmail: ((email))\n\nService number: ((serviceNumber))\n\nService background: ((serviceBackgroundSummary))\n\nRequested status: ((requestedMembershipStatus))\n\n---\n\nReview the member in Approve Users:\n\n((approveUsersUrl))\n\nKind regards,\n\nSODC Admin",
   },
   passwordReset: {
     subject: "Reset your SODC password",
@@ -142,7 +142,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     body: "Hello,\n\nWe received a request to reset the password for your SODC account.\n\nUse this secure link to choose a new password:\n\n((resetLink))\n\nIf you did not request this, you can ignore this email. Your password will not change.\n\nKind regards,\n\nSODC Admin",
   },
   paymentDisputeOpsAlert: {
-    subject: "[SODC OPS] Payment dispute — ((orderId))",
+    subject: "[SODC] Payment dispute — ((orderId))",
     variables: [
     "orderId",
     "eventTitle",
@@ -155,10 +155,10 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "reconciliationDashboardUrl",
     "stripeEventId"
     ],
-    body: "A payment dispute event has been received.\n\nOrder ID: ((orderId))\n\nEvent: ((eventTitle))\n\nCustomer: ((customerDisplay))\n\nDispute ID: ((stripeDisputeId))\n\nStripe status: ((disputeStripeStatus))\n\nReason: ((disputeReason))\n\nLocal state: ((disputeLocalState))\n\nStripe event type: ((stripeEventType))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+    body: "A Stripe payment dispute needs review.\n\nTicket order ID: ((orderId))\n\nEvent: ((eventTitle))\n\nMember: ((customerDisplay))\n\nStripe dispute ID: ((stripeDisputeId))\n\nStripe dispute status: ((disputeStripeStatus))\n\nStripe dispute reason: ((disputeReason))\n\nSODC dispute state: ((disputeLocalState))\n\nStripe event type: ((stripeEventType))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview the dispute in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nKind regards,\n\nSODC Admin",
   },
   paymentReconciliationExceptionAlert: {
-    subject: "[SODC OPS] Reconciliation exception — ((orderId))",
+    subject: "[SODC] Payment reconciliation exception — ((orderId))",
     variables: [
     "orderId",
     "eventTitle",
@@ -168,7 +168,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "reconciliationDashboardUrl",
     "stripeEventId"
     ],
-    body: "A payment reconciliation exception requires your attention.\n\nOrder ID: ((orderId))\n\nEvent: ((eventTitle))\n\nCustomer: ((customerDisplay))\n\nException type: ((exceptionType))\n\nNote: ((exceptionNote))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nSODC Ops",
+    body: "A payment reconciliation exception needs review.\n\nTicket order ID: ((orderId))\n\nEvent: ((eventTitle))\n\nMember: ((customerDisplay))\n\nException type: ((exceptionType))\n\nRecorded note: ((exceptionNote))\n\nStripe event ID: ((stripeEventId))\n\n---\n\nReview the exception in the reconciliation dashboard:\n\n((reconciliationDashboardUrl))\n\nKind regards,\n\nSODC Admin",
   },
   ticketOrderFailed: {
     subject: "Payment unsuccessful — ((eventTitle))",


### PR DESCRIPTION
Closes #477.

## What changed

- standardise the four moderator and operations email subjects with the `[SODC]` prefix
- remove member names from the pending-approval subject while retaining the authorised review detail in the body
- make visible labels and remediation-link wording consistent, including using “Member” rather than “Customer”
- apply the exact automated `Kind regards, SODC Admin` sign-off to all four templates
- update the generated manifest, operator documentation and tone/privacy contract tests

## Impact

Internal recipients receive concise, consistently structured alerts while preserving the identifiers, member context and links needed to complete moderation and payment-operations work. Member personal details no longer appear in the pending-approval email subject.

The repository Markdown templates remain the source of truth and will need to be synchronised into GOV.UK Notify under #478.

## Validation

- Functions: 75 test files, 798 tests
- Application: 88 test files, 720 tests
- Functions and application builds
- Root and Functions ESLint
- `git diff --check`
