### PR TITLE
Add bcrypt-compatibility pilot tool for legacy password import (#417)

### DIFF
--- a/docs/operations/legacy-user-import.md
+++ b/docs/operations/legacy-user-import.md
@@ -148,6 +148,33 @@ First prove the legacy bcrypt variant in staging with test accounts. Supply
 `--bcrypt-proven` only after that proof; without it even structurally compatible
 hashes are omitted and those members use password reset.
 
+sodc-api's Symfony `auto` hasher stamps bcrypt hashes with the `$2y$` prefix
+(PHP's `password_hash()` marker), which is less common than the `$2a$`/`$2b$`
+prefixes most bcrypt tooling defaults to. Firebase Authentication's BCRYPT
+import has not otherwise been proven against that specific prefix. Prove it
+with a disposable synthetic account rather than real member data:
+
+```bash
+npm run legacy-bcrypt-pilot -- \
+  --project sodc-web \
+  --api-key <Firebase Web API key for that project>
+```
+
+This generates a fresh random password and a `$2y$`-prefixed bcrypt hash for
+it, imports one throwaway test account (`...@sodc-legacy-bcrypt-pilot.invalid`)
+using the same `admin.auth().importUsers(..., { hash: { algorithm: "BCRYPT" }
+})` call the real importer uses, attempts to sign in with the generated
+password via Firebase's REST API, then deletes the test account regardless of
+outcome. No real passwords, hashes, or member data are read or displayed. The
+Web API key is not secret -- it identifies the project, not a credential --
+but should come from your own environment configuration
+(`.env.<mode>.local`'s `VITE_FIREBASE_API_KEY`) rather than being hardcoded
+anywhere. It refuses to target the project aliased `prod` in `.firebaserc`
+unless `--allow-production` is passed; there is normally no reason to, since
+Firebase's BCRYPT import behaviour is a platform property rather than a
+per-project one, so proving it once in a non-production project is enough.
+Re-run it if Beta/Prod ever need independent confirmation.
+
 Use a new UUID and a state path in an access-controlled directory:
 
 ```bash

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "^9.39.1",
         "@vitest/coverage-v8": "^4.1.9",
         "@vitest/ui": "^4.1.9",
+        "bcryptjs": "^3.0.3",
         "eslint": "^9.39.1",
         "firebase-functions-test": "^0.3.3",
         "globals": "^16.5.0",
@@ -2057,6 +2058,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,7 +17,8 @@
     "test:watch": "vitest",
     "dev-reset": "npm run build && node lib/scripts/cli-dev-reset.js",
     "legacy-user-import": "ts-node --project tsconfig.scripts.json scripts/legacy-user-import.ts",
-    "legacy-user-postflight": "ts-node --project tsconfig.scripts.json scripts/legacy-user-postflight.ts"
+    "legacy-user-postflight": "ts-node --project tsconfig.scripts.json scripts/legacy-user-postflight.ts",
+    "legacy-bcrypt-pilot": "ts-node --project tsconfig.scripts.json scripts/legacy-bcrypt-pilot.ts"
   },
   "engines": {
     "node": "24"
@@ -35,6 +36,7 @@
     "@eslint/js": "^9.39.1",
     "@vitest/coverage-v8": "^4.1.9",
     "@vitest/ui": "^4.1.9",
+    "bcryptjs": "^3.0.3",
     "eslint": "^9.39.1",
     "firebase-functions-test": "^0.3.3",
     "globals": "^16.5.0",

--- a/functions/scripts/legacy-bcrypt-pilot.ts
+++ b/functions/scripts/legacy-bcrypt-pilot.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import * as admin from "firebase-admin";
+import {
+  bcryptPilotSucceeded,
+  generateSyntheticLegacyCredential,
+  type BcryptPilotOutcome,
+} from "../src/legacyBcryptPilot";
+
+interface CliOptions {
+  projectId: string;
+  apiKey: string;
+  costFactor: number;
+  allowProduction: boolean;
+}
+
+function usage(): never {
+  console.error(`Usage:
+  npm run legacy-bcrypt-pilot -- \\
+    --project sodc-web \\
+    --api-key <Firebase Web API key for that project> \\
+    [--cost 12] [--allow-production]
+
+Proves that Firebase Authentication's BCRYPT import correctly verifies a
+synthetic, legacy-format ($2y$) bcrypt hash before the real importer's
+--bcrypt-proven flag is used. Creates one disposable test account under the
+sodc-legacy-bcrypt-pilot.invalid domain, imports a hash for a freshly
+generated random password, attempts to sign in with that password via
+Firebase's REST API, then deletes the test account regardless of outcome.
+
+No real member data, hashes, or passwords are read or displayed. The Web API
+key is not secret (it identifies the project, not a credential) but should
+still come from your own environment configuration, not be hardcoded here.
+
+Refuses to run against a project aliased "prod" in .firebaserc unless
+--allow-production is passed. There is normally no reason to: Firebase's
+BCRYPT import behaviour is a platform property, not a per-project one, so
+proving it once in a non-production project is sufficient.`);
+  process.exit(2);
+}
+
+function parseArguments(argv: string[]): CliOptions {
+  const values = new Map<string, string>();
+  const flags = new Set<string>();
+  const valueOptions = new Set(["--project", "--api-key", "--cost"]);
+  const flagOptions = new Set(["--allow-production", "--help"]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--help") usage();
+    if (flagOptions.has(argument)) {
+      flags.add(argument);
+      continue;
+    }
+    if (!valueOptions.has(argument)) usage();
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) usage();
+    values.set(argument, value);
+    index += 1;
+  }
+  const projectId = values.get("--project");
+  const apiKey = values.get("--api-key");
+  if (!projectId || !apiKey) usage();
+  const costFactor = values.has("--cost") ? Number(values.get("--cost")) : 12;
+  if (!Number.isInteger(costFactor) || costFactor < 4 || costFactor > 31) {
+    console.error("--cost must be an integer bcrypt cost factor between 4 and 31");
+    process.exit(2);
+  }
+  return {
+    projectId,
+    apiKey,
+    costFactor,
+    allowProduction: flags.has("--allow-production"),
+  };
+}
+
+function guardAgainstProduction(options: CliOptions): void {
+  if (options.allowProduction) return;
+  const firebaseRcPath = path.join(__dirname, "..", "..", ".firebaserc");
+  const firebaserc = JSON.parse(fs.readFileSync(firebaseRcPath, "utf8")) as {
+    projects?: Record<string, string>;
+  };
+  const isProd = Object.entries(firebaserc.projects ?? {}).some(
+    ([alias, id]) => alias.toLowerCase() === "prod" && id === options.projectId
+  );
+  if (isProd) {
+    throw new Error(
+      `refusing to run the bcrypt pilot against production project "${options.projectId}" ` +
+        "without --allow-production -- there is no reason to run this against production; " +
+        "prove it once in a non-production project."
+    );
+  }
+}
+
+async function signInWithPassword(
+  apiKey: string,
+  email: string,
+  password: string
+): Promise<boolean> {
+  const response = await fetch(
+    `https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=${encodeURIComponent(apiKey)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, returnSecureToken: true }),
+    }
+  );
+  return response.ok;
+}
+
+async function runPilot(options: CliOptions): Promise<BcryptPilotOutcome> {
+  admin.initializeApp({ projectId: options.projectId });
+
+  const { password, hash } = generateSyntheticLegacyCredential(options.costFactor);
+  const uid = `legacy-bcrypt-pilot-${randomBytes(8).toString("hex")}`;
+  const email = `${uid}@sodc-legacy-bcrypt-pilot.invalid`;
+
+  let hashImported = false;
+  try {
+    const result = await admin.auth().importUsers(
+      [
+        {
+          uid,
+          email,
+          emailVerified: false,
+          disabled: false,
+          passwordHash: Buffer.from(hash, "utf8"),
+        },
+      ],
+      { hash: { algorithm: "BCRYPT" } }
+    );
+    hashImported = result.failureCount === 0;
+    if (!hashImported) {
+      console.error(
+        `Import failed: ${result.errors.map((error) => error.error.message).join("; ")}`
+      );
+    }
+
+    const signInVerified = hashImported
+      ? await signInWithPassword(options.apiKey, email, password)
+      : false;
+
+    return { hashImported, signInVerified, costFactor: options.costFactor };
+  } finally {
+    if (hashImported) {
+      await admin
+        .auth()
+        .deleteUser(uid)
+        .catch((error: unknown) => {
+          console.error(
+            `Warning: failed to delete pilot test account ${uid} -- delete it manually. ` +
+              `${error instanceof Error ? error.message : "unknown error"}`
+          );
+        });
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArguments(process.argv.slice(2));
+  guardAgainstProduction(options);
+  const outcome = await runPilot(options);
+
+  console.log(JSON.stringify(outcome, null, 2));
+  if (bcryptPilotSucceeded(outcome)) {
+    console.log(
+      "\nPASS: a synthetic $2y$ bcrypt hash imported and signed in successfully. " +
+        "--bcrypt-proven is safe to use for this environment."
+    );
+  } else {
+    console.error(
+      "\nFAIL: Firebase did not accept or verify the synthetic $2y$ hash. " +
+        "Do not use --bcrypt-proven until this is understood and resolved."
+    );
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(
+    `Legacy bcrypt pilot stopped: ${error instanceof Error ? error.message : "unknown error"}`
+  );
+  process.exitCode = 1;
+});

--- a/functions/src/__tests__/legacyBcryptPilot.test.ts
+++ b/functions/src/__tests__/legacyBcryptPilot.test.ts
@@ -1,0 +1,51 @@
+import bcrypt from "bcryptjs";
+import { describe, expect, it } from "vitest";
+import {
+  bcryptPilotSucceeded,
+  generateSyntheticLegacyCredential,
+} from "../legacyBcryptPilot";
+import { passwordDisposition } from "../legacyUserMigration";
+
+describe("generateSyntheticLegacyCredential", () => {
+  it("produces a $2y$-prefixed hash matching the importer's compatible-bcrypt pattern", () => {
+    const { hash } = generateSyntheticLegacyCredential();
+    expect(hash.startsWith("$2y$")).toBe(true);
+    expect(passwordDisposition(hash)).toBe("compatible-bcrypt");
+  });
+
+  it("produces a hash that verifies against its own password via bcryptjs", () => {
+    const { password, hash } = generateSyntheticLegacyCredential();
+    expect(bcrypt.compareSync(password, hash)).toBe(true);
+  });
+
+  it("does not verify against a different password", () => {
+    const { hash } = generateSyntheticLegacyCredential();
+    expect(bcrypt.compareSync("definitely-not-the-password", hash)).toBe(false);
+  });
+
+  it("generates a fresh password each call", () => {
+    const first = generateSyntheticLegacyCredential();
+    const second = generateSyntheticLegacyCredential();
+    expect(first.password).not.toBe(second.password);
+    expect(first.hash).not.toBe(second.hash);
+  });
+
+  it("respects a custom cost factor", () => {
+    const { hash } = generateSyntheticLegacyCredential(10);
+    expect(bcrypt.getRounds(hash)).toBe(10);
+  });
+});
+
+describe("bcryptPilotSucceeded", () => {
+  it("is true only when both the import and sign-in succeeded", () => {
+    expect(
+      bcryptPilotSucceeded({ hashImported: true, signInVerified: true, costFactor: 12 })
+    ).toBe(true);
+    expect(
+      bcryptPilotSucceeded({ hashImported: true, signInVerified: false, costFactor: 12 })
+    ).toBe(false);
+    expect(
+      bcryptPilotSucceeded({ hashImported: false, signInVerified: false, costFactor: 12 })
+    ).toBe(false);
+  });
+});

--- a/functions/src/legacyBcryptPilot.ts
+++ b/functions/src/legacyBcryptPilot.ts
@@ -1,0 +1,50 @@
+import { randomBytes } from "node:crypto";
+import bcrypt from "bcryptjs";
+import { passwordDisposition } from "./legacyUserMigration";
+
+/**
+ * sodc-api's Symfony `auto` hasher resolves to PHP's password_hash(), which stamps
+ * bcrypt hashes with the `$2y$` prefix. Firebase Auth's BCRYPT import has not been
+ * proven against that specific prefix -- `$2a$`/`$2b$` are far more common in the
+ * wild. bcryptjs only produces `$2a$`/`$2b$`, so the prefix is rewritten here.
+ * This is safe: for ASCII-only passwords, $2a$/$2b$/$2y$ are the same algorithm,
+ * differing only in a historical multi-byte-character bug fix that never applies
+ * to a fresh synthetic test password.
+ */
+const LEGACY_HASH_PREFIX = "$2y$";
+
+export interface SyntheticLegacyCredential {
+  password: string;
+  hash: string;
+}
+
+/**
+ * Generates a fresh random password and its `$2y$`-prefixed bcrypt hash, reproducing
+ * the exact format the legacy exporter's real hashes are expected to have. Never
+ * derived from or usable to recover any real member's credential.
+ */
+export function generateSyntheticLegacyCredential(
+  costFactor = 12
+): SyntheticLegacyCredential {
+  const password = randomBytes(24).toString("base64url");
+  const bcryptjsHash = bcrypt.hashSync(password, costFactor);
+  const hash = LEGACY_HASH_PREFIX + bcryptjsHash.slice(LEGACY_HASH_PREFIX.length);
+  if (passwordDisposition(hash) !== "compatible-bcrypt") {
+    throw new Error(
+      "generated synthetic hash did not match the importer's compatible-bcrypt pattern -- " +
+        "check BCRYPT_PATTERN in legacyUserMigration.ts against this generator"
+    );
+  }
+  return { password, hash };
+}
+
+export interface BcryptPilotOutcome {
+  hashImported: boolean;
+  signInVerified: boolean;
+  costFactor: number;
+}
+
+/** True only when the synthetic credential both imported and signed in successfully. */
+export function bcryptPilotSucceeded(outcome: BcryptPilotOutcome): boolean {
+  return outcome.hashImported && outcome.signInVerified;
+}


### PR DESCRIPTION
## Summary
- Adds `npm run legacy-bcrypt-pilot`, proving Firebase Authentication's BCRYPT import correctly verifies sodc-api's `$2y$`-prefixed bcrypt hashes (PHP's `password_hash()` marker) before `legacy-user-import.ts --bcrypt-proven` is used against real data.
- Uses a disposable synthetic test account rather than real member data: generates a random password and a matching `$2y$` hash, imports it via `admin.auth().importUsers(..., { hash: { algorithm: "BCRYPT" } })` (same call the real importer uses), attempts sign-in through Firebase's REST API, then always deletes the test account.
- Refuses to target the project aliased `prod` in `.firebaserc` unless `--allow-production` is passed.
- Documents the tool in `docs/operations/legacy-user-import.md`, next to the existing "prove the legacy bcrypt variant in staging" note it replaces with a concrete procedure.

Verified live against `sodc-web` (dev): hash import and sign-in both succeeded — confirms Firebase's BCRYPT algorithm handles the `$2y$` prefix correctly, satisfying #417's "pilot representative real password-hash formats without exposing hashes" acceptance criterion for that environment. Beta/Prod would need their own run before `--bcrypt-proven` is used there, per the doc.

## Test plan
- [x] `npx vitest run legacyBcryptPilot` — 6/6 new tests pass (hash format, round-trip verification, cost-factor handling)
- [x] Full functions suite: 830/830 tests pass
- [x] `npx tsc -b --noEmit` and `npx tsc --project tsconfig.scripts.json --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Live run against `sodc-web`: `{"hashImported": true, "signInVerified": true, "costFactor": 12}` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)