### PR TITLE
Make service background editable in profile review dialog

### DIFF
--- a/dataconnect/api/user-mutations.gql
+++ b/dataconnect/api/user-mutations.gql
@@ -220,6 +220,10 @@ mutation ConfirmProfileReview(
   $rank: String!
   $shareContactInfo: Boolean!
   $announcementOptOutAll: Boolean!
+  $isRegular: Boolean
+  $isReserve: Boolean
+  $isCivilServant: Boolean
+  $isIndustry: Boolean
 ) @auth(expr: "auth.token.enabled == true") {
   user_update(
     id_expr: "auth.uid"
@@ -232,6 +236,10 @@ mutation ConfirmProfileReview(
       rank: $rank
       shareContactInfo: $shareContactInfo
       announcementOptOutAll: $announcementOptOutAll
+      isRegular: $isRegular
+      isReserve: $isReserve
+      isCivilServant: $isCivilServant
+      isIndustry: $isIndustry
       profileReviewedAt_expr: "request.time"
       updatedAt_expr: "request.time"
       updatedBy_expr: "auth.uid"

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -413,6 +413,10 @@ export interface ConfirmProfileReviewVariables {
   rank: string;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  isRegular?: boolean | null;
+  isReserve?: boolean | null;
+  isCivilServant?: boolean | null;
+  isIndustry?: boolean | null;
 }
 
 export interface ConsumeCallableRateLimitData {

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -22777,6 +22777,10 @@ export interface ConfirmProfileReviewVariables {
   rank: string;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  isRegular?: boolean | null;
+  isReserve?: boolean | null;
+  isCivilServant?: boolean | null;
+  isIndustry?: boolean | null;
 }
 ```
 ### Return Type
@@ -22804,13 +22808,17 @@ const confirmProfileReviewVars: ConfirmProfileReviewVariables = {
   rank: ..., 
   shareContactInfo: ..., 
   announcementOptOutAll: ..., 
+  isRegular: ..., // optional
+  isReserve: ..., // optional
+  isCivilServant: ..., // optional
+  isIndustry: ..., // optional
 };
 
 // Call the `confirmProfileReview()` function to execute the mutation.
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await confirmProfileReview(confirmProfileReviewVars);
 // Variables can be defined inline as well.
-const { data } = await confirmProfileReview({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
+const { data } = await confirmProfileReview({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -22841,12 +22849,16 @@ const confirmProfileReviewVars: ConfirmProfileReviewVariables = {
   rank: ..., 
   shareContactInfo: ..., 
   announcementOptOutAll: ..., 
+  isRegular: ..., // optional
+  isReserve: ..., // optional
+  isCivilServant: ..., // optional
+  isIndustry: ..., // optional
 };
 
 // Call the `confirmProfileReviewRef()` function to get a reference to the mutation.
 const ref = confirmProfileReviewRef(confirmProfileReviewVars);
 // Variables can be defined inline as well.
-const ref = confirmProfileReviewRef({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
+const ref = confirmProfileReviewRef({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -435,6 +435,10 @@ export interface ConfirmProfileReviewVariables {
   rank: string;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  isRegular?: boolean | null;
+  isReserve?: boolean | null;
+  isCivilServant?: boolean | null;
+  isIndustry?: boolean | null;
 }
 
 export interface ConsumeCallableRateLimitData {

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -18734,6 +18734,10 @@ export interface ConfirmProfileReviewVariables {
   rank: string;
   shareContactInfo: boolean;
   announcementOptOutAll: boolean;
+  isRegular?: boolean | null;
+  isReserve?: boolean | null;
+  isCivilServant?: boolean | null;
+  isIndustry?: boolean | null;
 }
 ```
 ### Return Type
@@ -18791,10 +18795,14 @@ export default function ConfirmProfileReviewComponent() {
     rank: ..., 
     shareContactInfo: ..., 
     announcementOptOutAll: ..., 
+    isRegular: ..., // optional
+    isReserve: ..., // optional
+    isCivilServant: ..., // optional
+    isIndustry: ..., // optional
   };
   mutation.mutate(confirmProfileReviewVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., });
+  mutation.mutate({ firstName: ..., lastName: ..., serviceNumber: ..., mobileNumber: ..., postNominals: ..., rank: ..., shareContactInfo: ..., announcementOptOutAll: ..., isRegular: ..., isReserve: ..., isCivilServant: ..., isIndustry: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -59,6 +59,10 @@ export default function ProfileReviewDialog({
   const [postNominals, setPostNominals] = useState("");
   const [rank, setRank] = useState("");
   const [shareContactInfo, setShareContactInfo] = useState(true);
+  const [isRegular, setIsRegular] = useState(false);
+  const [isReserve, setIsReserve] = useState(false);
+  const [isCivilServant, setIsCivilServant] = useState(false);
+  const [isIndustry, setIsIndustry] = useState(false);
   const [announcementOptOutAll, setAnnouncementOptOutAll] = useState(false);
   const [sectionOptOutIds, setSectionOptOutIds] = useState<Set<string>>(new Set());
   const [preferencesInitialised, setPreferencesInitialised] = useState(false);
@@ -78,6 +82,10 @@ export default function ProfileReviewDialog({
     setPostNominals(userData.postNominals || "");
     setRank(userData.rank || "");
     setShareContactInfo(userData.shareContactInfo ?? true);
+    setIsRegular(userData.isRegular ?? false);
+    setIsReserve(userData.isReserve ?? false);
+    setIsCivilServant(userData.isCivilServant ?? false);
+    setIsIndustry(userData.isIndustry ?? false);
   }, [userData]);
 
   useEffect(() => {
@@ -130,6 +138,10 @@ export default function ProfileReviewDialog({
         rank,
         shareContactInfo,
         announcementOptOutAll,
+        isRegular,
+        isReserve,
+        isCivilServant,
+        isIndustry,
       });
 
       const displayName = `${lastName.trim()}, ${firstName.trim()}`;
@@ -276,24 +288,45 @@ export default function ProfileReviewDialog({
               <Typography id="review-service-background-heading" variant="h6" component="h2">
                 Service background
               </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                This can be changed on your Profile page.
-              </Typography>
               <FormGroup>
                 <FormControlLabel
-                  control={<Checkbox checked={userData.isRegular ?? false} disabled />}
+                  control={
+                    <Checkbox
+                      checked={isRegular}
+                      onChange={(event) => setIsRegular(event.target.checked)}
+                      disabled={submitting}
+                    />
+                  }
                   label="Regular"
                 />
                 <FormControlLabel
-                  control={<Checkbox checked={userData.isReserve ?? false} disabled />}
+                  control={
+                    <Checkbox
+                      checked={isReserve}
+                      onChange={(event) => setIsReserve(event.target.checked)}
+                      disabled={submitting}
+                    />
+                  }
                   label="Reserve"
                 />
                 <FormControlLabel
-                  control={<Checkbox checked={userData.isCivilServant ?? false} disabled />}
+                  control={
+                    <Checkbox
+                      checked={isCivilServant}
+                      onChange={(event) => setIsCivilServant(event.target.checked)}
+                      disabled={submitting}
+                    />
+                  }
                   label="Civil Servant"
                 />
                 <FormControlLabel
-                  control={<Checkbox checked={userData.isIndustry ?? false} disabled />}
+                  control={
+                    <Checkbox
+                      checked={isIndustry}
+                      onChange={(event) => setIsIndustry(event.target.checked)}
+                      disabled={submitting}
+                    />
+                  }
                   label="Industry"
                 />
               </FormGroup>

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -212,7 +212,7 @@ describe("ProfileReviewDialog", () => {
       }),
     ).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Regular" })).toBeChecked();
-    expect(screen.getByRole("checkbox", { name: "Regular" })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: "Regular" })).toBeEnabled();
     expect(screen.getByRole("checkbox", { name: "Reserve" })).not.toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Civil Servant" })).not.toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Industry" })).toBeChecked();
@@ -244,10 +244,43 @@ describe("ProfileReviewDialog", () => {
           rank: "Wing Commander",
           shareContactInfo: true,
           announcementOptOutAll: false,
+          isRegular: true,
+          isReserve: false,
+          isCivilServant: false,
+          isIndustry: true,
         },
       );
     });
     expect(firebaseFunctions.updateDisplayName).toHaveBeenCalledWith("Member, Alex");
+    expect(onReviewed).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits edited service background selections", async () => {
+    const interaction = userEvent.setup();
+    const onReviewed = vi.fn();
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={onReviewed}
+      />,
+    );
+
+    await interaction.click(screen.getByRole("checkbox", { name: "Regular" }));
+    await interaction.click(screen.getByRole("checkbox", { name: "Reserve" }));
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    await waitFor(() => {
+      expect(generated.confirmProfileReview).toHaveBeenCalledWith(
+        {},
+        expect.objectContaining({
+          isRegular: false,
+          isReserve: true,
+          isCivilServant: false,
+          isIndustry: true,
+        }),
+      );
+    });
     expect(onReviewed).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary
- The Regular / Reserve / Civil Servant / Industry checkboxes in the periodic profile review dialog were previously read-only ("This can be changed on your Profile page"). They're now editable directly in the review flow.
- Extended the `ConfirmProfileReview` Data Connect mutation (`dataconnect/api/user-mutations.gql`) to accept and persist `isRegular`/`isReserve`/`isCivilServant`/`isIndustry`, and regenerated the client/admin SDKs.
- Wired the checkboxes in `ProfileReviewDialog.tsx` to component state, initialized from the user's current values and included in the submit payload.

## ⚠️ Deploy note
This changes a Data Connect connector operation (persisted query). Merging alone is **not** sufficient — after merge, someone needs to run `firebase deploy --only dataconnect --project <target>` against each relevant environment (dev/beta/prod) or the new fields won't be accepted by the backend, per the pattern in `docs/operations/environments-dev-beta-prod.md`.

## Test plan
- [x] `npx vitest run src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx` — all 7 tests pass, including a new test asserting edited checkbox values are submitted
- [x] `npx tsc --noEmit` — clean
- [ ] Manual verification in a live environment after `dataconnect` deploy (not done here — dialog requires an authenticated user with a stale `profileReviewedAt`, and this app has no local emulator wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)