### PR TITLE
Show accommodation conditionally in booking emails; clarify eligibility

### DIFF
--- a/functions/email-templates/bookingConfirmation.md
+++ b/functions/email-templates/bookingConfirmation.md
@@ -9,7 +9,7 @@ variables:
   - revisionNumber
   - ticketLinesSummary
   - bookerDietaryNote
-  - accommodationSummary
+  - accommodationRequested
   - bookingTotalFormatted
   - sectionBookingsUrl
   - myPaymentsUrl
@@ -34,7 +34,7 @@ Where: ((eventLocation))
 
 Your dietary note: ((bookerDietaryNote))
 
-Accommodation: ((accommodationSummary))
+((accommodationRequested??Accommodation requested — see your booking for details.))
 
 Total: ((bookingTotalFormatted))
 

--- a/functions/email-templates/bookingRevision.md
+++ b/functions/email-templates/bookingRevision.md
@@ -9,7 +9,7 @@ variables:
   - revisionNumber
   - ticketLinesSummary
   - bookerDietaryNote
-  - accommodationSummary
+  - accommodationRequested
   - bookingTotalFormatted
   - sectionBookingsUrl
   - myPaymentsUrl
@@ -40,7 +40,7 @@ Where: ((eventLocation))
 
 Your dietary note: ((bookerDietaryNote))
 
-Accommodation: ((accommodationSummary))
+((accommodationRequested??Accommodation requested — see your booking for details.))
 
 Previous total: ((previousTotalFormatted))
 

--- a/functions/src/__tests__/bookingEmailDispatcher.test.ts
+++ b/functions/src/__tests__/bookingEmailDispatcher.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
 import * as admin from "@dataconnect/admin-generated";
 import {
+  accommodationRequestedCondition,
   bookingConfirmationDeliveryKey,
   bookingRevisionDeliveryKey,
   bookingTotalMinorFromLines,
@@ -60,6 +61,13 @@ describe("bookingEmailDispatcher helpers", () => {
     );
     expect(formatSignedDeltaAmount(1500)).toBe("+15.00 GBP");
     expect(formatSignedDeltaAmount(-500)).toBe("-5.00 GBP");
+  });
+
+  it("accommodationRequestedCondition returns GOV.UK Notify's literal yes/no condition value", () => {
+    // The optional-content ((var??text)) syntax requires the personalisation
+    // value to be exactly "yes" or "no", not a boolean.
+    expect(accommodationRequestedCondition(true)).toBe("yes");
+    expect(accommodationRequestedCondition(false)).toBe("no");
   });
 });
 

--- a/functions/src/bookingEmailDispatcher.ts
+++ b/functions/src/bookingEmailDispatcher.ts
@@ -55,7 +55,10 @@ export type BookingEmailPersonalisation = {
   revisionNumber: number;
   ticketLinesSummary: string;
   bookerDietaryNote: string;
-  accommodationSummary: string;
+  // GOV.UK Notify optional-content condition -- must be the literal string
+  // "yes"/"no", not a boolean, and its ((var??text)) text cannot itself
+  // contain a placeholder, so the accommodation note isn't shown here.
+  accommodationRequested: "yes" | "no";
   bookingTotalFormatted: string;
   sectionBookingsUrl: string;
   myPaymentsUrl: string;
@@ -117,12 +120,9 @@ export function buildTicketLinesSummary(lines: BookingLineRow[]): string {
     .join("\n");
 }
 
-export function buildAccommodationSummary(requested: boolean, note: string | null | undefined): string {
-  if (!requested) {
-    return "Not requested";
-  }
-  const trimmed = note?.trim();
-  return trimmed && trimmed.length > 0 ? `Requested — ${trimmed}` : "Requested";
+/** GOV.UK Notify optional-content conditions must be the literal string "yes"/"no". */
+export function accommodationRequestedCondition(requested: boolean): "yes" | "no" {
+  return requested ? "yes" : "no";
 }
 
 export function paymentAdjustmentStatusLabel(status: BookingPaymentAdjustmentStatus): string {
@@ -166,10 +166,7 @@ function buildBasePersonalisation(args: {
     revisionNumber: booking.revisionNumber,
     ticketLinesSummary: buildTicketLinesSummary(booking.lines),
     bookerDietaryNote: booking.bookerDietaryNote?.trim() || "—",
-    accommodationSummary: buildAccommodationSummary(
-      booking.accommodationRequested,
-      booking.accommodationNote
-    ),
+    accommodationRequested: accommodationRequestedCondition(booking.accommodationRequested),
     bookingTotalFormatted: formatMinorCurrency(totalMinor, "GBP"),
     sectionBookingsUrl: `${base}/sections/${booking.event.section.id}`,
     myPaymentsUrl: `${base}/payments`,

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -19,12 +19,12 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "revisionNumber",
     "ticketLinesSummary",
     "bookerDietaryNote",
-    "accommodationSummary",
+    "accommodationRequested",
     "bookingTotalFormatted",
     "sectionBookingsUrl",
     "myPaymentsUrl"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been confirmed.\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your booking (revision ((revisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nTotal: ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been confirmed.\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your booking (revision ((revisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\n((accommodationRequested??Accommodation requested — see your booking for details.))\n\nTotal: ((bookingTotalFormatted))\n\n---\n\nYou can view your booking and payment status at any time:\n\n((sectionBookingsUrl))\n\nIf payment is outstanding, visit My Payments:\n\n((myPaymentsUrl))\n\nSODC",
   },
   bookingRevision: {
     subject: "Your SODC booking has been updated — ((eventTitle))",
@@ -36,7 +36,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "revisionNumber",
     "ticketLinesSummary",
     "bookerDietaryNote",
-    "accommodationSummary",
+    "accommodationRequested",
     "bookingTotalFormatted",
     "sectionBookingsUrl",
     "myPaymentsUrl",
@@ -47,7 +47,7 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "revisedTotalFormatted",
     "deltaAmountFormatted"
     ],
-    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Updated booking (revision ((revisedRevisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\nAccommodation: ((accommodationSummary))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nDifference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
+    body: "Dear ((customerFirstName)),\n\nYour booking for ((eventTitle)) has been updated (revision ((previousRevisionNumber)) to ((revisedRevisionNumber))).\n\n---\n\n# Event details\n\nWhen: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Updated booking (revision ((revisedRevisionNumber)))\n\n((ticketLinesSummary))\n\nYour dietary note: ((bookerDietaryNote))\n\n((accommodationRequested??Accommodation requested — see your booking for details.))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nDifference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nManage payments:\n\n((myPaymentsUrl))\n\nSODC",
   },
   emailChangeVerification: {
     subject: "Confirm your new SODC email address",

--- a/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
+++ b/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from "@mui/material";
 import { formatGbpMajorAmount } from "../../../../shared/utils/currencyDisplay";
-import { getMembershipStatusLabel } from "../../../../shared/utils/membershipStatusLabels";
 
 interface TicketType {
   id: string;
@@ -115,9 +114,8 @@ export default function TicketSelectionStep({
         disabled={!canRequestAccommodation}
       />
       <Typography variant="caption" color="text.secondary">
-        {canRequestAccommodation
-          ? "Overnight accommodation at the venue, where available."
-          : `Accommodation requests are available for ${getMembershipStatusLabel("REGULAR")} or ${getMembershipStatusLabel("RESERVE")} members only.`}
+        Accommodation is only available for Serving Members.
+        {canRequestAccommodation ? " Overnight accommodation at the venue, where available." : ""}
       </Typography>
     </FormControl>
   );


### PR DESCRIPTION
## Summary
- Replaced the unconditional "Accommodation: ..." line in \`bookingConfirmation\`/\`bookingRevision\` with GOV.UK Notify's optional-content syntax (\`((accommodationRequested??...))\`), so it's fully omitted for members who didn't request it — no more "Accommodation: Not requested" noise for everyone else.
- The condition value must be Notify's literal \`"yes"\`/\`"no"\` string, and Notify disallows a placeholder inside conditional text, so the free-text accommodation note is no longer inlined in these emails (still visible in the app).
- Booking form now always states the eligibility rule ("only available for Serving Members"), not just when the checkbox is already disabled.

Closes #493.

## Test plan
- [x] \`npx tsc -b --noEmit\` clean
- [x] Full frontend + Functions test suites passing, including new \`accommodationRequestedCondition\` coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)