### PR TITLE
Normalize generated SDK formatting before drift checks

### DIFF
--- a/scripts/deploy-environment-lib.mjs
+++ b/scripts/deploy-environment-lib.mjs
@@ -207,6 +207,12 @@ export function createPreflightSteps(environment) {
       args: ["dataconnect:sdk:generate", "--project", environment],
     },
     {
+      id: "normalize-generated-sdk",
+      label: "Normalize generated SDK formatting",
+      command: "node",
+      args: ["scripts/normalize-generated-sdk.mjs"],
+    },
+    {
       id: "generated-drift-check",
       label: "Confirm generated SDKs match the reviewed commit",
       command: "git",

--- a/scripts/deploy-environment.test.mjs
+++ b/scripts/deploy-environment.test.mjs
@@ -65,6 +65,7 @@ describe("environment deployment configuration", () => {
       "clean-checkout",
       "required-apis-check",
       "generate-dataconnect-sdk",
+      "normalize-generated-sdk",
       "generated-drift-check",
       "environment-config-check",
       "frontend-lint",
@@ -168,7 +169,7 @@ describe("environment deployment execution", () => {
 
   it.each([
     ["clean-checkout", 1],
-    ["generated-drift-check", 4],
+    ["generated-drift-check", 5],
   ])("blocks deployment when %s reports files", async (blockedStep, expectedCalls) => {
     const execute = vi.fn(async (step) => ({
       stdout: step.id === blockedStep ? " M generated/index.d.ts" : "",

--- a/scripts/normalize-generated-sdk.mjs
+++ b/scripts/normalize-generated-sdk.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+// firebase-tools currently emits whitespace-only blank lines in these two runtime
+// bundles. The reviewed files intentionally normalize those lines; keep this list
+// narrow so generated documentation and examples remain byte-for-byte untouched.
+const generatedRuntimeFiles = [
+  "src/dataconnect-generated/esm/index.esm.js",
+  "src/dataconnect-generated/index.cjs.js",
+];
+
+await Promise.all(generatedRuntimeFiles.map(async (relativePath) => {
+  const filePath = path.join(repositoryRoot, relativePath);
+  const original = await readFile(filePath, "utf8");
+  const normalized = original.replace(/[ \t]+$/gm, "");
+  if (normalized !== original) await writeFile(filePath, normalized, "utf8");
+}));


### PR DESCRIPTION
## What changed

- Normalize the two Data Connect runtime bundles that firebase-tools emits with whitespace-only blank lines.
- Run that narrow normalization immediately after SDK generation and before the reviewed-drift check.
- Keep generated documentation and examples byte-for-byte untouched.

## Root cause

PR #529 reviewed normalized runtime bundles, but firebase-tools regenerates those blank lines with two spaces. The deployment guard correctly detected the whitespace-only difference and stopped before deployment.

## Impact

Deployment preflight can still fail on meaningful generated SDK drift, while ignoring this known generator-only whitespace variance.

## Validation

- Regenerated both Data Connect SDKs with firebase-tools, ran normalization, and confirmed both generated directories were clean.
- `npm run test:deploy-safety` (55 tests)
- `npm run lint`
- `git diff --check`