### PR TITLE
Align generated Data Connect SDK output

### DIFF
--- a/src/dataconnect-generated/.guides/usage.md
+++ b/src/dataconnect-generated/.guides/usage.md
@@ -87,13 +87,13 @@ const { data } = await CreateGovNotifyDeliveryConfiguration(dataConnect);
 // Operation ChangeGovNotifyDeliveryMode:  For variables, look at type ChangeGovNotifyDeliveryModeVars in ../index.d.ts
 const { data } = await ChangeGovNotifyDeliveryMode(dataConnect, changeGovNotifyDeliveryModeVars);
 
-// Operation GetNotifyReplyToConfiguration:
+// Operation GetNotifyReplyToConfiguration: 
 const { data } = await GetNotifyReplyToConfiguration(dataConnect);
 
 // Operation ListNotifyReplyToAudits:  For variables, look at type ListNotifyReplyToAuditsVars in ../index.d.ts
 const { data } = await ListNotifyReplyToAudits(dataConnect, listNotifyReplyToAuditsVars);
 
-// Operation CreateNotifyEmailConfiguration:
+// Operation CreateNotifyEmailConfiguration: 
 const { data } = await CreateNotifyEmailConfiguration(dataConnect);
 
 // Operation CreateNotifyReplyToAddress:  For variables, look at type CreateNotifyReplyToAddressVars in ../index.d.ts

--- a/src/dataconnect-generated/esm/index.esm.js
+++ b/src/dataconnect-generated/esm/index.esm.js
@@ -143,7 +143,7 @@ export const getGovNotifyDeliveryConfigurationRef = (dc) => {
 getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfiguration';
 
 export function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -156,7 +156,7 @@ export const listGovNotifyDeliveryModeAuditsRef = (dcOrVars, vars) => {
 listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAudits';
 
 export function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -193,7 +193,7 @@ export const getNotifyReplyToConfigurationRef = (dc) => {
 getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration';
 
 export function getNotifyReplyToConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -206,7 +206,7 @@ export const listNotifyReplyToAuditsRef = (dcOrVars, vars) => {
 listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 
 export function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2392,3 +2392,4 @@ export function confirmProfileReview(dcOrVars, vars) {
   const { dc: dcInstance, vars: inputVars } = validateArgs(connectorConfig, dcOrVars, vars, true);
   return executeMutation(confirmProfileReviewRef(dcInstance, inputVars));
 }
+

--- a/src/dataconnect-generated/index.cjs.js
+++ b/src/dataconnect-generated/index.cjs.js
@@ -165,7 +165,7 @@ getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfig
 exports.getGovNotifyDeliveryConfigurationRef = getGovNotifyDeliveryConfigurationRef;
 
 exports.getGovNotifyDeliveryConfiguration = function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -180,7 +180,7 @@ listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAud
 exports.listGovNotifyDeliveryModeAuditsRef = listGovNotifyDeliveryModeAuditsRef;
 
 exports.listGovNotifyDeliveryModeAudits = function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -223,7 +223,7 @@ getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration'
 exports.getNotifyReplyToConfigurationRef = getNotifyReplyToConfigurationRef;
 
 exports.getNotifyReplyToConfiguration = function getNotifyReplyToConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -238,7 +238,7 @@ listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 exports.listNotifyReplyToAuditsRef = listNotifyReplyToAuditsRef;
 
 exports.listNotifyReplyToAudits = function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }


### PR DESCRIPTION
## What changed

- record the exact frontend Data Connect SDK output produced by the Firebase generator used in the deployment workflow

## Why

PR #481 included manually normalised whitespace in three generated files. A fresh `firebase dataconnect:sdk:generate` therefore changed the reviewed checkout, causing the guarded deployment command to stop at generated-drift validation. A second attempt then stopped at the initial clean-checkout guard.

This change restores generator reproducibility without bypassing either deployment safety check.

## Validation

- `npx firebase dataconnect:sdk:generate --project dev` leaves both generated SDK directories unchanged
- deployment workflow tests: 8 passed
- application build passed
- Functions build passed
