### PR TITLE
Fix reply-to admin UI: reason-field confusion and address lookup failures

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -163,7 +163,7 @@ mutation CreateNotifyReplyToAddress(
   $emailAddress: String!
   $notifyUuid: String!
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $newValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
   notifyReplyToAddress_insert(data: {
@@ -193,7 +193,7 @@ mutation UpdateNotifyReplyToAddressIdentity(
   $emailAddress: String!
   $notifyUuid: String!
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String!
   $newValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
@@ -232,7 +232,7 @@ mutation RecordNotifyReplyToProviderAcceptance(
   $providerNotificationId: String!
   $verificationMode: GovNotifyDeliveryMode!
   $changedBy: String!
-  $reason: String!
+  $reason: String
 ) @auth(level: NO_ACCESS) @transaction {
   changed: notifyReplyToAddress_updateMany(
     where: { id: { eq: $id }, version: { eq: $expectedVersion } }
@@ -263,7 +263,7 @@ mutation ConfirmNotifyReplyToVerification(
   $id: UUID!
   $expectedVersion: Int!
   $changedBy: String!
-  $reason: String!
+  $reason: String
 ) @auth(level: NO_ACCESS) @transaction {
   changed: notifyReplyToAddress_updateMany(
     where: {
@@ -294,7 +294,7 @@ mutation UpdateNotifyReplyToAvailability(
   $enabled: Boolean!
   $announcementSelectable: Boolean!
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String!
   $newValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
@@ -327,7 +327,7 @@ mutation ChangeNotifyReplyToDefault(
   $previousAddressId: UUID
   $newAddressId: UUID
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String
   $newValue: String
 ) @auth(level: NO_ACCESS) @transaction {
@@ -360,7 +360,7 @@ mutation DisableDefaultNotifyReplyToAddress(
   $expectedConfigurationVersion: Int!
   $replacementAddressId: UUID
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
   addressChanged: notifyReplyToAddress_updateMany(
@@ -403,7 +403,7 @@ mutation SetNotifyTemplateReplyToOverride(
   $templateKey: String!
   $replyToAddressId: UUID!
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String
   $newValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
@@ -427,7 +427,7 @@ mutation SetNotifyTemplateReplyToOverride(
 mutation ClearNotifyTemplateReplyToOverride(
   $templateKey: String!
   $changedBy: String!
-  $reason: String!
+  $reason: String
   $previousValue: String!
 ) @auth(level: NO_ACCESS) @transaction {
   notifyTemplateReplyToOverride_delete(key: { templateKey: $templateKey })

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -171,7 +171,8 @@ type NotifyReplyToAudit @table {
   previousValue: String
   newValue: String
   changedBy: String!
-  reason: String!
+  # Optional: only the site-wide delivery mode audit requires a reason.
+  reason: String
   changedAt: Timestamp! @default(expr: "request.time")
 }
 

--- a/docs/operations/govuk-notify-email-reply-to.md
+++ b/docs/operations/govuk-notify-email-reply-to.md
@@ -55,7 +55,9 @@ the deployment.
 1. In the target site's admin area, open **Email delivery**.
 2. Under **Reply-to addresses**, enter the display label, visible email address,
    and the environment's Notify reply-to UUID.
-3. Enter an audit reason and add the address. It starts disabled and unverified.
+3. Select **Add address**. It starts disabled and unverified. Only the
+   site-wide delivery mode change requires an audit reason; reply-to actions
+   are still recorded in "Recent reply-to changes" by who and when, without one.
 4. Set the site email mode to **Team test** or **Live**, then select **Send test**.
    The test goes only to the signed-in administrator's verified account email.
 5. Open the delivered message and inspect its `Reply-To` header. Confirm that it

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -331,7 +331,7 @@ export interface ChangeNotifyReplyToDefaultVariables {
   previousAddressId?: UUIDString | null;
   newAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue?: string | null;
 }
@@ -379,7 +379,7 @@ export interface ClearNotifyTemplateReplyToOverrideData {
 export interface ClearNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 
@@ -392,7 +392,7 @@ export interface ConfirmNotifyReplyToVerificationVariables {
   id: UUIDString;
   expectedVersion: number;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 
 export interface ConfirmProfileReviewData {
@@ -661,7 +661,7 @@ export interface CreateNotifyReplyToAddressVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   newValue: string;
 }
 
@@ -854,7 +854,7 @@ export interface DisableDefaultNotifyReplyToAddressVariables {
   expectedConfigurationVersion: number;
   replacementAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 
@@ -2524,7 +2524,7 @@ export interface ListNotifyReplyToAuditsData {
     previousValue?: string | null;
     newValue?: string | null;
     changedBy: string;
-    reason: string;
+    reason?: string | null;
     changedAt: TimestampString;
   } & NotifyReplyToAudit_Key)[];
 }
@@ -2947,7 +2947,7 @@ export interface RecordNotifyReplyToProviderAcceptanceVariables {
   providerNotificationId: string;
   verificationMode: GovNotifyDeliveryMode;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 
 export interface RecordSectionFileAuditData {
@@ -3043,7 +3043,7 @@ export interface SetNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   replyToAddressId: UUIDString;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue: string;
 }
@@ -3228,7 +3228,7 @@ export interface UpdateNotifyReplyToAddressIdentityVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -3244,7 +3244,7 @@ export interface UpdateNotifyReplyToAvailabilityVariables {
   enabled: boolean;
   announcementSelectable: boolean;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }

--- a/functions/src/notifyReplyToAdmin.ts
+++ b/functions/src/notifyReplyToAdmin.ts
@@ -79,7 +79,9 @@ function addressValue(address: Address): string {
 
 function requireAddress(configuration: Configuration, idValue: unknown): Address {
   const id = validateUUID(requireString(idValue, "addressId"), "addressId");
-  const address = configuration.notifyReplyToAddresses.find((candidate) => candidate.id === id);
+  const address = configuration.notifyReplyToAddresses.find(
+    (candidate) => validateUUID(candidate.id, "addressId") === id
+  );
   if (!address) throw new HttpsError("not-found", "Reply-to address not found");
   return address;
 }

--- a/functions/src/notifyReplyToAdmin.ts
+++ b/functions/src/notifyReplyToAdmin.ts
@@ -36,7 +36,6 @@ import { getGovNotifyEmailReplyToId } from "./govNotifyReplyToId";
 import { enforceRateLimit } from "./rateLimiter";
 
 const AUDIT_LIMIT = 50;
-const REASON_MIN_LENGTH = 5;
 const APP_BASE_URL = (process.env.APP_BASE_URL || "http://localhost:5173").replace(/\/$/, "");
 
 type Configuration = Awaited<ReturnType<typeof getOrCreateNotifyReplyToConfiguration>>;
@@ -51,8 +50,12 @@ export interface NotifyReplyToAdminConfiguration {
   audits: Awaited<ReturnType<typeof listNotifyReplyToAudits>>["data"]["notifyReplyToAudits"];
 }
 
-function reason(value: unknown): string {
-  return validateStringLength(requireString(value, "reason"), "reason", 500, REASON_MIN_LENGTH);
+// Reply-to actions do not require a reason; only the site-wide delivery mode
+// audit (functions/src/govNotifyDeliveryAdmin.ts) does.
+function optionalReason(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? validateStringLength(trimmed, "reason", 500, 0) : undefined;
 }
 
 function expectedVersion(value: unknown, fieldName = "expectedVersion"): number {
@@ -138,7 +141,7 @@ export const createNotifyReplyToAddress = onCall(
       emailAddress,
       notifyUuid,
       changedBy: request.auth!.uid,
-      reason: reason(request.data?.reason),
+      reason: optionalReason(request.data?.reason),
       newValue: JSON.stringify({ id, displayLabel, emailAddress, notifyUuid }),
     });
     return readAdminConfiguration();
@@ -164,7 +167,7 @@ export const updateNotifyReplyToAddress = onCall(
       emailAddress,
       notifyUuid,
       changedBy: request.auth!.uid,
-      reason: reason(request.data?.reason),
+      reason: optionalReason(request.data?.reason),
       previousValue: addressValue(address),
       newValue: JSON.stringify({ id: address.id, displayLabel, emailAddress, notifyUuid }),
     });
@@ -181,7 +184,7 @@ export const sendNotifyReplyToVerificationTest = onCall(
     const configuration = await getOrCreateNotifyReplyToConfiguration();
     const address = requireAddress(configuration, request.data?.addressId);
     const version = expectedVersion(request.data?.expectedVersion);
-    const changeReason = reason(request.data?.reason);
+    const changeReason = optionalReason(request.data?.reason);
     if (address.version !== version) throw new HttpsError("aborted", "Reply-to address changed; reload and try again");
     const adminEmail = request.auth!.token.email;
     if (typeof adminEmail !== "string" || request.auth!.token.email_verified !== true) {
@@ -230,7 +233,7 @@ export const confirmNotifyReplyToVerification = onCall(
       id: address.id,
       expectedVersion: expectedVersion(request.data?.expectedVersion),
       changedBy: request.auth!.uid,
-      reason: reason(request.data?.reason),
+      reason: optionalReason(request.data?.reason),
     });
     assertChanged(result.data.changed, "Reply-to address changed; reload and try again");
     return readAdminConfiguration();
@@ -244,7 +247,7 @@ export const updateNotifyReplyToAvailability = onCall(
     const configuration = await getOrCreateNotifyReplyToConfiguration();
     const address = requireAddress(configuration, request.data?.addressId);
     const version = expectedVersion(request.data?.expectedVersion);
-    const changeReason = reason(request.data?.reason);
+    const changeReason = optionalReason(request.data?.reason);
     const enabled = request.data?.enabled === true;
     const announcementSelectable = enabled && request.data?.announcementSelectable === true;
     if (enabled && address.verificationStatus !== "VERIFIED") {
@@ -304,7 +307,7 @@ export const changeNotifyReplyToDefault = onCall(
       previousAddressId,
       newAddressId,
       changedBy: request.auth!.uid,
-      reason: reason(request.data?.reason),
+      reason: optionalReason(request.data?.reason),
       previousValue: JSON.stringify({ addressId: previousAddressId }),
       newValue: JSON.stringify({ addressId: newAddressId }),
     });
@@ -321,7 +324,7 @@ export const setNotifyTemplateReplyToOverride = onCall(
     if (!EMAIL_TEMPLATE_MANIFEST[templateKey]) throw new HttpsError("invalid-argument", "Unknown automated email template");
     const configuration = await getOrCreateNotifyReplyToConfiguration();
     const existing = configuration.notifyTemplateReplyToOverrides.find((row) => row.templateKey === templateKey);
-    const changeReason = reason(request.data?.reason);
+    const changeReason = optionalReason(request.data?.reason);
     if (!request.data?.addressId) {
       if (!existing) throw new HttpsError("failed-precondition", "This template already uses the system default");
       await dcClearOverride({

--- a/functions/src/notifyReplyToConfiguration.ts
+++ b/functions/src/notifyReplyToConfiguration.ts
@@ -5,6 +5,7 @@ import {
   type GetNotifyReplyToConfigurationData,
 } from "@dataconnect/admin-generated";
 import { getGovNotifyEmailReplyToId } from "./govNotifyReplyToId";
+import { validateUUID } from "./helpers";
 
 type ConfigurationData = GetNotifyReplyToConfigurationData;
 type AddressRow = ConfigurationData["notifyReplyToAddresses"][number];
@@ -124,8 +125,9 @@ export async function resolveNotifyReplyToForAnnouncement(
 ): Promise<ResolvedNotifyReplyTo> {
   const configuration = await getOrCreateNotifyReplyToConfiguration();
   if (selectedAddressId) {
+    const normalizedSelectedAddressId = validateUUID(selectedAddressId, "replyToAddressId");
     const selected = configuration.notifyReplyToAddresses.find(
-      (address) => address.id === selectedAddressId,
+      (address) => validateUUID(address.id, "replyToAddressId") === normalizedSelectedAddressId,
     );
     if (!isUsable(selected) || !selected.announcementSelectable) {
       throw new NotifyReplyToSelectionError(

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -657,7 +657,7 @@ export interface ListNotifyReplyToAuditsData {
     previousValue?: string | null;
     newValue?: string | null;
     changedBy: string;
-    reason: string;
+    reason?: string | null;
     changedAt: TimestampString;
   } & NotifyReplyToAudit_Key)[];
 }
@@ -9747,7 +9747,7 @@ export interface CreateNotifyReplyToAddressVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   newValue: string;
 }
 ```
@@ -9774,7 +9774,7 @@ const createNotifyReplyToAddressVars: CreateNotifyReplyToAddressVariables = {
   emailAddress: ..., 
   notifyUuid: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   newValue: ..., 
 };
 
@@ -9812,7 +9812,7 @@ const createNotifyReplyToAddressVars: CreateNotifyReplyToAddressVariables = {
   emailAddress: ..., 
   notifyUuid: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   newValue: ..., 
 };
 
@@ -9880,7 +9880,7 @@ export interface UpdateNotifyReplyToAddressIdentityVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -9909,7 +9909,7 @@ const updateNotifyReplyToAddressIdentityVars: UpdateNotifyReplyToAddressIdentity
   emailAddress: ..., 
   notifyUuid: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
   newValue: ..., 
 };
@@ -9949,7 +9949,7 @@ const updateNotifyReplyToAddressIdentityVars: UpdateNotifyReplyToAddressIdentity
   emailAddress: ..., 
   notifyUuid: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
   newValue: ..., 
 };
@@ -10017,7 +10017,7 @@ export interface RecordNotifyReplyToProviderAcceptanceVariables {
   providerNotificationId: string;
   verificationMode: GovNotifyDeliveryMode;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 ```
 ### Return Type
@@ -10043,7 +10043,7 @@ const recordNotifyReplyToProviderAcceptanceVars: RecordNotifyReplyToProviderAcce
   providerNotificationId: ..., 
   verificationMode: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
 };
 
 // Call the `recordNotifyReplyToProviderAcceptance()` function to execute the mutation.
@@ -10080,7 +10080,7 @@ const recordNotifyReplyToProviderAcceptanceVars: RecordNotifyReplyToProviderAcce
   providerNotificationId: ..., 
   verificationMode: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
 };
 
 // Call the `recordNotifyReplyToProviderAcceptanceRef()` function to get a reference to the mutation.
@@ -10144,7 +10144,7 @@ export interface ConfirmNotifyReplyToVerificationVariables {
   id: UUIDString;
   expectedVersion: number;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 ```
 ### Return Type
@@ -10168,7 +10168,7 @@ const confirmNotifyReplyToVerificationVars: ConfirmNotifyReplyToVerificationVari
   id: ..., 
   expectedVersion: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
 };
 
 // Call the `confirmNotifyReplyToVerification()` function to execute the mutation.
@@ -10203,7 +10203,7 @@ const confirmNotifyReplyToVerificationVars: ConfirmNotifyReplyToVerificationVari
   id: ..., 
   expectedVersion: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
 };
 
 // Call the `confirmNotifyReplyToVerificationRef()` function to get a reference to the mutation.
@@ -10269,7 +10269,7 @@ export interface UpdateNotifyReplyToAvailabilityVariables {
   enabled: boolean;
   announcementSelectable: boolean;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -10297,7 +10297,7 @@ const updateNotifyReplyToAvailabilityVars: UpdateNotifyReplyToAvailabilityVariab
   enabled: ..., 
   announcementSelectable: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
   newValue: ..., 
 };
@@ -10336,7 +10336,7 @@ const updateNotifyReplyToAvailabilityVars: UpdateNotifyReplyToAvailabilityVariab
   enabled: ..., 
   announcementSelectable: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
   newValue: ..., 
 };
@@ -10403,7 +10403,7 @@ export interface ChangeNotifyReplyToDefaultVariables {
   previousAddressId?: UUIDString | null;
   newAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue?: string | null;
 }
@@ -10430,7 +10430,7 @@ const changeNotifyReplyToDefaultVars: ChangeNotifyReplyToDefaultVariables = {
   previousAddressId: ..., // optional
   newAddressId: ..., // optional
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., // optional
   newValue: ..., // optional
 };
@@ -10468,7 +10468,7 @@ const changeNotifyReplyToDefaultVars: ChangeNotifyReplyToDefaultVariables = {
   previousAddressId: ..., // optional
   newAddressId: ..., // optional
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., // optional
   newValue: ..., // optional
 };
@@ -10536,7 +10536,7 @@ export interface DisableDefaultNotifyReplyToAddressVariables {
   expectedConfigurationVersion: number;
   replacementAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 ```
@@ -10564,7 +10564,7 @@ const disableDefaultNotifyReplyToAddressVars: DisableDefaultNotifyReplyToAddress
   expectedConfigurationVersion: ..., 
   replacementAddressId: ..., // optional
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
 };
 
@@ -10604,7 +10604,7 @@ const disableDefaultNotifyReplyToAddressVars: DisableDefaultNotifyReplyToAddress
   expectedConfigurationVersion: ..., 
   replacementAddressId: ..., // optional
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
 };
 
@@ -10671,7 +10671,7 @@ export interface SetNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   replyToAddressId: UUIDString;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue: string;
 }
@@ -10697,7 +10697,7 @@ const setNotifyTemplateReplyToOverrideVars: SetNotifyTemplateReplyToOverrideVari
   templateKey: ..., 
   replyToAddressId: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., // optional
   newValue: ..., 
 };
@@ -10734,7 +10734,7 @@ const setNotifyTemplateReplyToOverrideVars: SetNotifyTemplateReplyToOverrideVari
   templateKey: ..., 
   replyToAddressId: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., // optional
   newValue: ..., 
 };
@@ -10799,7 +10799,7 @@ The `ClearNotifyTemplateReplyToOverride` mutation requires an argument of type `
 export interface ClearNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 ```
@@ -10823,7 +10823,7 @@ import { connectorConfig, clearNotifyTemplateReplyToOverride, ClearNotifyTemplat
 const clearNotifyTemplateReplyToOverrideVars: ClearNotifyTemplateReplyToOverrideVariables = {
   templateKey: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
 };
 
@@ -10858,7 +10858,7 @@ import { connectorConfig, clearNotifyTemplateReplyToOverrideRef, ClearNotifyTemp
 const clearNotifyTemplateReplyToOverrideVars: ClearNotifyTemplateReplyToOverrideVariables = {
   templateKey: ..., 
   changedBy: ..., 
-  reason: ..., 
+  reason: ..., // optional
   previousValue: ..., 
 };
 

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -352,7 +352,7 @@ export interface ChangeNotifyReplyToDefaultVariables {
   previousAddressId?: UUIDString | null;
   newAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue?: string | null;
 }
@@ -400,7 +400,7 @@ export interface ClearNotifyTemplateReplyToOverrideData {
 export interface ClearNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 
@@ -413,7 +413,7 @@ export interface ConfirmNotifyReplyToVerificationVariables {
   id: UUIDString;
   expectedVersion: number;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 
 export interface ConfirmProfileReviewData {
@@ -682,7 +682,7 @@ export interface CreateNotifyReplyToAddressVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   newValue: string;
 }
 
@@ -875,7 +875,7 @@ export interface DisableDefaultNotifyReplyToAddressVariables {
   expectedConfigurationVersion: number;
   replacementAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 
@@ -2545,7 +2545,7 @@ export interface ListNotifyReplyToAuditsData {
     previousValue?: string | null;
     newValue?: string | null;
     changedBy: string;
-    reason: string;
+    reason?: string | null;
     changedAt: TimestampString;
   } & NotifyReplyToAudit_Key)[];
 }
@@ -2968,7 +2968,7 @@ export interface RecordNotifyReplyToProviderAcceptanceVariables {
   providerNotificationId: string;
   verificationMode: GovNotifyDeliveryMode;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 
 export interface RecordSectionFileAuditData {
@@ -3064,7 +3064,7 @@ export interface SetNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   replyToAddressId: UUIDString;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue: string;
 }
@@ -3249,7 +3249,7 @@ export interface UpdateNotifyReplyToAddressIdentityVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -3265,7 +3265,7 @@ export interface UpdateNotifyReplyToAvailabilityVariables {
   enabled: boolean;
   announcementSelectable: boolean;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -616,7 +616,7 @@ export interface ListNotifyReplyToAuditsData {
     previousValue?: string | null;
     newValue?: string | null;
     changedBy: string;
-    reason: string;
+    reason?: string | null;
     changedAt: TimestampString;
   } & NotifyReplyToAudit_Key)[];
 }
@@ -7797,7 +7797,7 @@ export interface CreateNotifyReplyToAddressVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   newValue: string;
 }
 ```
@@ -7854,7 +7854,7 @@ export default function CreateNotifyReplyToAddressComponent() {
     emailAddress: ..., 
     notifyUuid: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     newValue: ..., 
   };
   mutation.mutate(createNotifyReplyToAddressVars);
@@ -7906,7 +7906,7 @@ export interface UpdateNotifyReplyToAddressIdentityVariables {
   emailAddress: string;
   notifyUuid: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -7965,7 +7965,7 @@ export default function UpdateNotifyReplyToAddressIdentityComponent() {
     emailAddress: ..., 
     notifyUuid: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., 
     newValue: ..., 
   };
@@ -8017,7 +8017,7 @@ export interface RecordNotifyReplyToProviderAcceptanceVariables {
   providerNotificationId: string;
   verificationMode: GovNotifyDeliveryMode;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 ```
 ### Return Type
@@ -8073,7 +8073,7 @@ export default function RecordNotifyReplyToProviderAcceptanceComponent() {
     providerNotificationId: ..., 
     verificationMode: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
   };
   mutation.mutate(recordNotifyReplyToProviderAcceptanceVars);
   // Variables can be defined inline as well.
@@ -8121,7 +8121,7 @@ export interface ConfirmNotifyReplyToVerificationVariables {
   id: UUIDString;
   expectedVersion: number;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
 }
 ```
 ### Return Type
@@ -8175,7 +8175,7 @@ export default function ConfirmNotifyReplyToVerificationComponent() {
     id: ..., 
     expectedVersion: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
   };
   mutation.mutate(confirmNotifyReplyToVerificationVars);
   // Variables can be defined inline as well.
@@ -8225,7 +8225,7 @@ export interface UpdateNotifyReplyToAvailabilityVariables {
   enabled: boolean;
   announcementSelectable: boolean;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
   newValue: string;
 }
@@ -8283,7 +8283,7 @@ export default function UpdateNotifyReplyToAvailabilityComponent() {
     enabled: ..., 
     announcementSelectable: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., 
     newValue: ..., 
   };
@@ -8334,7 +8334,7 @@ export interface ChangeNotifyReplyToDefaultVariables {
   previousAddressId?: UUIDString | null;
   newAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue?: string | null;
 }
@@ -8391,7 +8391,7 @@ export default function ChangeNotifyReplyToDefaultComponent() {
     previousAddressId: ..., // optional
     newAddressId: ..., // optional
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., // optional
     newValue: ..., // optional
   };
@@ -8443,7 +8443,7 @@ export interface DisableDefaultNotifyReplyToAddressVariables {
   expectedConfigurationVersion: number;
   replacementAddressId?: UUIDString | null;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 ```
@@ -8501,7 +8501,7 @@ export default function DisableDefaultNotifyReplyToAddressComponent() {
     expectedConfigurationVersion: ..., 
     replacementAddressId: ..., // optional
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., 
   };
   mutation.mutate(disableDefaultNotifyReplyToAddressVars);
@@ -8551,7 +8551,7 @@ export interface SetNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   replyToAddressId: UUIDString;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue?: string | null;
   newValue: string;
 }
@@ -8607,7 +8607,7 @@ export default function SetNotifyTemplateReplyToOverrideComponent() {
     templateKey: ..., 
     replyToAddressId: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., // optional
     newValue: ..., 
   };
@@ -8656,7 +8656,7 @@ The `ClearNotifyTemplateReplyToOverride` Mutation requires an argument of type `
 export interface ClearNotifyTemplateReplyToOverrideVariables {
   templateKey: string;
   changedBy: string;
-  reason: string;
+  reason?: string | null;
   previousValue: string;
 }
 ```
@@ -8710,7 +8710,7 @@ export default function ClearNotifyTemplateReplyToOverrideComponent() {
   const clearNotifyTemplateReplyToOverrideVars: ClearNotifyTemplateReplyToOverrideVariables = {
     templateKey: ..., 
     changedBy: ..., 
-    reason: ..., 
+    reason: ..., // optional
     previousValue: ..., 
   };
   mutation.mutate(clearNotifyTemplateReplyToOverrideVars);

--- a/src/features/admin/components/EmailDeliverySettingsPage.tsx
+++ b/src/features/admin/components/EmailDeliverySettingsPage.tsx
@@ -161,7 +161,7 @@ export default function EmailDeliverySettingsPage({ onBack }: Props) {
             </FormControl>
             <TextField
               fullWidth
-              label="Reason for change"
+              label="Reason for delivery mode change"
               value={reason}
               onChange={(event) => setReason(event.target.value)}
               inputProps={{ maxLength: 500 }}

--- a/src/features/admin/components/NotifyReplyToSettings.tsx
+++ b/src/features/admin/components/NotifyReplyToSettings.tsx
@@ -40,7 +40,6 @@ export default function NotifyReplyToSettings() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [reason, setReason] = useState("");
   const [editing, setEditing] = useState<NotifyReplyToAddress | null>(null);
   const [displayLabel, setDisplayLabel] = useState("");
   const [emailAddress, setEmailAddress] = useState("");
@@ -66,7 +65,6 @@ export default function NotifyReplyToSettings() {
       address.enabled && address.verificationStatus === "VERIFIED") ?? [],
     [configuration],
   );
-  const canChange = reason.trim().length >= 5 && !saving;
 
   const run = async (
     label: string,
@@ -76,7 +74,6 @@ export default function NotifyReplyToSettings() {
     setError(null);
     try {
       setConfiguration(await action());
-      setReason("");
     } catch (caught) {
       reportError(`admin.notify-reply-to.${label}`, caught);
       setError(toAdminUserFacingError(caught, "email-configuration").message);
@@ -100,7 +97,6 @@ export default function NotifyReplyToSettings() {
   };
 
   const saveAddress = async () => {
-    if (!canChange) return;
     await run(editing ? "update" : "create", () => editing
       ? updateNotifyReplyToAddress({
         addressId: editing.id,
@@ -108,9 +104,8 @@ export default function NotifyReplyToSettings() {
         displayLabel,
         emailAddress,
         notifyUuid,
-        reason: reason.trim(),
       })
-      : createNotifyReplyToAddress({ displayLabel, emailAddress, notifyUuid, reason: reason.trim() }));
+      : createNotifyReplyToAddress({ displayLabel, emailAddress, notifyUuid }));
     resetForm();
   };
 
@@ -136,15 +131,6 @@ export default function NotifyReplyToSettings() {
                 : "No site-wide default is set; GOV.UK Notify's service default will be used."}
           </Alert>
 
-          <TextField
-            fullWidth
-            label="Reason for change"
-            value={reason}
-            onChange={(event) => setReason(event.target.value)}
-            inputProps={{ maxLength: 500 }}
-            helperText="Required for every change and verification step (at least 5 characters)."
-          />
-
           <Paper variant="outlined" sx={{ p: 3 }}>
             <Typography variant="h6">{editing ? "Edit reply-to address" : "Add reply-to address"}</Typography>
             {editing && (
@@ -159,7 +145,7 @@ export default function NotifyReplyToSettings() {
               <Stack direction="row" spacing={1}>
                 <Button
                   variant="contained"
-                  disabled={!canChange || !displayLabel.trim() || !emailAddress.trim() || !notifyUuid.trim()}
+                  disabled={saving || !displayLabel.trim() || !emailAddress.trim() || !notifyUuid.trim()}
                   onClick={() => void saveAddress()}
                 >
                   {editing ? "Save and reverify" : "Add address"}
@@ -198,41 +184,38 @@ export default function NotifyReplyToSettings() {
                     <Stack direction="row" spacing={1} flexWrap="wrap" alignContent="flex-start">
                       <Button size="small" onClick={() => beginEdit(address)} disabled={saving || isDefault}>Edit</Button>
                       {address.verificationStatus !== "VERIFIED" && (
-                        <Button size="small" disabled={!canChange} onClick={() => void run("test", () => sendNotifyReplyToVerificationTest({
-                          addressId: address.id, expectedVersion: address.version, reason: reason.trim(),
+                        <Button size="small" disabled={saving} onClick={() => void run("test", () => sendNotifyReplyToVerificationTest({
+                          addressId: address.id, expectedVersion: address.version,
                         }))}>Send test</Button>
                       )}
                       {address.verificationStatus === "PROVIDER_ACCEPTED" && (
-                        <Button size="small" variant="outlined" disabled={!canChange} onClick={() => void run("confirm", () => confirmNotifyReplyToVerification({
-                          addressId: address.id, expectedVersion: address.version, reason: reason.trim(),
+                        <Button size="small" variant="outlined" disabled={saving} onClick={() => void run("confirm", () => confirmNotifyReplyToVerification({
+                          addressId: address.id, expectedVersion: address.version,
                         }))}>Confirm Reply-To</Button>
                       )}
                       {address.verificationStatus === "VERIFIED" && (
-                        <Button size="small" disabled={!canChange} onClick={() => void run("availability", () => updateNotifyReplyToAvailability({
+                        <Button size="small" disabled={saving} onClick={() => void run("availability", () => updateNotifyReplyToAvailability({
                           addressId: address.id,
                           expectedVersion: address.version,
                           expectedConfigurationVersion: configuration.configuration.version,
                           enabled: !address.enabled,
                           announcementSelectable: address.enabled ? false : address.announcementSelectable,
                           clearDefault: isDefault && address.enabled,
-                          reason: reason.trim(),
                         }))}>{address.enabled ? "Disable" : "Enable"}</Button>
                       )}
                       {address.enabled && (
-                        <Button size="small" disabled={!canChange} onClick={() => void run("announcement", () => updateNotifyReplyToAvailability({
+                        <Button size="small" disabled={saving} onClick={() => void run("announcement", () => updateNotifyReplyToAvailability({
                           addressId: address.id,
                           expectedVersion: address.version,
                           expectedConfigurationVersion: configuration.configuration.version,
                           enabled: true,
                           announcementSelectable: !address.announcementSelectable,
-                          reason: reason.trim(),
                         }))}>{address.announcementSelectable ? "Remove from announcements" : "Allow for announcements"}</Button>
                       )}
                       {address.enabled && !isDefault && (
-                        <Button size="small" disabled={!canChange} onClick={() => void run("default", () => changeNotifyReplyToDefault({
+                        <Button size="small" disabled={saving} onClick={() => void run("default", () => changeNotifyReplyToDefault({
                           addressId: address.id,
                           expectedVersion: configuration.configuration.version,
-                          reason: reason.trim(),
                         }))}>Make default</Button>
                       )}
                     </Stack>
@@ -245,11 +228,10 @@ export default function NotifyReplyToSettings() {
           {configuration.configuration.defaultAddressId && (
             <Button
               color="warning"
-              disabled={!canChange}
+              disabled={saving}
               onClick={() => void run("clear-default", () => changeNotifyReplyToDefault({
                 clearDefault: true,
                 expectedVersion: configuration.configuration.version,
-                reason: reason.trim(),
               }))}
             >
               Clear system default
@@ -271,11 +253,10 @@ export default function NotifyReplyToSettings() {
                       labelId={`reply-to-${templateKey}`}
                       label={templateKey}
                       value={override?.addressId ?? ""}
-                      disabled={!canChange}
+                      disabled={saving}
                       onChange={(event) => void run("template-override", () => setNotifyTemplateReplyToOverride({
                         templateKey,
                         addressId: event.target.value || undefined,
-                        reason: reason.trim(),
                       }))}
                     >
                       <MenuItem value="">System default</MenuItem>
@@ -302,7 +283,7 @@ export default function NotifyReplyToSettings() {
                     {new Date(audit.changedAt).toLocaleString()} · {audit.changedBy}
                     {audit.templateKey ? ` · ${audit.templateKey}` : ""}
                   </Typography>
-                  <Typography variant="body2">{audit.reason}</Typography>
+                  {audit.reason && <Typography variant="body2">{audit.reason}</Typography>}
                 </Box>
               ))}
           </Paper>

--- a/src/features/admin/components/__tests__/EmailDeliverySettingsPage.test.tsx
+++ b/src/features/admin/components/__tests__/EmailDeliverySettingsPage.test.tsx
@@ -45,7 +45,7 @@ describe("EmailDeliverySettingsPage", () => {
     render(<EmailDeliverySettingsPage onBack={vi.fn()} />);
 
     await user.click(await screen.findByRole("radio", { name: /Team test/ }));
-    await user.type(screen.getByLabelText("Reason for change"), "Team verification");
+    await user.type(screen.getByLabelText("Reason for delivery mode change"), "Team verification");
     await user.click(screen.getByRole("button", { name: "Save delivery mode" }));
 
     expect(screen.getByRole("dialog")).toHaveTextContent("Increase email delivery scope?");

--- a/src/shared/utils/firebaseFunctions/notifyReplyToConfiguration.ts
+++ b/src/shared/utils/firebaseFunctions/notifyReplyToConfiguration.ts
@@ -42,7 +42,7 @@ export interface NotifyReplyToAdminConfiguration {
     previousValue?: string | null;
     newValue?: string | null;
     changedBy: string;
-    reason: string;
+    reason?: string | null;
     changedAt: string;
   }>;
 }
@@ -55,32 +55,32 @@ export const getNotifyReplyToAdminConfiguration = () =>
   call<void, NotifyReplyToAdminConfiguration>("getNotifyReplyToAdminConfiguration", undefined);
 
 export const createNotifyReplyToAddress = (data: {
-  displayLabel: string; emailAddress: string; notifyUuid: string; reason: string;
+  displayLabel: string; emailAddress: string; notifyUuid: string;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("createNotifyReplyToAddress", data);
 
 export const updateNotifyReplyToAddress = (data: {
   addressId: string; expectedVersion: number; displayLabel: string;
-  emailAddress: string; notifyUuid: string; reason: string;
+  emailAddress: string; notifyUuid: string;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("updateNotifyReplyToAddress", data);
 
 export const sendNotifyReplyToVerificationTest = (data: {
-  addressId: string; expectedVersion: number; reason: string;
+  addressId: string; expectedVersion: number;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("sendNotifyReplyToVerificationTest", data);
 
 export const confirmNotifyReplyToVerification = (data: {
-  addressId: string; expectedVersion: number; reason: string;
+  addressId: string; expectedVersion: number;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("confirmNotifyReplyToVerification", data);
 
 export const updateNotifyReplyToAvailability = (data: {
   addressId: string; expectedVersion: number; expectedConfigurationVersion: number;
   enabled: boolean; announcementSelectable: boolean; clearDefault?: boolean;
-  replacementAddressId?: string; reason: string;
+  replacementAddressId?: string;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("updateNotifyReplyToAvailability", data);
 
 export const changeNotifyReplyToDefault = (data: {
-  addressId?: string; clearDefault?: boolean; expectedVersion: number; reason: string;
+  addressId?: string; clearDefault?: boolean; expectedVersion: number;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("changeNotifyReplyToDefault", data);
 
 export const setNotifyTemplateReplyToOverride = (data: {
-  templateKey: string; addressId?: string; reason: string;
+  templateKey: string; addressId?: string;
 }) => call<typeof data, NotifyReplyToAdminConfiguration>("setNotifyTemplateReplyToOverride", data);


### PR DESCRIPTION
## Summary
- Relabelled the two identically-named "Reason for change" fields on the Email delivery admin page so filling in one doesn't leave the other's dependent buttons silently disabled.
- Dropped the reason requirement for reply-to actions entirely (add/verify/enable/default/template override) per operator decision — only the site-wide delivery mode change still requires one. `NotifyReplyToAudit.reason` is now nullable end-to-end (schema, mutations, Functions, frontend).
- Fixed `requireAddress()` and `resolveNotifyReplyToForAnnouncement()` comparing a `validateUUID()`-normalized (hyphenated) client ID against Data Connect's raw compact-hex `NotifyReplyToAddress.id`, which made every address lookup by ID fail with `NOT_FOUND` — breaking Send test, Confirm Reply-To, Enable, Make default, template overrides, and announcement reply-to selection.

Closes #485.

## Test plan
- [x] `npx tsc -b --noEmit` clean
- [x] Frontend and Functions test suites passing
- [x] Deployed to Dev; `npm run deployment:check -- --env dev` passes (0 failed)
- [x] Reproduced the original failures live (Cloud Logging + direct Data Connect query) before fixing, confirmed the deployed fix resolves them

🤖 Generated with [Claude Code](https://claude.com/claude-code)