### PR TITLE
Make membership status a dropdown in profile review dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,7 @@ function AppContent() {
   const [profileReviewCompletedForUid, setProfileReviewCompletedForUid] = useState<string | null>(
     null,
   );
+  const [profileReviewSaved, setProfileReviewSaved] = useState(false);
   const { isEnabled, isEnabledClaimResolved } = useEnabledClaim(user);
   const checkoutReturn = isCheckoutReturnSearch(location.search);
   const authReturnTo = safeReturnTo(location.search);
@@ -141,6 +142,7 @@ function AppContent() {
     if (!user) return;
     setProfileReviewCompletedForUid(user.uid);
     await refetch?.();
+    setProfileReviewSaved(true);
   }, [refetch, user]);
 
   // Check if email is verified
@@ -387,6 +389,21 @@ function AppContent() {
       >
         <Alert onClose={handleCloseLogoutSnackbar} severity="success" sx={{ width: "100%" }}>
           You have been successfully logged out.
+        </Alert>
+      </Snackbar>
+      <Snackbar
+        open={profileReviewSaved}
+        autoHideDuration={6000}
+        onClose={() => setProfileReviewSaved(false)}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        sx={{ mt: 10 }}
+      >
+        <Alert
+          onClose={() => setProfileReviewSaved(false)}
+          severity="success"
+          sx={{ width: "100%" }}
+        >
+          Your profile has been saved.
         </Alert>
       </Snackbar>
       {header}

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -10,6 +10,8 @@ import { ROUTES } from "../constants";
 import { sectionDetailLocationState } from "../shared/navigation/sectionNavigationState";
 import { createMockUser } from "../test-utils/mocks/firebase";
 
+const mockRefetchUserData = vi.hoisted(() => vi.fn());
+
 let currentUser: User | null = null;
 let enabledClaim = false;
 let enabledClaimResolved = true;
@@ -98,7 +100,7 @@ vi.mock("../features/users/hooks/useUserData", () => ({
       : null,
     loading: false,
     error: null,
-    refetch: vi.fn(),
+    refetch: mockRefetchUserData,
   })),
 }));
 
@@ -323,6 +325,7 @@ describe("App routing", () => {
     profileReviewedAt = new Date().toISOString();
     headerShouldThrow = false;
     memberWelcomeShouldThrow = false;
+    mockRefetchUserData.mockResolvedValue(undefined);
     needsProfileCompletion = false;
     mockSectionsData = sectionsData();
     vi.clearAllMocks();
@@ -483,6 +486,8 @@ describe("App routing", () => {
         screen.queryByRole("dialog", { name: "Please review your profile" }),
       ).not.toBeInTheDocument();
     });
+    expect(mockRefetchUserData).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Your profile has been saved.")).toBeInTheDocument();
   });
 
   it("does not show profile review before email verification", async () => {

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -140,21 +140,6 @@ export default function ProfileReviewDialog({
         else await optInSection.mutateAsync({ sectionId: section.id });
       }
 
-      await confirmProfileReview(dataConnect, {
-        firstName: firstName.trim(),
-        lastName: lastName.trim(),
-        serviceNumber: serviceNumber.trim(),
-        mobileNumber: normalizedMobileNumber,
-        postNominals: postNominals.trim() || null,
-        rank,
-        shareContactInfo,
-        announcementOptOutAll,
-        isRegular,
-        isReserve,
-        isCivilServant,
-        isIndustry,
-      });
-
       const currentStatus = userData.membershipStatus || null;
       if (membershipStatus && membershipStatus !== currentStatus) {
         const currentUser = auth.currentUser;
@@ -173,6 +158,21 @@ export default function ProfileReviewDialog({
           return;
         }
       }
+
+      await confirmProfileReview(dataConnect, {
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+        serviceNumber: serviceNumber.trim(),
+        mobileNumber: normalizedMobileNumber,
+        postNominals: postNominals.trim() || null,
+        rank,
+        shareContactInfo,
+        announcementOptOutAll,
+        isRegular,
+        isReserve,
+        isCivilServant,
+        isIndustry,
+      });
 
       const displayName = `${lastName.trim()}, ${firstName.trim()}`;
       try {

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -9,21 +9,25 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  FormControl,
   FormControlLabel,
   FormGroup,
+  InputLabel,
+  MenuItem,
+  Select,
   Stack,
   TextField,
   Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import { confirmProfileReview } from "@dataconnect/generated";
+import { confirmProfileReview, MembershipStatus } from "@dataconnect/generated";
 import {
   useGetMyAnnouncementPreferences,
   useOptInSectionAnnouncement,
   useOptOutSectionAnnouncement,
 } from "@dataconnect/generated/react";
-import { dataConnect } from "../../../config/firebase";
+import { dataConnect, auth } from "../../../config/firebase";
 import {
   MAX_MOBILE_NUMBER_LENGTH,
   MAX_NAME_LENGTH,
@@ -32,11 +36,16 @@ import {
   MEMBERSHIP_STATUS_OPTIONS,
 } from "../../../constants";
 import RankSelect from "../../../shared/components/RankSelect";
-import { updateDisplayName } from "../../../shared/utils/firebaseFunctions";
+import { updateDisplayName, updateMembershipStatus } from "../../../shared/utils/firebaseFunctions";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
 import type { UserData } from "../../../types";
 import { getAnnouncementSections } from "../../account/utils/announcementPreferences";
-import { reportError, toProfileUserFacingError } from "../../../shared/errors";
+import { NON_RESTRICTED_STATUSES, isRestrictedStatus } from "../../users/utils/membershipStatusValidation";
+import {
+  reportError,
+  toProfileDomainUserFacingError,
+  toProfileUserFacingError,
+} from "../../../shared/errors";
 import FailureState from "../../../shared/components/FailureState";
 
 interface ProfileReviewDialogProps {
@@ -58,6 +67,7 @@ export default function ProfileReviewDialog({
   const [mobileNumber, setMobileNumber] = useState("");
   const [postNominals, setPostNominals] = useState("");
   const [rank, setRank] = useState("");
+  const [membershipStatus, setMembershipStatus] = useState<MembershipStatus | "">("");
   const [shareContactInfo, setShareContactInfo] = useState(true);
   const [isRegular, setIsRegular] = useState(false);
   const [isReserve, setIsReserve] = useState(false);
@@ -81,6 +91,7 @@ export default function ProfileReviewDialog({
     setMobileNumber(userData.mobileNumber || "");
     setPostNominals(userData.postNominals || "");
     setRank(userData.rank || "");
+    setMembershipStatus(userData.membershipStatus || "");
     setShareContactInfo(userData.shareContactInfo ?? true);
     setIsRegular(userData.isRegular ?? false);
     setIsReserve(userData.isReserve ?? false);
@@ -144,6 +155,25 @@ export default function ProfileReviewDialog({
         isIndustry,
       });
 
+      const currentStatus = userData.membershipStatus || null;
+      if (membershipStatus && membershipStatus !== currentStatus) {
+        const currentUser = auth.currentUser;
+        if (!currentUser) {
+          throw new Error("You must be logged in to update your membership status");
+        }
+        const statusResult = await updateMembershipStatus(
+          currentUser.uid,
+          membershipStatus as MembershipStatus,
+        );
+        if (!statusResult.success) {
+          const statusError = new Error(statusResult.error || "Membership status update failed");
+          reportError("profile.review.membership-status", statusError);
+          setError(toProfileDomainUserFacingError(statusResult.domainCode, "update").message);
+          setSubmitting(false);
+          return;
+        }
+      }
+
       const displayName = `${lastName.trim()}, ${firstName.trim()}`;
       try {
         const displayNameResult = await updateDisplayName(displayName);
@@ -166,12 +196,16 @@ export default function ProfileReviewDialog({
     }
   };
 
+  const statusLocked =
+    userData.membershipStatus != null && isRestrictedStatus(userData.membershipStatus);
+
   const missingRequiredField =
     !firstName.trim() ||
     !lastName.trim() ||
     !serviceNumber.trim() ||
     !mobileNumber.trim() ||
-    !rank;
+    !rank ||
+    !membershipStatus;
 
   return (
     <Dialog
@@ -224,17 +258,39 @@ export default function ProfileReviewDialog({
               inputProps={{ readOnly: true }}
               helperText="This verified sign-in address can be changed later in Account settings."
             />
-            <TextField
-              label="Membership status"
-              value={
-                MEMBERSHIP_STATUS_OPTIONS.find(
-                  (option) => option.value === userData.membershipStatus,
-                )?.label ?? userData.membershipStatus
-              }
-              fullWidth
-              inputProps={{ readOnly: true }}
-              helperText="This can be changed on your Profile page."
-            />
+            <FormControl fullWidth required>
+              <InputLabel>Membership status</InputLabel>
+              <Select
+                value={membershipStatus}
+                label="Membership status"
+                onChange={(event) => setMembershipStatus(event.target.value as MembershipStatus)}
+                disabled={submitting || statusLocked}
+                data-testid="review-membership-status-select"
+              >
+                {statusLocked ? (
+                  MEMBERSHIP_STATUS_OPTIONS.filter(
+                    (option) => option.value === userData.membershipStatus,
+                  ).map((status) => (
+                    <MenuItem key={status.value} value={status.value}>
+                      {status.label}
+                    </MenuItem>
+                  ))
+                ) : (
+                  MEMBERSHIP_STATUS_OPTIONS.filter((option) =>
+                    NON_RESTRICTED_STATUSES.includes(option.value),
+                  ).map((status) => (
+                    <MenuItem key={status.value} value={status.value}>
+                      {status.label}
+                    </MenuItem>
+                  ))
+                )}
+              </Select>
+              {statusLocked && (
+                <Typography variant="caption" sx={{ color: "text.secondary", mt: 1, ml: 1.5 }}>
+                  Cannot change from restricted status
+                </Typography>
+              )}
+            </FormControl>
             <TextField
               label="Service number"
               value={serviceNumber}

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -320,6 +320,37 @@ describe("ProfileReviewDialog", () => {
     expect(onReviewed).toHaveBeenCalledTimes(1);
   });
 
+  it("does not confirm the review when the membership status update fails", async () => {
+    const interaction = userEvent.setup();
+    const onReviewed = vi.fn();
+    vi.mocked(firebaseFunctions.updateMembershipStatus).mockResolvedValueOnce({
+      success: false,
+      error: "Membership status update failed",
+    });
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={onReviewed}
+      />,
+    );
+
+    const selectRoot = screen.getByTestId("review-membership-status-select");
+    const trigger =
+      selectRoot.querySelector('[role="combobox"]') ??
+      selectRoot.querySelector(".MuiSelect-select") ??
+      selectRoot;
+    fireEvent.mouseDown(trigger);
+    await interaction.click(await screen.findByRole("option", { name: "Reserve" }));
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.updateMembershipStatus).toHaveBeenCalledWith("user-1", "RESERVE");
+    });
+    expect(generated.confirmProfileReview).not.toHaveBeenCalled();
+    expect(onReviewed).not.toHaveBeenCalled();
+  });
+
   it("does not call updateMembershipStatus when the status is unchanged", async () => {
     const interaction = userEvent.setup();
     const onReviewed = vi.fn();

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -11,7 +11,15 @@ import ProfileReviewDialog from "../ProfileReviewDialog";
 vi.mock("@dataconnect/generated", () => ({
   confirmProfileReview: vi.fn().mockResolvedValue({ data: {} }),
   MembershipStatus: {
+    PENDING: "PENDING",
     REGULAR: "REGULAR",
+    RESERVE: "RESERVE",
+    CIVIL_SERVICE: "CIVIL_SERVICE",
+    INDUSTRY: "INDUSTRY",
+    RETIRED: "RETIRED",
+    RESIGNED: "RESIGNED",
+    LOST: "LOST",
+    DECEASED: "DECEASED",
   },
   SectionUserGroupPurpose: {
     ACCESS: "ACCESS",
@@ -42,10 +50,12 @@ vi.mock("@dataconnect/generated/react", () => ({
 
 vi.mock("../../../../config/firebase", () => ({
   dataConnect: {},
+  auth: { currentUser: { uid: "user-1" } },
 }));
 
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   updateDisplayName: vi.fn().mockResolvedValue({ success: true }),
+  updateMembershipStatus: vi.fn().mockResolvedValue({ success: true }),
 }));
 
 const userData: UserData = {
@@ -73,6 +83,7 @@ describe("ProfileReviewDialog", () => {
     vi.clearAllMocks();
     vi.mocked(generated.confirmProfileReview).mockResolvedValue({ data: {} } as never);
     vi.mocked(firebaseFunctions.updateDisplayName).mockResolvedValue({ success: true });
+    vi.mocked(firebaseFunctions.updateMembershipStatus).mockResolvedValue({ success: true });
     mockOptOut.mockResolvedValue(undefined);
     mockOptIn.mockResolvedValue(undefined);
     vi.mocked(generatedReact.useGetMyAnnouncementPreferences).mockReturnValue({
@@ -204,8 +215,7 @@ describe("ProfileReviewDialog", () => {
     );
     expect(screen.getByRole("textbox", { name: "Email" })).toHaveValue("verified@example.com");
     expect(screen.getByRole("textbox", { name: "Email" })).toHaveAttribute("readonly");
-    expect(screen.getByRole("textbox", { name: "Membership status" })).toHaveValue("Regular");
-    expect(screen.getByRole("textbox", { name: "Membership status" })).toHaveAttribute("readonly");
+    expect(screen.getByTestId("review-membership-status-select")).toHaveTextContent("Regular");
     expect(
       screen.getByRole("checkbox", {
         name: "Share my email address and mobile number with members in my sections",
@@ -282,6 +292,49 @@ describe("ProfileReviewDialog", () => {
       );
     });
     expect(onReviewed).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits an updated membership status", async () => {
+    const interaction = userEvent.setup();
+    const onReviewed = vi.fn();
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={onReviewed}
+      />,
+    );
+
+    const selectRoot = screen.getByTestId("review-membership-status-select");
+    const trigger =
+      selectRoot.querySelector('[role="combobox"]') ??
+      selectRoot.querySelector(".MuiSelect-select") ??
+      selectRoot;
+    fireEvent.mouseDown(trigger);
+    await interaction.click(await screen.findByRole("option", { name: "Reserve" }));
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.updateMembershipStatus).toHaveBeenCalledWith("user-1", "RESERVE");
+    });
+    expect(onReviewed).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call updateMembershipStatus when the status is unchanged", async () => {
+    const interaction = userEvent.setup();
+    const onReviewed = vi.fn();
+    render(
+      <ProfileReviewDialog
+        userData={userData}
+        userEmail="verified@example.com"
+        onReviewed={onReviewed}
+      />,
+    );
+
+    await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
+
+    await waitFor(() => expect(onReviewed).toHaveBeenCalledTimes(1));
+    expect(firebaseFunctions.updateMembershipStatus).not.toHaveBeenCalled();
   });
 
   it("keeps the review open and allows retry when saving fails", async () => {

--- a/src/features/users/hooks/__tests__/useUserData.test.ts
+++ b/src/features/users/hooks/__tests__/useUserData.test.ts
@@ -7,6 +7,9 @@ import { getCurrentUserRef } from "@dataconnect/generated";
 
 vi.mock("firebase/data-connect", () => ({
   executeQuery: vi.fn(),
+  QueryFetchPolicy: {
+    SERVER_ONLY: "SERVER_ONLY",
+  },
 }));
 
 vi.mock("@dataconnect/generated", () => ({
@@ -173,5 +176,9 @@ describe("useUserData", () => {
     await waitFor(() => {
       expect(vi.mocked(dataConnect.executeQuery).mock.calls.length).toBeGreaterThan(callCount);
     });
+    expect(vi.mocked(dataConnect.executeQuery)).toHaveBeenLastCalledWith(
+      mockRef,
+      { fetchPolicy: "SERVER_ONLY" },
+    );
   });
 });

--- a/src/features/users/hooks/useUserData.ts
+++ b/src/features/users/hooks/useUserData.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { type User } from "firebase/auth";
-import { executeQuery } from "firebase/data-connect";
+import { executeQuery, QueryFetchPolicy } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
 import { getCurrentUserRef } from "@dataconnect/generated";
 import type { UserData } from "../../../types";
@@ -58,7 +58,10 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
     setError(null);
     try {
       const ref = getCurrentUserRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeQuery(
+        ref,
+        force ? { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } : undefined,
+      );
       if (result.data?.user) {
         setUserData(result.data.user as UserData);
         authErrorRef.current = false; // Reset auth error flag on success
@@ -141,4 +144,3 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
 
   return { userData, loading, error, refetch: () => fetchUserData(true) };
 }
-


### PR DESCRIPTION
## Summary
- The Membership status field in the periodic profile review dialog was previously a read-only text field pointing users to the Profile page.
- Replaced it with the same `Select` dropdown used on the Profile page (`Profile.tsx`), including the restricted-status locking behavior (statuses like Pending/Resigned/Lost/Deceased can't be selected into or out of via this flow).
- Reuses the existing `updateMembershipStatus` callable function, so server-side transition validation (`canUserChangeStatus`) is unchanged — no Data Connect schema/connector changes needed this time.

## Test plan
- [x] `npx vitest run src/features/profile` — all 22 tests pass, including new coverage for selecting a new status and for the unchanged-status no-op case
- [x] `npx vitest run` (full suite) — 701 tests pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual verification in a live environment (not done here — dialog requires an authenticated user with a stale `profileReviewedAt`, and this app has no local emulator wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)