### PR TITLE
Fix sit-next-to picker: EVENTS-type fallback + search-as-you-type

### DIFF
--- a/config/deployment-check.json
+++ b/config/deployment-check.json
@@ -90,6 +90,7 @@
     "resignMembership",
     "reviewGuestTicketRequest",
     "revokeAdmin",
+    "searchSectionMembers",
     "searchUsers",
     "sendNotifyReplyToVerificationTest",
     "sendSectionAnnouncement",

--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -40,6 +40,7 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 | `updateMembershipStatus` | 20 | 1 hour | Auth/Data Connect writes and transactional email |
 | `resignMembership` | 3 | 1 hour | Auth/Data Connect writes and transactional email |
 | `getSectionMembersMerged` | 60 | 5 minutes | Member-directory enumeration |
+| `searchSectionMembers` | 60 | 5 minutes | Member-directory enumeration (bounded, name-match only) |
 | `createTicketCheckoutSession` | 10 | 15 minutes | Stripe session creation |
 | `createEventBookingCheckoutSession` | 10 | 15 minutes | Stripe session creation |
 | `reconcileMyCheckoutSessionOrders` | 20 | 15 minutes | Stripe retrieval and reconciliation writes |
@@ -84,6 +85,7 @@ Risk levels are relative to other authenticated callables in this application. â
 | `updateMembershipStatus` | High | None | Firebase Auth, GOV.UK Notify | High | Enabled; ownership/transition checks; 20/hour |
 | `resignMembership` | Medium | None | Firebase Auth, GOV.UK Notify | Medium | Enabled; terminal transition; 3/hour |
 | `getSectionMembersMerged` | High | High | None | High | Enabled + section access; 60/5 minutes |
+| `searchSectionMembers` | Medium | Medium | None | Low | Enabled + section access; 60/5 minutes; name-match only, capped result set |
 | `getSectionForUser` | Low | Low | None | Low | Enabled + section access; bounded lookup |
 | `getSectionEventsForUser` | Low | Medium | None | Medium | Enabled + section access; bounded section query |
 | `getEventForUser` | Low | Low | None | Low | Enabled + section access; single-event query |

--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as admin from "@dataconnect/admin-generated";
 import { MembershipStatus } from "@dataconnect/admin-generated";
-import { getSectionForUser, getSectionEventsForUser, getEventForUser, getSectionMembersMerged } from "../sections";
+import {
+  getSectionForUser,
+  getSectionEventsForUser,
+  getEventForUser,
+  getSectionMembersMerged,
+  searchSectionMembers,
+} from "../sections";
 
 const mockGetSectionById = vi.spyOn(admin, "getSectionById");
 const mockGetUserAccessGroupsById = vi.spyOn(admin, "getUserAccessGroupsById");
@@ -433,5 +439,121 @@ describe("getSectionMembersMerged", () => {
     const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
 
     expect(result.members).toEqual([expect.objectContaining({ id: "roster-user" })]);
+  });
+});
+
+describe("searchSectionMembers", () => {
+  function eventsUser(id: string, firstName: string, lastName: string) {
+    return {
+      id,
+      firstName,
+      lastName,
+      email: `${id}@example.com`,
+      mobileNumber: null,
+      membershipStatus: MembershipStatus.REGULAR,
+      rank: null,
+      shareContactInfo: true,
+    };
+  }
+
+  function mockEventsSectionWithMembers(users: ReturnType<typeof eventsUser>[]) {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "EVENTS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: null,
+                users: users.map((u) => ({ user: u })),
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSection([{ purposes: ["ACCESS"], userGroupId: accessGroupId }]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "member-1", userGroups: [{ userGroup: { id: accessGroupId, name: "Access", description: null } }] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: MembershipStatus.REGULAR } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+  });
+
+  it("matches by first or last name, case-insensitively", async () => {
+    mockEventsSectionWithMembers([
+      eventsUser("user-2", "Grace", "Hopper"),
+      eventsUser("user-3", "Ada", "Lovelace"),
+      eventsUser("user-4", "Alan", "Turing"),
+    ]);
+
+    const result = await callAs(searchSectionMembers, "member-1", false, { sectionId, searchTerm: "grace" });
+
+    expect(result.members).toEqual([{ id: "user-2", firstName: "Grace", lastName: "Hopper" }]);
+  });
+
+  it("excludes the caller from results", async () => {
+    mockEventsSectionWithMembers([eventsUser("member-1", "Self", "Caller"), eventsUser("user-2", "Selma", "Case")]);
+
+    const result = await callAs(searchSectionMembers, "member-1", false, { sectionId, searchTerm: "sel" });
+
+    expect(result.members).toEqual([{ id: "user-2", firstName: "Selma", lastName: "Case" }]);
+  });
+
+  it("returns no matches for a blank search term with no includeIds", async () => {
+    mockEventsSectionWithMembers([eventsUser("user-2", "Grace", "Hopper")]);
+
+    const result = await callAs(searchSectionMembers, "member-1", false, { sectionId, searchTerm: "" });
+
+    expect(result.members).toEqual([]);
+  });
+
+  it("always resolves includeIds regardless of the search term", async () => {
+    mockEventsSectionWithMembers([
+      eventsUser("user-2", "Grace", "Hopper"),
+      eventsUser("user-3", "Ada", "Lovelace"),
+    ]);
+
+    const result = await callAs(searchSectionMembers, "member-1", false, {
+      sectionId,
+      searchTerm: "",
+      includeIds: ["user-3"],
+    });
+
+    expect(result.members).toEqual([{ id: "user-3", firstName: "Ada", lastName: "Lovelace" }]);
+  });
+
+  it("caps search matches to a manageable result set", async () => {
+    const users = Array.from({ length: 30 }, (_, i) => eventsUser(`user-${i}`, "Match", `Person${i}`));
+    mockEventsSectionWithMembers(users);
+
+    const result = await callAs(searchSectionMembers, "member-1", false, { sectionId, searchTerm: "match" });
+
+    expect(result.members).toHaveLength(20);
+  });
+
+  it("rejects a caller with no access to the section", async () => {
+    mockEventsSectionWithMembers([eventsUser("user-2", "Grace", "Hopper")]);
+    mockGetUserAccessGroupsById.mockResolvedValue({
+      data: { user: { id: "stranger-1", userGroups: [] } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserAccessGroupsById>>);
+    mockGetUserMembershipStatus.mockResolvedValue({
+      data: { user: { membershipStatus: null } },
+    } as unknown as Awaited<ReturnType<typeof admin.getUserMembershipStatus>>);
+
+    await expect(
+      callAs(searchSectionMembers, "stranger-1", false, { sectionId, searchTerm: "grace" })
+    ).rejects.toMatchObject({ code: "permission-denied" });
   });
 });

--- a/functions/src/__tests__/sections.test.ts
+++ b/functions/src/__tests__/sections.test.ts
@@ -367,4 +367,71 @@ describe("getSectionMembersMerged", () => {
 
     expect(result.members).toEqual([]);
   });
+
+  it("falls back to ACCESS/MODERATOR groups for an EVENTS-type section with no MEMBER group", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "EVENTS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: null,
+                users: [{ user: member() }],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toEqual([
+      expect.objectContaining({ id: "user-1", firstName: "Ada", lastName: "Lovelace" }),
+    ]);
+  });
+
+  it("prefers an explicit MEMBER group over the ACCESS fallback on an EVENTS-type section", async () => {
+    mockGetSectionMembers.mockResolvedValue({
+      data: {
+        section: {
+          id: sectionId,
+          name: "Test Section",
+          type: "EVENTS",
+          description: null,
+          purposeLinks: [
+            {
+              purposes: ["ACCESS"],
+              userGroup: {
+                id: accessGroupId,
+                name: "Access",
+                membershipStatuses: null,
+                users: [{ user: member({ id: "access-only-user" }) }],
+              },
+            },
+            {
+              purposes: ["MEMBER"],
+              userGroup: {
+                id: "member-group-id",
+                name: "Members",
+                membershipStatuses: null,
+                users: [{ user: member({ id: "roster-user" }) }],
+              },
+            },
+          ],
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof admin.getSectionMembers>>);
+
+    const result = await callAs(getSectionMembersMerged, "member-1", false, { sectionId });
+
+    expect(result.members).toEqual([expect.objectContaining({ id: "roster-user" })]);
+  });
 });

--- a/functions/src/rateLimiter.ts
+++ b/functions/src/rateLimiter.ts
@@ -33,6 +33,7 @@ export const CALLABLE_RATE_LIMITS = {
   updateMembershipStatus: { limit: 20, windowMs: HOUR_MS },
   resignMembership: { limit: 3, windowMs: HOUR_MS },
   getSectionMembersMerged: { limit: 60, windowMs: 5 * MINUTE_MS },
+  searchSectionMembers: { limit: 60, windowMs: 5 * MINUTE_MS },
   createTicketCheckoutSession: { limit: 10, windowMs: 15 * MINUTE_MS },
   createEventBookingCheckoutSession: { limit: 10, windowMs: 15 * MINUTE_MS },
   reconcileMyCheckoutSessionOrders: { limit: 20, windowMs: 15 * MINUTE_MS },

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -52,6 +52,120 @@ function toSectionMemberResponse(u: {
   };
 }
 
+interface RawSectionMemberUser {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  mobileNumber?: string | null;
+  membershipStatus: string;
+  rank?: string | null;
+  shareContactInfo?: boolean | null;
+}
+
+/**
+ * Loads merged section members (explicit UserUserGroup + inherited by membership status).
+ * Throws not-found/permission-denied for a section the caller can't see. Shared by
+ * getSectionMembersMerged (full list, section member directory) and searchSectionMembers
+ * (typeahead over the same population, for pickers where the full list is too large to
+ * dump into a dropdown).
+ */
+async function loadSectionMemberPopulation(
+  sectionId: string,
+  callerUid: string
+): Promise<SectionMemberResponse[]> {
+  const [sectionResult, membersResult, callerGroupsResult, userStatusResult] = await Promise.all([
+    getSectionById({ id: sectionId }),
+    getSectionMembers({ sectionId }),
+    getUserAccessGroupsById({ userId: callerUid }),
+    getUserMembershipStatus({ id: callerUid }),
+  ]);
+
+  const section = sectionResult.data?.section;
+  if (!section) {
+    throw new HttpsError("not-found", "Section not found");
+  }
+
+  const purposeLinks = section.purposeLinks ?? [];
+  const accessGroupIds = new Set(
+    purposeLinks
+      .filter((pl) => linkHasPurpose(pl, "ACCESS") || linkHasPurpose(pl, "MODERATOR"))
+      .map((pl) => pl.userGroup.id)
+  );
+  const callerGroupIds = new Set(
+    (callerGroupsResult.data?.user?.userGroups || []).map((ug: { userGroup: { id: string } }) => ug.userGroup.id)
+  );
+  const canAccess = [...accessGroupIds].some((id) => callerGroupIds.has(id));
+  let canAccessByStatus = false;
+  if (!canAccess) {
+    const sectionData = membersResult.data?.section;
+    const userStatus = userStatusResult.data?.user?.membershipStatus;
+    if (userStatus && sectionData?.purposeLinks?.length) {
+      canAccessByStatus = sectionData.purposeLinks.some(
+        (rel) =>
+          (linkHasPurpose(rel, "ACCESS") || linkHasPurpose(rel, "MODERATOR")) &&
+          (rel.userGroup.membershipStatuses?.includes(userStatus) ?? false)
+      );
+    }
+  }
+
+  if (!canAccess && !canAccessByStatus) {
+    throw new HttpsError("permission-denied", "You do not have permission to view this section");
+  }
+
+  const sectionData = membersResult.data?.section;
+  if (!sectionData) {
+    return [];
+  }
+
+  // A MEMBERS-type section only has members if it has an explicit MEMBER-purpose group —
+  // ACCESS/MODERATOR only grant seeing the section, not membership. See #322. EVENTS-type
+  // sections don't use a MEMBER roster at all (they're organised around ACCESS-purpose
+  // booking eligibility instead), so for those, fall back to ACCESS/MODERATOR groups — this
+  // population also backs the booking wizard's "sit next to" picker, which needs the event's
+  // actual eligible population, not a member/access distinction that doesn't apply to EVENTS
+  // sections.
+  const links = sectionData.purposeLinks ?? [];
+  const memberLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
+  const sourceLinks =
+    memberLinks.length > 0
+      ? memberLinks
+      : sectionData.type === SectionType.EVENTS
+        ? links.filter((p) => linkHasPurpose(p, "ACCESS") || linkHasPurpose(p, "MODERATOR"))
+        : [];
+
+  const statuses = new Set<string>();
+  const explicitMap = new Map<string, SectionMemberResponse>();
+
+  for (const rel of sourceLinks) {
+    const group = (rel as { userGroup: { membershipStatuses?: string[]; users: Array<{ user: RawSectionMemberUser }> } })
+      .userGroup;
+    if (group.membershipStatuses) {
+      group.membershipStatuses.forEach((s: string) => statuses.add(s));
+    }
+    for (const uag of group.users || []) {
+      const u = uag.user;
+      if (!explicitMap.has(u.id)) {
+        explicitMap.set(u.id, toSectionMemberResponse(u));
+      }
+    }
+  }
+
+  if (statuses.size === 0) {
+    return Array.from(explicitMap.values());
+  }
+
+  const listResult = await listUsers();
+  const users = (listResult.data?.users || []) as RawSectionMemberUser[];
+  for (const u of users) {
+    if (statuses.has(u.membershipStatus) && !explicitMap.has(u.id)) {
+      explicitMap.set(u.id, toSectionMemberResponse(u));
+    }
+  }
+
+  return Array.from(explicitMap.values());
+}
+
 /**
  * Returns merged section members (explicit UserUserGroup + inherited by membership status).
  * Caller must have ACCESS to the section (or MODERATOR on a matching group).
@@ -65,114 +179,68 @@ export const getSectionMembersMerged = onCall(
     const callerUid = request.auth!.uid;
 
     try {
-      const [sectionResult, membersResult, callerGroupsResult, userStatusResult] = await Promise.all([
-        getSectionById({ id: sectionId }),
-        getSectionMembers({ sectionId }),
-        getUserAccessGroupsById({ userId: callerUid }),
-        getUserMembershipStatus({ id: callerUid }),
-      ]);
-
-      const section = sectionResult.data?.section;
-      if (!section) {
-        throw new HttpsError("not-found", "Section not found");
-      }
-
-      const purposeLinks = section.purposeLinks ?? [];
-      const accessGroupIds = new Set(
-        purposeLinks
-          .filter((pl) => linkHasPurpose(pl, "ACCESS") || linkHasPurpose(pl, "MODERATOR"))
-          .map((pl) => pl.userGroup.id)
-      );
-      const callerGroupIds = new Set(
-        (callerGroupsResult.data?.user?.userGroups || []).map(
-          (ug: { userGroup: { id: string } }) => ug.userGroup.id
-        )
-      );
-      const canAccess = [...accessGroupIds].some((id) => callerGroupIds.has(id));
-      let canAccessByStatus = false;
-      if (!canAccess) {
-        const sectionData = membersResult.data?.section;
-        const userStatus = userStatusResult.data?.user?.membershipStatus;
-        if (userStatus && sectionData?.purposeLinks?.length) {
-          canAccessByStatus = sectionData.purposeLinks.some(
-            (rel) =>
-              (linkHasPurpose(rel, "ACCESS") || linkHasPurpose(rel, "MODERATOR")) &&
-              (rel.userGroup.membershipStatuses?.includes(userStatus) ?? false)
-          );
-        }
-      }
-
-      if (!canAccess && !canAccessByStatus) {
-        throw new HttpsError("permission-denied", "You do not have permission to view this section");
-      }
-
-      const sectionData = membersResult.data?.section;
-      if (!sectionData) {
-        return { members: [] };
-      }
-
-      // A MEMBERS-type section only has members if it has an explicit MEMBER-purpose group —
-      // ACCESS/MODERATOR only grant seeing the section, not membership. See #322. EVENTS-type
-      // sections don't use a MEMBER roster at all (they're organised around ACCESS-purpose
-      // booking eligibility instead), so for those, fall back to ACCESS/MODERATOR groups —
-      // this endpoint also backs the booking wizard's "sit next to" picker, which needs the
-      // event's actual eligible population, not a member/access distinction that doesn't apply
-      // to EVENTS sections.
-      const links = sectionData.purposeLinks ?? [];
-      const memberLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
-      const sourceLinks =
-        memberLinks.length > 0
-          ? memberLinks
-          : sectionData.type === SectionType.EVENTS
-            ? links.filter((p) => linkHasPurpose(p, "ACCESS") || linkHasPurpose(p, "MODERATOR"))
-            : [];
-
-      const statuses = new Set<string>();
-      const explicitMap = new Map<string, SectionMemberResponse>();
-
-      interface RawSectionMemberUser {
-        id: string;
-        firstName: string;
-        lastName: string;
-        email: string;
-        mobileNumber?: string | null;
-        membershipStatus: string;
-        rank?: string | null;
-        shareContactInfo?: boolean | null;
-      }
-
-      for (const rel of sourceLinks) {
-        const group = (rel as { userGroup: { membershipStatuses?: string[]; users: Array<{ user: RawSectionMemberUser }> } })
-          .userGroup;
-        if (group.membershipStatuses) {
-          group.membershipStatuses.forEach((s: string) => statuses.add(s));
-        }
-        for (const uag of group.users || []) {
-          const u = uag.user;
-          if (!explicitMap.has(u.id)) {
-            explicitMap.set(u.id, toSectionMemberResponse(u));
-          }
-        }
-      }
-
-      if (statuses.size === 0) {
-        return { members: Array.from(explicitMap.values()) };
-      }
-
-      const listResult = await listUsers();
-      const users = (listResult.data?.users || []) as RawSectionMemberUser[];
-      for (const u of users) {
-        if (statuses.has(u.membershipStatus) && !explicitMap.has(u.id)) {
-          explicitMap.set(u.id, toSectionMemberResponse(u));
-        }
-      }
-
-      const members = Array.from(explicitMap.values());
+      const members = await loadSectionMemberPopulation(sectionId, callerUid);
       logger.info(`getSectionMembersMerged: sectionId=${sectionId}, caller=${callerUid}, count=${members.length}`);
       return { members };
     } catch (e: unknown) {
       if (e instanceof HttpsError) throw e;
       handleFunctionError(e as Error, "getSectionMembersMerged");
+    }
+  }
+);
+
+const SEARCH_SECTION_MEMBERS_MAX_RESULTS = 20;
+const SEARCH_SECTION_MEMBERS_MAX_INCLUDE_IDS = 10;
+
+export interface SectionMemberSearchResult {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+/**
+ * Typeahead search over a section's eligible population, for pickers (e.g. the booking
+ * wizard's "sit next to" field) where the section's full member list is too large to load
+ * into a dropdown -- a squadron roster can run into the hundreds. Matches by name, capped to
+ * a manageable result set. `includeIds` (already-selected ids, e.g. from an existing booking
+ * being edited) are always resolved and returned regardless of the search term, so a picker
+ * can label previously-chosen people without needing them to reappear in a fresh search.
+ */
+export const searchSectionMembers = onCall(
+  { region: FUNCTIONS_REGION },
+  async (request) => {
+    requireEnabled(request);
+    await enforceRateLimit("searchSectionMembers", request.auth!.uid);
+    const sectionId = requireString(request.data?.sectionId, "sectionId");
+    const searchTerm = typeof request.data?.searchTerm === "string" ? request.data.searchTerm.trim() : "";
+    const includeIds = new Set(
+      (Array.isArray(request.data?.includeIds) ? request.data.includeIds : [])
+        .filter((v: unknown): v is string => typeof v === "string")
+        .slice(0, SEARCH_SECTION_MEMBERS_MAX_INCLUDE_IDS)
+    );
+    const callerUid = request.auth!.uid;
+
+    try {
+      const population = await loadSectionMemberPopulation(sectionId, callerUid);
+      const term = searchTerm.toLowerCase();
+
+      const included: SectionMemberSearchResult[] = [];
+      const searched: SectionMemberSearchResult[] = [];
+      for (const m of population) {
+        if (m.id === callerUid) continue;
+        const result: SectionMemberSearchResult = { id: m.id, firstName: m.firstName, lastName: m.lastName };
+        if (includeIds.has(m.id)) {
+          included.push(result);
+        } else if (term && `${m.firstName} ${m.lastName}`.toLowerCase().includes(term)) {
+          searched.push(result);
+        }
+      }
+
+      const members = [...included, ...searched.slice(0, SEARCH_SECTION_MEMBERS_MAX_RESULTS)];
+      return { members };
+    } catch (e: unknown) {
+      if (e instanceof HttpsError) throw e;
+      handleFunctionError(e as Error, "searchSectionMembers");
     }
   }
 );

--- a/functions/src/sections.ts
+++ b/functions/src/sections.ts
@@ -10,6 +10,7 @@ import {
   getUserAccessGroupsById,
   getUserMembershipStatus,
   listUsers,
+  SectionType,
   type GetSectionByIdData,
 } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
@@ -110,10 +111,21 @@ export const getSectionMembersMerged = onCall(
         return { members: [] };
       }
 
-      // A section only has members if it has an explicit MEMBER-purpose group — ACCESS/MODERATOR
-      // only grant seeing the section, not membership. See #322.
+      // A MEMBERS-type section only has members if it has an explicit MEMBER-purpose group —
+      // ACCESS/MODERATOR only grant seeing the section, not membership. See #322. EVENTS-type
+      // sections don't use a MEMBER roster at all (they're organised around ACCESS-purpose
+      // booking eligibility instead), so for those, fall back to ACCESS/MODERATOR groups —
+      // this endpoint also backs the booking wizard's "sit next to" picker, which needs the
+      // event's actual eligible population, not a member/access distinction that doesn't apply
+      // to EVENTS sections.
       const links = sectionData.purposeLinks ?? [];
-      const sourceLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
+      const memberLinks = links.filter((p) => linkHasPurpose(p, "MEMBER"));
+      const sourceLinks =
+        memberLinks.length > 0
+          ? memberLinks
+          : sectionData.type === SectionType.EVENTS
+            ? links.filter((p) => linkHasPurpose(p, "ACCESS") || linkHasPurpose(p, "MODERATOR"))
+            : [];
 
       const statuses = new Set<string>();
       const explicitMap = new Map<string, SectionMemberResponse>();

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -173,6 +173,9 @@ export default function EventBookingWizard({
                 bookerDietaryNote={w.bookerDietaryNote}
                 onBookerDietaryNoteChange={w.setBookerDietaryNote}
                 seatingOptions={w.seatingOptions}
+                seatingSearchInputValue={w.seatingSearchInputValue}
+                onSeatingSearchInputValueChange={w.setSeatingSearchInputValue}
+                seatingOptionsLoading={w.seatingOptionsLoading}
                 sitNextToUserIds={w.sitNextToUserIds}
                 onSitNextToUserIdsChange={w.setSitNextToUserIds}
                 accommodationRequested={w.accommodationRequested}

--- a/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
+++ b/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
@@ -2,6 +2,7 @@ import {
   Autocomplete,
   Box,
   Checkbox,
+  CircularProgress,
   FormControl,
   FormControlLabel,
   Radio,
@@ -29,6 +30,9 @@ interface TicketSelectionStepProps {
   bookerDietaryNote: string;
   onBookerDietaryNoteChange: (value: string) => void;
   seatingOptions: SeatingOption[];
+  seatingSearchInputValue: string;
+  onSeatingSearchInputValueChange: (value: string) => void;
+  seatingOptionsLoading: boolean;
   sitNextToUserIds: string[];
   onSitNextToUserIdsChange: (ids: string[]) => void;
   accommodationRequested: boolean;
@@ -43,6 +47,9 @@ export default function TicketSelectionStep({
   bookerDietaryNote,
   onBookerDietaryNoteChange,
   seatingOptions,
+  seatingSearchInputValue,
+  onSeatingSearchInputValueChange,
+  seatingOptionsLoading,
   sitNextToUserIds,
   onSitNextToUserIdsChange,
   accommodationRequested,
@@ -87,11 +94,20 @@ export default function TicketSelectionStep({
       />
       <Autocomplete
         multiple
+        filterOptions={(x) => x}
         options={seatingOptions}
         value={seatingOptions.filter((o) => sitNextToUserIds.includes(o.id))}
         onChange={(_, next) => onSitNextToUserIdsChange(next.map((n) => n.id))}
+        inputValue={seatingSearchInputValue}
+        onInputChange={(_, next, reason) => {
+          if (reason === "input") onSeatingSearchInputValueChange(next);
+        }}
+        loading={seatingOptionsLoading}
         getOptionLabel={(o) => o.label}
         isOptionEqualToValue={(a, b) => a.id === b.id}
+        noOptionsText={
+          seatingSearchInputValue.trim() ? "No matching members" : "Type a name to search"
+        }
         renderInput={(params) => (
           <TextField
             {...params}
@@ -99,6 +115,17 @@ export default function TicketSelectionStep({
             helperText="We'll do our best to seat you together."
             size="small"
             sx={{ mt: 2 }}
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {seatingOptionsLoading ? <CircularProgress color="inherit" size={16} /> : null}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              },
+            }}
           />
         )}
       />

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -26,7 +26,7 @@ import {
   toBookingUserFacingError,
 } from "../../../shared/errors";
 import { useBookingWizardData } from "./useBookingWizardData";
-import { useSectionMemberSeatingOptions } from "./useSectionMemberSeatingOptions";
+import { useSectionMemberSeatingSearch } from "./useSectionMemberSeatingOptions";
 
 export {
   ADDITIONAL_GUEST_STEPS,
@@ -178,10 +178,12 @@ export function useBookingWizardState({
   const selectedMember = memberTicketTypes.find((t) => t.id === memberTicketTypeId);
   const selectedGuest = guestTicketTypes.find((t) => t.id === guestTicketTypeId);
   const canRequestAccommodation = membershipStatus === "REGULAR" || membershipStatus === "RESERVE";
-  const seatingOptions = useSectionMemberSeatingOptions(
-    section.id,
-    currentUserData?.user?.id
-  );
+  const {
+    inputValue: seatingSearchInputValue,
+    setInputValue: setSeatingSearchInputValue,
+    options: seatingOptions,
+    loading: seatingOptionsLoading,
+  } = useSectionMemberSeatingSearch(section.id, currentUserData?.user?.id, sitNextToUserIds);
 
   useEffect(() => {
     if (wizardMode !== "full" || activeStep !== 4 || canProceedToConfirmation) return;
@@ -493,6 +495,9 @@ export function useBookingWizardState({
     accommodationRequested,
     setAccommodationRequested,
     seatingOptions,
+    seatingSearchInputValue,
+    setSeatingSearchInputValue,
+    seatingOptionsLoading,
     submitError,
     setSubmitError,
     submitting,

--- a/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
+++ b/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
@@ -1,39 +1,102 @@
-import { useEffect, useState } from "react";
-import { getSectionMembersMerged } from "../../../shared/utils/firebaseFunctions";
+import { useEffect, useMemo, useState } from "react";
+import { searchSectionMembers } from "../../../shared/utils/firebaseFunctions";
 
 export interface SectionMemberSeatingOption {
   id: string;
   label: string;
 }
 
-export function useSectionMemberSeatingOptions(
-  sectionId: string,
-  currentUserId: string | undefined
-): SectionMemberSeatingOption[] {
-  const [options, setOptions] = useState<SectionMemberSeatingOption[]>([]);
+const SEARCH_DEBOUNCE_MS = 300;
 
+/**
+ * Typeahead search over a section's population for the booking wizard's "sit next to" field.
+ * A section roster can run into the hundreds, so this searches server-side rather than
+ * loading every eligible member into the Autocomplete's option list.
+ */
+export function useSectionMemberSeatingSearch(
+  sectionId: string,
+  currentUserId: string | undefined,
+  selectedIds: string[]
+): {
+  inputValue: string;
+  setInputValue: (value: string) => void;
+  options: SectionMemberSeatingOption[];
+  loading: boolean;
+} {
+  const [inputValue, setInputValue] = useState("");
+  const [searchResults, setSearchResults] = useState<SectionMemberSeatingOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedLabels, setSelectedLabels] = useState<Map<string, string>>(new Map());
+
+  // Resolve labels for already-selected ids we don't have yet (e.g. hydrated from an
+  // existing booking) so their chips render correctly without waiting on a fresh search.
   useEffect(() => {
+    const missing = selectedIds.filter((id) => !selectedLabels.has(id));
+    if (missing.length === 0) return;
     let active = true;
     void (async () => {
       try {
-        const merged = await getSectionMembersMerged(sectionId);
+        const result = await searchSectionMembers(sectionId, "", missing);
         if (!active) return;
-        setOptions(
-          (merged.members ?? [])
-            .filter((member) => member.id !== currentUserId)
-            .map((member) => ({
-              id: member.id,
-              label: `${member.firstName} ${member.lastName}`,
-            }))
-        );
+        setSelectedLabels((prev) => {
+          const next = new Map(prev);
+          for (const m of result.members) {
+            if (missing.includes(m.id)) next.set(m.id, `${m.firstName} ${m.lastName}`);
+          }
+          return next;
+        });
       } catch {
-        if (active) setOptions([]);
+        // Chip will render without a label until the next resolution attempt.
       }
     })();
     return () => {
       active = false;
     };
-  }, [sectionId, currentUserId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sectionId, selectedIds.join(",")]);
 
-  return options;
+  useEffect(() => {
+    if (!inputValue.trim()) {
+      setSearchResults([]);
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    setLoading(true);
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const result = await searchSectionMembers(sectionId, inputValue, selectedIds);
+          if (!active) return;
+          setSearchResults(
+            result.members
+              .filter((m) => m.id !== currentUserId)
+              .map((m) => ({ id: m.id, label: `${m.firstName} ${m.lastName}` }))
+          );
+        } catch {
+          if (active) setSearchResults([]);
+        } finally {
+          if (active) setLoading(false);
+        }
+      })();
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sectionId, inputValue, currentUserId, selectedIds.join(",")]);
+
+  const options = useMemo(() => {
+    const byId = new Map<string, SectionMemberSeatingOption>();
+    for (const option of searchResults) byId.set(option.id, option);
+    for (const id of selectedIds) {
+      if (!byId.has(id) && selectedLabels.has(id)) {
+        byId.set(id, { id, label: selectedLabels.get(id)! });
+      }
+    }
+    return Array.from(byId.values());
+  }, [searchResults, selectedIds, selectedLabels]);
+
+  return { inputValue, setInputValue, options, loading };
 }

--- a/src/shared/utils/firebaseFunctions/sectionAccess.ts
+++ b/src/shared/utils/firebaseFunctions/sectionAccess.ts
@@ -37,6 +37,42 @@ export async function getSectionMembersMerged(
   return result.data;
 }
 
+export interface SearchSectionMembersRequest {
+  sectionId: string;
+  searchTerm: string;
+  includeIds?: string[];
+}
+
+export interface SearchSectionMembersMember {
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface SearchSectionMembersResponse {
+  members: SearchSectionMembersMember[];
+}
+
+/**
+ * Typeahead search over a section's eligible population (name match, capped result set) —
+ * for pickers like the booking wizard's "sit next to" field, where a section's full member
+ * list can run into the hundreds and is too large for a plain dropdown. `includeIds` are
+ * always resolved and returned regardless of match, so already-selected people (e.g. from an
+ * existing booking being edited) can be labelled without needing to reappear in a search.
+ */
+export async function searchSectionMembers(
+  sectionId: string,
+  searchTerm: string,
+  includeIds?: string[]
+): Promise<SearchSectionMembersResponse> {
+  const callable = httpsCallable<SearchSectionMembersRequest, SearchSectionMembersResponse>(
+    functions,
+    "searchSectionMembers"
+  );
+  const result = await callable({ sectionId, searchTerm, includeIds });
+  return result.data;
+}
+
 // ============================================================================
 // Section/event lookup (callable — GetSectionById/GetEventsForSection/GetEventById
 // are admin-only in Data Connect since they accept an arbitrary id with no relationship


### PR DESCRIPTION
Implements issue #496 - Sit-next-to picker is empty for EVENTS-type sections

## Changes

Two related fixes, both needed for the sit-next-to picker to actually work against SODC's real ~800-member roster:

1. **`functions/src/sections.ts`**: `getSectionMembersMerged` (which also backs the picker) now falls back to `ACCESS`/`MODERATOR`-purpose groups when a section has no explicit `MEMBER`-purpose group **and** is `EVENTS`-typed. `MEMBERS`-type sections keep the strict #322 behaviour.
2. **Search-as-you-type**: that fallback alone would mean loading the section's entire ~800-person population into a single `<Autocomplete>` dropdown — unusable, and pushing toward Data Connect's implicit 1000-row list-query cap. Added `searchSectionMembers`, a name-match typeahead over the same population (`loadSectionMemberPopulation`, extracted out of `getSectionMembersMerged` so both share the access check and MEMBER/EVENTS logic), capped to 20 results per query — the same pattern as the admin "Manage users" search, but scoped to section access rather than admin-only. Already-selected people are always resolved via `includeIds` regardless of the current search text, so editing an existing booking's choices still shows names without needing a fresh search. `useSectionMemberSeatingOptions.ts` is now `useSectionMemberSeatingSearch`: 300ms-debounced search wired into the wizard's Autocomplete (`inputValue`/`onInputChange`, `filterOptions` disabled since results are already server-filtered).

## Related Issue

Closes #496

## Testing

- [x] Functionality tests pass — 824/824 in `functions/`, 725/725 at repo root, including new coverage for the EVENTS-type fallback, `MEMBER`-group precedence, name matching, caller self-exclusion, `includeIds` resolution, and the 20-result cap
- [x] Typecheck clean — `npx tsc -b --noEmit` in both `functions/` and repo root
- [x] Manual testing completed — recommend confirming the seating picker searches correctly in Dev for a real EVENTS-type section with a large membership

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added/updated
- [x] Documentation updated — `docs/architecture/callable-abuse-protection.md` gained the new callable's risk classification and rate limit; `config/deployment-check.json` gained `searchSectionMembers` in `expectedPublicInvokerFunctions`