### PR TITLE
Fix stale UI state after mutations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,9 +133,7 @@ function AppContent() {
 
   const handleProfileUpdate = useCallback(() => {
     // Refetch user data after profile update
-    if (refetch) {
-      refetch();
-    }
+    return refetch?.();
   }, [refetch]);
 
   const handleProfileReviewed = useCallback(async () => {
@@ -595,6 +593,7 @@ function AppContent() {
                             userDataLoading={userDataLoading}
                             isAdmin={isAdmin}
                             onBack={() => navigateBackOr(ROUTES.HOME)}
+                            onUserDataUpdate={handleProfileUpdate}
                           />
                         </Suspense>
                       ) : user ? (
@@ -606,7 +605,7 @@ function AppContent() {
                   }
                 />
                 <Route path={ROUTES.PERMISSIONS} element={<Navigate to={ROUTES.MANAGE_USERS} replace />} />
-                <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
+                <Route path={ROUTES.MANAGE_USERS} element={renderAdminOnly("Manage Users", <Suspense fallback={<LoadingFallback />}><ManageUsers onBack={() => navigateBackOr(ROUTES.HOME)} onCurrentUserUpdate={handleProfileUpdate} /></Suspense>)} />
                 <Route path={ROUTES.APPROVE_USERS} element={renderAdminOnly("Approve Users", <Suspense fallback={<LoadingFallback />}><ApproveUsers onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
                 <Route path={ROUTES.USER_GROUPS} element={renderAdminOnly("User Groups", <Suspense fallback={<LoadingFallback />}><UserGroups onBack={() => navigateBackOr(ROUTES.HOME)} /></Suspense>)} />
                 <Route

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -59,6 +59,7 @@ import {
   toMemberDataError,
 } from "../../../shared/errors";
 import FailureState from "../../../shared/components/FailureState";
+import { invalidateAnnouncementPreferences } from "../../../shared/query/invalidation";
 
 export interface AccountSettingsPageProps {
   user: User;
@@ -66,6 +67,7 @@ export interface AccountSettingsPageProps {
   userDataLoading?: boolean;
   isAdmin: boolean;
   onBack?: () => void;
+  onUserDataUpdate?: () => void | Promise<void>;
 }
 
 function usesEmailPassword(user: User): boolean {
@@ -108,6 +110,7 @@ function AnnouncementPreferencesList() {
             ? { ...old, user: { ...old.user, announcementOptOutAll: newOptOut } }
             : old,
       );
+      await invalidateAnnouncementPreferences(queryClient);
       setSnackbar(
         newOptOut
           ? "Opted out of all announcement emails"
@@ -141,6 +144,7 @@ function AnnouncementPreferencesList() {
           return { ...old, user: { ...old.user, optOuts: newOptOuts } };
         }
       );
+      await invalidateAnnouncementPreferences(queryClient);
       setLocalOverrides(prev => { const m = new Map(prev); m.delete(sectionId); return m; });
       setSnackbar(newOptedOut ? "Opted out of announcements" : "Opted in to announcements");
     } catch (error) {
@@ -232,6 +236,7 @@ export default function AccountSettingsPage({
   userDataLoading = false,
   isAdmin,
   onBack,
+  onUserDataUpdate,
 }: AccountSettingsPageProps) {
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -362,6 +367,10 @@ export default function AccountSettingsPage({
         shareContactInfo: newValue,
       };
       await upsertUser(dataConnect, vars);
+      if (onUserDataUpdate) {
+        await onUserDataUpdate();
+        setShareContactInfoOverride(null);
+      }
     } catch (error) {
       reportError("account.privacy-setting", error);
       setShareContactInfoOverride(null);

--- a/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
+++ b/src/features/account/components/__tests__/AccountSettingsPage.test.tsx
@@ -208,6 +208,26 @@ describe("AccountSettingsPage", () => {
     expect(toggle).not.toBeChecked();
   });
 
+  it("refreshes App-owned user data after saving the privacy setting", async () => {
+    const user = userEvent.setup();
+    const onUserDataUpdate = vi.fn().mockResolvedValue(undefined);
+    renderAccountSettings({
+      user: mockUser,
+      userData,
+      isAdmin: false,
+      onUserDataUpdate,
+    });
+
+    await user.click(screen.getByRole("switch", {
+      name: "Share my contact details with other section members",
+    }));
+
+    await waitFor(() => expect(onUserDataUpdate).toHaveBeenCalledOnce());
+    expect(onUserDataUpdate.mock.invocationCallOrder[0]).toBeGreaterThan(
+      mockUpsertUser.mock.invocationCallOrder[0],
+    );
+  });
+
   it("reverts the toggle and shows an error if the upsert fails", async () => {
     const user = userEvent.setup();
     mockUpsertUser.mockRejectedValueOnce(new Error("Network error"));

--- a/src/features/admin/components/AnnouncementSendHistory.tsx
+++ b/src/features/admin/components/AnnouncementSendHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Alert,
   Box,
@@ -206,17 +206,27 @@ export default function AnnouncementSendHistory({ sectionId, refreshTrigger }: P
   const [sends, setSends] = useState<AnnouncementSend[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const historyRequestIdRef = useRef(0);
 
   useEffect(() => {
+    const requestId = ++historyRequestIdRef.current;
     setLoading(true);
     setError(null);
     getAnnouncementSendHistory(sectionId)
-      .then(setSends)
+      .then((result) => {
+        if (historyRequestIdRef.current === requestId) setSends(result);
+      })
       .catch((caught: unknown) => {
+        if (historyRequestIdRef.current !== requestId) return;
         reportError("admin.announcements.history", caught, { sectionId });
         setError(toAdminUserFacingError(caught, "announcements").message);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (historyRequestIdRef.current === requestId) setLoading(false);
+      });
+    return () => {
+      if (historyRequestIdRef.current === requestId) historyRequestIdRef.current += 1;
+    };
   }, [sectionId, refreshTrigger]);
 
   return (

--- a/src/features/admin/components/AuditLogs.tsx
+++ b/src/features/admin/components/AuditLogs.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Box,
   Alert,
@@ -42,6 +42,7 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
   const [allUsers, setAllUsers] = useState<ListUsersData["users"]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const dataRequestIdRef = useRef(0);
 
   const fetchAllUsers = useCallback(async () => {
     try {
@@ -54,27 +55,34 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
   }, []);
 
   const fetchData = useCallback(async () => {
+    const requestId = ++dataRequestIdRef.current;
     setLoading(true);
     setError(null);
     try {
       if (tabValue === 0) {
         const ref = listUsersRef(dataConnect);
         const result = await executeQuery(ref);
+        if (dataRequestIdRef.current !== requestId) return;
         setUsers(result.data?.users || []);
       } else if (tabValue === 1) {
         const ref = listUserGroupsRef(dataConnect);
         const result = await executeQuery(ref);
+        if (dataRequestIdRef.current !== requestId) return;
         setUserGroups(result.data?.userGroups || []);
       } else if (tabValue === 2) {
         const ref = listSectionsRef(dataConnect);
         const result = await executeQuery(ref);
+        if (dataRequestIdRef.current !== requestId) return;
         setSections(result.data?.sections || []);
       }
     } catch (caught) {
+      if (dataRequestIdRef.current !== requestId) return;
       reportError("admin.audit-logs.load", caught, { tab: tabValue });
       setError(toAdminUserFacingError(caught, "audit-logs").message);
     } finally {
-      setLoading(false);
+      if (dataRequestIdRef.current === requestId) {
+        setLoading(false);
+      }
     }
   }, [tabValue]);
 

--- a/src/features/admin/components/ManageSectionFiles.tsx
+++ b/src/features/admin/components/ManageSectionFiles.tsx
@@ -91,16 +91,18 @@ export default function ManageSectionFiles({
     void load();
   }, [load]);
 
-  const run = async (operation: () => Promise<void>, success: string) => {
+  const run = async (operation: () => Promise<void>, success: string): Promise<boolean> => {
     setBusy(true);
     setNotice(null);
     try {
       await operation();
       setNotice({ severity: "success", text: success });
       await load();
+      return true;
     } catch (error) {
       reportError("admin.section-files.operation", error, { sectionId });
       setNotice({ severity: "error", text: toAdminUserFacingError(error, "files").message });
+      return false;
     } finally {
       setBusy(false);
       setStage(null);
@@ -315,7 +317,9 @@ export default function ManageSectionFiles({
                   description: value.description?.trim() || null,
                 }),
                 "File details updated.",
-              ).then(() => setEditing(null));
+              ).then((saved) => {
+                if (saved) setEditing(null);
+              });
             }}
           >
             Save
@@ -340,7 +344,9 @@ export default function ManageSectionFiles({
               if (!deleting) return;
               const value = deleting;
               void run(() => deleteSectionFile(sectionId, value.id), "File deleted.")
-                .then(() => setDeleting(null));
+                .then((deleted) => {
+                  if (deleted) setDeleting(null);
+                });
             }}
           >
             Delete file

--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -33,6 +33,8 @@ import {
 } from "./ManageSectionsSurfaces";
 import type { SectionUserGroupRow, SectionWithDetails } from "./manageSectionsTypes";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateSectionsForUser } from "../../../shared/query/invalidation";
 
 interface ManageSectionsProps {
   onBack: () => void;
@@ -48,6 +50,7 @@ interface ManageSectionsLocationState {
 }
 
 export default function ManageSections({ onBack }: ManageSectionsProps) {
+  const queryClient = useQueryClient();
   const location = useLocation();
   const initialState = location.state as ManageSectionsLocationState | null;
   const isAdmin = useAdminClaim(auth.currentUser);
@@ -224,7 +227,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     try {
       const ref = deleteSectionRef(dataConnect, { id: section.id });
       await executeMutation(ref);
-      await fetchSections();
+      await Promise.all([fetchSections(), invalidateSectionsForUser(queryClient)]);
       showSuccess(`Section "${section.name}" deleted`);
     } catch (caught) {
       reportError("admin.sections.delete", caught, { sectionId: section.id });
@@ -259,7 +262,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
         await executeMutation(ref);
       }
       setDialogOpen(false);
-      await fetchSections();
+      await Promise.all([fetchSections(), invalidateSectionsForUser(queryClient)]);
       showSuccess(`Section ${editingSection ? "updated" : "created"}`);
     } catch (caught) {
       reportError("admin.sections.save", caught, { editing: Boolean(editingSection) });
@@ -292,6 +295,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       await executeMutation(ref);
 
       await fetchSectionUserGroups(editingSection.id);
+      await invalidateSectionsForUser(queryClient);
 
       setSelectedUserGroup(null);
       setSelectedPurpose(SectionUserGroupPurpose.ACCESS);
@@ -340,6 +344,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
       
       // Refresh section user groups
       await fetchSectionUserGroups(editingSection.id);
+      await invalidateSectionsForUser(queryClient);
       showSuccess("User group removed from section");
     } catch (caught) {
       reportError("admin.sections.remove-group", caught, { sectionId: editingSection.id, userGroupId });

--- a/src/features/admin/components/ManageUsers.tsx
+++ b/src/features/admin/components/ManageUsers.tsx
@@ -31,9 +31,10 @@ import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 
 interface ManageUsersProps {
   onBack: () => void;
+  onCurrentUserUpdate?: () => void | Promise<void>;
 }
 
-export default function ManageUsers({ onBack }: ManageUsersProps) {
+export default function ManageUsers({ onBack, onCurrentUserUpdate }: ManageUsersProps) {
   const isAdmin = useAdminClaim(auth.currentUser);
   const [tabValue, setTabValue] = useState(0);
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([]);
@@ -209,9 +210,12 @@ export default function ManageUsers({ onBack }: ManageUsersProps) {
     setEditingUser(null);
   };
 
-  const handleSaveEdit = () => {
+  const handleSaveEdit = async () => {
     refetchSearch();
-    void fetchAdminUsers();
+    await fetchAdminUsers();
+    if (editingUser?.uid === auth.currentUser?.uid) {
+      await onCurrentUserUpdate?.();
+    }
   };
 
   const handleSuccessSnackbar = (message: string) => {

--- a/src/features/admin/components/NotifyReplyToSettings.tsx
+++ b/src/features/admin/components/NotifyReplyToSettings.tsx
@@ -69,14 +69,16 @@ export default function NotifyReplyToSettings() {
   const run = async (
     label: string,
     action: () => Promise<NotifyReplyToAdminConfiguration>,
-  ) => {
+  ): Promise<boolean> => {
     setSaving(true);
     setError(null);
     try {
       setConfiguration(await action());
+      return true;
     } catch (caught) {
       reportError(`admin.notify-reply-to.${label}`, caught);
       setError(toAdminUserFacingError(caught, "email-configuration").message);
+      return false;
     } finally {
       setSaving(false);
     }
@@ -97,7 +99,7 @@ export default function NotifyReplyToSettings() {
   };
 
   const saveAddress = async () => {
-    await run(editing ? "update" : "create", () => editing
+    const saved = await run(editing ? "update" : "create", () => editing
       ? updateNotifyReplyToAddress({
         addressId: editing.id,
         expectedVersion: editing.version,
@@ -106,7 +108,7 @@ export default function NotifyReplyToSettings() {
         notifyUuid,
       })
       : createNotifyReplyToAddress({ displayLabel, emailAddress, notifyUuid }));
-    resetForm();
+    if (saved) resetForm();
   };
 
   return (

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -283,7 +283,11 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           })
         );
       }
-      refetchEvents();
+      const refreshes: Array<Promise<unknown>> = [refetchEvents()];
+      if (editingEvent && ticketTypesEventId === editingEvent.id) {
+        refreshes.push(refetchEventDetail());
+      }
+      await Promise.all(refreshes);
       setEventDialogOpen(false);
       showSuccess(`Event ${editingEvent ? "updated" : "created"}`);
     } catch (err: unknown) {

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Box,
   Alert,
 } from "@mui/material";
-import { executeQuery, executeMutation } from "firebase/data-connect";
+import { executeQuery, executeMutation, QueryFetchPolicy } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
 import {
   listUserGroupsRef,
@@ -74,6 +74,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const [userSearchTerm, setUserSearchTerm] = useState("");
   const [searchResults, setSearchResults] = useState<UserSearchResult[]>([]);
   const [searchingUsers, setSearchingUsers] = useState(false);
+  const userSearchRequestIdRef = useRef(0);
   const [addingUserId, setAddingUserId] = useState<string | null>(null);
 
   // All users: for merged group membership (explicit + by membership status)
@@ -110,15 +111,18 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
     }
   }, []);
 
-  const fetchGroupDetails = useCallback(async (groupId: string) => {
-    if (groupDetails[groupId]) {
+  const fetchGroupDetails = useCallback(async (groupId: string, force = false) => {
+    if (!force && groupDetails[groupId]) {
       return;
     }
 
     setLoadingDetails((prev) => ({ ...prev, [groupId]: true }));
     try {
       const ref = getUserGroupByIdRef(dataConnect, { id: groupId });
-      const result = await executeQuery(ref);
+      const result = await executeQuery(
+        ref,
+        force ? { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } : undefined,
+      );
       
       if (result.data?.userGroup) {
         setGroupDetails((prev) => ({
@@ -214,8 +218,10 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   };
 
   const handleSearchUsers = useCallback(async (term: string) => {
+    const requestId = ++userSearchRequestIdRef.current;
     if (!term.trim() || term.length < 2) {
       setSearchResults([]);
+      setSearchingUsers(false);
       return;
     }
 
@@ -253,14 +259,18 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
             return null;
           })
         );
+        if (userSearchRequestIdRef.current !== requestId) return;
         setSearchResults(usersWithData.filter((u): u is NonNullable<typeof u> => u !== null));
       }
     } catch (caught) {
+      if (userSearchRequestIdRef.current !== requestId) return;
       reportError("admin.user-groups.search", caught);
       setError(toAdminUserFacingError(caught, "users").message);
       setSearchResults([]);
     } finally {
-      setSearchingUsers(false);
+      if (userSearchRequestIdRef.current === requestId) {
+        setSearchingUsers(false);
+      }
     }
   }, []);
 
@@ -399,6 +409,9 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       }
       setDialogOpen(false);
       await fetchUserGroupsList();
+      if (editingGroup) {
+        await fetchGroupDetails(editingGroup.id, true);
+      }
       showSuccess(`User group ${editingGroup ? "updated" : "created"}`);
     } catch (caught) {
       reportError("admin.user-groups.save", caught, { editing: Boolean(editingGroup) });

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -58,6 +58,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const { snackbar, showSuccess, close: closeSnackbar } = useSnackbar();
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
   const [groupDetails, setGroupDetails] = useState<Record<string, UserGroupDetails>>({});
+  const groupDetailsRef = useRef<Record<string, UserGroupDetails>>({});
   const [loadingDetails, setLoadingDetails] = useState<Record<string, boolean>>({});
   
   // Create/Edit dialog state
@@ -112,7 +113,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   }, []);
 
   const fetchGroupDetails = useCallback(async (groupId: string, force = false) => {
-    if (!force && groupDetails[groupId]) {
+    if (!force && groupDetailsRef.current[groupId]) {
       return;
     }
 
@@ -125,10 +126,11 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       );
       
       if (result.data?.userGroup) {
-        setGroupDetails((prev) => ({
-          ...prev,
-          [groupId]: result.data.userGroup!,
-        }));
+        setGroupDetails((prev) => {
+          const next = { ...prev, [groupId]: result.data.userGroup! };
+          groupDetailsRef.current = next;
+          return next;
+        });
       }
     } catch (caught) {
       reportError("admin.user-groups.details", caught, { groupId });
@@ -136,7 +138,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
     } finally {
       setLoadingDetails((prev) => ({ ...prev, [groupId]: false }));
     }
-  }, [groupDetails]);
+  }, []);
 
   useEffect(() => {
     fetchUserGroupsList();
@@ -303,8 +305,10 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       await executeMutation(ref);
 
       // Refresh group details
-      delete groupDetails[addingToGroupId];
-      setGroupDetails({ ...groupDetails });
+      const nextGroupDetails = { ...groupDetails };
+      delete nextGroupDetails[addingToGroupId];
+      groupDetailsRef.current = nextGroupDetails;
+      setGroupDetails(nextGroupDetails);
       await fetchGroupDetails(addingToGroupId);
 
       setAddUserDialogOpen(false);
@@ -333,8 +337,10 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       await executeMutation(ref);
 
       // Refresh group details
-      delete groupDetails[groupId];
-      setGroupDetails({ ...groupDetails });
+      const nextGroupDetails = { ...groupDetails };
+      delete nextGroupDetails[groupId];
+      groupDetailsRef.current = nextGroupDetails;
+      setGroupDetails(nextGroupDetails);
       await fetchGroupDetails(groupId);
       showSuccess("User removed from group");
     } catch (caught) {
@@ -371,8 +377,10 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       if (expandedGroupId === group.id) {
         setExpandedGroupId(null);
       }
-      delete groupDetails[group.id];
-      setGroupDetails({ ...groupDetails });
+      const nextGroupDetails = { ...groupDetails };
+      delete nextGroupDetails[group.id];
+      groupDetailsRef.current = nextGroupDetails;
+      setGroupDetails(nextGroupDetails);
       showSuccess(`User group "${group.name}" deleted`);
     } catch (caught) {
       reportError("admin.user-groups.delete", caught, { groupId: group.id });

--- a/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
+++ b/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
@@ -150,6 +150,28 @@ describe("AnnouncementSendHistory", () => {
     expect(screen.queryByText(/network/i)).not.toBeInTheDocument();
   });
 
+  it("ignores a superseded history response", async () => {
+    let resolveFirst!: (value: firebaseFunctions.AnnouncementSend[]) => void;
+    let resolveSecond!: (value: firebaseFunctions.AnnouncementSend[]) => void;
+    vi.mocked(firebaseFunctions.getAnnouncementSendHistory)
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveFirst = resolve; }))
+      .mockImplementationOnce(() => new Promise((resolve) => { resolveSecond = resolve; }));
+
+    const { rerender } = render(
+      <AnnouncementSendHistory sectionId={SECTION_ID} refreshTrigger={0} />,
+    );
+    rerender(<AnnouncementSendHistory sectionId={SECTION_ID} refreshTrigger={1} />);
+
+    resolveSecond([mockSends[1]]);
+    expect(await screen.findByText("uuid-2")).toBeInTheDocument();
+
+    resolveFirst([mockSends[0]]);
+    await waitFor(() => {
+      expect(screen.getByText("uuid-2")).toBeInTheDocument();
+      expect(screen.queryByText("BULK: Alpha Update")).not.toBeInTheDocument();
+    });
+  });
+
   it("renders send rows with date, template name, and counts", async () => {
     vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
 

--- a/src/features/admin/components/__tests__/AuditLogs.test.tsx
+++ b/src/features/admin/components/__tests__/AuditLogs.test.tsx
@@ -1,0 +1,86 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "../../../../test-utils";
+import AuditLogs from "../AuditLogs";
+import { executeQuery } from "firebase/data-connect";
+
+vi.mock("firebase/data-connect", () => ({ executeQuery: vi.fn() }));
+vi.mock("../../../../config/firebase", () => ({ dataConnect: {} }));
+vi.mock("@dataconnect/generated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+  return {
+    ...actual,
+    listUsersRef: vi.fn(() => ({ kind: "users" })),
+    listUserGroupsRef: vi.fn(() => ({ kind: "groups" })),
+    listSectionsRef: vi.fn(() => ({ kind: "sections" })),
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolver) => { resolve = resolver; });
+  return { promise, resolve };
+}
+
+describe("AuditLogs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the current tab loading when an older request resolves out of order", async () => {
+    const user = userEvent.setup();
+    const staleUsers = deferred<{ data: { users: Array<Record<string, unknown>> } }>();
+    const currentGroups = deferred<{ data: { userGroups: Array<Record<string, unknown>> } }>();
+    let usersCall = 0;
+
+    vi.mocked(executeQuery).mockImplementation((ref: unknown) => {
+      const kind = (ref as { kind: string }).kind;
+      if (kind === "users") {
+        usersCall += 1;
+        if (usersCall === 1) return Promise.resolve({ data: { users: [] } }) as never;
+        return staleUsers.promise as never;
+      }
+      if (kind === "groups") return currentGroups.promise as never;
+      return Promise.resolve({ data: { sections: [] } }) as never;
+    });
+
+    render(<AuditLogs onBack={vi.fn()} />);
+    await waitFor(() => expect(usersCall).toBe(2));
+    await user.click(screen.getByRole("tab", { name: "User Groups" }));
+    await waitFor(() => expect(vi.mocked(executeQuery).mock.calls.length).toBe(3));
+
+    staleUsers.resolve({
+      data: {
+        users: [{
+          id: "stale-user",
+          firstName: "Stale",
+          lastName: "User",
+          email: "stale@example.com",
+          membershipStatus: "REGULAR",
+        }],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("No user groups found")).not.toBeInTheDocument();
+
+    currentGroups.resolve({
+      data: {
+        userGroups: [{
+          id: "group-1",
+          name: "Current Group",
+          description: "Latest response",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+          createdBy: "system",
+          updatedBy: "system",
+        }],
+      },
+    });
+
+    expect(await screen.findByText("Current Group")).toBeInTheDocument();
+    expect(screen.queryByText("Stale User")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
+++ b/src/features/admin/components/__tests__/ManageSectionFiles.test.tsx
@@ -131,4 +131,21 @@ describe("ManageSectionFiles", () => {
     expect(screen.queryByText(/permission-denied/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Joining instructions")).not.toBeInTheDocument();
   });
+
+  it("keeps the edit dialog and entered values open when saving fails", async () => {
+    vi.mocked(updateSectionFileMetadata).mockRejectedValue(new Error("save failed"));
+    const user = userEvent.setup();
+    render(<ManageSectionFiles sectionId="section-1" sectionName="Test Section" onBack={vi.fn()} />);
+    await screen.findByText("Joining instructions");
+
+    await user.click(screen.getByRole("button", { name: "Edit Joining instructions" }));
+    const name = screen.getByLabelText("Display name");
+    await user.clear(name);
+    await user.type(name, "Keep this value");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText(/could not complete the file operation/i)).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Edit file details" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Display name")).toHaveValue("Keep this value");
+  });
 });

--- a/src/features/admin/components/__tests__/ManageSections.test.tsx
+++ b/src/features/admin/components/__tests__/ManageSections.test.tsx
@@ -1,0 +1,119 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { useQuery } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { executeMutation, executeQuery } from "firebase/data-connect";
+import { render, screen } from "../../../../test-utils";
+import ManageSections from "../ManageSections";
+
+vi.mock("firebase/data-connect", () => ({
+  executeQuery: vi.fn(),
+  executeMutation: vi.fn(),
+}));
+vi.mock("../../../../config/firebase", () => ({
+  auth: { currentUser: { uid: "admin-1" } },
+  dataConnect: {},
+}));
+vi.mock("../../../users/hooks/useAdminClaim", () => ({ useAdminClaim: () => true }));
+vi.mock("../SectionEventsManager", () => ({ default: () => null }));
+vi.mock("@dataconnect/generated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+  return {
+    ...actual,
+    listSectionsRef: vi.fn(() => ({ kind: "list-sections" })),
+    listUserGroupsRef: vi.fn(() => ({ kind: "list-user-groups" })),
+    createSectionRef: vi.fn((_dc: unknown, vars: unknown) => ({ kind: "create-section", vars })),
+    updateSectionRef: vi.fn(),
+    deleteSectionRef: vi.fn(),
+    getSectionByIdRef: vi.fn(),
+    grantUserGroupToSectionForPurposeRef: vi.fn(),
+    revokeUserGroupFromSectionForPurposeRef: vi.fn(),
+  };
+});
+vi.mock("../ManageSectionsSurfaces", () => ({
+  ManageSectionsListSurface: ({ sections, onCreate }: { sections: Array<{ id: string; name: string }>; onCreate: () => void }) => (
+    <div>
+      <button onClick={onCreate}>Create Section</button>
+      {sections.map((section) => <div key={section.id}>{section.name}</div>)}
+    </div>
+  ),
+  SectionEditorDialogSurface: ({
+    open,
+    sectionName,
+    onSectionNameChange,
+    onSubmit,
+  }: {
+    open: boolean;
+    sectionName: string;
+    onSectionNameChange: (value: string) => void;
+    onSubmit: () => void;
+  }) => open ? (
+    <div>
+      <label>Section Name<input value={sectionName} onChange={(event) => onSectionNameChange(event.target.value)} /></label>
+      <button onClick={onSubmit}>Save Section</button>
+    </div>
+  ) : null,
+  AddSectionUserGroupDialogSurface: () => null,
+}));
+
+let created = false;
+let navigationLabel = "Old navigation";
+
+function NavigationProbe() {
+  const query = useQuery({
+    queryKey: ["GetSectionsForUser"],
+    queryFn: async () => navigationLabel,
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+  return <div>Navigation: {query.data ?? "Loading"}</div>;
+}
+
+describe("ManageSections", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    created = false;
+    navigationLabel = "Old navigation";
+    vi.mocked(executeQuery).mockImplementation((ref: unknown) => {
+      const kind = (ref as { kind: string }).kind;
+      if (kind === "list-user-groups") return Promise.resolve({ data: { userGroups: [] } }) as never;
+      if (kind === "list-sections") {
+        return Promise.resolve({
+          data: {
+            sections: created
+              ? [
+                  { id: "section-1", name: "Existing Section", type: "MEMBERS", description: null },
+                  { id: "section-2", name: "New Section", type: "MEMBERS", description: null },
+                ]
+              : [{ id: "section-1", name: "Existing Section", type: "MEMBERS", description: null }],
+          },
+        }) as never;
+      }
+      return Promise.resolve({ data: null }) as never;
+    });
+    vi.mocked(executeMutation).mockImplementation(async () => {
+      created = true;
+      navigationLabel = "New Section";
+      return {} as never;
+    });
+  });
+
+  it("renders the saved section and refreshes the persistent navigation query", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <NavigationProbe />
+        <ManageSections onBack={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("Existing Section")).toBeInTheDocument();
+    expect(await screen.findByText("Navigation: Old navigation")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Create Section" }));
+    await user.type(screen.getByLabelText("Section Name"), "New Section");
+    await user.click(screen.getByRole("button", { name: "Save Section" }));
+
+    expect(await screen.findByText("New Section")).toBeInTheDocument();
+    expect(await screen.findByText("Navigation: New Section")).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/ManageUsers.test.tsx
+++ b/src/features/admin/components/__tests__/ManageUsers.test.tsx
@@ -3,6 +3,7 @@ import { describe, beforeEach, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render, screen, waitFor } from "../../../../test-utils";
 import ManageUsers from "../ManageUsers";
+import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 
 const mocks = vi.hoisted(() => ({
   refetchSearch: vi.fn(),
@@ -49,12 +50,24 @@ vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   revokeAdminClaim: vi.fn(),
 }));
 vi.mock("../../../users/components/UsersTable", () => ({
-  default: ({ users, onEdit }: { users: typeof searchUsers; onEdit: (user: (typeof searchUsers)[number]) => void }) => (
+  default: ({
+    users,
+    onEdit,
+    onGrantAdmin,
+    onRevokeAdmin,
+  }: {
+    users: typeof searchUsers;
+    onEdit: (user: (typeof searchUsers)[number]) => void;
+    onGrantAdmin: (uid: string) => void;
+    onRevokeAdmin: (uid: string) => void;
+  }) => (
     <div>
       {users.map((user) => (
-        <button key={user.uid} onClick={() => onEdit(user)}>
-          Edit {user.email}
-        </button>
+        <div key={user.uid}>
+          <button onClick={() => onEdit(user)}>Edit {user.email}</button>
+          <button onClick={() => onGrantAdmin(user.uid)}>Grant {user.email}</button>
+          <button onClick={() => onRevokeAdmin(user.uid)}>Revoke {user.email}</button>
+        </div>
       ))}
     </div>
   ),
@@ -80,6 +93,8 @@ describe("ManageUsers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.listAdminUsers.mockResolvedValue({ success: true, users: [] });
+    vi.mocked(firebaseFunctions.grantAdminClaim).mockResolvedValue({ success: true, message: "Admin granted" });
+    vi.mocked(firebaseFunctions.revokeAdminClaim).mockResolvedValue({ success: true, message: "Admin revoked" });
   });
 
   it("refreshes rendered app-level user state after an admin edits their own profile", async () => {
@@ -104,5 +119,40 @@ describe("ManageUsers", () => {
 
     await waitFor(() => expect(mocks.listAdminUsers).toHaveBeenCalledTimes(2));
     expect(screen.getByText("Current-user refreshes: 0")).toBeInTheDocument();
+  });
+
+  it("renders successful grant and revoke outcomes after refreshing administrator state", async () => {
+    const user = userEvent.setup();
+    mocks.listAdminUsers.mockResolvedValue({
+      success: true,
+      users: [
+        {
+          uid: "current-user",
+          email: "current@example.com",
+          displayName: "Current, User",
+          emailVerified: true,
+          disabled: false,
+          metadata: { creationTime: "2026-01-01", lastSignInTime: "2026-08-10" },
+        },
+        {
+          uid: "second-admin",
+          email: "admin@example.com",
+          displayName: "Second, Admin",
+          emailVerified: true,
+          disabled: false,
+          metadata: { creationTime: "2026-01-01", lastSignInTime: "2026-08-10" },
+        },
+      ],
+    });
+    render(<Harness />);
+
+    await waitFor(() => expect(mocks.listAdminUsers).toHaveBeenCalledOnce());
+    await user.click(screen.getByRole("button", { name: "Grant other@example.com" }));
+    expect(await screen.findByText("Admin granted")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Revoke current@example.com" }));
+    expect(await screen.findByText("Admin revoked")).toBeInTheDocument();
+    expect(firebaseFunctions.grantAdminClaim).toHaveBeenCalledWith("other-user");
+    expect(firebaseFunctions.revokeAdminClaim).toHaveBeenCalledWith("current-user");
   });
 });

--- a/src/features/admin/components/__tests__/ManageUsers.test.tsx
+++ b/src/features/admin/components/__tests__/ManageUsers.test.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "../../../../test-utils";
+import ManageUsers from "../ManageUsers";
+
+const mocks = vi.hoisted(() => ({
+  refetchSearch: vi.fn(),
+  listAdminUsers: vi.fn(),
+}));
+
+const searchUsers = [
+  {
+    uid: "current-user",
+    email: "current@example.com",
+    displayName: "Current, User",
+    customClaims: { admin: true, enabled: true },
+  },
+  {
+    uid: "other-user",
+    email: "other@example.com",
+    displayName: "Other, User",
+    customClaims: { admin: false, enabled: true },
+  },
+];
+
+vi.mock("../../../users/hooks/useUserSearch", () => ({
+  useUserSearch: () => ({
+    users: searchUsers,
+    loading: false,
+    error: null,
+    page: 1,
+    totalPages: 1,
+    total: searchUsers.length,
+    setPage: vi.fn(),
+    setSearchTerm: vi.fn(),
+    searchTerm: "user",
+    refetch: mocks.refetchSearch,
+  }),
+}));
+
+vi.mock("../../../users/hooks/useAdminClaim", () => ({ useAdminClaim: () => true }));
+vi.mock("../../../../config/firebase", () => ({
+  auth: { currentUser: { uid: "current-user" } },
+}));
+vi.mock("../listAdminUsers", () => ({ listAdminUsers: mocks.listAdminUsers }));
+vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
+  grantAdminClaim: vi.fn(),
+  revokeAdminClaim: vi.fn(),
+}));
+vi.mock("../../../users/components/UsersTable", () => ({
+  default: ({ users, onEdit }: { users: typeof searchUsers; onEdit: (user: (typeof searchUsers)[number]) => void }) => (
+    <div>
+      {users.map((user) => (
+        <button key={user.uid} onClick={() => onEdit(user)}>
+          Edit {user.email}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+vi.mock("../../../profile/components/EditUserDialog", () => ({
+  default: ({ open, user, onSave }: { open: boolean; user: (typeof searchUsers)[number] | null; onSave: () => void }) =>
+    open ? <button onClick={onSave}>Save {user?.email}</button> : null,
+}));
+vi.mock("../../../users/components/AdminUsersTable", () => ({ default: () => null }));
+vi.mock("../UserGroupMemberships", () => ({ default: () => null }));
+
+function Harness() {
+  const [refreshes, setRefreshes] = useState(0);
+  return (
+    <>
+      <div>Current-user refreshes: {refreshes}</div>
+      <ManageUsers onBack={vi.fn()} onCurrentUserUpdate={() => setRefreshes((value) => value + 1)} />
+    </>
+  );
+}
+
+describe("ManageUsers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listAdminUsers.mockResolvedValue({ success: true, users: [] });
+  });
+
+  it("refreshes rendered app-level user state after an admin edits their own profile", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(await screen.findByRole("button", { name: "Edit current@example.com" }));
+    await user.click(screen.getByRole("button", { name: "Save current@example.com" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Current-user refreshes: 1")).toBeInTheDocument();
+    });
+    expect(mocks.refetchSearch).toHaveBeenCalled();
+  });
+
+  it("does not refresh app-level current-user state when another user is edited", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(await screen.findByRole("button", { name: "Edit other@example.com" }));
+    await user.click(screen.getByRole("button", { name: "Save other@example.com" }));
+
+    await waitFor(() => expect(mocks.listAdminUsers).toHaveBeenCalledTimes(2));
+    expect(screen.getByText("Current-user refreshes: 0")).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/NotifyReplyToSettings.test.tsx
+++ b/src/features/admin/components/__tests__/NotifyReplyToSettings.test.tsx
@@ -24,6 +24,37 @@ const emptyConfiguration: notifyConfiguration.NotifyReplyToAdminConfiguration = 
   audits: [],
 };
 
+function address(
+  overrides: Partial<notifyConfiguration.NotifyReplyToAddress> = {},
+): notifyConfiguration.NotifyReplyToAddress {
+  return {
+    id: "address-1",
+    displayLabel: "Membership",
+    emailAddress: "members@example.com",
+    notifyUuid: "notify-uuid",
+    enabled: false,
+    announcementSelectable: false,
+    verificationStatus: "UNVERIFIED",
+    version: 1,
+    createdAt: "2026-08-10T10:00:00Z",
+    updatedAt: "2026-08-10T10:00:00Z",
+    createdBy: "admin-1",
+    updatedBy: "admin-1",
+    ...overrides,
+  };
+}
+
+function configuration(
+  replyToAddress: notifyConfiguration.NotifyReplyToAddress,
+  overrides: Partial<notifyConfiguration.NotifyReplyToAdminConfiguration> = {},
+): notifyConfiguration.NotifyReplyToAdminConfiguration {
+  return {
+    ...emptyConfiguration,
+    addresses: [replyToAddress],
+    ...overrides,
+  };
+}
+
 describe("NotifyReplyToSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -45,5 +76,170 @@ describe("NotifyReplyToSettings", () => {
     expect(screen.getByLabelText("Email address")).toHaveValue("members@example.com");
     expect(screen.getByLabelText("GOV.UK Notify reply-to UUID")).toHaveValue("notify-uuid");
     expect(screen.getByText("We could not complete the email configuration operation. Please try again.")).toBeInTheDocument();
+  });
+
+  it("renders the saved configuration and resets the edit form after a successful update", async () => {
+    const user = userEvent.setup();
+    const existingAddress = address();
+    const updatedAddress = address({ displayLabel: "Updated Membership", version: 2 });
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue(
+      configuration(existingAddress),
+    );
+    vi.mocked(notifyConfiguration.updateNotifyReplyToAddress).mockResolvedValue(
+      configuration(updatedAddress),
+    );
+    render(<NotifyReplyToSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    expect(screen.getByRole("heading", { name: "Edit reply-to address" })).toBeInTheDocument();
+    await user.clear(screen.getByLabelText("Display label"));
+    await user.type(screen.getByLabelText("Display label"), "Updated Membership");
+    await user.click(screen.getByRole("button", { name: "Save and reverify" }));
+
+    expect(await screen.findByText("Updated Membership")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Add reply-to address" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Display label")).toHaveValue("");
+    expect(notifyConfiguration.updateNotifyReplyToAddress).toHaveBeenCalledWith({
+      addressId: "address-1",
+      expectedVersion: 1,
+      displayLabel: "Updated Membership",
+      emailAddress: "members@example.com",
+      notifyUuid: "notify-uuid",
+    });
+  });
+
+  it("renders provider verification progress after testing and confirming an address", async () => {
+    const user = userEvent.setup();
+    const acceptedAddress = address({
+      verificationStatus: "PROVIDER_ACCEPTED",
+      providerAcceptedAt: "2026-08-10T10:05:00Z",
+      verificationMode: "TEAM_TEST",
+    });
+    const verifiedAddress = address({
+      verificationStatus: "VERIFIED",
+      verifiedAt: "2026-08-10T10:06:00Z",
+      version: 2,
+    });
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue(
+      configuration(acceptedAddress),
+    );
+    vi.mocked(notifyConfiguration.sendNotifyReplyToVerificationTest).mockResolvedValue(
+      configuration(acceptedAddress),
+    );
+    vi.mocked(notifyConfiguration.confirmNotifyReplyToVerification).mockResolvedValue(
+      configuration(verifiedAddress),
+    );
+    render(<NotifyReplyToSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Send test" }));
+    await waitFor(() => {
+      expect(notifyConfiguration.sendNotifyReplyToVerificationTest).toHaveBeenCalledWith({
+        addressId: "address-1",
+        expectedVersion: 1,
+      });
+    });
+    await user.click(screen.getByRole("button", { name: "Confirm Reply-To" }));
+
+    expect(await screen.findByText("Verified")).toBeInTheDocument();
+    expect(notifyConfiguration.confirmNotifyReplyToVerification).toHaveBeenCalledWith({
+      addressId: "address-1",
+      expectedVersion: 1,
+    });
+  });
+
+  it("renders availability, default, and announcement changes returned by the server", async () => {
+    const user = userEvent.setup();
+    let current = address({ verificationStatus: "VERIFIED", enabled: true });
+    let defaultAddressId: string | null = null;
+    const currentConfiguration = () => configuration(current, {
+      configuration: {
+        version: current.version,
+        defaultAddressId,
+      },
+    });
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue(currentConfiguration());
+    vi.mocked(notifyConfiguration.updateNotifyReplyToAvailability).mockImplementation(async (request) => {
+      current = address({
+        ...current,
+        enabled: request.enabled,
+        announcementSelectable: request.announcementSelectable,
+        version: current.version + 1,
+      });
+      if (request.clearDefault) defaultAddressId = null;
+      return currentConfiguration();
+    });
+    vi.mocked(notifyConfiguration.changeNotifyReplyToDefault).mockImplementation(async (request) => {
+      current = address({ ...current, version: current.version + 1 });
+      defaultAddressId = request.clearDefault ? null : current.id;
+      return currentConfiguration();
+    });
+    render(<NotifyReplyToSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Allow for announcements" }));
+    expect(await screen.findByText("Announcements")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Make default" }));
+    expect(await screen.findByText("System default")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear system default" }));
+    await waitFor(() => expect(screen.queryByText("System default")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Disable" }));
+    expect(await screen.findByRole("button", { name: "Enable" })).toBeInTheDocument();
+    expect(screen.queryByText("Enabled")).not.toBeInTheDocument();
+  });
+
+  it("renders a newly enabled address and applies a template override", async () => {
+    const user = userEvent.setup();
+    const disabledAddress = address({ verificationStatus: "VERIFIED" });
+    const enabledAddress = address({ verificationStatus: "VERIFIED", enabled: true, version: 2 });
+    const enabledConfiguration = configuration(enabledAddress, { templateKeys: ["WELCOME"] });
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue(
+      configuration(disabledAddress, { templateKeys: ["WELCOME"] }),
+    );
+    vi.mocked(notifyConfiguration.updateNotifyReplyToAvailability).mockResolvedValue(enabledConfiguration);
+    vi.mocked(notifyConfiguration.setNotifyTemplateReplyToOverride).mockResolvedValue({
+      ...enabledConfiguration,
+      templateOverrides: [{
+        templateKey: "WELCOME",
+        addressId: "address-1",
+        updatedAt: "2026-08-10T10:10:00Z",
+        updatedBy: "admin-1",
+      }],
+    });
+    render(<NotifyReplyToSettings />);
+
+    await user.click(await screen.findByRole("button", { name: "Enable" }));
+    expect(await screen.findByText("Enabled")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox", { name: "WELCOME" }));
+    await user.click(await screen.findByRole("option", { name: "Membership — members@example.com" }));
+
+    await waitFor(() => {
+      expect(notifyConfiguration.setNotifyTemplateReplyToOverride).toHaveBeenCalledWith({
+        templateKey: "WELCOME",
+        addressId: "address-1",
+      });
+    });
+  });
+
+  it("renders recent configuration audit details", async () => {
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue({
+      ...emptyConfiguration,
+      audits: [{
+        id: "audit-1",
+        action: "DEFAULT_CHANGED",
+        templateKey: "WELCOME",
+        changedBy: "admin@example.com",
+        reason: "New membership mailbox",
+        changedAt: "2026-08-10T10:15:00Z",
+      }],
+    });
+
+    render(<NotifyReplyToSettings />);
+
+    expect(await screen.findByText("DEFAULT CHANGED")).toBeInTheDocument();
+    expect(screen.getByText(/admin@example.com.*WELCOME/)).toBeInTheDocument();
+    expect(screen.getByText("New membership mailbox")).toBeInTheDocument();
   });
 });

--- a/src/features/admin/components/__tests__/NotifyReplyToSettings.test.tsx
+++ b/src/features/admin/components/__tests__/NotifyReplyToSettings.test.tsx
@@ -1,0 +1,49 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "../../../../test-utils";
+import NotifyReplyToSettings from "../NotifyReplyToSettings";
+import * as notifyConfiguration from "../../../../shared/utils/firebaseFunctions/notifyReplyToConfiguration";
+
+vi.mock("../../../../shared/utils/firebaseFunctions/notifyReplyToConfiguration", () => ({
+  getNotifyReplyToAdminConfiguration: vi.fn(),
+  createNotifyReplyToAddress: vi.fn(),
+  updateNotifyReplyToAddress: vi.fn(),
+  sendNotifyReplyToVerificationTest: vi.fn(),
+  confirmNotifyReplyToVerification: vi.fn(),
+  updateNotifyReplyToAvailability: vi.fn(),
+  changeNotifyReplyToDefault: vi.fn(),
+  setNotifyTemplateReplyToOverride: vi.fn(),
+}));
+
+const emptyConfiguration: notifyConfiguration.NotifyReplyToAdminConfiguration = {
+  configuration: { version: 1, defaultAddressId: null },
+  addresses: [],
+  templateOverrides: [],
+  templateKeys: [],
+  environmentFallbackConfigured: false,
+  audits: [],
+};
+
+describe("NotifyReplyToSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(notifyConfiguration.getNotifyReplyToAdminConfiguration).mockResolvedValue(emptyConfiguration);
+  });
+
+  it("keeps the entered address visible when creation fails", async () => {
+    const user = userEvent.setup();
+    vi.mocked(notifyConfiguration.createNotifyReplyToAddress).mockRejectedValue(new Error("save failed"));
+    render(<NotifyReplyToSettings />);
+
+    await user.type(await screen.findByLabelText("Display label"), "Membership");
+    await user.type(screen.getByLabelText("Email address"), "members@example.com");
+    await user.type(screen.getByLabelText("GOV.UK Notify reply-to UUID"), "notify-uuid");
+    await user.click(screen.getByRole("button", { name: "Add address" }));
+
+    await waitFor(() => expect(notifyConfiguration.createNotifyReplyToAddress).toHaveBeenCalledOnce());
+    expect(screen.getByLabelText("Display label")).toHaveValue("Membership");
+    expect(screen.getByLabelText("Email address")).toHaveValue("members@example.com");
+    expect(screen.getByLabelText("GOV.UK Notify reply-to UUID")).toHaveValue("notify-uuid");
+    expect(screen.getByText("We could not complete the email configuration operation. Please try again.")).toBeInTheDocument();
+  });
+});

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -73,7 +73,10 @@ function mockTicketOrders(overrides: DataConnectQueryResultOverrides) {
 
 vi.mock("@dataconnect/generated", async () => {
   const actual = await vi.importActual("@dataconnect/generated");
-  return { ...actual };
+  return {
+    ...actual,
+    updateEventRef: vi.fn((_dc: unknown, vars: unknown) => ({ type: "mutation", vars })),
+  };
 });
 
 describe("SectionEventsManager", () => {
@@ -389,6 +392,48 @@ describe("SectionEventsManager", () => {
     expect(screen.getByLabelText(/title/i)).toHaveValue("Annual Dinner");
     expect(screen.getByLabelText(/location/i)).toHaveValue("Main Hall");
     expect(screen.getByLabelText(/max guests without moderator approval/i)).toHaveValue(2);
+  });
+
+  it("refetches selected event detail as well as the list after editing", async () => {
+    const user = userEvent.setup();
+    const refetchEvents = vi.fn().mockResolvedValue({});
+    const refetchEventDetail = vi.fn().mockResolvedValue({});
+    const event = {
+      id: "ev-1",
+      title: "Annual Dinner",
+      startDateTime: "2025-03-01T18:00:00Z",
+      endDateTime: "2025-03-01T22:00:00Z",
+      bookingStartDateTime: "2025-02-01T00:00:00Z",
+      bookingEndDateTime: "2025-02-28T23:59:59Z",
+      location: "Main Hall",
+      guestOfHonour: "Jane Doe",
+      maxGuestsWithoutModeratorApproval: 2,
+    };
+    mockGetEventsForSection({
+      data: { section: { id: sectionId, events: [event] } },
+      isLoading: false,
+      isError: false,
+      refetch: refetchEvents,
+    });
+    mockGetEventById({
+      data: { event: { ...event, ticketTypes: [] } },
+      isLoading: false,
+      isError: false,
+      refetch: refetchEventDetail,
+    });
+
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+    await user.click(screen.getByRole("button", { name: /event admin/i }));
+    await user.click(screen.getByRole("button", { name: /^event details$/i }));
+    await user.click(screen.getByRole("button", { name: /edit event details/i }));
+    await user.clear(screen.getByLabelText(/title/i));
+    await user.type(screen.getByLabelText(/title/i), "Updated Dinner");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(refetchEvents).toHaveBeenCalledOnce();
+      expect(refetchEventDetail).toHaveBeenCalledOnce();
+    });
   });
 
   it("shows empty-state alerts for moderation, booking audit, and payment activity", async () => {

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -394,10 +394,8 @@ describe("SectionEventsManager", () => {
     expect(screen.getByLabelText(/max guests without moderator approval/i)).toHaveValue(2);
   });
 
-  it("refetches selected event detail as well as the list after editing", async () => {
+  it("renders refreshed selected-event details after editing", async () => {
     const user = userEvent.setup();
-    const refetchEvents = vi.fn().mockResolvedValue({});
-    const refetchEventDetail = vi.fn().mockResolvedValue({});
     const event = {
       id: "ev-1",
       title: "Annual Dinner",
@@ -409,6 +407,25 @@ describe("SectionEventsManager", () => {
       guestOfHonour: "Jane Doe",
       maxGuestsWithoutModeratorApproval: 2,
     };
+    const updatedEvent = { ...event, title: "Updated Dinner" };
+    const refetchEvents = vi.fn().mockImplementation(async () => {
+      mockGetEventsForSection({
+        data: { section: { id: sectionId, events: [updatedEvent] } },
+        isLoading: false,
+        isError: false,
+        refetch: refetchEvents,
+      });
+      return {};
+    });
+    const refetchEventDetail = vi.fn().mockImplementation(async () => {
+      mockGetEventById({
+        data: { event: { ...updatedEvent, ticketTypes: [] } },
+        isLoading: false,
+        isError: false,
+        refetch: refetchEventDetail,
+      });
+      return {};
+    });
     mockGetEventsForSection({
       data: { section: { id: sectionId, events: [event] } },
       isLoading: false,
@@ -434,6 +451,7 @@ describe("SectionEventsManager", () => {
       expect(refetchEvents).toHaveBeenCalledOnce();
       expect(refetchEventDetail).toHaveBeenCalledOnce();
     });
+    expect(await screen.findByText("Updated Dinner")).toBeInTheDocument();
   });
 
   it("shows empty-state alerts for moderation, booking audit, and payment activity", async () => {

--- a/src/features/admin/components/__tests__/UserGroups.test.tsx
+++ b/src/features/admin/components/__tests__/UserGroups.test.tsx
@@ -1,0 +1,149 @@
+import { describe, beforeEach, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { executeMutation, executeQuery, QueryFetchPolicy } from "firebase/data-connect";
+import { render, screen } from "../../../../test-utils";
+import UserGroups from "../UserGroups";
+
+vi.mock("firebase/data-connect", () => ({
+  executeQuery: vi.fn(),
+  executeMutation: vi.fn(),
+  QueryFetchPolicy: { SERVER_ONLY: "server-only" },
+}));
+vi.mock("../../../../config/firebase", () => ({
+  auth: { currentUser: { uid: "admin-1" } },
+  dataConnect: {},
+}));
+vi.mock("../../../users/hooks/useAdminClaim", () => ({ useAdminClaim: () => true }));
+vi.mock("../../../users/utils/searchUsers", () => ({ searchUsers: vi.fn() }));
+vi.mock("@dataconnect/generated", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+  return {
+    ...actual,
+    listUserGroupsRef: vi.fn(() => ({ kind: "list-groups" })),
+    listUsersRef: vi.fn(() => ({ kind: "list-users" })),
+    getUserGroupByIdRef: vi.fn(() => ({ kind: "group-detail" })),
+    updateUserGroupRef: vi.fn((_dc: unknown, vars: unknown) => ({ kind: "update-group", vars })),
+    createUserGroupRef: vi.fn(),
+    deleteUserGroupRef: vi.fn(),
+    addUserToUserGroupRef: vi.fn(),
+    removeUserFromUserGroupRef: vi.fn(),
+    getUserWithAccessGroupsRef: vi.fn(),
+  };
+});
+vi.mock("../UserGroupsSurfaces", () => ({
+  UserGroupsListSurface: ({
+    userGroups,
+    mergedUsersForGroup,
+    onExpand,
+    onEdit,
+  }: {
+    userGroups: Array<{ id: string; name: string }>;
+    mergedUsersForGroup: Array<{ id: string; firstName: string; lastName: string }>;
+    onExpand: (group: { id: string; name: string }) => void;
+    onEdit: (group: { id: string; name: string }) => void;
+  }) => (
+    <div>
+      {userGroups.map((group) => (
+        <div key={group.id}>
+          <span>{group.name}</span>
+          <button onClick={() => onExpand(group)}>Expand {group.name}</button>
+          <button onClick={() => onEdit(group)}>Edit {group.name}</button>
+        </div>
+      ))}
+      {mergedUsersForGroup.map((user) => <div key={user.id}>{user.firstName} {user.lastName}</div>)}
+    </div>
+  ),
+  UserGroupDialogSurface: ({
+    open,
+    groupName,
+    onGroupNameChange,
+    onSubmit,
+  }: {
+    open: boolean;
+    groupName: string;
+    onGroupNameChange: (value: string) => void;
+    onSubmit: () => void;
+  }) => open ? (
+    <div>
+      <label>Group Name<input value={groupName} onChange={(event) => onGroupNameChange(event.target.value)} /></label>
+      <button onClick={onSubmit}>Save Group</button>
+    </div>
+  ) : null,
+  AddUserToGroupDialogSurface: () => null,
+  UserDetailDialogSurface: () => null,
+}));
+
+let updated = false;
+
+function groupDetail(firstName: string) {
+  return {
+    id: "group-1",
+    name: updated ? "Updated Group" : "Original Group",
+    description: null,
+    membershipStatuses: [],
+    purposeLinks: [],
+    users: [{
+      user: {
+        id: firstName.toLowerCase(),
+        firstName,
+        lastName: "Member",
+        email: `${firstName.toLowerCase()}@example.com`,
+        membershipStatus: "REGULAR",
+      },
+    }],
+  };
+}
+
+describe("UserGroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updated = false;
+    vi.mocked(executeMutation).mockImplementation(async () => {
+      updated = true;
+      return {} as never;
+    });
+    vi.mocked(executeQuery).mockImplementation((ref: unknown, options?: unknown) => {
+      const kind = (ref as { kind: string }).kind;
+      if (kind === "list-users") return Promise.resolve({ data: { users: [] } }) as never;
+      if (kind === "list-groups") {
+        return Promise.resolve({
+          data: {
+            userGroups: [{
+              id: "group-1",
+              name: updated ? "Updated Group" : "Original Group",
+              description: null,
+              membershipStatuses: [],
+            }],
+          },
+        }) as never;
+      }
+      if (kind === "group-detail") {
+        const forced = (options as { fetchPolicy?: string } | undefined)?.fetchPolicy === QueryFetchPolicy.SERVER_ONLY;
+        return Promise.resolve({ data: { userGroup: groupDetail(forced ? "After" : "Before") } }) as never;
+      }
+      return Promise.resolve({ data: null }) as never;
+    });
+  });
+
+  it("replaces cached group details with server data after editing", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <UserGroups onBack={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Expand Original Group" }));
+    expect(await screen.findByText("Before Member")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Edit Original Group" }));
+    await user.clear(screen.getByLabelText("Group Name"));
+    await user.type(screen.getByLabelText("Group Name"), "Updated Group");
+    await user.click(screen.getByRole("button", { name: "Save Group" }));
+
+    expect(await screen.findByText("Updated Group")).toBeInTheDocument();
+    expect(await screen.findByText("After Member")).toBeInTheDocument();
+    expect(screen.queryByText("Before Member")).not.toBeInTheDocument();
+  });
+});

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -45,7 +45,7 @@ interface EditUserDialogProps {
   open: boolean;
   user: SearchUser | null;
   onClose: () => void;
-  onSave: () => void;
+  onSave: () => void | Promise<void>;
   onSuccess?: (message: string) => void;
 }
 
@@ -235,7 +235,7 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
       
       // Success - reset submitting, close dialog immediately and show success message via callback
       setSubmitting(false);
-      onSave();
+      await onSave();
       const successMessage = "User profile updated successfully";
       if (onSuccess) {
         onSuccess(successMessage);

--- a/src/features/profile/components/ProfileReviewDialog.tsx
+++ b/src/features/profile/components/ProfileReviewDialog.tsx
@@ -47,6 +47,8 @@ import {
   toProfileUserFacingError,
 } from "../../../shared/errors";
 import FailureState from "../../../shared/components/FailureState";
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateAnnouncementPreferences } from "../../../shared/query/invalidation";
 
 interface ProfileReviewDialogProps {
   userData: UserData;
@@ -59,6 +61,7 @@ export default function ProfileReviewDialog({
   userEmail,
   onReviewed,
 }: ProfileReviewDialogProps) {
+  const queryClient = useQueryClient();
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const [firstName, setFirstName] = useState("");
@@ -187,6 +190,7 @@ export default function ProfileReviewDialog({
         reportError("profile.review.display-name", displayNameError);
       }
 
+      await invalidateAnnouncementPreferences(queryClient);
       await onReviewed();
     } catch (caught) {
       reportError("profile.review", caught);

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -7,6 +7,11 @@ import * as generatedReact from "@dataconnect/generated/react";
 import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 import type { UserData } from "../../../../types";
 import ProfileReviewDialog from "../ProfileReviewDialog";
+import { invalidateAnnouncementPreferences } from "../../../../shared/query/invalidation";
+
+vi.mock("../../../../shared/query/invalidation", () => ({
+  invalidateAnnouncementPreferences: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@dataconnect/generated", () => ({
   confirmProfileReview: vi.fn().mockResolvedValue({ data: {} }),
@@ -263,6 +268,7 @@ describe("ProfileReviewDialog", () => {
     });
     expect(firebaseFunctions.updateDisplayName).toHaveBeenCalledWith("Member, Alex");
     expect(onReviewed).toHaveBeenCalledTimes(1);
+    expect(invalidateAnnouncementPreferences).toHaveBeenCalledOnce();
   });
 
   it("submits edited service background selections", async () => {

--- a/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
+++ b/src/features/profile/components/__tests__/ProfileReviewDialog.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { fireEvent, render, screen, waitFor } from "../../../../test-utils";
 import { MembershipStatus } from "@dataconnect/generated";
@@ -237,13 +238,21 @@ describe("ProfileReviewDialog", () => {
   it("normalises and atomically submits the reviewed fields before completing", async () => {
     const interaction = userEvent.setup();
     const onReviewed = vi.fn();
-    render(
-      <ProfileReviewDialog
-        userData={{ ...userData, mobileNumber: "07700 900123" }}
-        userEmail="verified@example.com"
-        onReviewed={onReviewed}
-      />,
-    );
+    function ReviewHarness() {
+      const [complete, setComplete] = useState(false);
+      if (complete) return <div>Profile review complete</div>;
+      return (
+        <ProfileReviewDialog
+          userData={{ ...userData, mobileNumber: "07700 900123" }}
+          userEmail="verified@example.com"
+          onReviewed={() => {
+            onReviewed();
+            setComplete(true);
+          }}
+        />
+      );
+    }
+    render(<ReviewHarness />);
 
     await interaction.click(screen.getByRole("button", { name: "Confirm profile" }));
 
@@ -269,6 +278,7 @@ describe("ProfileReviewDialog", () => {
     expect(firebaseFunctions.updateDisplayName).toHaveBeenCalledWith("Member, Alex");
     expect(onReviewed).toHaveBeenCalledTimes(1);
     expect(invalidateAnnouncementPreferences).toHaveBeenCalledOnce();
+    expect(await screen.findByText("Profile review complete")).toBeInTheDocument();
   });
 
   it("submits edited service background selections", async () => {

--- a/src/features/sections/components/AnnouncementOptOutToggle.tsx
+++ b/src/features/sections/components/AnnouncementOptOutToggle.tsx
@@ -7,6 +7,7 @@ import {
   useOptOutSectionAnnouncement,
   useOptInSectionAnnouncement,
 } from "@dataconnect/generated/react";
+import { invalidateAnnouncementPreferences } from "../../../shared/query/invalidation";
 
 interface AnnouncementOptOutToggleProps {
   sectionId: string;
@@ -42,6 +43,7 @@ export default function AnnouncementOptOutToggle({ sectionId }: AnnouncementOptO
           ? { sectionAnnouncementOptOut: { createdAt: new Date().toISOString() } }
           : { sectionAnnouncementOptOut: null }
       );
+      await invalidateAnnouncementPreferences(queryClient);
       setLocalOptedOut(null);
       setSnackbar(
         newOptedOut

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -6,6 +6,7 @@ import {
   Snackbar,
 } from "@mui/material";
 import { useGetUserAccessGroups, useGetSectionsForUser } from "@dataconnect/generated/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { dataConnect } from "../../../config/firebase";
 import { executeMutation } from "firebase/data-connect";
 import PageHeader from "../../../shared/components/PageHeader";
@@ -48,6 +49,7 @@ import {
   SectionEventsListView,
   SectionMembersView,
 } from "./SectionDetailViews";
+import { invalidateUserSectionAccess } from "../../../shared/query/invalidation";
 
 interface SectionDetailProps {
   sectionId: string;
@@ -55,6 +57,7 @@ interface SectionDetailProps {
 }
 
 export default function SectionDetail({ sectionId, onBack }: SectionDetailProps) {
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const location = useLocation();
   const locationState = location.state as SectionDetailLocationState | null;
@@ -339,10 +342,11 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
         message: "Successfully subscribed to this section.",
         severity: "success",
       });
-      // Refetch to update UI
-      refetchSection();
-      refetchMembers();
-      // The user's user groups will be refetched automatically by the hook
+      await Promise.all([
+        refetchSection(),
+        refetchMembers(),
+        invalidateUserSectionAccess(queryClient),
+      ]);
     } catch (error) {
       console.error("Error subscribing:", error);
       setSnackbar({
@@ -380,9 +384,11 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
         message: "Successfully unsubscribed from this section.",
         severity: "success",
       });
-      // Refetch to update UI
-      refetchSection();
-      refetchMembers();
+      await Promise.all([
+        refetchSection(),
+        refetchMembers(),
+        invalidateUserSectionAccess(queryClient),
+      ]);
     } catch (error) {
       console.error("Error unsubscribing:", error);
       setSnackbar({

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -940,7 +940,7 @@ describe("EventBookingWizard", () => {
     expect(screen.queryByRole("button", { name: "Pay for all tickets" })).not.toBeInTheDocument();
   });
 
-  it("starts additional guest requests with blank guest details when guests are already approved", async () => {
+  it("starts additional guest requests blank and invalidates My Bookings after submission", async () => {
     const user = userEvent.setup();
 
     vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
@@ -1070,6 +1070,21 @@ describe("EventBookingWizard", () => {
     expect(screen.getByLabelText("Dietary requirements (optional)")).toHaveValue("");
     expect(screen.queryByDisplayValue("Alex Approved")).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue("Jamie Included")).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Guest name"), "New Guest");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Submit request" }));
+
+    await waitFor(() => {
+      expect(firebaseFunctions.submitAdditionalGuestTicketRequests).toHaveBeenCalledWith({
+        bookingId: "booking-1",
+        guestTicketTypeId: "ticket-guest",
+        idempotencyKey: expect.any(String),
+        guests: [{ guestDisplayName: "New Guest", dietaryNote: null }],
+      });
+    });
+    expect(invalidateMyBookings).toHaveBeenCalledOnce();
+    expect(await screen.findByText("Your booking")).toBeInTheDocument();
   });
 
   it("omits declined extra guests when editing a booking", async () => {

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -6,6 +6,11 @@ import EventBookingWizard from "../EventBookingWizard";
 import { BookingStatus, GuestTicketRequestStatus, TicketAudience, TicketOrderStatus } from "@dataconnect/generated";
 import * as reactGenerated from "@dataconnect/generated/react";
 import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
+import { invalidateMyBookings } from "../../../../shared/query/invalidation";
+
+vi.mock("../../../../shared/query/invalidation", () => ({
+  invalidateMyBookings: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@dataconnect/generated/react", () => ({
   useGetCurrentUser: vi.fn(),
@@ -574,6 +579,7 @@ describe("EventBookingWizard", () => {
     await waitFor(() => {
       expect(firebaseFunctions.submitEventBooking).toHaveBeenCalled();
     });
+    expect(invalidateMyBookings).toHaveBeenCalledOnce();
 
     rerender(
       <MemoryRouter>

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -14,6 +14,11 @@ import {
   dataConnectQueryResult,
   type DataConnectQueryResultOverrides,
 } from '../../../../test-utils/dataConnectMocks';
+import { invalidateUserSectionAccess } from '../../../../shared/query/invalidation';
+
+vi.mock('../../../../shared/query/invalidation', () => ({
+  invalidateUserSectionAccess: vi.fn().mockResolvedValue(undefined),
+}));
 
 // Mock the DataConnect hooks (SectionDetail uses getSectionMembersMerged callable, not useGetSectionMembers)
 vi.mock('@dataconnect/generated/react', () => ({
@@ -1340,6 +1345,7 @@ describe('SectionDetail', () => {
     await waitFor(() => {
       expect(screen.getByText(/successfully subscribed/i)).toBeInTheDocument();
     });
+    expect(invalidateUserSectionAccess).toHaveBeenCalledOnce();
 
     // click outside to dismiss snackbar (exercises handleCloseSnackbar)
     await user.click(document.body);
@@ -1404,6 +1410,7 @@ describe('SectionDetail', () => {
     await waitFor(() => {
       expect(screen.getByText(/successfully unsubscribed/i)).toBeInTheDocument();
     });
+    expect(invalidateUserSectionAccess).toHaveBeenCalledOnce();
   });
 
   it('shows announcement toggle for user with MODERATOR access (tests || branch in grantsAccess)', async () => {

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -1340,12 +1340,29 @@ describe('SectionDetail', () => {
       expect(screen.getByRole('button', { name: /^subscribe$/i })).toBeInTheDocument();
     });
 
+    vi.mocked(invalidateUserSectionAccess).mockImplementationOnce(async () => {
+      mockGetUserAccessGroups({
+        data: {
+          user: {
+            id: 'user-1',
+            userGroups: [
+              { userGroup: { id: 'view-group-1' } },
+              { userGroup: { id: 'member-group-1' } },
+            ],
+          },
+        },
+        isLoading: false,
+        isError: false,
+      });
+    });
+
     await user.click(screen.getByRole('button', { name: /^subscribe$/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/successfully subscribed/i)).toBeInTheDocument();
     });
     expect(invalidateUserSectionAccess).toHaveBeenCalledOnce();
+    expect(await screen.findByRole('button', { name: /unsubscribe/i })).toBeInTheDocument();
 
     // click outside to dismiss snackbar (exercises handleCloseSnackbar)
     await user.click(document.body);
@@ -1405,12 +1422,26 @@ describe('SectionDetail', () => {
       expect(screen.getByRole('button', { name: /unsubscribe/i })).toBeInTheDocument();
     });
 
+    vi.mocked(invalidateUserSectionAccess).mockImplementationOnce(async () => {
+      mockGetUserAccessGroups({
+        data: {
+          user: {
+            id: 'user-1',
+            userGroups: [{ userGroup: { id: 'view-group-1' } }],
+          },
+        },
+        isLoading: false,
+        isError: false,
+      });
+    });
+
     await user.click(screen.getByRole('button', { name: /unsubscribe/i }));
 
     await waitFor(() => {
       expect(screen.getByText(/successfully unsubscribed/i)).toBeInTheDocument();
     });
     expect(invalidateUserSectionAccess).toHaveBeenCalledOnce();
+    expect(await screen.findByRole('button', { name: /^subscribe$/i })).toBeInTheDocument();
   });
 
   it('shows announcement toggle for user with MODERATOR access (tests || branch in grantsAccess)', async () => {

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -27,6 +27,8 @@ import {
 } from "../../../shared/errors";
 import { useBookingWizardData } from "./useBookingWizardData";
 import { useSectionMemberSeatingSearch } from "./useSectionMemberSeatingOptions";
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateMyBookings } from "../../../shared/query/invalidation";
 
 export {
   ADDITIONAL_GUEST_STEPS,
@@ -59,6 +61,7 @@ export function useBookingWizardState({
   onBookingComplete,
   onHasExistingBookingChange,
 }: UseBookingWizardStateProps) {
+  const queryClient = useQueryClient();
   const [wizardMode, setWizardMode] = useState<WizardMode>("full");
   const [activeStep, setActiveStep] = useState(0);
   const [memberTicketTypeId, setMemberTicketTypeId] = useState<string | null>(null);
@@ -319,7 +322,10 @@ export function useBookingWizardState({
           return;
         }
         await submitAdditionalGuestRequest(existingTerminalBooking.id);
-        await refetchMyBookings();
+        await Promise.all([
+          refetchMyBookings(),
+          invalidateMyBookings(queryClient),
+        ]);
         onBookingComplete?.();
         closeWizard();
         return;
@@ -365,7 +371,10 @@ export function useBookingWizardState({
       }
 
       hydratedBookingIdRef.current = result.bookingId;
-      await refetchMyBookings();
+      await Promise.all([
+        refetchMyBookings(),
+        invalidateMyBookings(queryClient),
+      ]);
       setIsEditingBooking(false);
       setPostSubmitFlow(true);
       setActiveStep(3);

--- a/src/features/users/hooks/__tests__/useUserSearch.test.ts
+++ b/src/features/users/hooks/__tests__/useUserSearch.test.ts
@@ -200,4 +200,35 @@ describe("useUserSearch", () => {
       expect(vi.mocked(searchUsersModule.searchUsers).mock.calls.length).toBeGreaterThan(callsBefore)
     );
   });
+
+  it("ignores an older search response that resolves after a newer term", async () => {
+    vi.useRealTimers();
+    type SearchResponse = Awaited<ReturnType<typeof searchUsersModule.searchUsers>>;
+    let resolveOld!: (value: SearchResponse) => void;
+    let resolveNew!: (value: SearchResponse) => void;
+    mockSearchUsers.mockImplementation((term) => new Promise((resolve) => {
+      if (term === "old") resolveOld = resolve;
+      if (term === "new") resolveNew = resolve;
+    }));
+
+    const { result } = renderHook(() => useUserSearch("", 0));
+    act(() => result.current.setSearchTerm("old"));
+    await waitFor(() => expect(mockSearchUsers).toHaveBeenCalledWith("old", 1, 25));
+
+    act(() => result.current.setSearchTerm("new"));
+    await waitFor(() => expect(mockSearchUsers).toHaveBeenCalledWith("new", 1, 25));
+
+    await act(async () => resolveNew({
+      success: true,
+      data: { users: [mockUsers[1]], total: 1, page: 1, pageSize: 25, totalPages: 1 },
+    }));
+    await waitFor(() => expect(result.current.users).toEqual([mockUsers[1]]));
+
+    await act(async () => resolveOld({
+      success: true,
+      data: { users: [mockUsers[0]], total: 1, page: 1, pageSize: 25, totalPages: 1 },
+    }));
+    expect(result.current.users).toEqual([mockUsers[1]]);
+    expect(result.current.loading).toBe(false);
+  });
 });

--- a/src/features/users/hooks/useUserSearch.ts
+++ b/src/features/users/hooks/useUserSearch.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { searchUsers } from "../utils/searchUsers";
 import type { SearchUser } from "../../../types";
 import { ITEMS_PER_PAGE } from "../../../constants";
@@ -34,8 +34,10 @@ export function useUserSearch(
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [total, setTotal] = useState(0);
+  const searchRequestIdRef = useRef(0);
 
   const performSearch = useCallback(async (term: string, pageNum: number = 1) => {
+    const requestId = ++searchRequestIdRef.current;
     if (!term.trim()) {
       setUsers([]);
       setError(null);
@@ -49,6 +51,7 @@ export function useUserSearch(
     setError(null);
     try {
       const result = await searchUsers(term, pageNum, ITEMS_PER_PAGE);
+      if (searchRequestIdRef.current !== requestId) return;
       if (result.success && result.data) {
         setUsers(result.data.users);
         setTotalPages(result.data.totalPages);
@@ -60,14 +63,21 @@ export function useUserSearch(
         setTotal(0);
       }
     } catch (caught) {
+      if (searchRequestIdRef.current !== requestId) return;
       reportError("admin.users.search", caught);
       setError(toAdminUserFacingError(caught, "users").message);
       setUsers([]);
       setTotalPages(1);
       setTotal(0);
     } finally {
-      setLoading(false);
+      if (searchRequestIdRef.current === requestId) {
+        setLoading(false);
+      }
     }
+  }, []);
+
+  useEffect(() => () => {
+    searchRequestIdRef.current += 1;
   }, []);
 
   // Debounced search - only triggers when searchTerm changes
@@ -78,6 +88,7 @@ export function useUserSearch(
         setPage(1);
       } else {
         // Clear results when search term is empty
+        searchRequestIdRef.current += 1;
         setUsers([]);
         setError(null);
         setTotalPages(1);
@@ -100,6 +111,7 @@ export function useUserSearch(
   }, [page, performSearch]); // searchTerm intentionally omitted to prevent immediate searches on typing
 
   const setSearchTerm = useCallback((term: string) => {
+    searchRequestIdRef.current += 1;
     setSearchTermState(term);
   }, []);
 

--- a/src/shared/query/__tests__/invalidation.test.ts
+++ b/src/shared/query/__tests__/invalidation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import type { QueryClient } from "@tanstack/react-query";
+import {
+  invalidateAnnouncementPreferences,
+  invalidateMyBookings,
+  invalidateSectionsForUser,
+  invalidateUserSectionAccess,
+} from "../invalidation";
+
+function queryClientWithInvalidateSpy() {
+  const invalidateQueries = vi.fn().mockResolvedValue(undefined);
+  return {
+    queryClient: { invalidateQueries } as unknown as QueryClient,
+    invalidateQueries,
+  };
+}
+
+describe("cross-view query invalidation", () => {
+  it("invalidates aggregate and section announcement preferences", async () => {
+    const { queryClient, invalidateQueries } = queryClientWithInvalidateSpy();
+
+    await invalidateAnnouncementPreferences(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetMyAnnouncementPreferences"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetSectionAnnouncementOptOut"] });
+  });
+
+  it("invalidates both sources of section membership", async () => {
+    const { queryClient, invalidateQueries } = queryClientWithInvalidateSpy();
+
+    await invalidateUserSectionAccess(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetUserAccessGroups"] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetSectionsForUser"] });
+  });
+
+  it("invalidates persistent section navigation", async () => {
+    const { queryClient, invalidateQueries } = queryClientWithInvalidateSpy();
+
+    await invalidateSectionsForUser(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetSectionsForUser"] });
+  });
+
+  it("invalidates the global My Bookings list", async () => {
+    const { queryClient, invalidateQueries } = queryClientWithInvalidateSpy();
+
+    await invalidateMyBookings(queryClient);
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetMyBookings"] });
+  });
+});

--- a/src/shared/query/__tests__/invalidation.test.ts
+++ b/src/shared/query/__tests__/invalidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import {
   invalidateAnnouncementPreferences,
   invalidateMyBookings,
@@ -40,6 +40,29 @@ describe("cross-view query invalidation", () => {
     await invalidateSectionsForUser(queryClient);
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetSectionsForUser"] });
+  });
+
+  it("refetches an active generated-query key and exposes the updated navigation data", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const queryKey = ["GetSectionsForUser", { uid: "user-1" }] as const;
+    let serverSections = ["Existing Section"];
+    const queryFn = vi.fn(async () => [...serverSections]);
+
+    await queryClient.fetchQuery({ queryKey, queryFn, staleTime: Number.POSITIVE_INFINITY });
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn,
+      staleTime: Number.POSITIVE_INFINITY,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    serverSections = ["Existing Section", "New Section"];
+    await invalidateSectionsForUser(queryClient);
+
+    expect(observer.getCurrentResult().data).toEqual(["Existing Section", "New Section"]);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    queryClient.clear();
   });
 
   it("invalidates the global My Bookings list", async () => {

--- a/src/shared/query/invalidation.ts
+++ b/src/shared/query/invalidation.ts
@@ -1,0 +1,28 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+/**
+ * Data Connect's generated React mutations do not know which other generated
+ * queries represent the same server state. Keep cross-view invalidation in one
+ * place so direct SDK mutations and callable functions behave consistently.
+ */
+export async function invalidateAnnouncementPreferences(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["GetMyAnnouncementPreferences"] }),
+    queryClient.invalidateQueries({ queryKey: ["GetSectionAnnouncementOptOut"] }),
+  ]);
+}
+
+export async function invalidateUserSectionAccess(queryClient: QueryClient) {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: ["GetUserAccessGroups"] }),
+    queryClient.invalidateQueries({ queryKey: ["GetSectionsForUser"] }),
+  ]);
+}
+
+export async function invalidateSectionsForUser(queryClient: QueryClient) {
+  await queryClient.invalidateQueries({ queryKey: ["GetSectionsForUser"] });
+}
+
+export async function invalidateMyBookings(queryClient: QueryClient) {
+  await queryClient.invalidateQueries({ queryKey: ["GetMyBookings"] });
+}


### PR DESCRIPTION
## Summary

- add shared TanStack Query invalidation helpers for state represented by multiple generated queries
- refresh selected event details, membership/access state, section navigation, announcement preferences, global bookings, and App-level user data after mutations
- force-refresh expanded user-group details after edits
- preserve forms and dialogs when mutations fail
- ignore superseded user search, user-group search, announcement-history, and audit-log responses
- add regression coverage for cross-view invalidation, event detail refresh, privacy/session refresh, failed dialog preservation, and asynchronous response races

## Root cause

The UI mixes generated TanStack Query hooks with direct Data Connect mutations, Firebase callable functions, and component-local state. Direct mutations and callables do not automatically invalidate other generated queries over the same server data, so successful writes could leave another mounted or cached view stale.

This change centralizes the required cross-view invalidation and explicitly refreshes non-query App/session state where appropriate.

## User impact

Saved settings and admin edits now appear without a hard reload across event administration, section membership, announcement preferences, account privacy, section navigation, user groups, bookings, and admin self-edit flows. Failed saves retain the user's entered data, and older asynchronous responses no longer overwrite newer results.

## Validation

- `npm run test:run` — 86 test files, 711 tests passed
- `npm run build`
- `npm run lint`
- `git diff --check`

Fixes #532
