### PR TITLE
Show membership status and service background in profile review

### DIFF
--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -29,6 +29,7 @@ import {
   MAX_NAME_LENGTH,
   MAX_POST_NOMINALS_LENGTH,
   MAX_SERVICE_NUMBER_LENGTH,
+  MEMBERSHIP_STATUS_OPTIONS,
 } from "../../../constants";
 import RankSelect from "../../../shared/components/RankSelect";
 import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
@@ -212,6 +213,17 @@ export default function ProfileReviewDialog({
               helperText="This verified sign-in address can be changed later in Account settings."
             />
             <TextField
+              label="Membership status"
+              value={
+                MEMBERSHIP_STATUS_OPTIONS.find(
+                  (option) => option.value === userData.membershipStatus,
+                )?.label ?? userData.membershipStatus
+              }
+              fullWidth
+              inputProps={{ readOnly: true }}
+              helperText="This can be changed on your Profile page."
+            />
+            <TextField
               label="Service number"
               value={serviceNumber}
               onChange={(event) => setServiceNumber(event.target.value)}
@@ -260,6 +272,32 @@ export default function ProfileReviewDialog({
               }
               label="Share my email address and mobile number with members in my sections"
             />
+            <Box component="section" aria-labelledby="review-service-background-heading">
+              <Typography id="review-service-background-heading" variant="h6" component="h2">
+                Service background
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                This can be changed on your Profile page.
+              </Typography>
+              <FormGroup>
+                <FormControlLabel
+                  control={<Checkbox checked={userData.isRegular ?? false} disabled />}
+                  label="Regular"
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={userData.isReserve ?? false} disabled />}
+                  label="Reserve"
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={userData.isCivilServant ?? false} disabled />}
+                  label="Civil Servant"
+                />
+                <FormControlLabel
+                  control={<Checkbox checked={userData.isIndustry ?? false} disabled />}
+                  label="Industry"
+                />
+              </FormGroup>
+            </Box>
             <Box component="section" aria-labelledby="review-announcements-heading">
               <Typography id="review-announcements-heading" variant="h6" component="h2">
                 Announcement emails

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -59,6 +59,10 @@ const userData: UserData = {
   rank: "Wing Commander",
   shareContactInfo: true,
   membershipStatus: MembershipStatus.REGULAR,
+  isRegular: true,
+  isReserve: false,
+  isCivilServant: false,
+  isIndustry: true,
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
   profileReviewedAt: null,
@@ -200,11 +204,18 @@ describe("ProfileReviewDialog", () => {
     );
     expect(screen.getByRole("textbox", { name: "Email" })).toHaveValue("verified@example.com");
     expect(screen.getByRole("textbox", { name: "Email" })).toHaveAttribute("readonly");
+    expect(screen.getByRole("textbox", { name: "Membership status" })).toHaveValue("Regular");
+    expect(screen.getByRole("textbox", { name: "Membership status" })).toHaveAttribute("readonly");
     expect(
       screen.getByRole("checkbox", {
         name: "Share my email address and mobile number with members in my sections",
       }),
     ).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Regular" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Regular" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Reserve" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Civil Servant" })).not.toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Industry" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Receive announcement emails" })).toBeChecked();
   });
 


### PR DESCRIPTION
## Summary
- The six-monthly profile review dialog (`ProfileReviewDialog`) was missing two fields the full Profile page shows: membership status and service background (Regular/Reserve/Civil Servant/Industry).
- Both are added as read-only display, matching the existing pattern for the read-only Email field, with a note pointing members to the Profile page to change them.

Closes #513

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx eslint` on changed files
- [x] `npx vitest run src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx` (6 passed)
- [x] Visual browser check — not done; this dialog only renders behind a real sign-in when a profile review is due, and I don't have dev-environment credentials to trigger it end-to-end.