### PR TITLE
Fix UUID hyphen-stripping bug in legacy user postflight reconciliation

### DIFF
--- a/functions/src/__tests__/legacyUserPostflight.test.ts
+++ b/functions/src/__tests__/legacyUserPostflight.test.ts
@@ -135,6 +135,53 @@ describe("legacy user postflight reconciliation", () => {
     expect(report.differences[0].correlationId).toHaveLength(20);
   });
 
+  it("matches an identity whose migrationBatchId Data Connect returned without hyphens", () => {
+    // Same underlying Data Connect formatting quirk as legacyUserId, hit on
+    // the very next field: migrationBatchId also comes back without hyphens
+    // on this query path, which broke the provenance check for every record
+    // even after the legacyUserId lookup itself was fixed.
+    const report = buildLegacyUserPostflightReport({
+      projectId: binding.projectId,
+      rawSourceRecords: 1,
+      normalizedRecords: [record],
+      sourceQuarantined: 0,
+      ledger: completedLedger(),
+      identities: [
+        identity({ migrationBatchId: binding.migrationBatchId.replace(/-/g, "") }),
+      ],
+      authUsers: new Map([[legacyUserId, auth()]]),
+      bcryptProven: true,
+    });
+
+    expect(report.outcome).toBe("match");
+    expect(report.reasonCounts["identity-provenance-mismatch"]).toBeUndefined();
+  });
+
+  it("matches an identity whose legacyUserId Data Connect returned without hyphens", () => {
+    // Data Connect's generated SDK returns `legacyUserId` as 32 hex characters
+    // with no hyphens, even though the schema types it as UUID and the ledger
+    // (sourced from the decrypted artifact) always uses the canonical
+    // 36-character hyphenated form. A real production postflight run hit this
+    // exact mismatch: every single record was reported as both
+    // identity-mapping-missing and identity-mapping-additional purely because
+    // of this formatting difference, even though the migration itself was
+    // fully correct.
+    const report = buildLegacyUserPostflightReport({
+      projectId: binding.projectId,
+      rawSourceRecords: 1,
+      normalizedRecords: [record],
+      sourceQuarantined: 0,
+      ledger: completedLedger(),
+      identities: [identity({ legacyUserId: legacyUserId.replace(/-/g, "") })],
+      authUsers: new Map([[legacyUserId, auth()]]),
+      bcryptProven: true,
+    });
+
+    expect(report.outcome).toBe("match");
+    expect(report.reasonCounts["identity-mapping-missing"]).toBeUndefined();
+    expect(report.reasonCounts["identity-mapping-additional"]).toBeUndefined();
+  });
+
   it("accepts a planned reconciliation exclusion without a destination record", () => {
     const ledger = createMigrationLedger(binding);
     recordMigrationExclusion(ledger, legacyUserId, "identity-mapping-conflict");

--- a/functions/src/legacyUserPostflight.ts
+++ b/functions/src/legacyUserPostflight.ts
@@ -89,6 +89,20 @@ function correlationId(sourceChecksum: string, legacyUserId: string): string {
   return sha256Hex(`${sourceChecksum}:${legacyUserId}`).slice(0, 20);
 }
 
+/**
+ * Data Connect's generated SDK returns some UUID-typed fields without hyphens
+ * (32 hex characters) on this query path -- confirmed for both
+ * `legacyUserIdentities.legacyUserId` and `legacyUserIdentities.migrationBatchId`
+ * -- even though the schema types them as UUID and `user.id` on the same
+ * response round-trips with hyphens intact. The ledger and decrypted source
+ * records always use the canonical 36-character hyphenated form. Normalize
+ * both sides before comparing any UUID sourced from this query so lookups and
+ * provenance checks aren't defeated by this formatting difference alone.
+ */
+function normalizeUuid(value: string): string {
+  return value.replace(/-/g, "").toLowerCase();
+}
+
 function sameNullable(left: unknown, right: unknown): boolean {
   return (left ?? null) === (right ?? null);
 }
@@ -146,10 +160,11 @@ export function buildLegacyUserPostflightReport(input: {
   );
   const identityById = new Map<string, PostflightIdentity>();
   for (const identity of input.identities) {
-    if (identityById.has(identity.legacyUserId)) {
+    const normalizedId = normalizeUuid(identity.legacyUserId);
+    if (identityById.has(normalizedId)) {
       add(identity.legacyUserId, "identity-provenance-mismatch");
     }
-    identityById.set(identity.legacyUserId, identity);
+    identityById.set(normalizedId, identity);
   }
 
   for (const legacyUserId of sourceById.keys()) {
@@ -176,20 +191,21 @@ export function buildLegacyUserPostflightReport(input: {
     if (!hasMigrationStage(input.ledger, legacyUserId, "access-reconciled")) {
       add(legacyUserId, "ledger-stage-incomplete");
     }
-    const identity = identityById.get(legacyUserId);
+    const identity = identityById.get(normalizeUuid(legacyUserId));
     if (!identity) {
       add(legacyUserId, "identity-mapping-missing");
       continue;
     }
     if (
       identity.sourceSystem !== LEGACY_SOURCE_SYSTEM ||
-      identity.migrationBatchId !== input.ledger.migrationBatchId ||
+      normalizeUuid(identity.migrationBatchId) !==
+        normalizeUuid(input.ledger.migrationBatchId) ||
       identity.recordSchemaVersion !== LEGACY_RECORD_SCHEMA_VERSION ||
       identity.sourceChecksum !== input.ledger.sourceChecksum ||
       !sameNullable(identity.oldUid, source.oldUid)
     ) add(legacyUserId, "identity-provenance-mismatch");
     if (
-      identity.user.id !== ledgerRecord.canonicalUid
+      normalizeUuid(identity.user.id) !== normalizeUuid(ledgerRecord.canonicalUid)
     ) add(legacyUserId, "canonical-uid-mismatch");
 
     const auth = input.authUsers.get(ledgerRecord.canonicalUid);
@@ -236,8 +252,11 @@ export function buildLegacyUserPostflightReport(input: {
       add(legacyUserId, "profile-field-mismatch");
     }
   }
+  const normalizedLedgerIds = new Set(
+    Object.keys(input.ledger.records).map(normalizeUuid)
+  );
   for (const identity of input.identities) {
-    if (!input.ledger.records[identity.legacyUserId]) {
+    if (!normalizedLedgerIds.has(normalizeUuid(identity.legacyUserId))) {
       add(identity.legacyUserId, "identity-mapping-additional");
     }
   }


### PR DESCRIPTION
## Summary
- Fixes a real bug found running postflight reconciliation against the completed 918-record production legacy user migration.
- Data Connect's generated SDK returns `legacyUserId` and `migrationBatchId` from `ListLegacyUserIdentitiesByBatch` without hyphens (32 hex chars), even though both are typed `UUID!` and `user.id` on the same response round-trips with hyphens intact. The ledger and decrypted source records always use the canonical 36-character hyphenated form.
- This caused a 100% false-positive mismatch: all 918 real records were reported as `identity-mapping-missing`/`identity-mapping-additional` (same underlying identity, wrong key format on each side), and after fixing that lookup, as `identity-provenance-mismatch` instead — the actual migration was correct throughout.
- Adds `normalizeUuid()` and applies it everywhere a UUID from this query is compared, including a defensive normalization of `user.id`/`canonicalUid` (empirically confirmed correctly hyphenated, but normalized anyway since it's free and this exact query path has now been wrong twice).
- Closes #511.

## Test plan
- [x] New tests for both the `legacyUserId` and `migrationBatchId` no-hyphen scenarios — the existing fixtures used matching formatting on both sides, which is exactly why this slipped through before hitting production.
- [x] Full functions suite: 846/846 pass
- [x] `npx tsc -b --noEmit` and `npm run lint` — clean
- [x] Re-ran the real production postflight after the fix: `outcome: "match"`, zero differences across all 918 real migrated records

🤖 Generated with [Claude Code](https://claude.com/claude-code)