### PR TITLE
Automate 5 previously-manual deployment-check controls

### DIFF
--- a/config/deployment-check.json
+++ b/config/deployment-check.json
@@ -8,6 +8,13 @@
     "sqlInstance": "sodc-web-instance",
     "database": "fdcdb"
   },
+  "appCheck": {
+    "services": [
+      "firebasedataconnect.googleapis.com",
+      "firebasestorage.googleapis.com",
+      "identitytoolkit.googleapis.com"
+    ]
+  },
   "requiredApis": [
     "artifactregistry.googleapis.com",
     "cloudbuild.googleapis.com",
@@ -118,7 +125,8 @@
       "hostingSite": "sodc-web",
       "hostingUrl": "https://sodc-web.web.app",
       "storageBucket": "sodc-web.firebasestorage.app",
-      "requireCloudSqlResilience": false
+      "requireCloudSqlResilience": false,
+      "allowLocalhostAuthDomain": true
     },
     "beta": {
       "projectId": "sodc-web-beta",

--- a/docs/operations/deployment-checks.md
+++ b/docs/operations/deployment-checks.md
@@ -124,17 +124,50 @@ The report does not include it. Production use requires an approved dedicated
 test identity and secret-handling mechanism; do not borrow a member or operator
 session token.
 
+## Automated checks added after initial release
+
+The following were originally "manual checks that remain" (below) but are now
+read-only automated checks, added once production use surfaced real gaps they
+would have caught:
+
+- **App Check enforcement** -- `firebaseappcheck.googleapis.com`'s services
+  API reports per-service `enforcementMode`. FAILs if App Check has no
+  services registered at all; WARNs if registered but any checked service is
+  still `UNENFORCED` (monitoring-only); PASSes once every checked service is
+  `ENFORCED`.
+- **Auth providers and authorized domains** -- Identity Platform's admin
+  config API confirms email/password sign-in is enabled, every expected
+  canonical domain is authorized, and `localhost` is authorized only in `dev`.
+- **Deployed Storage rules content and a negative unauthenticated probe** --
+  the Firebase Security Rules API's deployed ruleset is byte-compared
+  (whitespace-normalized) against the checked-in `storage.rules`, and an
+  unauthenticated fetch against the bucket confirms it is denied.
+- **Scanner service-account scope** -- confirms the malware scanner's service
+  account carries no project-level IAM roles at all, only the specific
+  resource-level grants checked elsewhere.
+- **Malware-definition refresh health** -- confirms the Cloud Scheduler
+  refresh job is `ENABLED` and its most recent attempt succeeded within the
+  last few hours. Deliberately checks the scheduler's own execution health
+  rather than the definitions file's content timestamp -- ClamAV's upstream
+  `daily.cld` doesn't necessarily change every time the refresh job runs, so a
+  content-age check would false-fail on a job that ran successfully but found
+  nothing new to download.
+
+These calls a raw access token against Google/Firebase Management REST APIs
+that have no `gcloud`/`firebase` CLI equivalent (App Check, Identity
+Toolkit config, Firebase Security Rules) using the same credentials already
+required for every other check -- no new authentication surface.
+
 ## Manual checks that remain
 
 The CLI deliberately reports a warning for controls that cannot be proved
 safely and completely through the current read-only APIs:
 
-- App Check registration, valid-token metrics, and enforcement state;
-- Authentication providers and authorized domains;
-- the active Firebase Storage ruleset and a negative unauthenticated probe;
-- scanner service-account scope beyond the required invocation permission;
-- malware-definition freshness and the scheduled refresh job;
-- SQL backups, point-in-time recovery, deletion protection, and restore tests;
+- App Check valid-token traffic metrics (enforcement mode itself is now
+  automated -- see above);
+- SQL restore-test results (backups, point-in-time recovery, and deletion
+  protection are automated; actually performing a restore is destructive and
+  out of scope for a read-only audit);
 - alerts, incident contacts, budget notifications, and external dashboard
   configuration; and
 - end-to-end member journeys that require real test data.

--- a/scripts/deployment-check-lib.mjs
+++ b/scripts/deployment-check-lib.mjs
@@ -171,6 +171,154 @@ export function assessFunctionInvokerPolicies(records, expectedPublicFunctions) 
   return { unreadable, unexpectedlyPublic, unexpectedlyPrivate, missingAudits };
 }
 
+/**
+ * Assesses Firebase App Check enforcement mode per service, matching what the read-only
+ * `firebaseappcheck.googleapis.com` API can prove: FAIL when App Check was never registered
+ * for any service (an empty list), WARN when registered but still in monitoring-only mode
+ * (any service not ENFORCED), PASS only once every checked service is ENFORCED.
+ */
+export function assessAppCheckEnforcement(services) {
+  const entries = (services ?? []).map((service) => ({
+    name: normalizeResourceName(service.name),
+    enforcementMode: service.enforcementMode,
+  }));
+  if (entries.length === 0) {
+    return {
+      status: RESULT_STATUS.FAIL,
+      summary: "App Check has no services registered; enforcement is not configured.",
+    };
+  }
+  const unenforced = entries.filter((entry) => entry.enforcementMode !== "ENFORCED");
+  if (unenforced.length > 0) {
+    return {
+      status: RESULT_STATUS.WARN,
+      summary: "App Check is registered but not yet enforced for all services (monitoring only).",
+      details: { services: entries },
+    };
+  }
+  return {
+    status: RESULT_STATUS.PASS,
+    summary: "App Check is registered and enforced for all checked services.",
+    details: { services: entries },
+  };
+}
+
+/**
+ * Assesses Identity Platform sign-in configuration: email/password sign-in is the site's
+ * only supported method, every expected canonical domain must be authorized, and `localhost`
+ * must only be authorized in environments that explicitly allow it (dev).
+ */
+export function assessAuthConfiguration(config, expectedAuthorizedDomains, allowLocalhost) {
+  const authorizedDomains = config?.authorizedDomains ?? [];
+  const issues = [];
+  if (config?.signIn?.email?.enabled !== true) {
+    issues.push("email/password sign-in is not enabled");
+  }
+  const missingDomains = expectedAuthorizedDomains.filter(
+    (domain) => !authorizedDomains.includes(domain)
+  );
+  if (missingDomains.length) {
+    issues.push(`missing authorized domain(s): ${missingDomains.join(", ")}`);
+  }
+  if (!allowLocalhost && authorizedDomains.includes("localhost")) {
+    issues.push("localhost is authorized outside of dev");
+  }
+  if (issues.length) {
+    return {
+      status: RESULT_STATUS.FAIL,
+      summary: `Auth configuration audit failed: ${issues.join("; ")}.`,
+      details: { authorizedDomains },
+    };
+  }
+  return {
+    status: RESULT_STATUS.PASS,
+    summary: "Auth sign-in method and authorized domains are configured correctly.",
+    details: { authorizedDomains },
+  };
+}
+
+/**
+ * Compares the deployed Firebase Storage ruleset's source against the checked-in
+ * `storage.rules`, normalizing line endings/trailing whitespace so formatting-only
+ * differences don't produce a false failure.
+ */
+export function assessStorageRulesContent(deployedContent, checkedInContent) {
+  const normalize = (value) =>
+    String(value ?? "")
+      .replace(/\r\n/g, "\n")
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+      .trim();
+  if (normalize(deployedContent) !== normalize(checkedInContent)) {
+    return {
+      status: RESULT_STATUS.FAIL,
+      summary: "Deployed Storage rules do not match the checked-in storage.rules.",
+    };
+  }
+  return {
+    status: RESULT_STATUS.PASS,
+    summary: "Deployed Storage rules match the checked-in storage.rules.",
+  };
+}
+
+/**
+ * Confirms a service account carries no project-level IAM bindings at all -- the expected
+ * shape for a least-privilege service account whose only grants are the specific
+ * resource-level bindings checked elsewhere (e.g. objectViewer on one bucket).
+ */
+export function assessServiceAccountProjectScope(serviceAccountEmail, projectRoles) {
+  if (projectRoles.length > 0) {
+    return {
+      status: RESULT_STATUS.FAIL,
+      summary: `${serviceAccountEmail} has unexpected project-level IAM role(s): ${projectRoles.join(", ")}.`,
+    };
+  }
+  return {
+    status: RESULT_STATUS.PASS,
+    summary: `${serviceAccountEmail} has no project-level IAM roles beyond its explicit resource-level grants.`,
+  };
+}
+
+/**
+ * Assesses whether the ClamAV definitions refresh schedule is enabled and its most recent
+ * attempt ran recently without error. Deliberately checks the scheduler's own execution
+ * health rather than the definitions file's content timestamp: ClamAV's upstream daily.cld
+ * doesn't necessarily change every time the refresh job runs, so a content-age check would
+ * false-fail whenever the job runs successfully but finds nothing new to download.
+ */
+export function assessDefinitionsFreshness({
+  schedulerState,
+  lastAttemptTime,
+  lastAttemptFailed,
+  now,
+  maxAgeHours,
+}) {
+  const issues = [];
+  if (schedulerState !== "ENABLED") {
+    issues.push(`refresh schedule is ${schedulerState ?? "unknown"}, not ENABLED`);
+  }
+  if (lastAttemptFailed) {
+    issues.push("the most recent refresh attempt failed");
+  }
+  const ageHours = (now.getTime() - new Date(lastAttemptTime).getTime()) / (60 * 60 * 1000);
+  if (!Number.isFinite(ageHours) || ageHours > maxAgeHours) {
+    issues.push(
+      `the last refresh attempt was ${Number.isFinite(ageHours) ? `${ageHours.toFixed(1)}h` : "an unknown time"} ago, older than the ${maxAgeHours}h limit`
+    );
+  }
+  if (issues.length) {
+    return {
+      status: RESULT_STATUS.FAIL,
+      summary: `Malware-definition refresh audit failed: ${issues.join("; ")}.`,
+    };
+  }
+  return {
+    status: RESULT_STATUS.PASS,
+    summary: "Malware-definition refresh schedule is enabled and its last attempt succeeded recently.",
+  };
+}
+
 async function walk(directory) {
   const entries = await readdir(directory, { withFileTypes: true });
   const files = [];

--- a/scripts/deployment-check.mjs
+++ b/scripts/deployment-check.mjs
@@ -6,8 +6,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   RESULT_STATUS,
+  assessAppCheckEnforcement,
+  assessAuthConfiguration,
+  assessDefinitionsFreshness,
   assessGovNotifyReplyToConfiguration,
   assessFunctionInvokerPolicies,
+  assessServiceAccountProjectScope,
+  assessStorageRulesContent,
   compareExpected,
   createReport,
   discoverFunctionContracts,
@@ -26,6 +31,30 @@ import {
 const execFileAsync = promisify(execFile);
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 let gcloudReady = true;
+let cachedAccessToken;
+
+async function accessToken() {
+  if (!cachedAccessToken) {
+    cachedAccessToken = (await run("gcloud", ["auth", "print-access-token"])).trim();
+  }
+  return cachedAccessToken;
+}
+
+/**
+ * Calls a Google/Firebase Management REST API that has no gcloud/firebase CLI equivalent
+ * (App Check, Identity Toolkit, Firebase Security Rules). Read-only GETs only.
+ */
+async function googleApiFetch(url, projectId) {
+  const token = await accessToken();
+  const response = await fetchWithTimeout(url, {
+    headers: { Authorization: `Bearer ${token}`, "X-Goog-User-Project": projectId },
+  });
+  const body = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    throw new Error(body?.error?.message ?? `request to ${url} failed with HTTP ${response.status}`);
+  }
+  return body;
+}
 
 const help = `Usage:
   npm run deployment:check -- --env <dev|beta|prod> [options]
@@ -244,6 +273,37 @@ async function main() {
     },
   });
 
+  if (gcloudReady) {
+    try {
+      const authConfig = await googleApiFetch(
+        `https://identitytoolkit.googleapis.com/admin/v2/projects/${target.projectId}/config`,
+        target.projectId
+      );
+      const expectedAuthorizedDomains = [
+        `${target.projectId}.firebaseapp.com`,
+        new URL(target.hostingUrl).hostname,
+      ];
+      const outcome = assessAuthConfiguration(
+        authConfig,
+        expectedAuthorizedDomains,
+        target.allowLocalhostAuthDomain === true
+      );
+      results.push(result("auth-config", outcome.status, outcome.summary, outcome.details));
+    } catch (error) {
+      results.push(
+        result("auth-config", RESULT_STATUS.FAIL, `Auth configuration audit failed: ${safeErrorMessage(error)}`)
+      );
+    }
+  } else {
+    results.push(
+      result(
+        "auth-config",
+        RESULT_STATUS.SKIP,
+        "Auth configuration audit skipped because the gcloud project/authentication preflight failed."
+      )
+    );
+  }
+
   await commandCheck(results, {
     id: "required-apis",
     label: "Required API audit failed",
@@ -256,6 +316,32 @@ async function main() {
       return { status: RESULT_STATUS.PASS, summary: "All required Google Cloud APIs are enabled." };
     },
   });
+
+  if (gcloudReady) {
+    try {
+      const appCheck = await googleApiFetch(
+        `https://firebaseappcheck.googleapis.com/v1/projects/${target.projectId}/services`,
+        target.projectId
+      );
+      const relevant = (appCheck.services ?? []).filter((service) =>
+        configuration.appCheck.services.includes(normalizeResourceName(service.name))
+      );
+      const outcome = assessAppCheckEnforcement(relevant);
+      results.push(result("app-check", outcome.status, outcome.summary, outcome.details));
+    } catch (error) {
+      results.push(
+        result("app-check", RESULT_STATUS.FAIL, `App Check audit failed: ${safeErrorMessage(error)}`)
+      );
+    }
+  } else {
+    results.push(
+      result(
+        "app-check",
+        RESULT_STATUS.SKIP,
+        "App Check audit skipped because the gcloud project/authentication preflight failed."
+      )
+    );
+  }
 
   await commandCheck(results, {
     id: "dataconnect",
@@ -293,7 +379,7 @@ async function main() {
         data.region === target.region &&
         backups?.enabled === true &&
         backups?.pointInTimeRecoveryEnabled === true &&
-        data.deletionProtectionEnabled === true;
+        data.settings?.deletionProtectionEnabled === true;
       if (!healthy) {
         throw new Error("region, automated backups, point-in-time recovery, or deletion protection differs");
       }
@@ -352,6 +438,46 @@ async function main() {
       return { status: RESULT_STATUS.PASS, summary: "Required malware-definition job exists." };
     },
   });
+
+  if (gcloudReady) {
+    try {
+      const scheduler = await runJson("gcloud", [
+        "scheduler",
+        "jobs",
+        "describe",
+        configuration.requiredCloudRunJobs[0],
+        "--project",
+        target.projectId,
+        "--location",
+        target.region,
+        "--format=json",
+      ]);
+      const outcome = assessDefinitionsFreshness({
+        schedulerState: scheduler.state,
+        lastAttemptTime: scheduler.lastAttemptTime,
+        lastAttemptFailed: Boolean(scheduler.status?.code),
+        now: new Date(),
+        maxAgeHours: 3,
+      });
+      results.push(result("malware-definitions-freshness", outcome.status, outcome.summary));
+    } catch (error) {
+      results.push(
+        result(
+          "malware-definitions-freshness",
+          RESULT_STATUS.FAIL,
+          `Malware-definition freshness audit failed: ${safeErrorMessage(error)}`
+        )
+      );
+    }
+  } else {
+    results.push(
+      result(
+        "malware-definitions-freshness",
+        RESULT_STATUS.SKIP,
+        "Malware-definition freshness audit skipped because the gcloud project/authentication preflight failed."
+      )
+    );
+  }
 
   const deployedFunctions = await commandCheck(results, {
     id: "functions",
@@ -567,6 +693,55 @@ async function main() {
     },
   });
 
+  if (gcloudReady) {
+    try {
+      const releases = await googleApiFetch(
+        `https://firebaserules.googleapis.com/v1/projects/${target.projectId}/releases`,
+        target.projectId
+      );
+      const release = (releases.releases ?? []).find((entry) =>
+        entry.name.endsWith(`firebase.storage/${target.storageBucket}`)
+      );
+      if (!release) throw new Error(`no Storage rules release found for ${target.storageBucket}`);
+      const ruleset = await googleApiFetch(
+        `https://firebaserules.googleapis.com/v1/${release.rulesetName}`,
+        target.projectId
+      );
+      const deployedContent = ruleset.source?.files?.[0]?.content;
+      const checkedInContent = await readFile(path.join(repositoryRoot, "storage.rules"), "utf8");
+      const outcome = assessStorageRulesContent(deployedContent, checkedInContent);
+      results.push(result("storage-rules-content", outcome.status, outcome.summary));
+
+      const probeUrl = `https://firebasestorage.googleapis.com/v0/b/${target.storageBucket}/o/_deployment-check-probe`;
+      const probeResponse = await fetchWithTimeout(probeUrl);
+      results.push(
+        result(
+          "storage-unauthenticated-probe",
+          probeResponse.status === 200 ? RESULT_STATUS.FAIL : RESULT_STATUS.PASS,
+          probeResponse.status === 200
+            ? "Unauthenticated Storage read succeeded; deployed rules do not deny read."
+            : `Unauthenticated Storage read was denied (HTTP ${probeResponse.status}).`
+        )
+      );
+    } catch (error) {
+      results.push(
+        result(
+          "storage-rules-content",
+          RESULT_STATUS.FAIL,
+          `Storage rules audit failed: ${safeErrorMessage(error)}`
+        )
+      );
+    }
+  } else {
+    results.push(
+      result(
+        "storage-rules-content",
+        RESULT_STATUS.SKIP,
+        "Storage rules audit skipped because the gcloud project/authentication preflight failed."
+      )
+    );
+  }
+
   let runtimeServiceAccount;
   if (deployedFunctions) {
     const uploadFunction = values(deployedFunctions).find(
@@ -706,6 +881,51 @@ async function main() {
     );
   }
 
+  if (gcloudReady) {
+    try {
+      const scannerService = await runJson("gcloud", [
+        "run",
+        "services",
+        "describe",
+        "section-file-malware-scanner",
+        "--region",
+        target.region,
+        "--project",
+        target.projectId,
+        "--format=json",
+      ]);
+      const scannerServiceAccount = scannerService.spec?.template?.spec?.serviceAccountName;
+      if (!scannerServiceAccount) throw new Error("scanner service did not report a service account");
+      const projectPolicy = await runJson("gcloud", [
+        "projects",
+        "get-iam-policy",
+        target.projectId,
+        "--flatten=bindings[].members",
+        `--filter=bindings.members:serviceAccount:${scannerServiceAccount}`,
+        "--format=json",
+      ]);
+      const projectRoles = values(projectPolicy).map((binding) => binding.bindings?.role ?? binding.role).filter(Boolean);
+      const outcome = assessServiceAccountProjectScope(scannerServiceAccount, projectRoles);
+      results.push(result("scanner-project-scope", outcome.status, outcome.summary));
+    } catch (error) {
+      results.push(
+        result(
+          "scanner-project-scope",
+          RESULT_STATUS.FAIL,
+          `Scanner service-account scope audit failed: ${safeErrorMessage(error)}`
+        )
+      );
+    }
+  } else {
+    results.push(
+      result(
+        "scanner-project-scope",
+        RESULT_STATUS.SKIP,
+        "Scanner service-account scope audit skipped because the gcloud project/authentication preflight failed."
+      )
+    );
+  }
+
   try {
     const rootResponse = await fetchWithTimeout(target.hostingUrl, { redirect: "follow" });
     if (!rootResponse.ok) throw new Error(`root returned HTTP ${rootResponse.status}`);
@@ -839,7 +1059,7 @@ async function main() {
     result(
       "manual-controls",
       RESULT_STATUS.WARN,
-      "Manually confirm App Check enforcement, Auth authorized domains/providers, deployed Storage rules, scanner definitions freshness, backups, and alerts."
+      "Manually confirm App Check valid-token traffic metrics, SQL restore-test results, alerting/incident-contact/budget-notification/external-dashboard configuration, and end-to-end member journeys with real test data."
     )
   );
 

--- a/scripts/deployment-check.test.mjs
+++ b/scripts/deployment-check.test.mjs
@@ -5,8 +5,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   RESULT_STATUS,
+  assessAppCheckEnforcement,
+  assessAuthConfiguration,
+  assessDefinitionsFreshness,
   assessGovNotifyReplyToConfiguration,
   assessFunctionInvokerPolicies,
+  assessServiceAccountProjectScope,
+  assessStorageRulesContent,
   compareExpected,
   createReport,
   discoverFunctionContracts,
@@ -270,5 +275,140 @@ describe("deployment check parsing and comparison", () => {
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
+  });
+
+  it("fails App Check audit when no services are registered", () => {
+    expect(assessAppCheckEnforcement([]).status).toBe(RESULT_STATUS.FAIL);
+  });
+
+  it("warns when App Check is registered but not fully enforced", () => {
+    const outcome = assessAppCheckEnforcement([
+      { name: "projects/1/services/firebasestorage.googleapis.com", enforcementMode: "ENFORCED" },
+      { name: "projects/1/services/identitytoolkit.googleapis.com", enforcementMode: "UNENFORCED" },
+    ]);
+    expect(outcome.status).toBe(RESULT_STATUS.WARN);
+    expect(outcome.details.services).toEqual([
+      { name: "firebasestorage.googleapis.com", enforcementMode: "ENFORCED" },
+      { name: "identitytoolkit.googleapis.com", enforcementMode: "UNENFORCED" },
+    ]);
+  });
+
+  it("passes App Check audit once every checked service is enforced", () => {
+    expect(
+      assessAppCheckEnforcement([
+        { name: "projects/1/services/firebasestorage.googleapis.com", enforcementMode: "ENFORCED" },
+      ]).status
+    ).toBe(RESULT_STATUS.PASS);
+  });
+
+  it("fails auth audit for disabled sign-in, missing domains, or stray localhost", () => {
+    expect(
+      assessAuthConfiguration(
+        { signIn: { email: { enabled: false } }, authorizedDomains: ["example.web.app"] },
+        ["example.web.app"],
+        false
+      ).status
+    ).toBe(RESULT_STATUS.FAIL);
+
+    const missingDomain = assessAuthConfiguration(
+      { signIn: { email: { enabled: true } }, authorizedDomains: ["example.web.app"] },
+      ["example.web.app", "example.firebaseapp.com"],
+      false
+    );
+    expect(missingDomain.status).toBe(RESULT_STATUS.FAIL);
+    expect(missingDomain.summary).toMatch(/example\.firebaseapp\.com/);
+
+    expect(
+      assessAuthConfiguration(
+        {
+          signIn: { email: { enabled: true } },
+          authorizedDomains: ["example.web.app", "localhost"],
+        },
+        ["example.web.app"],
+        false
+      ).status
+    ).toBe(RESULT_STATUS.FAIL);
+  });
+
+  it("passes auth audit when localhost is explicitly allowed", () => {
+    expect(
+      assessAuthConfiguration(
+        {
+          signIn: { email: { enabled: true } },
+          authorizedDomains: ["example.web.app", "localhost"],
+        },
+        ["example.web.app"],
+        true
+      ).status
+    ).toBe(RESULT_STATUS.PASS);
+  });
+
+  it("compares deployed and checked-in Storage rules ignoring trailing whitespace", () => {
+    expect(assessStorageRulesContent("allow read;\n", "allow read;  \n").status).toBe(
+      RESULT_STATUS.PASS
+    );
+    expect(assessStorageRulesContent("allow read;", "allow read, write;").status).toBe(
+      RESULT_STATUS.FAIL
+    );
+  });
+
+  it("fails service-account project scope audit when any project-level role exists", () => {
+    const outcome = assessServiceAccountProjectScope("scanner@example.iam.gserviceaccount.com", [
+      "roles/editor",
+    ]);
+    expect(outcome.status).toBe(RESULT_STATUS.FAIL);
+    expect(outcome.summary).toMatch(/roles\/editor/);
+  });
+
+  it("passes service-account project scope audit when no project-level roles exist", () => {
+    expect(assessServiceAccountProjectScope("scanner@example.iam.gserviceaccount.com", []).status).toBe(
+      RESULT_STATUS.PASS
+    );
+  });
+
+  it("fails definitions freshness audit for a disabled schedule, failed attempt, or stale attempt", () => {
+    const now = new Date("2026-01-01T12:00:00Z");
+    expect(
+      assessDefinitionsFreshness({
+        schedulerState: "PAUSED",
+        lastAttemptTime: "2026-01-01T11:00:00Z",
+        lastAttemptFailed: false,
+        now,
+        maxAgeHours: 3,
+      }).status
+    ).toBe(RESULT_STATUS.FAIL);
+
+    expect(
+      assessDefinitionsFreshness({
+        schedulerState: "ENABLED",
+        lastAttemptTime: "2026-01-01T11:00:00Z",
+        lastAttemptFailed: true,
+        now,
+        maxAgeHours: 3,
+      }).status
+    ).toBe(RESULT_STATUS.FAIL);
+
+    expect(
+      assessDefinitionsFreshness({
+        schedulerState: "ENABLED",
+        lastAttemptTime: "2026-01-01T08:00:00Z",
+        lastAttemptFailed: false,
+        now,
+        maxAgeHours: 3,
+      }).status
+    ).toBe(RESULT_STATUS.FAIL);
+  });
+
+  it("passes definitions freshness audit for an enabled schedule with a recent successful attempt", () => {
+    const now = new Date("2026-01-01T12:00:00Z");
+    expect(
+      assessDefinitionsFreshness({
+        schedulerState: "ENABLED",
+        lastAttemptTime: "2026-01-01T10:00:00Z",
+        lastAttemptFailed: false,
+        now,
+        maxAgeHours: 3,
+      }).status
+    ).toBe(RESULT_STATUS.PASS);
   });
 });


### PR DESCRIPTION
## Summary
- Automates 5 of the 8 controls `docs/operations/deployment-checks.md` previously listed as permanently manual: App Check enforcement mode, Auth providers/authorized domains, deployed Storage rules content + a negative unauthenticated probe, scanner service-account project-level IAM scope, and malware-definition refresh job health.
- New checks use `firebaseappcheck.googleapis.com`, Identity Toolkit's admin config API, and the Firebase Security Rules API directly (via an access-token fetch helper) — none of these have a `gcloud`/`firebase` CLI equivalent, but all use the same credentials every other check already requires.
- **Fixes a pre-existing bug** found while verifying the new checks live: the Cloud SQL resilience check referenced `deletionProtectionEnabled` at the top level of the `DatabaseInstance` resource — a field that doesn't exist in the Cloud SQL Admin API at all (confirmed via the API discovery document). The real field is `settings.deletionProtectionEnabled`. This check could never have passed for any instance, ever.
- Doc updated to reflect what's now automated vs. genuinely still manual (App Check traffic metrics, SQL restore tests, alerting/budget/dashboard config, and end-to-end member journeys needing real test data).
- Closes #507.

**Real finding surfaced along the way**: running the updated tool against `sodc-web-production` found `localhost` is currently an authorized Auth domain in production — flagged separately, not fixed in this PR.

## Test plan
- [x] `npx vitest run --config vitest.deploy-safety.config.ts` — 45/45 pass (new pure-function tests for all 5 checks + the freshness redesign)
- [x] `npx vitest run` (full frontend suite) — 697/697 pass
- [x] `npx eslint` on all touched files — clean
- [x] Ran `npm run deployment:check -- --env dev` and `--env prod` live — all 5 new checks return correct real results against both environments, including the fixed Cloud SQL check now passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)