### PR TITLE
Fix deployment-check false positives for Cloud Run job/service

### DIFF
--- a/config/deployment-check.json
+++ b/config/deployment-check.json
@@ -106,21 +106,24 @@
       "viteMode": "development",
       "hostingSite": "sodc-web",
       "hostingUrl": "https://sodc-web.web.app",
-      "storageBucket": "sodc-web.firebasestorage.app"
+      "storageBucket": "sodc-web.firebasestorage.app",
+      "requireCloudSqlResilience": false
     },
     "beta": {
       "projectId": "sodc-web-beta",
       "viteMode": "staging",
       "hostingSite": "sodc-web-beta",
       "hostingUrl": "https://sodc-web-beta.web.app",
-      "storageBucket": "sodc-web-beta.firebasestorage.app"
+      "storageBucket": "sodc-web-beta.firebasestorage.app",
+      "requireCloudSqlResilience": true
     },
     "prod": {
       "projectId": "sodc-web-production",
       "viteMode": "production",
       "hostingSite": "sodc-web-production",
       "hostingUrl": "https://sodc-web-production.web.app",
-      "storageBucket": "sodc-web-production.firebasestorage.app"
+      "storageBucket": "sodc-web-production.firebasestorage.app",
+      "requireCloudSqlResilience": true
     }
   }
 }

--- a/docs/operations/deployment-checks.md
+++ b/docs/operations/deployment-checks.md
@@ -46,6 +46,10 @@ tokens, signed URLs, or raw log messages.
 - the expected Data Connect service and `api` connector exist;
 - the declared Cloud SQL instance/database use the expected region and have
   automated backups, point-in-time recovery, and deletion protection enabled;
+  this is a hard failure on Beta and Prod, and a warning-only check on Dev per
+  each environment's `requireCloudSqlResilience` flag in
+  `config/deployment-check.json` — Dev data is disposable and does not warrant
+  the backup-storage cost;
 - the expected Hosting site exists;
 - every Function exported from `functions/src` is deployed, Gen 2, `ACTIVE`,
   and in `europe-west2`; unexpected Functions are reported as warnings;

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -71,7 +71,14 @@ function values(value) {
 function resourceNames(items) {
   return items.map((item) =>
     normalizeResourceName(
-      item.name ?? item.id ?? item.projectId ?? item.site ?? item.siteId ?? item.service ?? item.appId
+      item.name ??
+        item.metadata?.name ??
+        item.id ??
+        item.projectId ??
+        item.site ??
+        item.siteId ??
+        item.service ??
+        item.appId
     )
   );
 }
@@ -267,6 +274,7 @@ async function main() {
     id: "cloud-sql",
     label: "Cloud SQL resilience audit failed",
     command: "gcloud",
+    optional: !target.requireCloudSqlResilience,
     args: [
       "sql",
       "instances",


### PR DESCRIPTION
## Summary
- `resourceNames()` in `scripts/deployment-check.mjs` only read `item.name`, but `gcloud run jobs/services list` returns Knative-style objects with the name at `item.metadata.name`. This made the definitions-job and malware-scanner checks always report "missing" even though both are deployed and healthy — confirmed directly against the `sodc-web` (dev) project.
- The Cloud SQL resilience check (region/backups/PITR/deletion protection) is now warning-only on dev via a new `requireCloudSqlResilience` flag per environment in `config/deployment-check.json`. Dev data is disposable and the team doesn't want the backup-storage cost there; the check remains a hard failure on beta/prod.
- Documented the dev/beta/prod distinction in `docs/operations/deployment-checks.md`.

## Test plan
- [x] `npx vitest run scripts/` passes
- [x] `node scripts/deployment-check.mjs --env dev` re-run against the live `sodc-web` project: Cloud Run job/service checks now `[PASS]`, Cloud SQL resilience is `[WARN]` (was `[FAIL]`), overall `0 failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)