### PR TITLE
Fix idle session recovery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,6 @@ function AppContent() {
     setLogoutSuccess,
     triggerEmailCheck,
   } = useAppAuthSession(handleLoggedOut);
-  const sessionRecovery = useSessionRecovery(user);
   const { checkoutQueryState, dismissCheckoutStatus } = useCheckoutQueryState(location, navigate);
   const isOnline = useOnlineStatus();
   const [mobileNavAnchorEl, setMobileNavAnchorEl] = useState<HTMLElement | null>(null);
@@ -120,6 +119,7 @@ function AppContent() {
   const isPublicAuthAction = location.pathname === ROUTES.AUTH_ACTION;
   const isAdmin = useAdminClaim(user);
   const { userData, loading: userDataLoading, refetch } = useUserData(user, isEnabled);
+  const sessionRecovery = useSessionRecovery(user, { onRecovered: refetch });
   const {
     membershipStatusForUnenabled,
     needsProfileCompletion,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, useCallback, useMemo, lazy, Suspense, type ReactElement } from "react";
 import { Box, Button, Typography, Snackbar, Alert, CircularProgress } from "@mui/material";
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from "react-router-dom";
-import { dataConnect } from "./config/firebase";
+import { signOut } from "firebase/auth";
+import { auth, dataConnect } from "./config/firebase";
 import { useUserData } from "./features/users/hooks/useUserData";
 import type { UserData } from "./types";
 import { useEnabledClaim } from "./features/users/hooks/useEnabledClaim";
@@ -20,6 +21,7 @@ import {
 } from "./shared/appShell/appRoutingHelpers";
 import { getSectionReturnTo, sectionDetailLocationState } from "./shared/navigation/sectionNavigationState";
 import { useAppAuthSession } from "./shared/appShell/useAppAuthSession";
+import { useSessionRecovery } from "./shared/appShell/useSessionRecovery";
 import { useCheckoutQueryState } from "./shared/appShell/useCheckoutQueryState";
 import { useOnlineStatus } from "./shared/appShell/useOnlineStatus";
 import { useUnenabledProfileCheck } from "./shared/appShell/useUnenabledProfileCheck";
@@ -104,6 +106,7 @@ function AppContent() {
     setLogoutSuccess,
     triggerEmailCheck,
   } = useAppAuthSession(handleLoggedOut);
+  const sessionRecovery = useSessionRecovery(user);
   const { checkoutQueryState, dismissCheckoutStatus } = useCheckoutQueryState(location, navigate);
   const isOnline = useOnlineStatus();
   const [mobileNavAnchorEl, setMobileNavAnchorEl] = useState<HTMLElement | null>(null);
@@ -161,6 +164,15 @@ function AppContent() {
     [isAdmin, isEnabled, userSectionsData]
   );
 
+  const handleSignInAgain = useCallback(async () => {
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    try {
+      await signOut(auth);
+    } finally {
+      navigate(accountSignInPath(returnTo), { replace: true });
+    }
+  }, [location.hash, location.pathname, location.search, navigate]);
+
   const header = (
     <>
       <Header
@@ -197,6 +209,45 @@ function AppContent() {
             <Typography variant="body2" color="text.secondary">
               The app needs network access to load account and section data.
             </Typography>
+          </Box>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (sessionRecovery.status !== "idle") {
+    const isRecovering = sessionRecovery.status === "recovering";
+    const timedOut = sessionRecovery.failure === "request-timeout";
+
+    return (
+      <Box sx={{ flexGrow: 1, width: "100%", display: "flex", flexDirection: "column", backgroundColor: "background.default" }}>
+        {header}
+        <Box component="main" sx={{ flexGrow: 1, width: "100%", pt: 12, pb: 4 }}>
+          <Box sx={{ maxWidth: { sm: "640px" }, mx: "auto", px: { xs: 3, sm: 4 } }}>
+            {isRecovering ? (
+              <Box sx={{ textAlign: "center" }}>
+                <CircularProgress aria-label="Refreshing your session" />
+                <Typography sx={{ mt: 2 }}>Refreshing your session…</Typography>
+              </Box>
+            ) : (
+              <Alert
+                severity="warning"
+                action={
+                  <Box sx={{ display: "flex", gap: 1 }}>
+                    <Button color="inherit" size="small" onClick={() => void sessionRecovery.retry()}>
+                      Try again
+                    </Button>
+                    <Button color="inherit" size="small" onClick={() => void handleSignInAgain()}>
+                      Sign in again
+                    </Button>
+                  </Box>
+                }
+              >
+                {timedOut
+                  ? "The request took too long after the app resumed. Try reconnecting your session."
+                  : "Your session could not be refreshed. Try again or sign in again."}
+              </Alert>
+            )}
           </Box>
         </Box>
       </Box>

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -11,6 +11,7 @@ import { sectionDetailLocationState } from "../shared/navigation/sectionNavigati
 import { createMockUser } from "../test-utils/mocks/firebase";
 
 const mockRefetchUserData = vi.hoisted(() => vi.fn());
+const mockRetrySession = vi.hoisted(() => vi.fn());
 
 let currentUser: User | null = null;
 let enabledClaim = false;
@@ -19,6 +20,8 @@ let adminClaim = false;
 let profileReviewedAt: string | null = new Date().toISOString();
 let headerShouldThrow = false;
 let memberWelcomeShouldThrow = false;
+let sessionRecoveryStatus: "idle" | "recovering" | "failed" = "idle";
+let sessionRecoveryFailure: "refresh-failed" | "request-timeout" | null = null;
 
 function purposeLink(purpose: "ACCESS" | "MODERATOR", id: string, name: string) {
   return {
@@ -113,6 +116,14 @@ vi.mock("../features/users/hooks/useEnabledClaim", () => ({
 
 vi.mock("../features/users/hooks/useAdminClaim", () => ({
   useAdminClaim: vi.fn((user: User | null) => Boolean(user && adminClaim)),
+}));
+
+vi.mock("../shared/appShell/useSessionRecovery", () => ({
+  useSessionRecovery: () => ({
+    status: sessionRecoveryStatus,
+    failure: sessionRecoveryFailure,
+    retry: mockRetrySession,
+  }),
 }));
 
 vi.mock("@dataconnect/generated/react", () => ({
@@ -325,6 +336,8 @@ describe("App routing", () => {
     profileReviewedAt = new Date().toISOString();
     headerShouldThrow = false;
     memberWelcomeShouldThrow = false;
+    sessionRecoveryStatus = "idle";
+    sessionRecoveryFailure = null;
     mockRefetchUserData.mockResolvedValue(undefined);
     needsProfileCompletion = false;
     mockSectionsData = sectionsData();
@@ -336,6 +349,32 @@ describe("App routing", () => {
 
     expect(await screen.findByRole("heading", { name: "Public Home Page" })).toBeInTheDocument();
     expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.HOME);
+  });
+
+  it("preserves the protected destination while refreshing an idle session", async () => {
+    signInEnabledUser();
+    sessionRecoveryStatus = "recovering";
+
+    renderApp([ROUTES.SECTIONS]);
+
+    expect(screen.getByLabelText("Refreshing your session")).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.SECTIONS);
+    expect(screen.queryByRole("heading", { name: "Sections Page" })).not.toBeInTheDocument();
+  });
+
+  it("replaces an indefinite spinner with retry actions after a request timeout", async () => {
+    signInEnabledUser();
+    sessionRecoveryStatus = "failed";
+    sessionRecoveryFailure = "request-timeout";
+    const user = userEvent.setup();
+
+    renderApp([ROUTES.SECTIONS]);
+
+    expect(screen.getByText(/request took too long/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in again" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+    expect(mockRetrySession).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.SECTIONS);
   });
 
   it("keeps the footer at the viewport edge on short pages without fixing it over content", async () => {

--- a/src/__tests__/App.routing.test.tsx
+++ b/src/__tests__/App.routing.test.tsx
@@ -22,6 +22,7 @@ let headerShouldThrow = false;
 let memberWelcomeShouldThrow = false;
 let sessionRecoveryStatus: "idle" | "recovering" | "failed" = "idle";
 let sessionRecoveryFailure: "refresh-failed" | "request-timeout" | null = null;
+let sessionRecoveryOnRecovered: (() => void | Promise<void>) | undefined;
 
 function purposeLink(purpose: "ACCESS" | "MODERATOR", id: string, name: string) {
   return {
@@ -119,11 +120,17 @@ vi.mock("../features/users/hooks/useAdminClaim", () => ({
 }));
 
 vi.mock("../shared/appShell/useSessionRecovery", () => ({
-  useSessionRecovery: () => ({
-    status: sessionRecoveryStatus,
-    failure: sessionRecoveryFailure,
-    retry: mockRetrySession,
-  }),
+  useSessionRecovery: (
+    _user: User | null,
+    options?: { onRecovered?: () => void | Promise<void> },
+  ) => {
+    sessionRecoveryOnRecovered = options?.onRecovered;
+    return {
+      status: sessionRecoveryStatus,
+      failure: sessionRecoveryFailure,
+      retry: mockRetrySession,
+    };
+  },
 }));
 
 vi.mock("@dataconnect/generated/react", () => ({
@@ -338,6 +345,7 @@ describe("App routing", () => {
     memberWelcomeShouldThrow = false;
     sessionRecoveryStatus = "idle";
     sessionRecoveryFailure = null;
+    sessionRecoveryOnRecovered = undefined;
     mockRefetchUserData.mockResolvedValue(undefined);
     needsProfileCompletion = false;
     mockSectionsData = sectionsData();
@@ -375,6 +383,26 @@ describe("App routing", () => {
     await user.click(screen.getByRole("button", { name: "Try again" }));
     expect(mockRetrySession).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.SECTIONS);
+  });
+
+  it("refreshes the member profile after session recovery", async () => {
+    signInEnabledUser();
+    renderApp([ROUTES.SECTIONS]);
+
+    await sessionRecoveryOnRecovered?.();
+
+    expect(mockRefetchUserData).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves an admin destination while refreshing an idle session", () => {
+    signInEnabledUser({ admin: true });
+    sessionRecoveryStatus = "recovering";
+
+    renderApp([ROUTES.MANAGE_USERS]);
+
+    expect(screen.getByLabelText("Refreshing your session")).toBeInTheDocument();
+    expect(screen.getByTestId("location")).toHaveTextContent(ROUTES.MANAGE_USERS);
+    expect(screen.queryByRole("heading", { name: "Manage Users Page" })).not.toBeInTheDocument();
   });
 
   it("keeps the footer at the viewport edge on short pages without fixing it over content", async () => {

--- a/src/features/admin/components/AuditLogs.tsx
+++ b/src/features/admin/components/AuditLogs.tsx
@@ -16,8 +16,8 @@ import {
   IconButton,
 } from "@mui/material";
 import { Refresh as RefreshIcon } from "@mui/icons-material";
-import { executeQuery } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
+import { executeDataConnectQuery } from "../../../shared/query/dataConnectExecution";
 import {
   listUsersRef,
   listUserGroupsRef,
@@ -47,7 +47,7 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
   const fetchAllUsers = useCallback(async () => {
     try {
       const ref = listUsersRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       setAllUsers(result.data?.users || []);
     } catch (error) {
       reportError("admin.audit-logs.user-lookup", error);
@@ -61,17 +61,17 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
     try {
       if (tabValue === 0) {
         const ref = listUsersRef(dataConnect);
-        const result = await executeQuery(ref);
+        const result = await executeDataConnectQuery(ref);
         if (dataRequestIdRef.current !== requestId) return;
         setUsers(result.data?.users || []);
       } else if (tabValue === 1) {
         const ref = listUserGroupsRef(dataConnect);
-        const result = await executeQuery(ref);
+        const result = await executeDataConnectQuery(ref);
         if (dataRequestIdRef.current !== requestId) return;
         setUserGroups(result.data?.userGroups || []);
       } else if (tabValue === 2) {
         const ref = listSectionsRef(dataConnect);
-        const result = await executeQuery(ref);
+        const result = await executeDataConnectQuery(ref);
         if (dataRequestIdRef.current !== requestId) return;
         setSections(result.data?.sections || []);
       }

--- a/src/features/admin/components/ManageSections.tsx
+++ b/src/features/admin/components/ManageSections.tsx
@@ -3,8 +3,11 @@ import {
   Box,
   Alert,
 } from "@mui/material";
-import { executeQuery, executeMutation } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
+import {
+  executeDataConnectMutation,
+  executeDataConnectQuery,
+} from "../../../shared/query/dataConnectExecution";
 import {
   listSectionsRef,
   createSectionRef,
@@ -108,7 +111,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     setError(null);
     try {
       const ref = listSectionsRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       
       // Get existing sections from database
       const existingSections: SectionWithDetails[] = result.data?.sections?.map((section) => ({
@@ -139,7 +142,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
   const fetchAllUserGroups = useCallback(async () => {
     try {
       const ref = listUserGroupsRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       setAllUserGroups(result.data?.userGroups || []);
     } catch (caught) {
       reportError("admin.sections.available-groups", caught);
@@ -150,7 +153,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     setLoadingUserGroups(true);
     try {
       const ref = getSectionByIdRef(dataConnect, { id: sectionId });
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       const section = result.data?.section;
       
       if (section?.purposeLinks?.length) {
@@ -226,7 +229,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
 
     try {
       const ref = deleteSectionRef(dataConnect, { id: section.id });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
       await Promise.all([fetchSections(), invalidateSectionsForUser(queryClient)]);
       showSuccess(`Section "${section.name}" deleted`);
     } catch (caught) {
@@ -251,7 +254,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
           name: sectionName.trim(),
           description: sectionDescription.trim() || null,
         });
-        await executeMutation(ref);
+        await executeDataConnectMutation(ref);
       } else {
         // Create new section
         const ref = createSectionRef(dataConnect, {
@@ -259,7 +262,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
           type: sectionType,
           description: sectionDescription.trim() || null,
         });
-        await executeMutation(ref);
+        await executeDataConnectMutation(ref);
       }
       setDialogOpen(false);
       await Promise.all([fetchSections(), invalidateSectionsForUser(queryClient)]);
@@ -292,7 +295,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
           )
         ),
       });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
 
       await fetchSectionUserGroups(editingSection.id);
       await invalidateSectionsForUser(queryClient);
@@ -323,7 +326,7 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
     setError(null);
     try {
       const refetch = getSectionByIdRef(dataConnect, { id: editingSection.id });
-      const currentSection = await executeQuery(refetch);
+      const currentSection = await executeDataConnectQuery(refetch);
       const currentLink = currentSection.data?.section?.purposeLinks?.find((link) => link.userGroup?.id === userGroupId);
       const currentPurposes = (currentLink?.purposes ?? []).filter((item) => item !== purpose);
 
@@ -332,14 +335,14 @@ export default function ManageSections({ onBack }: ManageSectionsProps) {
           sectionId: editingSection.id,
           userGroupId,
         });
-        await executeMutation(deleteRef);
+        await executeDataConnectMutation(deleteRef);
       } else {
         const updateRef = grantUserGroupToSectionForPurposeRef(dataConnect, {
           sectionId: editingSection.id,
           userGroupId,
           purposes: currentPurposes,
         });
-        await executeMutation(updateRef);
+        await executeDataConnectMutation(updateRef);
       }
       
       // Refresh section user groups

--- a/src/features/admin/components/PaymentReconciliationDashboard.tsx
+++ b/src/features/admin/components/PaymentReconciliationDashboard.tsx
@@ -19,7 +19,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { executeMutation } from "firebase/data-connect";
+import { executeDataConnectMutation } from "../../../shared/query/dataConnectExecution";
 import {
   resolvePaymentReconciliationExceptionRef,
   PaymentReconciliationExceptionType,
@@ -68,7 +68,7 @@ export default function PaymentReconciliationDashboard({ onBack }: PaymentReconc
     setResolvingId(id);
     setError(null);
     try {
-      await executeMutation(resolvePaymentReconciliationExceptionRef(dataConnect, { id, note: "Reviewed in dashboard" }));
+      await executeDataConnectMutation(resolvePaymentReconciliationExceptionRef(dataConnect, { id, note: "Reviewed in dashboard" }));
       await refetch();
       showSuccess("Exception marked reviewed");
     } catch (err) {

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -1,7 +1,10 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
 import { Box } from "@mui/material";
-import { executeQuery, executeMutation } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
+import {
+  executeDataConnectMutation,
+  executeDataConnectQuery,
+} from "../../../shared/query/dataConnectExecution";
 import { reviewGuestTicketRequest } from "../../../shared/utils/firebaseFunctions";
 import {
   useGetEventsForSection,
@@ -196,7 +199,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
     setLoadingUserGroups(true);
     try {
       const ref = listUserGroupsRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       setAllUserGroups((result.data?.userGroups ?? []).map((ug) => ({ id: ug.id, name: ug.name })));
     } catch (caught) {
       reportError("admin.events.user-groups", caught, { sectionId });
@@ -255,7 +258,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
     }
     try {
       if (editingEvent) {
-        await executeMutation(
+        await executeDataConnectMutation(
           updateEventRef(dataConnect, {
             id: editingEvent.id,
             title: title.trim(),
@@ -269,7 +272,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           })
         );
       } else {
-        await executeMutation(
+        await executeDataConnectMutation(
           createEventRef(dataConnect, {
             sectionId: sectionId as UUIDString,
             title: title.trim(),
@@ -303,23 +306,23 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
     setDeletingEventId(event.id);
     setError(null);
     try {
-      const bookingsResult = await executeQuery(listEventBookingsForAdminRef(dataConnect, { eventId: event.id as UUIDString }));
+      const bookingsResult = await executeDataConnectQuery(listEventBookingsForAdminRef(dataConnect, { eventId: event.id as UUIDString }));
       const bookingsList = bookingsResult.data?.event?.bookings ?? [];
       for (const b of bookingsList) {
         for (const gtr of b.guestTicketRequests) {
-          await executeMutation(adminDeleteGuestTicketRequestRef(dataConnect, { id: gtr.id }));
+          await executeDataConnectMutation(adminDeleteGuestTicketRequestRef(dataConnect, { id: gtr.id }));
         }
         for (const line of b.lines) {
-          await executeMutation(adminDeleteBookingLineRef(dataConnect, { id: line.id }));
+          await executeDataConnectMutation(adminDeleteBookingLineRef(dataConnect, { id: line.id }));
         }
-        await executeMutation(adminDeleteBookingRef(dataConnect, { id: b.id }));
+        await executeDataConnectMutation(adminDeleteBookingRef(dataConnect, { id: b.id }));
       }
-      const detailResult = await executeQuery(getEventByIdRef(dataConnect, { id: event.id as UUIDString }));
+      const detailResult = await executeDataConnectQuery(getEventByIdRef(dataConnect, { id: event.id as UUIDString }));
       const ticketTypes = detailResult.data?.event?.ticketTypes ?? [];
       for (const tt of ticketTypes) {
-        await executeMutation(deleteTicketTypeRef(dataConnect, { id: tt.id }));
+        await executeDataConnectMutation(deleteTicketTypeRef(dataConnect, { id: tt.id }));
       }
-      await executeMutation(deleteEventRef(dataConnect, { id: event.id }));
+      await executeDataConnectMutation(deleteEventRef(dataConnect, { id: event.id }));
       refetchEvents();
       if (ticketTypesEventId === event.id) setTicketTypesEventId(null);
       showSuccess(`Event "${event.title}" deleted`);
@@ -368,7 +371,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
     setError(null);
     try {
       if (editingTicketType) {
-        await executeMutation(
+        await executeDataConnectMutation(
           updateTicketTypeRef(dataConnect, {
             id: editingTicketType.id,
             userGroupId: ttAccessGroup.id as UUIDString,
@@ -380,7 +383,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           })
         );
       } else {
-        await executeMutation(
+        await executeDataConnectMutation(
           createTicketTypeRef(dataConnect, {
             eventId: ticketTypesEventId as UUIDString,
             userGroupId: ttAccessGroup.id as UUIDString,
@@ -409,7 +412,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
     setDeletingTicketTypeId(id);
     setError(null);
     try {
-      await executeMutation(deleteTicketTypeRef(dataConnect, { id }));
+      await executeDataConnectMutation(deleteTicketTypeRef(dataConnect, { id }));
       refetchEventDetail();
       refetchEvents();
       showSuccess("Ticket type deleted");

--- a/src/features/admin/components/UserGroupMemberships.tsx
+++ b/src/features/admin/components/UserGroupMemberships.tsx
@@ -26,8 +26,11 @@ import {
   PersonRemove as PersonRemoveIcon,
   PersonAdd as PersonAddIcon,
 } from "@mui/icons-material";
-import { executeQuery, executeMutation } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
+import {
+  executeDataConnectMutation,
+  executeDataConnectQuery,
+} from "../../../shared/query/dataConnectExecution";
 import {
   getUserWithAccessGroupsRef,
   listUserGroupsRef,
@@ -67,7 +70,7 @@ export default function UserGroupMemberships({
     setError(null);
     try {
       const ref = getUserWithAccessGroupsRef(dataConnect, { id: userId });
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       setUserData(result.data?.user || null);
     } catch (caught) {
       reportError("admin.user-memberships.load", caught, { userId });
@@ -80,7 +83,7 @@ export default function UserGroupMemberships({
   const fetchAllGroups = useCallback(async () => {
     try {
       const ref = listUserGroupsRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       setAllGroups(result.data?.userGroups || []);
     } catch (caught) {
       reportError("admin.user-memberships.available-groups", caught, { userId });
@@ -104,7 +107,7 @@ export default function UserGroupMemberships({
         userId,
         userGroupId: groupId,
       });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
       await fetchUserData();
       if (onUpdate) {
         onUpdate();
@@ -132,7 +135,7 @@ export default function UserGroupMemberships({
         userId,
         userGroupId: groupId,
       });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
       await fetchUserData();
       if (onUpdate) {
         onUpdate();

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -3,8 +3,12 @@ import {
   Box,
   Alert,
 } from "@mui/material";
-import { executeQuery, executeMutation, QueryFetchPolicy } from "firebase/data-connect";
+import { QueryFetchPolicy } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
+import {
+  executeDataConnectMutation,
+  executeDataConnectQuery,
+} from "../../../shared/query/dataConnectExecution";
 import {
   listUserGroupsRef,
   listUsersRef,
@@ -89,7 +93,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
     setError(null);
     try {
       const ref = listUserGroupsRef(dataConnect);
-      const result = await executeQuery(ref);
+      const result = await executeDataConnectQuery(ref);
       
       const existingGroups: UserGroupWithDetails[] = result.data?.userGroups?.map((group) => ({
         id: group.id,
@@ -120,7 +124,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
     setLoadingDetails((prev) => ({ ...prev, [groupId]: true }));
     try {
       const ref = getUserGroupByIdRef(dataConnect, { id: groupId });
-      const result = await executeQuery(
+      const result = await executeDataConnectQuery(
         ref,
         force ? { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } : undefined,
       );
@@ -161,7 +165,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
     (async () => {
       try {
         const ref = listUsersRef(dataConnect);
-        const result = await executeQuery(ref);
+        const result = await executeDataConnectQuery(ref);
         if (!cancelled && result.data?.users) {
           setAllUsers(
             result.data.users.map((u) => ({
@@ -236,7 +240,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
           result.data.users.map(async (user) => {
             try {
               const userRef = getUserWithAccessGroupsRef(dataConnect, { id: user.uid });
-              const userResult = await executeQuery(userRef);
+              const userResult = await executeDataConnectQuery(userRef);
               if (userResult.data?.user) {
                 return {
                   id: userResult.data.user.id,
@@ -302,7 +306,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         userId,
         userGroupId: addingToGroupId,
       });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
 
       // Refresh group details
       const nextGroupDetails = { ...groupDetails };
@@ -334,7 +338,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         userId,
         userGroupId: groupId,
       });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
 
       // Refresh group details
       const nextGroupDetails = { ...groupDetails };
@@ -372,7 +376,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
 
     try {
       const ref = deleteUserGroupRef(dataConnect, { id: group.id });
-      await executeMutation(ref);
+      await executeDataConnectMutation(ref);
       await fetchUserGroupsList();
       if (expandedGroupId === group.id) {
         setExpandedGroupId(null);
@@ -405,7 +409,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
           description: groupDescription.trim() || null,
           membershipStatuses: selectedStatuses.length > 0 ? selectedStatuses : null,
         });
-        await executeMutation(ref);
+        await executeDataConnectMutation(ref);
       } else {
         // Create new group
         const ref = createUserGroupRef(dataConnect, {
@@ -413,7 +417,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
           description: groupDescription.trim() || null,
           membershipStatuses: selectedStatuses.length > 0 ? selectedStatuses : null,
         });
-        await executeMutation(ref);
+        await executeDataConnectMutation(ref);
       }
       setDialogOpen(false);
       await fetchUserGroupsList();

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -12,7 +12,7 @@ import {
   Divider,
 } from "@mui/material";
 import { dataConnect } from "../../../config/firebase";
-import { executeMutation, mutationRef } from "firebase/data-connect";
+import { mutationRef } from "firebase/data-connect";
 import { MembershipStatus } from "@dataconnect/generated";
 import { validateUserForm } from "../../users/utils/userHelpers";
 import {
@@ -26,6 +26,7 @@ import { syncPendingUserClaims, updateDisplayName } from "../../../shared/utils/
 import RankSelect from "../../../shared/components/RankSelect";
 import { normalizeMobileNumber } from "../../../shared/utils/mobileNumber";
 import { reportError, toProfileUserFacingError } from "../../../shared/errors";
+import { executeDataConnectMutation } from "../../../shared/query/dataConnectExecution";
 
 interface ProfileCompletionProps {
   userEmail: string;
@@ -97,7 +98,7 @@ export default function ProfileCompletion({
         rank: rank || null,
       });
 
-      const result = await executeMutation(mutation);
+      const result = await executeDataConnectMutation(mutation);
 
       if (!result.data) {
         throw new Error("Failed to save profile");

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -8,7 +8,7 @@ import {
 import { useGetUserAccessGroups, useGetSectionsForUser } from "@dataconnect/generated/react";
 import { useQueryClient } from "@tanstack/react-query";
 import { dataConnect } from "../../../config/firebase";
-import { executeMutation } from "firebase/data-connect";
+import { executeDataConnectMutation } from "../../../shared/query/dataConnectExecution";
 import PageHeader from "../../../shared/components/PageHeader";
 import AnnouncementOptOutToggle from "./AnnouncementOptOutToggle";
 import FailureState from "../../../shared/components/FailureState";
@@ -375,7 +375,7 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     setSubscribing(true);
     try {
       const { unsubscribeFromUserGroupRef } = await import("@dataconnect/generated");
-      await executeMutation(unsubscribeFromUserGroupRef(dataConnect, {
+      await executeDataConnectMutation(unsubscribeFromUserGroupRef(dataConnect, {
         userGroupId: userMemberGroup.id as UUIDString,
       }));
 

--- a/src/features/users/hooks/__tests__/useTokenRefresh.test.ts
+++ b/src/features/users/hooks/__tests__/useTokenRefresh.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockUser } from "../../../../test-utils/mocks/firebase";
+
+const authMocks = vi.hoisted(() => ({
+  tokenListener: null as ((user: ReturnType<typeof createMockUser> | null) => void) | null,
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("firebase/auth", () => ({
+  onIdTokenChanged: vi.fn((_auth, callback) => {
+    authMocks.tokenListener = callback;
+    return authMocks.unsubscribe;
+  }),
+}));
+
+vi.mock("../../../config/firebase", () => ({ auth: {} }));
+
+import { refreshToken, useTokenRefresh } from "../useTokenRefresh";
+
+describe("useTokenRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.tokenListener = null;
+  });
+
+  it("shares one forced refresh between concurrent callers", async () => {
+    let resolveToken!: (token: string) => void;
+    const getIdToken = vi.fn(
+      () => new Promise<string>((resolve) => {
+        resolveToken = resolve;
+      }),
+    );
+    const user = createMockUser({ uid: "concurrent-user", getIdToken });
+    const onTokenChange = vi.fn();
+    renderHook(() => useTokenRefresh(user, onTokenChange));
+
+    const first = refreshToken(user);
+    const second = refreshToken(user);
+
+    expect(second).toBe(first);
+    expect(getIdToken).toHaveBeenCalledTimes(1);
+    expect(getIdToken).toHaveBeenCalledWith(true);
+
+    resolveToken("new-token");
+    await act(async () => first);
+    expect(onTokenChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not force another refresh from the token-change listener", async () => {
+    const getIdToken = vi.fn().mockResolvedValue("listener-token");
+    const user = createMockUser({ uid: "listener-user", getIdToken });
+    const onTokenChange = vi.fn();
+    renderHook(() => useTokenRefresh(user, onTokenChange));
+
+    await act(async () => {
+      await authMocks.tokenListener?.(user);
+    });
+
+    expect(getIdToken).toHaveBeenCalledTimes(1);
+    expect(getIdToken).toHaveBeenCalledWith();
+    expect(onTokenChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/users/hooks/__tests__/useUserData.test.ts
+++ b/src/features/users/hooks/__tests__/useUserData.test.ts
@@ -117,6 +117,32 @@ describe("useUserData", () => {
     expect(result.current.error?.message).toBe("Query failed");
   });
 
+  it("refreshes once and retries after an authentication error", async () => {
+    vi.mocked(dataConnect.executeQuery)
+      .mockRejectedValueOnce(new Error("unauthorized"))
+      .mockResolvedValueOnce({ data: { user: mockUserData } } as any);
+    const user = enabledUser("retry-user");
+
+    const { result } = renderHook(() => useUserData(user, true));
+
+    await waitFor(() => expect(result.current.userData).toEqual(mockUserData));
+    expect(user.getIdToken).toHaveBeenCalledTimes(1);
+    expect(user.getIdToken).toHaveBeenCalledWith(true);
+    expect(dataConnect.executeQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("exits loading with an error when a Data Connect request never settles", async () => {
+    vi.mocked(dataConnect.executeQuery).mockReturnValue(
+      new Promise<never>(() => undefined),
+    );
+
+    const { result } = renderHook(() => useUserData(enabledUser("timeout-user"), true, 5));
+
+    await waitFor(() => expect(result.current.error?.message).toBe("Loading the current user timed out"));
+    expect(result.current.loading).toBe(false);
+    expect(result.current.userData).toBeNull();
+  });
+
   it("silences 'not found' errors — userData is null but no error state", async () => {
     vi.mocked(dataConnect.executeQuery).mockRejectedValue(new Error("User not found in database"));
 

--- a/src/features/users/hooks/__tests__/useUserData.test.ts
+++ b/src/features/users/hooks/__tests__/useUserData.test.ts
@@ -119,7 +119,7 @@ describe("useUserData", () => {
 
   it("refreshes once and retries after an authentication error", async () => {
     vi.mocked(dataConnect.executeQuery)
-      .mockRejectedValueOnce(new Error("unauthorized"))
+      .mockRejectedValueOnce({ code: "dataconnect/unauthorized" })
       .mockResolvedValueOnce({ data: { user: mockUserData } } as any);
     const user = enabledUser("retry-user");
 

--- a/src/features/users/hooks/useAdminClaim.ts
+++ b/src/features/users/hooks/useAdminClaim.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState, useCallback } from "react";
 import { type User } from "firebase/auth";
 import { useTokenRefresh } from "./useTokenRefresh";
+import { withTimeout } from "../../../shared/utils/withTimeout";
+
+const CLAIM_CHECK_TIMEOUT_MS = 15_000;
 
 export function useAdminClaim(user: User | null): boolean {
   const [isAdmin, setIsAdmin] = useState(false);
@@ -12,7 +15,11 @@ export function useAdminClaim(user: User | null): boolean {
     }
 
     try {
-      const tokenResult = await user.getIdTokenResult();
+      const tokenResult = await withTimeout(
+        user.getIdTokenResult(),
+        CLAIM_CHECK_TIMEOUT_MS,
+        "Checking the administrator claim timed out",
+      );
       setIsAdmin(tokenResult.claims.admin === true);
     } catch (error) {
       console.error("Error checking admin claim:", error);
@@ -29,4 +36,3 @@ export function useAdminClaim(user: User | null): boolean {
 
   return isAdmin;
 }
-

--- a/src/features/users/hooks/useEnabledClaim.ts
+++ b/src/features/users/hooks/useEnabledClaim.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState, useCallback } from "react";
 import { type User } from "firebase/auth";
 import { useTokenRefresh } from "./useTokenRefresh";
+import { withTimeout } from "../../../shared/utils/withTimeout";
+
+const CLAIM_CHECK_TIMEOUT_MS = 15_000;
 
 export interface EnabledClaimState {
   isEnabled: boolean;
@@ -19,7 +22,11 @@ export function useEnabledClaim(user: User | null): EnabledClaimState {
     }
 
     try {
-      const tokenResult = await user.getIdTokenResult();
+      const tokenResult = await withTimeout(
+        user.getIdTokenResult(),
+        CLAIM_CHECK_TIMEOUT_MS,
+        "Checking the enabled account claim timed out",
+      );
       setIsEnabled(tokenResult.claims.enabled === true);
     } catch (error) {
       console.error("Error checking enabled claim:", error);

--- a/src/features/users/hooks/useTokenRefresh.ts
+++ b/src/features/users/hooks/useTokenRefresh.ts
@@ -1,17 +1,30 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { onIdTokenChanged, type User } from "firebase/auth";
 import { auth } from "../../../config/firebase";
+import { withTimeout } from "../../../shared/utils/withTimeout";
+
+export const TOKEN_REFRESH_TIMEOUT_MS = 15_000;
 
 // Global singleton to ensure only one onIdTokenChanged listener exists
 let tokenRefreshSetup: {
   unsubscribe: (() => void) | null;
   callbacks: Set<() => void>;
   currentUser: User | null;
+  lastNotifiedToken: string | null;
 } = {
   unsubscribe: null,
   callbacks: new Set(),
   currentUser: null,
+  lastNotifiedToken: null,
 };
+
+let refreshInFlight: { uid: string; promise: Promise<void> } | null = null;
+
+function notifyTokenCallbacks(token: string) {
+  if (tokenRefreshSetup.lastNotifiedToken === token) return;
+  tokenRefreshSetup.lastNotifiedToken = token;
+  tokenRefreshSetup.callbacks.forEach((callback) => callback());
+}
 
 /**
  * Hook to detect claim changes via onIdTokenChanged
@@ -19,25 +32,17 @@ let tokenRefreshSetup: {
  * Provides a manual refresh function for handling auth errors
  */
 export function useTokenRefresh(user: User | null, onTokenChange?: () => void) {
-  const onTokenChangeRef = useRef(onTokenChange);
-
-  // Keep refs up to date
   useEffect(() => {
-    onTokenChangeRef.current = onTokenChange;
+    if (!onTokenChange) return;
+    tokenRefreshSetup.callbacks.add(onTokenChange);
+    return () => {
+      tokenRefreshSetup.callbacks.delete(onTokenChange);
+    };
   }, [onTokenChange]);
 
   useEffect(() => {
     if (!user) {
-      // Remove callback if user logs out
-      if (onTokenChangeRef.current) {
-        tokenRefreshSetup.callbacks.delete(onTokenChangeRef.current);
-      }
       return;
-    }
-
-    // Add callback to set
-    if (onTokenChangeRef.current) {
-      tokenRefreshSetup.callbacks.add(onTokenChangeRef.current);
     }
 
     // Only set up listener once (when currentUser is null or different)
@@ -48,12 +53,17 @@ export function useTokenRefresh(user: User | null, onTokenChange?: () => void) {
       }
 
       // Listen for token changes (fires when claims are updated server-side)
+      tokenRefreshSetup.lastNotifiedToken = null;
       const unsubscribe = onIdTokenChanged(auth, async (currentUser) => {
         if (currentUser && currentUser.uid === user.uid) {
-          // Force refresh to get latest claims
-          await currentUser.getIdToken(true);
-          // Notify all callbacks
-          tokenRefreshSetup.callbacks.forEach(callback => callback());
+          try {
+            // Read the token emitted by Firebase without forcing another refresh from
+            // inside the token-change listener.
+            const token = await currentUser.getIdToken();
+            notifyTokenCallbacks(token);
+          } catch (error) {
+            console.error("Error reading changed ID token:", error);
+          }
         }
       });
 
@@ -62,31 +72,41 @@ export function useTokenRefresh(user: User | null, onTokenChange?: () => void) {
         unsubscribe,
         callbacks: tokenRefreshSetup.callbacks,
         currentUser: user,
+        lastNotifiedToken: tokenRefreshSetup.lastNotifiedToken,
       };
     }
-
-    // Cleanup: remove callback when component unmounts
-    return () => {
-      if (onTokenChangeRef.current) {
-        tokenRefreshSetup.callbacks.delete(onTokenChangeRef.current);
-      }
-    };
   }, [user]);
 }
 
 /**
  * Manually refresh token (useful when handling auth errors)
  */
-export async function refreshToken(user: User | null): Promise<void> {
-  if (!user) return;
-  
-  try {
-    await user.getIdToken(true);
-    // Notify all callbacks
-    tokenRefreshSetup.callbacks.forEach(callback => callback());
-  } catch (error) {
-    console.error("Error refreshing token:", error);
-    throw error;
-  }
-}
+export function refreshToken(
+  user: User | null,
+  timeoutMs = TOKEN_REFRESH_TIMEOUT_MS,
+): Promise<void> {
+  if (!user) return Promise.reject(new Error("No authenticated user to refresh"));
 
+  if (refreshInFlight?.uid === user.uid) {
+    return refreshInFlight.promise;
+  }
+
+  const promise = withTimeout(
+    user.getIdToken(true),
+    timeoutMs,
+    "Refreshing the authenticated session timed out",
+  )
+    .then((token) => notifyTokenCallbacks(token))
+    .catch((error) => {
+      console.error("Error refreshing token:", error);
+      throw error;
+    })
+    .finally(() => {
+      if (refreshInFlight?.promise === promise) {
+        refreshInFlight = null;
+      }
+    });
+
+  refreshInFlight = { uid: user.uid, promise };
+  return promise;
+}

--- a/src/features/users/hooks/useUserData.ts
+++ b/src/features/users/hooks/useUserData.ts
@@ -4,8 +4,17 @@ import { executeQuery, QueryFetchPolicy } from "firebase/data-connect";
 import { dataConnect } from "../../../config/firebase";
 import { getCurrentUserRef } from "@dataconnect/generated";
 import type { UserData } from "../../../types";
+import { withTimeout } from "../../../shared/utils/withTimeout";
+import { refreshToken } from "./useTokenRefresh";
+import { isAuthenticationFailure } from "../../../shared/auth/isAuthenticationFailure";
 
-export function useUserData(firebaseUser: User | null, accountEnabled?: boolean) {
+export const USER_DATA_REQUEST_TIMEOUT_MS = 30_000;
+
+export function useUserData(
+  firebaseUser: User | null,
+  accountEnabled?: boolean,
+  requestTimeoutMs = USER_DATA_REQUEST_TIMEOUT_MS,
+) {
   const [userData, setUserData] = useState<UserData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -24,7 +33,11 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
     // Check if user has enabled claim before attempting query
     // GetCurrentUser requires enabled claim, so don't call it if user doesn't have it
     try {
-      const tokenResult = await firebaseUser.getIdTokenResult();
+      const tokenResult = await withTimeout(
+        firebaseUser.getIdTokenResult(),
+        requestTimeoutMs,
+        "Checking the current user's claims timed out",
+      );
       const isEnabled = tokenResult.claims.enabled === true;
       
       if (!isEnabled) {
@@ -58,9 +71,13 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
     setError(null);
     try {
       const ref = getCurrentUserRef(dataConnect);
-      const result = await executeQuery(
-        ref,
-        force ? { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } : undefined,
+      const result = await withTimeout(
+        executeQuery(
+          ref,
+          force ? { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } : undefined,
+        ),
+        requestTimeoutMs,
+        "Loading the current user timed out",
       );
       if (result.data?.user) {
         setUserData(result.data.user as UserData);
@@ -71,9 +88,7 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
       hasFetchedRef.current = firebaseUser.uid;
     } catch (err: any) {
       // Check if it's an auth error (401/403) - might be stale token or user doesn't have enabled claim
-      const isAuthError = err?.code === 401 || err?.code === 403 || 
-                         err?.message?.includes("unauthorized") ||
-                         err?.message?.includes("permission");
+      const isAuthError = isAuthenticationFailure(err);
       
       if (isAuthError) {
         // Mark that we've hit an auth error for this user
@@ -82,9 +97,13 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
         // Only try refreshing token if we haven't already tried (first time)
         if (hasFetchedRef.current !== firebaseUser.uid) {
           try {
-            await firebaseUser.getIdToken(true);
+            await refreshToken(firebaseUser);
             const ref = getCurrentUserRef(dataConnect);
-            const result = await executeQuery(ref);
+            const result = await withTimeout(
+              executeQuery(ref),
+              requestTimeoutMs,
+              "Retrying the current user request timed out",
+            );
             if (result.data?.user) {
               setUserData(result.data.user as UserData);
               authErrorRef.current = false; // Reset on success
@@ -116,7 +135,7 @@ export function useUserData(firebaseUser: User | null, accountEnabled?: boolean)
       setLoading(false);
       fetchingRef.current = false;
     }
-  }, [firebaseUser]);
+  }, [firebaseUser, requestTimeoutMs]);
 
   useEffect(() => {
     if (!firebaseUser) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,27 +1,12 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import { ColorModeProvider } from './shared/appShell/ColorModeProvider'
 import { CookiePreferencesProvider } from './shared/cookies/CookiePreferencesProvider'
 import './index.css'
 import App from './App.tsx'
-
-// Create a TanStack Query client instance
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      // Data Connect's fetch has no client-side timeout, so a request issued on a
-      // connection the browser/OS silently dropped while the tab was idle/backgrounded
-      // can hang forever, leaving a page stuck on its loading spinner. Refetching on
-      // window focus (the default we were previously opting out of) gives an already-
-      // mounted stuck query a fresh attempt as soon as the user comes back to the tab.
-      refetchOnWindowFocus: true,
-      staleTime: 30_000,
-    },
-  },
-})
+import { queryClient } from './shared/query/queryClient'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/shared/appShell/__tests__/useSessionRecovery.test.tsx
+++ b/src/shared/appShell/__tests__/useSessionRecovery.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider, QueryObserver } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMockUser } from "../../../test-utils/mocks/firebase";
+import { OperationTimeoutError } from "../../utils/withTimeout";
 
 const refreshTokenMock = vi.hoisted(() => vi.fn());
 
@@ -88,6 +89,44 @@ describe("useSessionRecovery", () => {
     await waitFor(() => expect(result.current.status).toBe("idle"));
   });
 
+  it("does not let an old user's recovery clear a newer recovery", async () => {
+    const resolvers = new Map<string, () => void>();
+    refreshTokenMock.mockImplementation(
+      (user: { uid: string }) =>
+        new Promise<void>((resolve) => {
+          resolvers.set(user.uid, resolve);
+        }),
+    );
+    const queryClient = new QueryClient();
+    const firstUser = createMockUser({ uid: "first-user" });
+    const secondUser = createMockUser({ uid: "second-user" });
+    const { result, rerender } = renderHook(
+      ({ user }) => useSessionRecovery(user),
+      {
+        initialProps: { user: firstUser },
+        wrapper: createWrapper(queryClient),
+      },
+    );
+
+    void result.current.retry();
+    await waitFor(() => expect(result.current.status).toBe("recovering"));
+
+    rerender({ user: secondUser });
+    await waitFor(() => expect(result.current.status).toBe("idle"));
+    void result.current.retry();
+    await waitFor(() => expect(refreshTokenMock).toHaveBeenCalledTimes(2));
+
+    resolvers.get(firstUser.uid)?.();
+    await act(async () => Promise.resolve());
+    expect(result.current.status).toBe("recovering");
+
+    void result.current.retry();
+    expect(refreshTokenMock).toHaveBeenCalledTimes(2);
+
+    resolvers.get(secondUser.uid)?.();
+    await waitFor(() => expect(result.current.status).toBe("idle"));
+  });
+
   it("exits recovery with an actionable failure when token refresh fails", async () => {
     refreshTokenMock.mockRejectedValue(new Error("refresh rejected"));
     const queryClient = new QueryClient();
@@ -101,6 +140,40 @@ describe("useSessionRecovery", () => {
     expect(result.current.status).toBe("failed");
     expect(result.current.failure).toBe("refresh-failed");
     expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("classifies a token refresh timeout separately from other refresh failures", async () => {
+    refreshTokenMock.mockRejectedValue(
+      new OperationTimeoutError("Refreshing the authenticated session timed out", 100),
+    );
+    const queryClient = new QueryClient();
+    const user = createMockUser({ uid: "refresh-timeout-user" });
+    const { result } = renderHook(() => useSessionRecovery(user), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => result.current.retry());
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toBe("request-timeout");
+  });
+
+  it("refreshes profile data after the token has recovered", async () => {
+    const queryClient = new QueryClient();
+    const user = createMockUser({ uid: "profile-refresh-user" });
+    const onRecovered = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(
+      () => useSessionRecovery(user, { onRecovered }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await act(async () => result.current.retry());
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(onRecovered).toHaveBeenCalledTimes(1);
+    expect(refreshTokenMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onRecovered.mock.invocationCallOrder[0],
+    );
   });
 
   it("refreshes once and retries an active query after an authentication error", async () => {

--- a/src/shared/appShell/__tests__/useSessionRecovery.test.tsx
+++ b/src/shared/appShell/__tests__/useSessionRecovery.test.tsx
@@ -1,0 +1,208 @@
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, QueryObserver } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMockUser } from "../../../test-utils/mocks/firebase";
+
+const refreshTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../features/users/hooks/useTokenRefresh", () => ({
+  refreshToken: refreshTokenMock,
+}));
+
+import { useSessionRecovery } from "../useSessionRecovery";
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function setVisibility(value: "hidden" | "visible") {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("useSessionRecovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshTokenMock.mockResolvedValue(undefined);
+    setVisibility("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("refreshes once and replaces active queries after resuming beyond the idle threshold", async () => {
+    const queryClient = new QueryClient();
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    let currentTime = 1_000;
+    const now = () => currentTime;
+    const user = createMockUser({ uid: "idle-user" });
+
+    const { result } = renderHook(
+      () => useSessionRecovery(user, { idleThresholdMs: 100, now }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    act(() => setVisibility("hidden"));
+    currentTime += 101;
+    act(() => setVisibility("visible"));
+
+    await waitFor(() => expect(refreshTokenMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.status).toBe("idle"));
+    expect(cancelSpy).toHaveBeenCalledWith({ type: "active" });
+    expect(invalidateSpy).toHaveBeenCalledWith({ type: "active" });
+  });
+
+  it("shares recovery when resume and manual retry overlap", async () => {
+    let finishRefresh!: () => void;
+    refreshTokenMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishRefresh = resolve;
+      }),
+    );
+    const queryClient = new QueryClient();
+    let currentTime = 1_000;
+    const now = () => currentTime;
+    const user = createMockUser({ uid: "overlap-user" });
+    const { result } = renderHook(
+      () => useSessionRecovery(user, { idleThresholdMs: 100, now }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    act(() => setVisibility("hidden"));
+    currentTime += 101;
+    act(() => setVisibility("visible"));
+    await waitFor(() => expect(result.current.status).toBe("recovering"));
+
+    void result.current.retry();
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+
+    finishRefresh();
+    await waitFor(() => expect(result.current.status).toBe("idle"));
+  });
+
+  it("exits recovery with an actionable failure when token refresh fails", async () => {
+    refreshTokenMock.mockRejectedValue(new Error("refresh rejected"));
+    const queryClient = new QueryClient();
+    const user = createMockUser({ uid: "failed-user" });
+    const { result } = renderHook(() => useSessionRecovery(user), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => result.current.retry());
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toBe("refresh-failed");
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes once and retries an active query after an authentication error", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const user = createMockUser({ uid: "auth-error-user" });
+    renderHook(() => useSessionRecovery(user), {
+      wrapper: createWrapper(queryClient),
+    });
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce({ code: "dataconnect/unauthorized" })
+      .mockResolvedValueOnce({ value: "recovered" });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["authenticated-query"],
+      queryFn,
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await waitFor(() => expect(observer.getCurrentResult().isSuccess).toBe(true));
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    expect(observer.getCurrentResult().data).toEqual({ value: "recovered" });
+    unsubscribe();
+  });
+
+  it("does not loop when the retried query is still unauthorized", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const user = createMockUser({ uid: "persistent-auth-error-user" });
+    renderHook(() => useSessionRecovery(user), {
+      wrapper: createWrapper(queryClient),
+    });
+    const queryFn = vi.fn().mockRejectedValue({ code: 401 });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: ["still-unauthorized"],
+      queryFn,
+      retry: false,
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await waitFor(() => expect(queryFn).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(observer.getCurrentResult().isError).toBe(true));
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("cancels a query that never settles and exits its indefinite loading state", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+    const user = createMockUser({ uid: "timeout-user" });
+    const { result } = renderHook(
+      () => useSessionRecovery(user, { queryTimeoutMs: 100 }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    const pendingQueryResult = queryClient
+      .fetchQuery({
+        queryKey: ["never-settles"],
+        queryFn: () => new Promise<never>(() => undefined),
+      })
+      .catch((error: unknown) => error);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(101);
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toBe("request-timeout");
+    expect(cancelSpy).toHaveBeenCalledWith({
+      queryKey: ["never-settles"],
+      exact: true,
+    });
+    await expect(pendingQueryResult).resolves.toBeDefined();
+  });
+
+  it("exits a generated mutation's indefinite loading state", async () => {
+    vi.useFakeTimers();
+    const queryClient = new QueryClient();
+    const user = createMockUser({ uid: "mutation-timeout-user" });
+    const { result } = renderHook(
+      () => useSessionRecovery(user, { queryTimeoutMs: 100 }),
+      { wrapper: createWrapper(queryClient) },
+    );
+    const mutation = queryClient.getMutationCache().build(queryClient, {
+      mutationFn: () => new Promise<never>(() => undefined),
+    });
+
+    void mutation.execute(undefined);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(101);
+    });
+
+    expect(result.current.status).toBe("failed");
+    expect(result.current.failure).toBe("request-timeout");
+  });
+});

--- a/src/shared/appShell/useSessionRecovery.ts
+++ b/src/shared/appShell/useSessionRecovery.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { User } from "firebase/auth";
+import { refreshToken } from "../../features/users/hooks/useTokenRefresh";
+import { isAuthenticationFailure } from "../auth/isAuthenticationFailure";
+
+export const SESSION_IDLE_THRESHOLD_MS = 5 * 60_000;
+export const PROTECTED_QUERY_TIMEOUT_MS = 30_000;
+
+export type SessionRecoveryFailure = "refresh-failed" | "request-timeout";
+export type SessionRecoveryStatus = "idle" | "recovering" | "failed";
+
+interface UseSessionRecoveryOptions {
+  idleThresholdMs?: number;
+  queryTimeoutMs?: number;
+  now?: () => number;
+}
+
+interface SessionRecoveryState {
+  status: SessionRecoveryStatus;
+  failure: SessionRecoveryFailure | null;
+}
+
+const INITIAL_STATE: SessionRecoveryState = { status: "idle", failure: null };
+
+export function useSessionRecovery(
+  user: User | null,
+  options: UseSessionRecoveryOptions = {},
+) {
+  const queryClient = useQueryClient();
+  const idleThresholdMs = options.idleThresholdMs ?? SESSION_IDLE_THRESHOLD_MS;
+  const queryTimeoutMs = options.queryTimeoutMs ?? PROTECTED_QUERY_TIMEOUT_MS;
+  const now = options.now ?? Date.now;
+  const [state, setState] = useState<SessionRecoveryState>(INITIAL_STATE);
+  const inactiveAtRef = useRef<number | null>(null);
+  const recoveryRef = useRef<Promise<void> | null>(null);
+
+  const recover = useCallback(async () => {
+    if (!user) return;
+    if (recoveryRef.current) return recoveryRef.current;
+
+    const operation = (async () => {
+      setState({ status: "recovering", failure: null });
+
+      try {
+        // Detach any pre-resume promises from query state before refreshing. Firebase
+        // Data Connect does not consume TanStack Query's AbortSignal, but cancelling
+        // still ensures a late result from the stale promise is ignored.
+        await queryClient.cancelQueries({ type: "active" });
+        await refreshToken(user);
+
+        // Do not await refetches here: the query watchdog below owns their bounded
+        // loading time and can offer recovery if the replacement transport also stalls.
+        void queryClient.invalidateQueries({ type: "active" });
+        setState(INITIAL_STATE);
+      } catch (error) {
+        console.error("[session-recovery] token refresh failed", error);
+        setState({ status: "failed", failure: "refresh-failed" });
+      } finally {
+        recoveryRef.current = null;
+      }
+    })();
+
+    recoveryRef.current = operation;
+    return operation;
+  }, [queryClient, user]);
+
+  useEffect(() => {
+    inactiveAtRef.current = null;
+    recoveryRef.current = null;
+    setState(INITIAL_STATE);
+  }, [user?.uid]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const markInactive = () => {
+      inactiveAtRef.current ??= now();
+    };
+
+    const resume = () => {
+      const inactiveAt = inactiveAtRef.current;
+      inactiveAtRef.current = null;
+      if (inactiveAt !== null && now() - inactiveAt >= idleThresholdMs) {
+        void recover();
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        markInactive();
+      } else {
+        resume();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("blur", markInactive);
+    window.addEventListener("focus", resume);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("blur", markInactive);
+      window.removeEventListener("focus", resume);
+    };
+  }, [idleThresholdMs, now, recover, user]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    const queryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    const mutationTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    const authRecoveryAttempts = new Set<string>();
+
+    const syncQueryTimers = () => {
+      const fetchingQueries = queryClient
+        .getQueryCache()
+        .getAll()
+        .filter((query) => query.state.fetchStatus === "fetching");
+      const fetchingHashes = new Set(fetchingQueries.map((query) => query.queryHash));
+
+      for (const [queryHash, timer] of queryTimers) {
+        if (!fetchingHashes.has(queryHash)) {
+          clearTimeout(timer);
+          queryTimers.delete(queryHash);
+        }
+      }
+
+      for (const query of fetchingQueries) {
+        if (queryTimers.has(query.queryHash)) continue;
+
+        const timer = setTimeout(() => {
+          queryTimers.delete(query.queryHash);
+          console.error("[session-recovery] protected query timed out", {
+            queryHash: query.queryHash,
+          });
+          void queryClient.cancelQueries({ queryKey: query.queryKey, exact: true });
+          setState({ status: "failed", failure: "request-timeout" });
+        }, queryTimeoutMs);
+        queryTimers.set(query.queryHash, timer);
+      }
+
+      for (const query of queryClient.getQueryCache().getAll()) {
+        if (query.state.status === "success") {
+          authRecoveryAttempts.delete(query.queryHash);
+        } else if (
+          query.state.status === "error" &&
+          isAuthenticationFailure(query.state.error) &&
+          !authRecoveryAttempts.has(query.queryHash)
+        ) {
+          authRecoveryAttempts.add(query.queryHash);
+          void recover();
+        }
+      }
+    };
+
+    const syncMutationTimers = () => {
+      const pendingMutations = queryClient
+        .getMutationCache()
+        .getAll()
+        .filter((mutation) => mutation.state.status === "pending");
+      const pendingIds = new Set(pendingMutations.map((mutation) => mutation.mutationId));
+
+      for (const [mutationId, timer] of mutationTimers) {
+        if (!pendingIds.has(mutationId)) {
+          clearTimeout(timer);
+          mutationTimers.delete(mutationId);
+        }
+      }
+
+      for (const mutation of pendingMutations) {
+        if (mutationTimers.has(mutation.mutationId)) continue;
+
+        const timer = setTimeout(() => {
+          mutationTimers.delete(mutation.mutationId);
+          console.error("[session-recovery] protected mutation timed out", {
+            mutationId: mutation.mutationId,
+          });
+          // TanStack mutations cannot be cancelled. Showing the recovery screen
+          // unmounts the stalled observer so its loading state cannot trap the UI.
+          setState({ status: "failed", failure: "request-timeout" });
+        }, queryTimeoutMs);
+        mutationTimers.set(mutation.mutationId, timer);
+      }
+    };
+
+    syncQueryTimers();
+    syncMutationTimers();
+    const unsubscribeQueries = queryClient.getQueryCache().subscribe(syncQueryTimers);
+    const unsubscribeMutations = queryClient.getMutationCache().subscribe(syncMutationTimers);
+    return () => {
+      unsubscribeQueries();
+      unsubscribeMutations();
+      queryTimers.forEach(clearTimeout);
+      mutationTimers.forEach(clearTimeout);
+    };
+  }, [queryClient, queryTimeoutMs, recover, user]);
+
+  return {
+    ...state,
+    retry: recover,
+  };
+}

--- a/src/shared/appShell/useSessionRecovery.ts
+++ b/src/shared/appShell/useSessionRecovery.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import type { User } from "firebase/auth";
 import { refreshToken } from "../../features/users/hooks/useTokenRefresh";
 import { isAuthenticationFailure } from "../auth/isAuthenticationFailure";
+import { OperationTimeoutError } from "../utils/withTimeout";
 
 export const SESSION_IDLE_THRESHOLD_MS = 5 * 60_000;
 export const PROTECTED_QUERY_TIMEOUT_MS = 30_000;
@@ -14,6 +15,7 @@ interface UseSessionRecoveryOptions {
   idleThresholdMs?: number;
   queryTimeoutMs?: number;
   now?: () => number;
+  onRecovered?: () => void | Promise<void>;
 }
 
 interface SessionRecoveryState {
@@ -31,14 +33,22 @@ export function useSessionRecovery(
   const idleThresholdMs = options.idleThresholdMs ?? SESSION_IDLE_THRESHOLD_MS;
   const queryTimeoutMs = options.queryTimeoutMs ?? PROTECTED_QUERY_TIMEOUT_MS;
   const now = options.now ?? Date.now;
+  const onRecoveredRef = useRef(options.onRecovered);
   const [state, setState] = useState<SessionRecoveryState>(INITIAL_STATE);
   const inactiveAtRef = useRef<number | null>(null);
-  const recoveryRef = useRef<Promise<void> | null>(null);
+  const recoveryRef = useRef<{ id: symbol; promise: Promise<void> } | null>(null);
+  const recoveryGenerationRef = useRef(0);
+
+  useEffect(() => {
+    onRecoveredRef.current = options.onRecovered;
+  }, [options.onRecovered]);
 
   const recover = useCallback(async () => {
     if (!user) return;
-    if (recoveryRef.current) return recoveryRef.current;
+    if (recoveryRef.current) return recoveryRef.current.promise;
 
+    const generation = recoveryGenerationRef.current;
+    const recoveryId = Symbol("session-recovery");
     const operation = (async () => {
       setState({ status: "recovering", failure: null });
 
@@ -48,24 +58,40 @@ export function useSessionRecovery(
         // still ensures a late result from the stale promise is ignored.
         await queryClient.cancelQueries({ type: "active" });
         await refreshToken(user);
+        if (generation !== recoveryGenerationRef.current) return;
+        await onRecoveredRef.current?.();
+        if (generation !== recoveryGenerationRef.current) return;
 
         // Do not await refetches here: the query watchdog below owns their bounded
         // loading time and can offer recovery if the replacement transport also stalls.
         void queryClient.invalidateQueries({ type: "active" });
         setState(INITIAL_STATE);
       } catch (error) {
-        console.error("[session-recovery] token refresh failed", error);
-        setState({ status: "failed", failure: "refresh-failed" });
+        if (generation !== recoveryGenerationRef.current) return;
+        const timedOut = error instanceof OperationTimeoutError;
+        console.error(
+          timedOut
+            ? "[session-recovery] token refresh timed out"
+            : "[session-recovery] token refresh failed",
+          error,
+        );
+        setState({
+          status: "failed",
+          failure: timedOut ? "request-timeout" : "refresh-failed",
+        });
       } finally {
-        recoveryRef.current = null;
+        if (recoveryRef.current?.id === recoveryId) {
+          recoveryRef.current = null;
+        }
       }
     })();
 
-    recoveryRef.current = operation;
+    recoveryRef.current = { id: recoveryId, promise: operation };
     return operation;
   }, [queryClient, user]);
 
   useEffect(() => {
+    recoveryGenerationRef.current += 1;
     inactiveAtRef.current = null;
     recoveryRef.current = null;
     setState(INITIAL_STATE);

--- a/src/shared/appShell/useUnenabledProfileCheck.ts
+++ b/src/shared/appShell/useUnenabledProfileCheck.ts
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { queryRef, executeQuery } from "firebase/data-connect";
+import { queryRef } from "firebase/data-connect";
 import type { User } from "firebase/auth";
 import { dataConnect } from "../../config/firebase";
 import type { UserData } from "../../types";
+import { executeDataConnectQuery } from "../query/dataConnectExecution";
 
 export function useUnenabledProfileCheck(
   user: User | null,
@@ -35,7 +36,7 @@ export function useUnenabledProfileCheck(
 
     checkingProfileRef.current = true;
     const ref = queryRef(dataConnect, "CheckUserProfileExists", {});
-    executeQuery(ref)
+    executeDataConnectQuery(ref)
       .then((result) => {
         const profileData = (result.data as { user?: { membershipStatus?: string } | null })?.user;
         setProfileExists(profileData !== null && profileData !== undefined);

--- a/src/shared/auth/__tests__/isAuthenticationFailure.test.ts
+++ b/src/shared/auth/__tests__/isAuthenticationFailure.test.ts
@@ -7,12 +7,20 @@ describe("isAuthenticationFailure", () => {
     { status: 403 },
     { code: "dataconnect/unauthorized" },
     { code: "functions/permission-denied" },
-    new Error("Request is unauthenticated"),
+    { code: "auth/unauthenticated" },
   ])("recognises an authentication or authorization response", (error) => {
     expect(isAuthenticationFailure(error)).toBe(true);
   });
 
   it("does not classify ordinary transport errors as authentication failures", () => {
     expect(isAuthenticationFailure(new Error("network unavailable"))).toBe(false);
+  });
+
+  it.each([
+    { status: 500, message: "unauthorized text from an upstream service" },
+    { code: "functions/invalid-argument", message: "permission denied is not the code" },
+    { code: "operation-timeout", message: "unauthenticated request timed out" },
+  ])("does not trust message text when the structured code is not an auth failure", (error) => {
+    expect(isAuthenticationFailure(error)).toBe(false);
   });
 });

--- a/src/shared/auth/__tests__/isAuthenticationFailure.test.ts
+++ b/src/shared/auth/__tests__/isAuthenticationFailure.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { isAuthenticationFailure } from "../isAuthenticationFailure";
+
+describe("isAuthenticationFailure", () => {
+  it.each([
+    { code: 401 },
+    { status: 403 },
+    { code: "dataconnect/unauthorized" },
+    { code: "functions/permission-denied" },
+    new Error("Request is unauthenticated"),
+  ])("recognises an authentication or authorization response", (error) => {
+    expect(isAuthenticationFailure(error)).toBe(true);
+  });
+
+  it("does not classify ordinary transport errors as authentication failures", () => {
+    expect(isAuthenticationFailure(new Error("network unavailable"))).toBe(false);
+  });
+});

--- a/src/shared/auth/isAuthenticationFailure.ts
+++ b/src/shared/auth/isAuthenticationFailure.ts
@@ -1,18 +1,23 @@
+import { extractErrorCode } from "../errors/errorHandling";
+
 export function isAuthenticationFailure(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
 
-  const candidate = error as { code?: unknown; status?: unknown; message?: unknown };
-  const code = String(candidate.code ?? candidate.status ?? "").toLowerCase();
-  const message = String(candidate.message ?? "").toLowerCase();
+  const candidate = error as { code?: unknown; status?: unknown };
+  const structuredCode = extractErrorCode(error);
+  const numericStatus =
+    typeof candidate.status === "number"
+      ? candidate.status
+      : typeof candidate.code === "number"
+        ? candidate.code
+        : null;
+  const code = structuredCode ?? "";
 
   return (
-    code === "401" ||
-    code === "403" ||
+    numericStatus === 401 ||
+    numericStatus === 403 ||
     code.includes("unauthenticated") ||
     code.includes("unauthorized") ||
-    code.includes("permission-denied") ||
-    message.includes("unauthenticated") ||
-    message.includes("unauthorized") ||
-    message.includes("permission denied")
+    code.includes("permission-denied")
   );
 }

--- a/src/shared/auth/isAuthenticationFailure.ts
+++ b/src/shared/auth/isAuthenticationFailure.ts
@@ -1,0 +1,18 @@
+export function isAuthenticationFailure(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const candidate = error as { code?: unknown; status?: unknown; message?: unknown };
+  const code = String(candidate.code ?? candidate.status ?? "").toLowerCase();
+  const message = String(candidate.message ?? "").toLowerCase();
+
+  return (
+    code === "401" ||
+    code === "403" ||
+    code.includes("unauthenticated") ||
+    code.includes("unauthorized") ||
+    code.includes("permission-denied") ||
+    message.includes("unauthenticated") ||
+    message.includes("unauthorized") ||
+    message.includes("permission denied")
+  );
+}

--- a/src/shared/query/__tests__/dataConnectExecution.test.ts
+++ b/src/shared/query/__tests__/dataConnectExecution.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const dataConnectMocks = vi.hoisted(() => ({
+  executeQuery: vi.fn(),
+  executeMutation: vi.fn(),
+}));
+
+vi.mock("firebase/data-connect", () => dataConnectMocks);
+
+import {
+  DATA_CONNECT_OPERATION_TIMEOUT_MS,
+  executeDataConnectMutation,
+  executeDataConnectQuery,
+} from "../dataConnectExecution";
+
+describe("bounded Data Connect execution", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns query results normally", async () => {
+    const response = { data: { users: [] } };
+    dataConnectMocks.executeQuery.mockResolvedValue(response);
+
+    await expect(executeDataConnectQuery({} as never)).resolves.toBe(response);
+  });
+
+  it("rejects a query that never settles", async () => {
+    vi.useFakeTimers();
+    dataConnectMocks.executeQuery.mockReturnValue(new Promise<never>(() => undefined));
+    const result = executeDataConnectQuery({} as never).catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(DATA_CONNECT_OPERATION_TIMEOUT_MS);
+
+    await expect(result).resolves.toMatchObject({
+      code: "operation-timeout",
+      message: "The Data Connect query timed out",
+    });
+  });
+
+  it("rejects a mutation that never settles", async () => {
+    vi.useFakeTimers();
+    dataConnectMocks.executeMutation.mockReturnValue(new Promise<never>(() => undefined));
+    const result = executeDataConnectMutation({} as never).catch((error: unknown) => error);
+
+    await vi.advanceTimersByTimeAsync(DATA_CONNECT_OPERATION_TIMEOUT_MS);
+
+    await expect(result).resolves.toMatchObject({
+      code: "operation-timeout",
+      message: "The Data Connect mutation timed out",
+    });
+  });
+});

--- a/src/shared/query/__tests__/queryClient.test.ts
+++ b/src/shared/query/__tests__/queryClient.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { queryClient } from "../queryClient";
+
+describe("queryClient retry policy", () => {
+  it("does not retry authentication failures before session recovery", async () => {
+    const queryFn = vi.fn().mockRejectedValue({ code: 401 });
+
+    await expect(
+      queryClient.fetchQuery({
+        queryKey: ["auth-retry-policy"],
+        queryFn,
+      }),
+    ).rejects.toMatchObject({ code: 401 });
+
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    queryClient.removeQueries({ queryKey: ["auth-retry-policy"] });
+  });
+
+  it("retains one retry for transient failures", async () => {
+    const queryFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary network error"))
+      .mockResolvedValueOnce("recovered");
+
+    await expect(
+      queryClient.fetchQuery({
+        queryKey: ["network-retry-policy"],
+        queryFn,
+      }),
+    ).resolves.toBe("recovered");
+
+    expect(queryFn).toHaveBeenCalledTimes(2);
+    queryClient.removeQueries({ queryKey: ["network-retry-policy"] });
+  });
+});

--- a/src/shared/query/dataConnectExecution.ts
+++ b/src/shared/query/dataConnectExecution.ts
@@ -1,0 +1,21 @@
+import { executeMutation, executeQuery } from "firebase/data-connect";
+import { withTimeout } from "../utils/withTimeout";
+
+export const DATA_CONNECT_OPERATION_TIMEOUT_MS = 30_000;
+
+const timedExecuteQuery = (...args: Parameters<typeof executeQuery>) =>
+  withTimeout(
+    executeQuery(...args),
+    DATA_CONNECT_OPERATION_TIMEOUT_MS,
+    "The Data Connect query timed out",
+  );
+
+const timedExecuteMutation = (...args: Parameters<typeof executeMutation>) =>
+  withTimeout(
+    executeMutation(...args),
+    DATA_CONNECT_OPERATION_TIMEOUT_MS,
+    "The Data Connect mutation timed out",
+  );
+
+export const executeDataConnectQuery = timedExecuteQuery as typeof executeQuery;
+export const executeDataConnectMutation = timedExecuteMutation as typeof executeMutation;

--- a/src/shared/query/queryClient.ts
+++ b/src/shared/query/queryClient.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from "@tanstack/react-query";
+import { isAuthenticationFailure } from "../auth/isAuthenticationFailure";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Authentication failures are recovered centrally after one coordinated token
+      // refresh. Retrying them here would repeat the stale-token request first.
+      retry: (failureCount, error) =>
+        !isAuthenticationFailure(error) && failureCount < 1,
+      refetchOnWindowFocus: true,
+      staleTime: 30_000,
+    },
+  },
+});

--- a/src/shared/utils/withTimeout.ts
+++ b/src/shared/utils/withTimeout.ts
@@ -1,0 +1,30 @@
+export class OperationTimeoutError extends Error {
+  readonly code = "operation-timeout";
+  readonly timeoutMs: number;
+
+  constructor(message: string, timeoutMs: number) {
+    super(message);
+    this.name = "OperationTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function withTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new OperationTimeoutError(message, timeoutMs));
+    }, timeoutMs);
+  });
+
+  return Promise.race([operation, timeout]).finally(() => {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- validate and refresh Firebase authentication when an idle tab returns to the foreground
- coordinate concurrent refresh attempts through a single in-flight token refresh
- replace stale authenticated query state and retry structured authorization failures once
- apply real timeouts to direct Data Connect calls and a global watchdog to generated-hook loading state
- refresh member profile data after session recovery
- show actionable retry and sign-in recovery states while preserving member and admin destinations
- add regression coverage for idle resume, concurrent refresh, user changes during recovery, authorization retry, refresh failure/timeouts, stalled queries and mutations, profile refresh, and member/admin recovery UI

## Root cause

The app relied on Firebase token-change callbacks and TanStack Query focus refetching, but neither reliably handled a silently dropped request after a long background period. Generated Data Connect hooks do not consume TanStack Query's abort signal, token refresh ownership was duplicated inside `onIdTokenChanged`, and protected loading states had no bounded escape path.

## Recovery behaviour

Direct `executeQuery`/`executeMutation` consumers now reject after a bounded timeout. Generated Data Connect hooks still cannot abort Firebase's underlying transport promise, but a global TanStack Query watchdog cancels/replaces their query state or unmounts a stalled mutation observer after 30 seconds. This bounds the UI loading state and prevents an indefinite spinner without claiming transport-level cancellation.

Returning to an idle protected session refreshes authentication, profile/claim data, and active query state. Structured 401/403/unauthenticated/permission-denied errors cause one coordinated refresh and one retry. If recovery or transport fails, the intended route is retained and the user sees retry/sign-in actions.

## Validation

- `npm run test:coverage` — 96 files, 756 tests passed; thresholds passed
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #535