### PR TITLE
Fix reply-to verification template resolution

### DIFF
--- a/functions/src/__tests__/notifyReplyToAdmin.test.ts
+++ b/functions/src/__tests__/notifyReplyToAdmin.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as admin from "@dataconnect/admin-generated";
+import { NotifyClient } from "notifications-node-client";
+import { sendNotifyReplyToVerificationTest } from "../notifyReplyToAdmin";
+
+const ADDRESS_ID = "11111111-1111-4111-8111-111111111111";
+const REPLY_TO_ID = "22222222-2222-4222-8222-222222222222";
+
+const configuration = {
+  notifyEmailConfiguration: {
+    version: 1,
+    updatedAt: "2026-08-10T05:00:00.000Z",
+    updatedBy: "admin-1",
+    defaultReplyToAddress: null,
+  },
+  notifyReplyToAddresses: [{
+    id: ADDRESS_ID,
+    displayLabel: "Membership",
+    emailAddress: "membership@example.org",
+    notifyUuid: REPLY_TO_ID,
+    enabled: false,
+    announcementSelectable: false,
+    verificationStatus: "UNVERIFIED",
+    providerAcceptedAt: null,
+    providerNotificationId: null,
+    verificationMode: null,
+    verifiedAt: null,
+    verifiedBy: null,
+    version: 3,
+    createdAt: "2026-08-10T05:00:00.000Z",
+    updatedAt: "2026-08-10T05:00:00.000Z",
+    createdBy: "admin-1",
+    updatedBy: "admin-1",
+  }],
+  notifyTemplateReplyToOverrides: [],
+};
+
+function runVerificationTest() {
+  return sendNotifyReplyToVerificationTest.run({
+    auth: {
+      uid: "admin-1",
+      token: {
+        admin: true,
+        enabled: true,
+        email: "admin@example.org",
+        email_verified: true,
+      },
+    },
+    data: { addressId: ADDRESS_ID, expectedVersion: 3 },
+  } as unknown as Parameters<typeof sendNotifyReplyToVerificationTest.run>[0]);
+}
+
+describe("reply-to verification template resolution", () => {
+  beforeEach(() => {
+    vi.stubEnv("GOV_NOTIFY_DELIVERY_MODE", "LIVE");
+    vi.stubEnv("GOV_NOTIFY_TEAM_API_KEY", "team-api-key");
+    vi.stubEnv("GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION", "environment-template-id");
+
+    vi.spyOn(admin, "ensureCallableRateLimitBucket").mockResolvedValue({ data: {} } as never);
+    vi.spyOn(admin, "consumeCallableRateLimit").mockResolvedValue({ data: {} } as never);
+    vi.spyOn(admin, "getNotifyReplyToConfiguration").mockResolvedValue({ data: configuration } as never);
+    vi.spyOn(admin, "getGovNotifyDeliveryConfiguration").mockResolvedValue({
+      data: {
+        govNotifyDeliveryConfiguration: {
+          mode: "LIVE",
+          version: 1,
+          updatedAt: "2026-08-10T05:00:00.000Z",
+          updatedBy: "admin-1",
+        },
+      },
+    } as never);
+    vi.spyOn(admin, "listNotifyReplyToAudits").mockResolvedValue({
+      data: { notifyReplyToAudits: [] },
+    } as never);
+    vi.spyOn(admin, "recordNotifyReplyToProviderAcceptance").mockResolvedValue({
+      data: { changed: 1 },
+    } as never);
+    vi.spyOn(NotifyClient.prototype, "sendEmail").mockResolvedValue({
+      data: { id: "provider-notification-id" },
+    } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("sends with the synced database binding ahead of the environment fallback", async () => {
+    vi.spyOn(admin, "getNotifyTemplateBindings").mockResolvedValue({
+      data: {
+        notifyTemplateBindings: [{
+          templateKey: "emailVerification",
+          notifyTemplateId: "database-template-id",
+        }],
+      },
+    } as never);
+
+    await runVerificationTest();
+
+    expect(NotifyClient.prototype.sendEmail).toHaveBeenCalledWith(
+      "database-template-id",
+      "admin@example.org",
+      expect.objectContaining({ emailReplyToId: REPLY_TO_ID }),
+    );
+  });
+
+  it("uses the environment template when no database binding exists", async () => {
+    vi.spyOn(admin, "getNotifyTemplateBindings").mockResolvedValue({
+      data: { notifyTemplateBindings: [] },
+    } as never);
+
+    await runVerificationTest();
+
+    expect(NotifyClient.prototype.sendEmail).toHaveBeenCalledWith(
+      "environment-template-id",
+      "admin@example.org",
+      expect.objectContaining({ emailReplyToId: REPLY_TO_ID }),
+    );
+  });
+});

--- a/functions/src/__tests__/notifyTemplateBindingConfiguration.test.ts
+++ b/functions/src/__tests__/notifyTemplateBindingConfiguration.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const dataConnectMocks = vi.hoisted(() => ({
+  getNotifyTemplateBindings: vi.fn(),
+}));
+
+vi.mock("@dataconnect/admin-generated", () => ({
+  getNotifyTemplateBindings: dataConnectMocks.getNotifyTemplateBindings,
+}));
+
+import { resolveNotifyTemplateId } from "../notifyTemplateBindingConfiguration";
+
+describe("Notify template binding resolution", () => {
+  beforeEach(() => {
+    dataConnectMocks.getNotifyTemplateBindings.mockReset();
+  });
+
+  it("returns the saved database binding for a template key", async () => {
+    dataConnectMocks.getNotifyTemplateBindings.mockResolvedValue({
+      data: {
+        notifyTemplateBindings: [{
+          templateKey: "emailVerification",
+          notifyTemplateId: "database-template-id",
+        }],
+      },
+    });
+
+    await expect(resolveNotifyTemplateId("emailVerification"))
+      .resolves.toBe("database-template-id");
+  });
+
+  it("returns undefined when the template has no saved binding", async () => {
+    dataConnectMocks.getNotifyTemplateBindings.mockResolvedValue({
+      data: { notifyTemplateBindings: [] },
+    });
+
+    await expect(resolveNotifyTemplateId("emailVerification"))
+      .resolves.toBeUndefined();
+  });
+
+  it("returns undefined when the binding lookup fails", async () => {
+    dataConnectMocks.getNotifyTemplateBindings.mockRejectedValue(new Error("unavailable"));
+
+    await expect(resolveNotifyTemplateId("emailVerification"))
+      .resolves.toBeUndefined();
+  });
+});

--- a/functions/src/notifyReplyToAdmin.ts
+++ b/functions/src/notifyReplyToAdmin.ts
@@ -33,6 +33,7 @@ import {
   type NotifyReplyToResolutionSource,
 } from "./notifyReplyToConfiguration";
 import { getGovNotifyEmailReplyToId } from "./govNotifyReplyToId";
+import { resolveNotifyTemplateId } from "./notifyTemplateBindingConfiguration";
 import { enforceRateLimit } from "./rateLimiter";
 
 const AUDIT_LIMIT = 50;
@@ -196,7 +197,8 @@ export const sendNotifyReplyToVerificationTest = onCall(
     if (delivery.effectiveMode === "SIMULATION") {
       throw new HttpsError("failed-precondition", "Raise the site email mode to Team test before sending a verification email");
     }
-    const templateId = process.env.GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION?.trim();
+    const templateId = await resolveNotifyTemplateId("emailVerification")
+      ?? process.env.GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION?.trim();
     if (!templateId) throw new HttpsError("failed-precondition", "The email verification Notify template is not configured");
     const response = await new NotifyClient(govNotifyApiKeyForMode(delivery.effectiveMode)).sendEmail(
       templateId,


### PR DESCRIPTION
## What changed

- Resolve the reply-to verification email template from the saved `emailVerification` Notify binding.
- Retain `GOV_NOTIFY_TEMPLATE_EMAIL_VERIFICATION` as a migration fallback.
- Add unit coverage for successful, missing, and failed database binding lookups.

## Why

The Email Templates page reports the database-backed binding as synced, but reply-to verification previously bypassed that binding and checked only the legacy environment variable. Environments using the synced binding therefore received a misleading `FAILED_PRECONDITION` error.

## Impact

Admins can send reply-to verification emails using the same synced template binding used by normal transactional email. Existing environment-variable configuration continues to work as a fallback.

## Validation

- `npm test` — 80 files, 865 tests passed
- `npm run build`
- ESLint on the changed implementation and tests
- `git diff --check`