### PR TITLE
Fix dark theme contrast and focus states

### DIFF
--- a/src/config/__tests__/theme.test.ts
+++ b/src/config/__tests__/theme.test.ts
@@ -1,0 +1,57 @@
+import { getContrastRatio } from "@mui/material/styles";
+import { describe, expect, it } from "vitest";
+import {
+  BRAND_PRIMARY,
+  BRAND_SECONDARY,
+  createAppTheme,
+} from "../theme";
+
+describe("createAppTheme", () => {
+  it("retains the established brand palette in light mode", () => {
+    const theme = createAppTheme("light");
+
+    expect(theme.palette.primary.main).toBe(BRAND_PRIMARY);
+    expect(theme.palette.secondary.main).toBe(BRAND_SECONDARY);
+    expect(theme.palette.background.default).toBe("#F9FAFB");
+  });
+
+  it("gives dark-mode primary actions and links accessible contrast", () => {
+    const theme = createAppTheme("dark");
+
+    expect(
+      getContrastRatio(theme.palette.primary.main, theme.palette.background.default)
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      getContrastRatio(theme.palette.primary.main, theme.palette.background.paper)
+    ).toBeGreaterThanOrEqual(4.5);
+    expect(
+      getContrastRatio(theme.palette.primary.contrastText, theme.palette.primary.main)
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("gives dark-mode secondary actions a visible boundary and readable label", () => {
+    const theme = createAppTheme("dark");
+
+    expect(
+      getContrastRatio(theme.palette.secondary.main, theme.palette.background.default)
+    ).toBeGreaterThanOrEqual(3);
+    expect(
+      getContrastRatio(theme.palette.secondary.contrastText, theme.palette.secondary.main)
+    ).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("provides a visible keyboard focus indicator for button-based controls", () => {
+    const root = themeButtonBaseRoot(createAppTheme("dark"));
+    const focusVisible = root["&.Mui-focusVisible"] as Record<string, unknown>;
+
+    expect(focusVisible.outline).toMatch(/^3px solid /);
+    expect(focusVisible.outlineOffset).toBe(2);
+  });
+});
+
+function themeButtonBaseRoot(theme: ReturnType<typeof createAppTheme>) {
+  return theme.components?.MuiButtonBase?.styleOverrides?.root as Record<
+    string,
+    unknown
+  >;
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,33 +1,47 @@
 import { alpha, createTheme, lighten, type Theme } from "@mui/material/styles";
 
-const PRIMARY = "#1A2F5A";
-const SECONDARY = "#770800";
+export const BRAND_PRIMARY = "#1A2F5A";
+export const BRAND_SECONDARY = "#770800";
 const LIGHT_BACKGROUND_DEFAULT = "#F9FAFB";
 
 export type AppColorMode = "light" | "dark";
 
-/**
- * primary.main stays the fixed brand navy in both modes — across the app it's only ever used as
- * a background (AppBar, avatars) or paired with an explicit white foreground, so it never needs
- * to contrast against the page's own background. primary.light is used for heading/link text
- * color rendered directly on the page background, which must lighten in dark mode to stay legible
- * against a dark background.
- */
 export function createAppTheme(mode: AppColorMode): Theme {
+  const primaryMain = mode === "dark" ? lighten(BRAND_PRIMARY, 0.55) : BRAND_PRIMARY;
+  const secondaryMain = mode === "dark" ? lighten(BRAND_SECONDARY, 0.35) : BRAND_SECONDARY;
+
   return createTheme({
     palette: {
       mode,
+      contrastThreshold: 4.5,
       primary: {
-        main: PRIMARY,
-        light: mode === "dark" ? lighten(PRIMARY, 0.55) : PRIMARY,
+        main: primaryMain,
+        light: mode === "dark" ? lighten(BRAND_PRIMARY, 0.7) : BRAND_PRIMARY,
+        dark: mode === "dark" ? lighten(BRAND_PRIMARY, 0.45) : undefined,
       },
-      secondary: { main: SECONDARY },
+      secondary: {
+        main: secondaryMain,
+        dark: mode === "dark" ? lighten(BRAND_SECONDARY, 0.3) : undefined,
+        contrastText: "#FFFFFF",
+      },
       ...(mode === "light"
         ? {
             background: { default: LIGHT_BACKGROUND_DEFAULT },
-            text: { secondary: alpha(PRIMARY, 0.75) },
+            text: { secondary: alpha(BRAND_PRIMARY, 0.75) },
           }
         : {}),
+    },
+    components: {
+      MuiButtonBase: {
+        styleOverrides: {
+          root: {
+            "&.Mui-focusVisible": {
+              outline: `3px solid ${primaryMain}`,
+              outlineOffset: 2,
+            },
+          },
+        },
+      },
     },
   });
 }

--- a/src/features/account/components/AccountSettingsPage.tsx
+++ b/src/features/account/components/AccountSettingsPage.tsx
@@ -609,6 +609,7 @@ export default function AccountSettingsPage({
                       }
                       sx={{
                         backgroundColor: "secondary.main",
+                        color: "secondary.contrastText",
                         "&:hover": {
                           backgroundColor: "secondary.main",
                           opacity: 0.9,

--- a/src/features/admin/components/AuditLogs.tsx
+++ b/src/features/admin/components/AuditLogs.tsx
@@ -143,17 +143,7 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
       <Tabs
         value={tabValue}
         onChange={(_, newValue) => setTabValue(newValue)}
-        sx={{
-          mb: 3,
-          "& .MuiTab-root": {
-            "&:focus": {
-              outline: "none",
-            },
-            "&:focus-visible": {
-              outline: "none",
-            },
-          },
-        }}
+        sx={{ mb: 3 }}
       >
         <Tab label="Users" />
         <Tab label="User Groups" />

--- a/src/features/admin/components/ManageUsers.tsx
+++ b/src/features/admin/components/ManageUsers.tsx
@@ -257,13 +257,7 @@ export default function ManageUsers({ onBack, onCurrentUserUpdate }: ManageUsers
           setTabValue(newValue);
           setSelectedUserId(null);
         }}
-        sx={{
-          mb: 3,
-          "& .MuiTab-root": {
-            "&:focus": { outline: "none" },
-            "&:focus-visible": { outline: "none" },
-          },
-        }}
+        sx={{ mb: 3 }}
       >
         <Tab label="Search users" />
         <Tab label="Administrators" />
@@ -320,7 +314,8 @@ export default function ManageUsers({ onBack, onCurrentUserUpdate }: ManageUsers
                   sx={{
                     mt: 4,
                     p: 2,
-                    border: "1px solid rgba(0, 0, 0, 0.12)",
+                    border: "1px solid",
+                    borderColor: "divider",
                     borderRadius: 1,
                   }}
                 >

--- a/src/features/admin/components/TemplateEditor.tsx
+++ b/src/features/admin/components/TemplateEditor.tsx
@@ -25,6 +25,7 @@ import {
 import {
   STANDARD_FOOTER,
   UNSUPPORTED_PATTERNS,
+  getGovNotifyPreviewColors,
   renderGovNotifyMarkdown,
 } from "../utils/govNotifyMarkdown";
 
@@ -470,17 +471,27 @@ export default function TemplateEditor({ sectionName }: TemplateEditorProps) {
                 </Typography>
               )}
               <Box
-                sx={{
-                  border: "1px solid",
-                  borderColor: "divider",
-                  borderRadius: 1,
-                  p: 2,
-                  bgcolor: "background.paper",
-                  fontSize: "0.875rem",
-                  lineHeight: 1.6,
-                  fontFamily: "Arial, sans-serif",
-                  "& a": { color: "primary.light" },
-                  "& h1,h2": { fontFamily: "inherit" },
+                sx={(theme) => {
+                  const colors = getGovNotifyPreviewColors(theme.palette.mode);
+                  return {
+                    "--notify-optional-bg": colors.optionalBackground,
+                    "--notify-optional-text": colors.optionalText,
+                    "--notify-optional-border": colors.optionalBorder,
+                    "--notify-variable-bg": colors.variableBackground,
+                    "--notify-variable-text": colors.variableText,
+                    "--notify-divider": colors.divider,
+                    "--notify-inset-text": colors.insetText,
+                    border: "1px solid",
+                    borderColor: "divider",
+                    borderRadius: 1,
+                    p: 2,
+                    bgcolor: "background.paper",
+                    fontSize: "0.875rem",
+                    lineHeight: 1.6,
+                    fontFamily: "Arial, sans-serif",
+                    "& a": { color: "primary.light" },
+                    "& h1,h2": { fontFamily: "inherit" },
+                  };
                 }}
                 dangerouslySetInnerHTML={{ __html: previewHtml }}
               />

--- a/src/features/admin/components/sectionEventsManagerSurfaces/adminSurfacePrimitives.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/adminSurfacePrimitives.tsx
@@ -33,10 +33,6 @@ export function AdminAccordion({
         "&:before": {
           display: "none",
         },
-        "&:focus, &:focus-visible, &:focus-within": {
-          outline: "none",
-          boxShadow: "0 10px 28px rgba(15, 23, 42, 0.06)",
-        },
       }}
     >
       <AccordionSummary
@@ -47,19 +43,14 @@ export function AdminAccordion({
           minHeight: 58,
           px: 2.5,
           transition: "background-color 150ms ease",
-          outline: "none",
-          boxShadow: "none",
           "&:hover": {
             bgcolor: "action.hover",
           },
-          "&:focus, &:focus-visible, &:active": {
-            outline: "none",
-            boxShadow: "none",
-          },
           "&.Mui-focusVisible": {
-            bgcolor: "background.paper",
-            outline: "none",
-            boxShadow: "none",
+            bgcolor: "action.focus",
+            outline: "3px solid",
+            outlineColor: "primary.main",
+            outlineOffset: -3,
           },
           "& .MuiTouchRipple-root": {
             display: "none",

--- a/src/features/admin/utils/__tests__/govNotifyMarkdown.test.ts
+++ b/src/features/admin/utils/__tests__/govNotifyMarkdown.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
+import { getContrastRatio } from "@mui/material/styles";
 import {
   STANDARD_FOOTER,
   UNSUPPORTED_PATTERNS,
+  getGovNotifyPreviewColors,
   renderGovNotifyMarkdown,
 } from "../govNotifyMarkdown";
 
@@ -151,7 +153,14 @@ describe("renderGovNotifyMarkdown", () => {
   it("renders optional content with green highlight", () => {
     const html = renderGovNotifyMarkdown("((show_extra??Extra info here))");
     expect(html).toContain("Extra info here");
-    expect(html).toContain("e8f5e9");
+    expect(html).toContain("--notify-optional-bg");
+    expect(html).toContain("--notify-optional-text");
+  });
+
+  it("renders variable highlights with theme-aware text and background colours", () => {
+    const html = renderGovNotifyMarkdown("Dear ((firstName)),");
+    expect(html).toContain("--notify-variable-bg");
+    expect(html).toContain("--notify-variable-text");
   });
 
   it("does not render H3 as heading", () => {
@@ -203,4 +212,20 @@ describe("renderGovNotifyMarkdown", () => {
     expect(html).toContain("<ul");
     expect(html).toContain("<a href=\"#\">Unsubscribe</a>");
   });
+});
+
+describe("getGovNotifyPreviewColors", () => {
+  it.each(["light", "dark"] as const)(
+    "keeps optional and variable highlights readable in %s mode",
+    (mode) => {
+      const colors = getGovNotifyPreviewColors(mode);
+
+      expect(
+        getContrastRatio(colors.optionalText, colors.optionalBackground)
+      ).toBeGreaterThanOrEqual(4.5);
+      expect(
+        getContrastRatio(colors.variableText, colors.variableBackground)
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  );
 });

--- a/src/features/admin/utils/govNotifyMarkdown.ts
+++ b/src/features/admin/utils/govNotifyMarkdown.ts
@@ -24,6 +24,40 @@ export const STANDARD_FOOTER =
   "[Unsubscribe](((unsubscribeUrl)))\n\n" +
   "SODC";
 
+export interface GovNotifyPreviewColors {
+  optionalBackground: string;
+  optionalText: string;
+  optionalBorder: string;
+  variableBackground: string;
+  variableText: string;
+  divider: string;
+  insetText: string;
+}
+
+export function getGovNotifyPreviewColors(
+  mode: "light" | "dark"
+): GovNotifyPreviewColors {
+  return mode === "dark"
+    ? {
+        optionalBackground: "#1B5E20",
+        optionalText: "#E8F5E9",
+        optionalBorder: "#81C784",
+        variableBackground: "#665A00",
+        variableText: "#FFF8C5",
+        divider: "rgba(255, 255, 255, 0.23)",
+        insetText: "rgba(255, 255, 255, 0.7)",
+      }
+    : {
+        optionalBackground: "#E8F5E9",
+        optionalText: "#1B5E20",
+        optionalBorder: "#66BB6A",
+        variableBackground: "#FFDD00",
+        variableText: "#0B0C0C",
+        divider: "#B1B4B6",
+        insetText: "#505A5F",
+      };
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")
@@ -51,7 +85,7 @@ function renderInline(line: string): string {
     if (match[1] !== undefined) {
       // ((var??optional text))
       parts.push(
-        `<span style="background:#e8f5e9;padding:0 2px;border:1px dashed #66bb6a">${escapeHtml(match[2])}</span>`
+        `<span style="background:var(--notify-optional-bg,#E8F5E9);color:var(--notify-optional-text,#1B5E20);padding:0 2px;border:1px dashed var(--notify-optional-border,#66BB6A)">${escapeHtml(match[2])}</span>`
       );
     } else if (match[3] !== undefined) {
       // [text](((var))) — personalisation variable as URL
@@ -62,7 +96,7 @@ function renderInline(line: string): string {
     } else if (match[7] !== undefined) {
       // ((variable))
       parts.push(
-        `<mark style="background:#ffdd00;padding:0 2px">${escapeHtml(match[7])}</mark>`
+        `<mark style="background:var(--notify-variable-bg,#FFDD00);color:var(--notify-variable-text,#0B0C0C);padding:0 2px">${escapeHtml(match[7])}</mark>`
       );
     }
 
@@ -104,7 +138,7 @@ export function renderGovNotifyMarkdown(body: string): string {
     if (/^---+$/.test(line)) {
       closeList();
       parts.push(
-        `<hr style="border:none;border-top:1px solid #b1b4b6;margin:1.5em 0" />`
+        `<hr style="border:none;border-top:1px solid var(--notify-divider,#B1B4B6);margin:1.5em 0" />`
       );
       continue;
     }
@@ -113,7 +147,7 @@ export function renderGovNotifyMarkdown(body: string): string {
     if (line.startsWith("^")) {
       closeList();
       parts.push(
-        `<div style="border-left:5px solid #b1b4b6;padding-left:1em;margin:1em 0;color:#505a5f">${renderInline(line.slice(1).trim())}</div>`
+        `<div style="border-left:5px solid var(--notify-divider,#B1B4B6);padding-left:1em;margin:1em 0;color:var(--notify-inset-text,#505A5F)">${renderInline(line.slice(1).trim())}</div>`
       );
       continue;
     }

--- a/src/features/auth/components/ProfileCompletion.tsx
+++ b/src/features/auth/components/ProfileCompletion.tsx
@@ -308,6 +308,7 @@ export default function ProfileCompletion({
               }
               sx={{
                 backgroundColor: "secondary.main",
+                color: "secondary.contrastText",
                 "&:hover": {
                   backgroundColor: "secondary.main",
                   opacity: 0.9,

--- a/src/features/profile/components/EditUserDialog.tsx
+++ b/src/features/profile/components/EditUserDialog.tsx
@@ -259,20 +259,22 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
           maxHeight: "70vh",
           overflowY: "auto",
           overflowX: "hidden",
+          scrollbarColor: (theme) =>
+            `${theme.palette.text.disabled} ${theme.palette.action.hover}`,
           pr: 1, // Padding for scrollbar
           // Ensure scrollbar is always visible when content overflows
           "&::-webkit-scrollbar": {
             width: "8px",
           },
           "&::-webkit-scrollbar-track": {
-            backgroundColor: "rgba(0, 0, 0, 0.05)",
+            backgroundColor: "action.hover",
             borderRadius: "4px",
           },
           "&::-webkit-scrollbar-thumb": {
-            backgroundColor: "rgba(0, 0, 0, 0.2)",
+            backgroundColor: "text.disabled",
             borderRadius: "4px",
             "&:hover": {
-              backgroundColor: "rgba(0, 0, 0, 0.3)",
+              backgroundColor: "text.secondary",
             },
           },
         }}
@@ -450,6 +452,7 @@ export default function EditUserDialog({ open, user, onClose, onSave, onSuccess 
           disabled={submitting || loading || !firstName.trim() || !lastName.trim() || !email.trim() || !serviceNumber.trim()}
           sx={{
             backgroundColor: "secondary.main",
+            color: "secondary.contrastText",
             "&:hover": {
               backgroundColor: "secondary.main",
               opacity: 0.9,

--- a/src/features/profile/components/Profile.tsx
+++ b/src/features/profile/components/Profile.tsx
@@ -373,6 +373,7 @@ export default function Profile({ userData, userDataLoading = false, userEmail, 
               }
               sx={{
                 backgroundColor: "secondary.main",
+                color: "secondary.contrastText",
                 "&:hover": {
                   backgroundColor: "secondary.main",
                   opacity: 0.9,

--- a/src/features/sections/components/AdditionalGuestRequestSection.tsx
+++ b/src/features/sections/components/AdditionalGuestRequestSection.tsx
@@ -299,7 +299,7 @@ export default function AdditionalGuestRequestSection({
             variant="contained"
             onClick={() => void handleSubmit()}
             disabled={submitting}
-            sx={{ backgroundColor: "secondary.main" }}
+            sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
           >
             {submitting ? "Submitting…" : "Submit request"}
           </Button>

--- a/src/features/sections/components/EventBookingStatusSummary.tsx
+++ b/src/features/sections/components/EventBookingStatusSummary.tsx
@@ -195,7 +195,7 @@ export default function EventBookingStatusSummary({
             variant="contained"
             disabled={payingTicketTypeId === paymentSummary.unpaidTicketTypeId}
             onClick={() => onPayNow?.(paymentSummary.unpaidTicketTypeId as string)}
-            sx={{ backgroundColor: "secondary.main" }}
+            sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
           >
             {payingTicketTypeId === paymentSummary.unpaidTicketTypeId ? "Starting checkout…" : "Pay for all tickets"}
           </Button>

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -257,7 +257,7 @@ export default function EventBookingWizard({
                   variant="contained"
                   onClick={w.handleNext}
                   disabled={w.submitting || w.payingAllTickets}
-                  sx={{ backgroundColor: "secondary.main" }}
+                  sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
                 >
                   Next
                 </Button>
@@ -268,7 +268,7 @@ export default function EventBookingWizard({
                   variant="contained"
                   onClick={() => void w.handleConfirm()}
                   disabled={w.submitting}
-                  sx={{ backgroundColor: "secondary.main" }}
+                  sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
                 >
                   {w.submitting
                     ? "Submitting…"
@@ -280,7 +280,11 @@ export default function EventBookingWizard({
                 </Button>
               ) : null}
               {w.wizardMode === "full" && w.activeStep === 4 ? (
-                <Button variant="contained" onClick={w.closeWizard} sx={{ backgroundColor: "secondary.main" }}>
+                <Button
+                  variant="contained"
+                  onClick={w.closeWizard}
+                  sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
+                >
                   Done
                 </Button>
               ) : null}

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -75,7 +75,7 @@ export function SectionDescriptionHeader({
               color="primary"
               onClick={onSubscribe}
               disabled={subscribing}
-              sx={{ backgroundColor: "secondary.main" }}
+              sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
             >
               {subscribing ? "Subscribing..." : "Subscribe"}
             </Button>
@@ -357,15 +357,7 @@ export function SectionEventDetailView({
             <Tabs
               value={activeTab}
               onChange={(_, v: EventDetailTab) => setActiveTab(v)}
-              sx={{
-                mb: 2,
-                borderBottom: 1,
-                borderColor: "divider",
-                "& .MuiTab-root": {
-                  "&:focus": { outline: "none" },
-                  "&:focus-visible": { outline: "none" },
-                },
-              }}
+              sx={{ mb: 2, borderBottom: 1, borderColor: "divider" }}
             >
               <Tab label={eventDetailTabLabel("about")} value="about" />
               <Tab label={eventDetailTabLabel("book")} value="book" />
@@ -380,7 +372,7 @@ export function SectionEventDetailView({
                   <Button
                     variant="contained"
                     onClick={handleGoToBook}
-                    sx={{ backgroundColor: "secondary.main" }}
+                    sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
                   >
                     {hasExistingBooking ? "View my booking" : "Book this event"}
                   </Button>

--- a/src/features/sections/components/wizardSteps/PaymentStep.tsx
+++ b/src/features/sections/components/wizardSteps/PaymentStep.tsx
@@ -69,7 +69,7 @@ export default function PaymentStep({
           variant="contained"
           disabled={payingAllTickets}
           onClick={onPayAllTickets}
-          sx={{ mt: 1, backgroundColor: "secondary.main" }}
+          sx={{ mt: 1, backgroundColor: "secondary.main", color: "secondary.contrastText" }}
         >
           {payingAllTickets ? "Starting checkout…" : "Pay for all tickets"}
         </Button>

--- a/src/features/users/components/AccountStatusMessage.tsx
+++ b/src/features/users/components/AccountStatusMessage.tsx
@@ -83,7 +83,7 @@ export default function AccountStatusMessage({ userData }: AccountStatusMessageP
             variant="contained"
             onClick={handleSignOut}
             disabled={submitting}
-            sx={{ backgroundColor: "secondary.main" }}
+            sx={{ backgroundColor: "secondary.main", color: "secondary.contrastText" }}
           >
             Sign out
           </Button>
@@ -92,4 +92,3 @@ export default function AccountStatusMessage({ userData }: AccountStatusMessageP
     </Box>
   );
 }
-

--- a/src/features/welcome/components/PublicHomePage.tsx
+++ b/src/features/welcome/components/PublicHomePage.tsx
@@ -48,7 +48,11 @@ export default function PublicHomePage({ onJoinClick, onLogInClick }: PublicHome
           variant="contained"
           size="large"
           onClick={onJoinClick}
-          sx={{ backgroundColor: "secondary.main", "&:hover": { backgroundColor: "secondary.main" } }}
+          sx={{
+            backgroundColor: "secondary.main",
+            color: "secondary.contrastText",
+            "&:hover": { backgroundColor: "secondary.main" },
+          }}
         >
           Join SODC
         </Button>

--- a/src/shared/components/AppSideNav.tsx
+++ b/src/shared/components/AppSideNav.tsx
@@ -92,7 +92,8 @@ export default function AppSideNav({ sections, adminLinks, pathname }: AppSideNa
         "& .MuiDrawer-paper": {
           width: drawerWidth,
           boxSizing: "border-box",
-          borderRight: "1px solid rgba(0,0,0,0.08)",
+          borderRight: "1px solid",
+          borderRightColor: "divider",
           top: `${headerHeight}px`,
           height: `calc(100% - ${headerHeight}px)`,
         },

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -5,6 +5,7 @@ import { signOut, type User } from "firebase/auth";
 import { auth } from "../../config/firebase";
 import type { UserData } from "../../types";
 import { useEnabledClaim } from "../../features/users/hooks/useEnabledClaim";
+import { BRAND_PRIMARY, BRAND_SECONDARY } from "../../config/theme";
 
 interface HeaderProps {
   user: User | null;
@@ -98,10 +99,15 @@ export default function Header({
     <AppBar
       position="fixed"
       sx={{
-        backgroundColor: "primary.main",
+        backgroundColor: BRAND_PRIMARY,
         top: 0,
         left: 0,
         right: 0,
+        "& .MuiButtonBase-root.Mui-focusVisible": {
+          outline: "3px solid",
+          outlineColor: "common.white",
+          outlineOffset: 2,
+        },
       }}
     >
       <Toolbar>
@@ -175,7 +181,7 @@ export default function Header({
               <Avatar
                 sx={{
                   flexShrink: 0,
-                  backgroundColor: "secondary.main",
+                  backgroundColor: BRAND_SECONDARY,
                   color: "white",
                   width: 40,
                   height: 40,
@@ -229,99 +235,44 @@ export default function Header({
               }}
             >
               {isEnabled && (
-                <MenuItem
-                  onClick={handleProfile}
-                  sx={{
-                    "&:focus": {
-                      outline: "none",
-                    },
-                    "&:focus-visible": {
-                      outline: "none",
-                    },
-                  }}
-                >
+                <MenuItem onClick={handleProfile}>
                   Profile
                 </MenuItem>
               )}
               {isEnabled && (
-                <MenuItem
-                  onClick={handleAccountSettings}
-                  sx={{
-                    "&:focus": {
-                      outline: "none",
-                    },
-                    "&:focus-visible": {
-                      outline: "none",
-                    },
-                  }}
-                >
+                <MenuItem onClick={handleAccountSettings}>
                   Account
                 </MenuItem>
               )}
               {isEnabled && (
-                <MenuItem
-                  onClick={handleMyBookings}
-                  sx={{
-                    "&:focus": {
-                      outline: "none",
-                    },
-                    "&:focus-visible": {
-                      outline: "none",
-                    },
-                  }}
-                >
+                <MenuItem onClick={handleMyBookings}>
                   My Bookings
                 </MenuItem>
               )}
               {isEnabled && (
-                <MenuItem
-                  onClick={handleMyPayments}
-                  sx={{
-                    "&:focus": {
-                      outline: "none",
-                    },
-                    "&:focus-visible": {
-                      outline: "none",
-                    },
-                  }}
-                >
+                <MenuItem onClick={handleMyPayments}>
                   My Payments
                 </MenuItem>
               )}
-              <MenuItem
-                onClick={handleLogOut}
-                sx={{
-                  "&:focus": {
-                    outline: "none",
-                  },
-                  "&:focus-visible": {
-                    outline: "none",
-                  },
-                }}
-              >
+              <MenuItem onClick={handleLogOut}>
                 Sign out
               </MenuItem>
             </Menu>
           </>
         ) : (
-          <Box sx={{ display: "flex", gap: 1 }}>
+          <Box sx={{ display: "flex", gap: { xs: 0.5, sm: 1 } }}>
             <Button
               onClick={onAccountClick}
               sx={{
                 textTransform: "none",
                 backgroundColor: "white",
-                color: "primary.main",
+                color: BRAND_PRIMARY,
                 borderRadius: "9999px",
-                px: 3,
+                px: { xs: 2, sm: 3 },
+                whiteSpace: "nowrap",
                 "&:hover": {
                   backgroundColor: "white",
                   opacity: 0.9,
-                },
-                "&:focus": {
-                  outline: "none",
-                },
-                "&:focus-visible": {
-                  outline: "none",
                 },
               }}
             >
@@ -331,20 +282,16 @@ export default function Header({
               onClick={onJoinClick || onAccountClick}
               sx={{
                 textTransform: "none",
-                backgroundColor: "secondary.main",
+                backgroundColor: BRAND_SECONDARY,
                 color: "white",
                 borderRadius: "9999px",
-                px: 3,
+                px: { xs: 2, sm: 3 },
+                whiteSpace: "nowrap",
                 "&:hover": {
-                  backgroundColor: "secondary.main",
+                  backgroundColor: BRAND_SECONDARY,
                   opacity: 0.9,
                 },
-                "&:focus": {
-                  outline: "none",
-                },
-                "&:focus-visible": {
-                  outline: "none",
-                },
+                border: "1px solid rgba(255, 255, 255, 0.72)",
               }}
             >
               Join


### PR DESCRIPTION
## Summary

- use accessible dark-mode palette values for interactive primary and secondary controls while preserving brand surfaces
- restore visible keyboard focus states across the header, tabs, and admin accordions
- make borders, scrollbars, secondary action labels, and GOV.UK Notify previews theme-aware
- prevent compact mobile header actions from wrapping
- add contrast and focus regression coverage

## Root cause

The fixed brand colours were also being used as interactive colours against dark backgrounds, producing insufficient contrast. Several component overrides additionally removed focus outlines or used light-theme-only border and preview colours.

## Impact

Dark-mode actions, links, focus states, admin surfaces, and email previews are now readable and discoverable. Light mode retains the existing brand appearance.

## Validation

- `npm run test:run` — 763 tests passed
- `npm run lint`
- `npm run build`
- desktop and 390px mobile visual review in light and dark modes

Closes #534