### PR TITLE
Add preflight review worksheet tooling for legacy user migration (#420)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ This folder captures architecture, domain decisions, and contributor-facing guid
 - `operations/section-file-storage.md`: private section-file bucket, lifecycle states, IAM, CORS, deployment order, and verification.
 - `operations/legacy-user-migration-schema.md`: approved legacy-user field mapping, secure Data Connect write boundary, staged profile completion, and deployment order.
 - `operations/legacy-user-import.md`: guarded dry-run/apply/resume workflow and PII-minimised postflight reconciliation.
+- `operations/legacy-user-migration-review.md`: turns a non-PII preflight report into a structured issue #420 review worksheet and approval-artifact stub.
 
 ## User Guides
 

--- a/docs/operations/legacy-user-import.md
+++ b/docs/operations/legacy-user-import.md
@@ -1,7 +1,11 @@
 # Legacy user import runbook
 
 This runbook covers the resumable importer introduced by issue #419. Read
-`legacy-user-migration-schema.md` first for the approved field mapping.
+`legacy-user-migration-schema.md` first for the approved field mapping. Before
+running dry-run, use
+[`legacy-user-migration-review.md`](legacy-user-migration-review.md) to turn
+the preflight report into a review worksheet and an approval-artifact stub for
+issue #420.
 
 The importer is intentionally fail-closed:
 

--- a/docs/operations/legacy-user-migration-review.md
+++ b/docs/operations/legacy-user-migration-review.md
@@ -1,0 +1,81 @@
+# Legacy user migration -- preflight review worksheet
+
+This tool supports the human review required by issue #420 before a legacy
+user import is approved. Read `legacy-user-migration-schema.md` first for the
+approved field mapping and `legacy-user-import.md` for the importer runbook
+this review gates.
+
+`sodc-api`'s exporter produces a non-PII aggregate `sodc-legacy-user-preflight/v2`
+report (record counts, rank/status distributions, missing-field counts -- no
+names, emails, or other member-identifying data). Reviewing that raw JSON by
+hand against #420's acceptance criteria is manual spreadsheet work. This CLI
+turns the report into a structured Markdown worksheet with the relevant counts
+already placed under each review question, plus an approval-artifact stub
+ready for the importer's `--approval` flag.
+
+The tool only reads the non-PII preflight report. It never touches the
+encrypted member artifact and performs no writes to Firebase or Data Connect.
+
+## Usage
+
+From `functions`:
+
+```bash
+npm run legacy-user-preflight-review -- \
+  --input /secure/path/legacy-user-preflight.json \
+  --project sodc-web-production \
+  --output /secure/path/legacy-user-preflight-worksheet.md \
+  --approval-output /secure/path/legacy-user-migration-approval-stub.json
+```
+
+`--input` and `--project` are required. `--output` and `--approval-output` are
+optional; omitting either prints that artifact to stdout instead of writing a
+file. Both outputs are non-PII and safe to keep alongside the preflight report,
+but keep them outside the repository like every other migration artifact.
+
+`--project` is the target Firebase project ID (e.g. `sodc-web-production`) and
+is copied verbatim into the approval stub's `projectId` field -- it is not
+validated against `.firebaserc` by this tool, since no Firebase project is
+contacted.
+
+## What the worksheet covers
+
+The worksheet walks through six sections matching #420's acceptance criteria,
+each with the relevant counts already filled in from the report and a
+checklist the reviewer ticks off:
+
+1. **Rank mapping** -- the exporter fails closed on any rank without an
+   approved target, so every rank in a real report is already approved; this
+   section is for plausibility review, and flags (rather than silently
+   ignoring) any rank value the tool doesn't recognise as evidence the
+   reviewer and exporter have drifted onto different schema versions.
+2. **Membership status** -- same fail-closed guarantee for status, with the
+   same drift-detection flag.
+3. **Required fields and identity conflicts** -- missing-field counts per
+   field. The worksheet explicitly notes that duplicate-email/identity
+   conflicts are *not* derivable from the preflight alone and must be reviewed
+   separately from the importer's dry-run output.
+4. **Sharing and communications defaults** -- how `isShared` and
+   `hasSubscriptions` map onto `shareContactInfo` and `announcementOptOutAll`.
+5. **Admin restoration allowlist** -- a reminder that admin claims cannot come
+   from this pipeline (the exported schema has no `roles` field) and must be
+   reviewed as a separate allowlist.
+6. **Password credentials** -- blank/null hash counts and the staging-proof
+   requirement before `--bcrypt-proven` is used.
+
+An unrecognised rank or membership status value stops the review with an
+explicit warning rather than rendering a worksheet that looks complete. If
+that happens, confirm the CLI's `APPROVED_LEGACY_RANK_TARGETS` /
+`APPROVED_LEGACY_MEMBERSHIP_STATUSES` (in
+`functions/src/legacyUserPreflightReview.ts`) are still in sync with
+`sodc-api`'s `LegacyUserExportSchema` before continuing.
+
+## Approval artifact stub
+
+The tool also emits a `sodc-legacy-user-migration-approval/v1` stub with
+`approved: false` and `sourceChecksum` left as an explicit placeholder --
+the checksum is only known once the importer's dry-run decrypts and hashes
+the real encrypted artifact (see `legacy-user-import.md`). Fill in the
+checksum from that dry-run, complete every checklist item in the worksheet,
+and only then flip `approved` to `true` before using it with
+`legacy-user-import.ts --approval`.

--- a/docs/operations/legacy-user-migration-schema.md
+++ b/docs/operations/legacy-user-migration-schema.md
@@ -65,7 +65,10 @@ account gates, persists profile corrections and the server review timestamp in
 one Data Connect write, and requires missing mobile/rank details to be resolved.
 
 The executable dry-run, apply, resume, and production approval procedure is in
-[`legacy-user-import.md`](legacy-user-import.md).
+[`legacy-user-import.md`](legacy-user-import.md). The preflight report this
+schema describes can be turned into a structured review worksheet with the
+tooling in
+[`legacy-user-migration-review.md`](legacy-user-migration-review.md).
 
 ## Announcement preferences
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
     "test:watch": "vitest",
     "dev-reset": "npm run build && node lib/scripts/cli-dev-reset.js",
     "legacy-user-import": "ts-node --project tsconfig.scripts.json scripts/legacy-user-import.ts",
-    "legacy-user-postflight": "ts-node --project tsconfig.scripts.json scripts/legacy-user-postflight.ts"
+    "legacy-user-postflight": "ts-node --project tsconfig.scripts.json scripts/legacy-user-postflight.ts",
+    "legacy-user-preflight-review": "ts-node --project tsconfig.scripts.json scripts/legacy-user-preflight-review.ts"
   },
   "engines": {
     "node": "24"

--- a/functions/scripts/legacy-user-preflight-review.ts
+++ b/functions/scripts/legacy-user-preflight-review.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildLegacyMigrationApprovalStub,
+  buildLegacyPreflightReviewWorksheet,
+  parseLegacyPreflightReport,
+} from "../src/legacyUserPreflightReview";
+
+interface CliOptions {
+  inputPath: string;
+  projectId: string;
+  outputPath?: string;
+  approvalOutputPath?: string;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  npm run legacy-user-preflight-review -- \\
+    --input ../secure/legacy-user-preflight.json \\
+    --project sodc-web \\
+    --output ../secure/legacy-user-preflight-worksheet.md \\
+    --approval-output ../secure/legacy-user-migration-approval-stub.json
+
+Reads a non-PII sodc-api preflight report and renders it as a Markdown review
+worksheet structured around issue #420's acceptance criteria, plus an
+approval-artifact stub for legacy-user-import.ts's --approval flag. Both
+outputs are non-PII; --output/--approval-output are optional and default to
+printing to stdout.`);
+  process.exit(2);
+}
+
+function parseArguments(argv: string[]): CliOptions {
+  const values = new Map<string, string>();
+  const valueOptions = new Set(["--input", "--project", "--output", "--approval-output"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help") usage();
+    if (!valueOptions.has(argument)) usage();
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) usage();
+    values.set(argument, value);
+    index += 1;
+  }
+  const inputPath = values.get("--input");
+  const projectId = values.get("--project");
+  if (!inputPath || !projectId) usage();
+  return {
+    inputPath,
+    projectId,
+    outputPath: values.get("--output"),
+    approvalOutputPath: values.get("--approval-output"),
+  };
+}
+
+function writeFile(outputPath: string, content: string): void {
+  const directory = path.dirname(outputPath);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = `${outputPath}.tmp`;
+  fs.writeFileSync(temporaryPath, content, { encoding: "utf8", mode: 0o600 });
+  fs.chmodSync(temporaryPath, 0o600);
+  fs.renameSync(temporaryPath, outputPath);
+  fs.chmodSync(outputPath, 0o600);
+}
+
+function main(): void {
+  const options = parseArguments(process.argv.slice(2));
+  const raw: unknown = JSON.parse(fs.readFileSync(options.inputPath, "utf8"));
+  const report = parseLegacyPreflightReport(raw);
+
+  const worksheet = buildLegacyPreflightReviewWorksheet(report);
+  console.log(worksheet);
+  if (options.outputPath) writeFile(options.outputPath, worksheet);
+
+  const approvalStub = buildLegacyMigrationApprovalStub(report, options.projectId);
+  const approvalJson = `${JSON.stringify(approvalStub, null, 2)}\n`;
+  if (options.approvalOutputPath) {
+    writeFile(options.approvalOutputPath, approvalJson);
+    console.log(`\nApproval stub written to ${options.approvalOutputPath}`);
+  } else {
+    console.log("\nApproval artifact stub:");
+    console.log(approvalJson);
+  }
+}
+
+try {
+  main();
+} catch (error: unknown) {
+  console.error(
+    `Legacy user preflight review stopped: ${error instanceof Error ? error.message : "unknown error"}`
+  );
+  process.exitCode = 1;
+}

--- a/functions/src/__tests__/legacyUserPreflightReview.test.ts
+++ b/functions/src/__tests__/legacyUserPreflightReview.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  APPROVED_LEGACY_MEMBERSHIP_STATUSES,
+  APPROVED_LEGACY_RANK_TARGETS,
+  buildLegacyMigrationApprovalStub,
+  buildLegacyPreflightReviewWorksheet,
+  parseLegacyPreflightReport,
+  type LegacyPreflightReport,
+} from "../legacyUserPreflightReview";
+
+function valueCounts(present: number, blank = 0, nullCount = 0) {
+  return { present, blank, null: nullCount };
+}
+
+function cohort(recordCount: number): LegacyPreflightReport["overall"] {
+  return {
+    recordCount,
+    requiredFields: {
+      usersComplete: recordCount - 1,
+      usersMissingAny: 1,
+      missingByField: { email: 0, firstName: 1, lastName: 0, serviceNumber: 0 },
+    },
+    fields: {
+      legacyUserId: { present: recordCount },
+      oldUid: { null: 1, present: recordCount - 1 },
+      email: valueCounts(recordCount),
+      firstName: valueCounts(recordCount - 1, 1),
+      lastName: valueCounts(recordCount),
+      mobileNumber: valueCounts(recordCount - 2, 1, 1),
+      postNominals: valueCounts(0, 0, recordCount),
+      serviceNumber: valueCounts(recordCount),
+      rank: { null: 1, values: { "Squadron Leader": 1, Mr: recordCount - 2 } },
+      membershipStatus: { REGULAR: recordCount - 1, PENDING: 1 },
+      isShared: { true: recordCount - 1, false: 0, null: 1 },
+      hasSubscriptions: { true: recordCount - 1, false: 1 },
+      passwordHash: valueCounts(recordCount - 1, 0, 1),
+    },
+  };
+}
+
+function preflight(overrides: Partial<LegacyPreflightReport> = {}): LegacyPreflightReport {
+  return {
+    schemaVersion: "sodc-legacy-user-preflight/v2",
+    recordSchemaVersion: "sodc-legacy-user/v1",
+    generatedAt: "2026-07-19T14:00:00Z",
+    overall: cohort(3),
+    byOldUid: { set: cohort(2), missing: cohort(1) },
+    ...overrides,
+  };
+}
+
+describe("parseLegacyPreflightReport", () => {
+  it("parses a well-formed preflight report", () => {
+    const parsed = parseLegacyPreflightReport(preflight());
+    expect(parsed.overall.recordCount).toBe(3);
+    expect(parsed.byOldUid.set.recordCount).toBe(2);
+    expect(parsed.byOldUid.missing.recordCount).toBe(1);
+  });
+
+  it("rejects a non-object input", () => {
+    expect(() => parseLegacyPreflightReport("not an object")).toThrow(/JSON object/);
+    expect(() => parseLegacyPreflightReport(null)).toThrow(/JSON object/);
+  });
+
+  it("rejects an unsupported schema version", () => {
+    expect(() =>
+      parseLegacyPreflightReport({ ...preflight(), schemaVersion: "sodc-legacy-user-preflight/v1" })
+    ).toThrow(/unsupported preflight schemaVersion/);
+  });
+
+  it("rejects an unsupported record schema version", () => {
+    expect(() =>
+      parseLegacyPreflightReport({ ...preflight(), recordSchemaVersion: "sodc-legacy-user/v0" })
+    ).toThrow(/unsupported preflight recordSchemaVersion/);
+  });
+
+  it("rejects a missing generatedAt", () => {
+    const { generatedAt: _generatedAt, ...rest } = preflight();
+    expect(() => parseLegacyPreflightReport(rest)).toThrow(/generatedAt/);
+  });
+
+  it("rejects a malformed cohort", () => {
+    const malformed = preflight();
+    // @ts-expect-error intentionally malformed for the test
+    malformed.overall.requiredFields = undefined;
+    expect(() => parseLegacyPreflightReport(malformed)).toThrow(/requiredFields is malformed/);
+  });
+
+  it("rejects a missing byOldUid section", () => {
+    const { byOldUid: _byOldUid, ...rest } = preflight();
+    expect(() => parseLegacyPreflightReport(rest)).toThrow(/byOldUid is missing/);
+  });
+});
+
+describe("buildLegacyPreflightReviewWorksheet", () => {
+  it("includes the record count and every approved rank/status row", () => {
+    const worksheet = buildLegacyPreflightReviewWorksheet(preflight());
+    expect(worksheet).toContain("**Total exportable records:** 3");
+    for (const rank of APPROVED_LEGACY_RANK_TARGETS) {
+      expect(worksheet).toContain(`| ${rank} |`);
+    }
+    for (const status of APPROVED_LEGACY_MEMBERSHIP_STATUSES) {
+      expect(worksheet).toContain(`| ${status} |`);
+    }
+  });
+
+  it("flags rank values outside the approved list instead of silently dropping them", () => {
+    const withUnexpectedRank = preflight();
+    withUnexpectedRank.overall.fields.rank.values["Group Captain (legacy typo)"] = 1;
+    const worksheet = buildLegacyPreflightReviewWorksheet(withUnexpectedRank);
+    expect(worksheet).toContain("Unexpected:");
+    expect(worksheet).toContain("Group Captain (legacy typo)");
+  });
+
+  it("flags membership status values outside the approved set", () => {
+    const withUnexpectedStatus = preflight();
+    withUnexpectedStatus.overall.fields.membershipStatus.RESERVE = 1;
+    const worksheet = buildLegacyPreflightReviewWorksheet(withUnexpectedStatus);
+    expect(worksheet).toContain("Unexpected:");
+    expect(worksheet).toContain("RESERVE");
+  });
+
+  it("reports required-field gaps per field", () => {
+    const worksheet = buildLegacyPreflightReviewWorksheet(preflight());
+    expect(worksheet).toContain("| firstName | 1 |");
+  });
+
+  it("does not claim to detect duplicate emails from the preflight alone", () => {
+    const worksheet = buildLegacyPreflightReviewWorksheet(preflight());
+    expect(worksheet).toContain("but not duplicate-email");
+  });
+
+  it("notes that admin claims cannot be derived from this artifact", () => {
+    const worksheet = buildLegacyPreflightReviewWorksheet(preflight());
+    expect(worksheet).toContain("no `roles` field");
+  });
+});
+
+describe("buildLegacyMigrationApprovalStub", () => {
+  it("carries the record schema version and expected count, unapproved by default", () => {
+    const stub = buildLegacyMigrationApprovalStub(preflight(), "sodc-web-production");
+    expect(stub).toEqual({
+      schemaVersion: "sodc-legacy-user-migration-approval/v1",
+      issue: 420,
+      approved: false,
+      projectId: "sodc-web-production",
+      sourceChecksum: expect.stringContaining("fill in"),
+      recordSchemaVersion: "sodc-legacy-user/v1",
+      expectedRecordCount: 3,
+    });
+  });
+});

--- a/functions/src/legacyUserPreflightReview.ts
+++ b/functions/src/legacyUserPreflightReview.ts
@@ -1,0 +1,425 @@
+import {
+  LEGACY_PREFLIGHT_SCHEMA_VERSION,
+  LEGACY_RECORD_SCHEMA_VERSION,
+} from "./legacyUserMigration";
+
+/**
+ * Mirrors sodc-api's LegacyUserExportSchema::RANKS target values. The exporter fails
+ * closed (throws before producing a preflight) if a legacy user's rank isn't one of
+ * these -- so every rank value that can appear in a real preflight is already an
+ * approved mapping. Keep this list in sync with LegacyUserExportSchema.php.
+ */
+export const APPROVED_LEGACY_RANK_TARGETS = [
+  "Squadron Leader",
+  "Air Chief Marshal",
+  "Air Marshal",
+  "Air Vice-Marshal",
+  "Air Commodore",
+  "Group Captain",
+  "Wing Commander",
+  "Flight Lieutenant",
+  "Mr",
+  "Dr",
+  "Flying Officer",
+  "Mrs",
+  "Ms",
+] as const;
+
+/**
+ * Mirrors sodc-api's LegacyUserExportSchema::MEMBERSHIP_STATUSES -- the exporter's
+ * role-precedence mapping (ROLE_RESIGNED > ROLE_DECEASED > ROLE_LOST > ROLE_SERVING >
+ * ROLE_RETIRED, else isMember ? REGULAR : PENDING) can only ever produce these six
+ * values. This is a deliberate subset of the platform's full MembershipStatus enum --
+ * the legacy system has no reliable way to distinguish RESERVE, CIVIL_SERVICE, or
+ * INDUSTRY, so no migrated account lands in those statuses automatically.
+ */
+export const APPROVED_LEGACY_MEMBERSHIP_STATUSES = [
+  "PENDING",
+  "REGULAR",
+  "RETIRED",
+  "RESIGNED",
+  "LOST",
+  "DECEASED",
+] as const;
+
+interface ValueCounts {
+  null: number;
+  blank: number;
+  present: number;
+}
+
+interface PreflightCohort {
+  recordCount: number;
+  requiredFields: {
+    usersComplete: number;
+    usersMissingAny: number;
+    missingByField: Record<string, number>;
+  };
+  fields: {
+    legacyUserId: { present: number };
+    oldUid: { null: number; present: number };
+    email: ValueCounts;
+    firstName: ValueCounts;
+    lastName: ValueCounts;
+    mobileNumber: ValueCounts;
+    postNominals: ValueCounts;
+    serviceNumber: ValueCounts;
+    rank: { null: number; values: Record<string, number> };
+    membershipStatus: Record<string, number>;
+    isShared: { true: number; false: number; null: number };
+    hasSubscriptions: { true: number; false: number };
+    passwordHash: ValueCounts;
+  };
+}
+
+export interface LegacyPreflightReport {
+  schemaVersion: string;
+  recordSchemaVersion: string;
+  generatedAt: string;
+  overall: PreflightCohort;
+  byOldUid: { set: PreflightCohort; missing: PreflightCohort };
+}
+
+function requireValueCounts(value: unknown, path: string): ValueCounts {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !Number.isInteger((value as ValueCounts).null) ||
+    !Number.isInteger((value as ValueCounts).blank) ||
+    !Number.isInteger((value as ValueCounts).present)
+  ) {
+    throw new Error(`preflight field ${path} must have null/blank/present integer counts`);
+  }
+  return value as ValueCounts;
+}
+
+function requireCohort(value: unknown, path: string): PreflightCohort {
+  if (!value || typeof value !== "object") {
+    throw new Error(`preflight cohort ${path} must be an object`);
+  }
+  const cohort = value as Record<string, unknown>;
+  if (!Number.isInteger(cohort.recordCount) || (cohort.recordCount as number) < 0) {
+    throw new Error(`preflight cohort ${path}.recordCount must be a non-negative integer`);
+  }
+  const requiredFields = cohort.requiredFields as PreflightCohort["requiredFields"] | undefined;
+  if (
+    !requiredFields ||
+    !Number.isInteger(requiredFields.usersComplete) ||
+    !Number.isInteger(requiredFields.usersMissingAny) ||
+    !requiredFields.missingByField ||
+    typeof requiredFields.missingByField !== "object"
+  ) {
+    throw new Error(`preflight cohort ${path}.requiredFields is malformed`);
+  }
+  const fields = cohort.fields as Record<string, unknown> | undefined;
+  if (!fields || typeof fields !== "object") {
+    throw new Error(`preflight cohort ${path}.fields must be an object`);
+  }
+  const legacyUserId = fields.legacyUserId as { present?: unknown } | undefined;
+  if (!legacyUserId || !Number.isInteger(legacyUserId.present)) {
+    throw new Error(`preflight cohort ${path}.fields.legacyUserId is malformed`);
+  }
+  const oldUid = fields.oldUid as { null?: unknown; present?: unknown } | undefined;
+  if (!oldUid || !Number.isInteger(oldUid.null) || !Number.isInteger(oldUid.present)) {
+    throw new Error(`preflight cohort ${path}.fields.oldUid is malformed`);
+  }
+  for (const field of [
+    "email",
+    "firstName",
+    "lastName",
+    "mobileNumber",
+    "postNominals",
+    "serviceNumber",
+    "passwordHash",
+  ]) {
+    requireValueCounts(fields[field], `${path}.fields.${field}`);
+  }
+  const rank = fields.rank as { null?: unknown; values?: unknown } | undefined;
+  if (!rank || !Number.isInteger(rank.null) || !rank.values || typeof rank.values !== "object") {
+    throw new Error(`preflight cohort ${path}.fields.rank is malformed`);
+  }
+  const membershipStatus = fields.membershipStatus;
+  if (!membershipStatus || typeof membershipStatus !== "object") {
+    throw new Error(`preflight cohort ${path}.fields.membershipStatus is malformed`);
+  }
+  const isShared = fields.isShared as { true?: unknown; false?: unknown; null?: unknown } | undefined;
+  if (
+    !isShared ||
+    !Number.isInteger(isShared.true) ||
+    !Number.isInteger(isShared.false) ||
+    !Number.isInteger(isShared.null)
+  ) {
+    throw new Error(`preflight cohort ${path}.fields.isShared is malformed`);
+  }
+  const hasSubscriptions = fields.hasSubscriptions as { true?: unknown; false?: unknown } | undefined;
+  if (!hasSubscriptions || !Number.isInteger(hasSubscriptions.true) || !Number.isInteger(hasSubscriptions.false)) {
+    throw new Error(`preflight cohort ${path}.fields.hasSubscriptions is malformed`);
+  }
+  return cohort as unknown as PreflightCohort;
+}
+
+/** Parses and structurally validates a real sodc-api preflight report. Fails closed on any shape mismatch. */
+export function parseLegacyPreflightReport(raw: unknown): LegacyPreflightReport {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("preflight report must be a JSON object");
+  }
+  const report = raw as Record<string, unknown>;
+  if (report.schemaVersion !== LEGACY_PREFLIGHT_SCHEMA_VERSION) {
+    throw new Error(
+      `unsupported preflight schemaVersion (expected ${LEGACY_PREFLIGHT_SCHEMA_VERSION})`
+    );
+  }
+  if (report.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION) {
+    throw new Error(
+      `unsupported preflight recordSchemaVersion (expected ${LEGACY_RECORD_SCHEMA_VERSION})`
+    );
+  }
+  if (typeof report.generatedAt !== "string" || !report.generatedAt) {
+    throw new Error("preflight report generatedAt must be a non-empty string");
+  }
+  const overall = requireCohort(report.overall, "overall");
+  const byOldUid = report.byOldUid as Record<string, unknown> | undefined;
+  if (!byOldUid) {
+    throw new Error("preflight report byOldUid is missing");
+  }
+  return {
+    schemaVersion: report.schemaVersion,
+    recordSchemaVersion: report.recordSchemaVersion,
+    generatedAt: report.generatedAt,
+    overall,
+    byOldUid: {
+      set: requireCohort(byOldUid.set, "byOldUid.set"),
+      missing: requireCohort(byOldUid.missing, "byOldUid.missing"),
+    },
+  };
+}
+
+function pct(part: number, total: number): string {
+  if (total === 0) return "n/a";
+  return `${((part / total) * 100).toFixed(1)}%`;
+}
+
+function formatValueCounts(counts: ValueCounts, total: number): string {
+  return (
+    `present ${counts.present} (${pct(counts.present, total)}), ` +
+    `blank ${counts.blank} (${pct(counts.blank, total)}), ` +
+    `null ${counts.null} (${pct(counts.null, total)})`
+  );
+}
+
+/**
+ * Renders the non-PII preflight counts as a Markdown worksheet structured around
+ * issue #420's own acceptance criteria, so a reviewer works through each decision
+ * with the actual computed numbers in front of them instead of a blank checklist.
+ */
+export function buildLegacyPreflightReviewWorksheet(report: LegacyPreflightReport): string {
+  const { overall, byOldUid } = report;
+  const total = overall.recordCount;
+  const lines: string[] = [];
+
+  lines.push("# Legacy user migration -- preflight review worksheet (issue #420)");
+  lines.push("");
+  lines.push(
+    `Generated from a \`${report.recordSchemaVersion}\` preflight report ` +
+      `(\`${report.schemaVersion}\`, produced ${report.generatedAt}). Non-PII aggregate counts only.`
+  );
+  lines.push("");
+  lines.push(`**Total exportable records:** ${total}`);
+  lines.push(
+    `- with a legacy \`oldUid\`: ${byOldUid.set.recordCount} (${pct(byOldUid.set.recordCount, total)})`
+  );
+  lines.push(
+    "- without a legacy `oldUid` (provenance only, never used as an identity key): " +
+      `${byOldUid.missing.recordCount} (${pct(byOldUid.missing.recordCount, total)})`
+  );
+  lines.push(
+    "- accounts with `ROLE_DELETED` are already excluded by the exporter and never appear here"
+  );
+  lines.push("");
+
+  lines.push("## 1. Every legacy rank is mapped or quarantined");
+  lines.push("");
+  lines.push(
+    "The exporter fails closed on any rank without an approved mapping, so every value " +
+      "below is already an approved target rank. Review the distribution for plausibility only."
+  );
+  lines.push("");
+  lines.push("| Rank | Count | % |");
+  lines.push("|---|---:|---:|");
+  for (const rank of APPROVED_LEGACY_RANK_TARGETS) {
+    const count = overall.fields.rank.values[rank] ?? 0;
+    lines.push(`| ${rank} | ${count} | ${pct(count, total)} |`);
+  }
+  lines.push(`| _(no rank recorded)_ | ${overall.fields.rank.null} | ${pct(overall.fields.rank.null, total)} |`);
+  const unexpectedRanks = Object.keys(overall.fields.rank.values).filter(
+    (value) => !(APPROVED_LEGACY_RANK_TARGETS as readonly string[]).includes(value)
+  );
+  if (unexpectedRanks.length > 0) {
+    lines.push("");
+    lines.push(
+      "**Unexpected:** rank value(s) not in the approved list appeared in this report: " +
+        `${unexpectedRanks.join(", ")}. Stop and investigate before continuing -- this should ` +
+        "not be possible if the exporter and this reviewer are on the same schema version."
+    );
+  }
+  lines.push("");
+  lines.push("- [ ] Rank distribution reviewed and looks plausible for the membership.");
+  lines.push("");
+
+  lines.push("## 2. Every account has an approved status or explicit exclusion");
+  lines.push("");
+  lines.push(
+    "Status is already assigned by role precedence (`ROLE_RESIGNED` > `ROLE_DECEASED` > " +
+      "`ROLE_LOST` > `ROLE_SERVING` > `ROLE_RETIRED`), falling back to `REGULAR` when `isMember` " +
+      "is true or `PENDING` otherwise. No migrated account can land in `RESERVE`, " +
+      "`CIVIL_SERVICE`, or `INDUSTRY` automatically -- the legacy system cannot distinguish them."
+  );
+  lines.push("");
+  lines.push("| Status | Count | % |");
+  lines.push("|---|---:|---:|");
+  for (const status of APPROVED_LEGACY_MEMBERSHIP_STATUSES) {
+    const count = overall.fields.membershipStatus[status] ?? 0;
+    lines.push(`| ${status} | ${count} | ${pct(count, total)} |`);
+  }
+  const unexpectedStatuses = Object.keys(overall.fields.membershipStatus).filter(
+    (value) => !(APPROVED_LEGACY_MEMBERSHIP_STATUSES as readonly string[]).includes(value)
+  );
+  if (unexpectedStatuses.length > 0) {
+    lines.push("");
+    lines.push(
+      `**Unexpected:** status value(s) outside the approved set appeared: ${unexpectedStatuses.join(", ")}. ` +
+        "Stop and investigate before continuing."
+    );
+  }
+  lines.push("");
+  lines.push(
+    "- [ ] Status distribution reviewed; any status that looks disproportionate " +
+      "(e.g. an unexpectedly high `PENDING` or `LOST` count) has been spot-checked."
+  );
+  lines.push(
+    "- [ ] Accounts that should be `RESERVE`/`CIVIL_SERVICE`/`INDUSTRY` are accepted as a " +
+      "post-migration manual correction, not blocking this migration."
+  );
+  lines.push("");
+
+  lines.push("## 3. Email, required-field, and identity conflicts");
+  lines.push("");
+  lines.push(
+    "Required fields (`email`, `firstName`, `lastName`, `serviceNumber`): " +
+      `${overall.requiredFields.usersComplete} complete ` +
+      `(${pct(overall.requiredFields.usersComplete, total)}), ` +
+      `${overall.requiredFields.usersMissingAny} missing at least one ` +
+      `(${pct(overall.requiredFields.usersMissingAny, total)}).`
+  );
+  lines.push("");
+  lines.push("| Field | Missing count |");
+  lines.push("|---|---:|");
+  for (const [field, count] of Object.entries(overall.requiredFields.missingByField)) {
+    lines.push(`| ${field} | ${count} |`);
+  }
+  lines.push("");
+  lines.push(
+    "**Note:** this preflight reports missing/blank required fields, but not duplicate-email " +
+      "or duplicate-identity counts -- those are only resolved at import time, when the importer " +
+      "reconciles each record against existing Firebase/Data Connect accounts and against other " +
+      "rows in the same artifact. Review the importer's dry-run create/link/conflict counts " +
+      "separately before approving apply."
+  );
+  lines.push("");
+  lines.push(
+    "- [ ] Missing-required-field counts reviewed; remediation plan agreed for blank " +
+      "`firstName`/`lastName` (fail closed) and blank `serviceNumber` (becomes `N/A`)."
+  );
+  lines.push("- [ ] Dry-run's email/identity collision report reviewed separately (not derivable from this preflight alone).");
+  lines.push("");
+
+  lines.push("## 4. Sharing and communications defaults");
+  lines.push("");
+  lines.push(
+    `\`isShared\` (-> \`shareContactInfo\`): true ${overall.fields.isShared.true} ` +
+      `(${pct(overall.fields.isShared.true, total)}), false ${overall.fields.isShared.false} ` +
+      `(${pct(overall.fields.isShared.false, total)}), null ${overall.fields.isShared.null} ` +
+      `(${pct(overall.fields.isShared.null, total)}). Null defaults to \`shareContactInfo=false\` ` +
+      "(privacy-safe) until the member confirms their profile."
+  );
+  lines.push("");
+  lines.push(
+    `\`hasSubscriptions\` (-> \`announcementOptOutAll\`, inverted): true ${overall.fields.hasSubscriptions.true} ` +
+      `(${pct(overall.fields.hasSubscriptions.true, total)}) become \`announcementOptOutAll=false\`; ` +
+      `false ${overall.fields.hasSubscriptions.false} (${pct(overall.fields.hasSubscriptions.false, total)}) ` +
+      "become `announcementOptOutAll=true`."
+  );
+  lines.push("");
+  lines.push("- [ ] Contact-sharing null-default (`false`) confirmed as the agreed privacy fallback.");
+  lines.push("- [ ] Communications opt-out mapping confirmed; no explicit legacy opt-out is silently overridden.");
+  lines.push("");
+
+  lines.push("## 5. Admin restoration allowlist");
+  lines.push("");
+  lines.push(
+    "Not derivable from this artifact -- the exported record schema has no `roles` field, so " +
+      "`ROLE_ADMIN` never reaches this pipeline. Admin claims must come from a separately " +
+      "reviewed allowlist applied after migration, never inferred from legacy data."
+  );
+  lines.push("");
+  lines.push("- [ ] Admin allowlist prepared and reviewed separately from this worksheet.");
+  lines.push("");
+
+  lines.push("## 6. Password credentials");
+  lines.push("");
+  lines.push(
+    `\`passwordHash\`: ${formatValueCounts(overall.fields.passwordHash, total)}. Blank/null ` +
+      "hashes always follow the in-app password-reset path; a compatible-bcrypt proof in " +
+      "staging is required before any hash is imported (`--bcrypt-proven`)."
+  );
+  lines.push("");
+  lines.push("- [ ] Blank-password count reviewed (evidence of no legacy login, not automatic `LOST`).");
+  lines.push("- [ ] Representative bcrypt hash format piloted against a non-production Firebase project.");
+  lines.push("");
+
+  lines.push("## Sign-off");
+  lines.push("");
+  lines.push(
+    `- [ ] All sections above reviewed for record count **${total}** ` +
+      `(schema \`${report.recordSchemaVersion}\`, generated ${report.generatedAt}).`
+  );
+  lines.push(
+    "- [ ] Ready to run the importer dry-run and produce the `sourceChecksum` for the approval artifact."
+  );
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export interface LegacyMigrationApprovalStub {
+  schemaVersion: "sodc-legacy-user-migration-approval/v1";
+  issue: 420;
+  approved: false;
+  projectId: string;
+  sourceChecksum: string;
+  recordSchemaVersion: string;
+  expectedRecordCount: number;
+}
+
+/**
+ * Produces an approval-artifact stub matching what legacy-user-import.ts's --approval
+ * flag expects (see docs/operations/legacy-user-import.md). sourceChecksum cannot be
+ * filled in from the preflight alone -- it is only known once the importer's dry-run
+ * decrypts and hashes the real encrypted artifact -- so it's left as an explicit
+ * placeholder. The operator fills it in, then flips approved to true once every
+ * worksheet section above has been signed off.
+ */
+export function buildLegacyMigrationApprovalStub(
+  report: LegacyPreflightReport,
+  projectId: string
+): LegacyMigrationApprovalStub {
+  return {
+    schemaVersion: "sodc-legacy-user-migration-approval/v1",
+    issue: 420,
+    approved: false,
+    projectId,
+    sourceChecksum: "<fill in from importer dry-run output>",
+    recordSchemaVersion: report.recordSchemaVersion,
+    expectedRecordCount: report.overall.recordCount,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `legacyUserPreflightReview.ts`, parsing and validating a real `sodc-legacy-user-preflight/v2` report and rendering it as a Markdown review worksheet structured around issue #420's acceptance criteria (rank mapping, membership status, required fields/identity conflicts, sharing/comms defaults, admin allowlist, password credentials), plus an approval-artifact stub for `legacy-user-import.ts --approval`.
- Adds the `legacy-user-preflight-review` CLI (`functions/scripts/legacy-user-preflight-review.ts`) and npm script, following the existing `legacy-user-postflight` conventions (atomic 0600 file writes, non-PII-only output).
- Documents the tool in a new `docs/operations/legacy-user-migration-review.md`, cross-linked from the existing schema/import runbooks and the docs index.
- Reads only the non-PII aggregate preflight report; never touches the encrypted member artifact and performs no writes to Firebase/Data Connect.

## Test plan
- [x] `npx vitest run legacyUserPreflightReview` — 14/14 new tests pass (parsing/validation, worksheet content, unexpected-rank/status flagging, approval stub shape)
- [x] Full functions suite: 838/838 tests pass
- [x] `npx tsc -b --noEmit` in `functions/` — clean
- [x] `npm run lint` in `functions/` — clean
- [x] `npm run test:coverage` in `functions/` — threshold intact (60.61% overall, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)