### PR TITLE
Change site title to "SODC"

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>sodc-web</title>
+    <title>SODC</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Updates the browser tab title in `index.html` from `sodc-web` to `SODC`

## Test plan
- [x] Verified the updated `<title>` tag renders in the browser pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)