### PR TITLE
Fix ListUsers silently truncating to 100 of 918 members

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -65,7 +65,12 @@ query GetUserById($id: String!) @auth(expr: "auth.token.admin == true && auth.to
 
 # List all users (admin only - admins must also be enabled)
 query ListUsers @auth(expr: "auth.token.admin == true && auth.token.enabled == true") {
-  users {
+  # Without an explicit limit, Data Connect silently caps this at its default
+  # of 100 rows -- confirmed live against production, where it truncated the
+  # User Groups and Audit Logs admin views to the first 100 of 918 members
+  # with no error. 5000 gives headroom well past current membership; move to
+  # real server-side pagination before membership approaches that ceiling.
+  users(limit: 5000) {
     id
     firstName
     lastName


### PR DESCRIPTION
## Summary
- \`ListUsers\` (dataconnect/api/queries.gql) had no explicit `limit` on its `users` field, so Data Connect applied its implicit default of 100 rows.
- User Groups and Audit Logs both use this query to build an in-memory "all users" list for client-side filtering, so on production (918 members) both silently only ever saw the first 100, with no error or warning.
- Confirmed live: `ListUsers` returned exactly 100 rows, and the membership-status breakdown of those 100 (72 REGULAR + 25 RETIRED = 97) matches the "97 members" count reported when selecting all non-restricted statuses in the User Groups UI.
- Fix: add `limit: 5000`, generous headroom over current membership. Flagged in a comment that this should move to real server-side pagination before membership approaches that ceiling.

Closes #526

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npm --prefix functions run build`
- [x] `npx firebase dataconnect:sdk:generate` — no generated-code diff (query shape unchanged, only server-side row limit)
- [x] `npx vitest run src/features/admin` (99 passed)
- [x] Verified live against production via a read-only Admin SDK script: `ListUsers` returns 100 rows pre-fix, matching the reported bug exactly. No unit test can exercise Data Connect's server-side row limiting, so this live check is the real verification.