### PR TITLE
Store member dietary notes on ticket lines

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -1992,7 +1992,6 @@ mutation UpsertPaymentReconciliationException(
 
 mutation UpdateBookingPreferencesFromCallable(
   $id: UUID!
-  $bookerDietaryNote: String
   $sitNextToUserIds: [String!]
   $accommodationRequested: Boolean!
   $accommodationNote: String
@@ -2000,7 +1999,6 @@ mutation UpdateBookingPreferencesFromCallable(
   booking_update(
     id: $id
     data: {
-      bookerDietaryNote: $bookerDietaryNote
       sitNextToUserIds: $sitNextToUserIds
       accommodationRequested: $accommodationRequested
       accommodationNote: $accommodationNote

--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -624,6 +624,14 @@ query ListEventBookingsForAdmin($eventId: UUID!) @auth(expr: "auth.token.admin =
       }
       lines: bookingLines_on_booking {
         id
+        sortOrder
+        guestDisplayName
+        dietaryNote
+        guestUser {
+          id
+          firstName
+          lastName
+        }
         ticketType {
           id
           title

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -484,8 +484,10 @@ type Booking @table @unique(fields: ["event", "booker", "clientSubmissionKey"]) 
   approvalReviewedBy: User
   approvalReviewedAt: Timestamp
   approvalNote: String
-  # Booker-level preferences captured during booking flow (#49).
+  # Legacy read fallback only. New submissions store every attendee's dietary
+  # requirements on their BookingLine; removed with legacy rows in #548.
   bookerDietaryNote: String
+  # Booker-level preferences captured during booking flow (#49).
   sitNextToUserIds: [String!]
   accommodationRequested: Boolean! @default(value: false)
   accommodationNote: String

--- a/docs/architecture/booking-data-model.md
+++ b/docs/architecture/booking-data-model.md
@@ -8,6 +8,7 @@ Persistence for member ticket booking. The current redesign is tracked by epic [
 - **Legacy null policy**: the #543 migration backfills any existing null limit to `0` before applying `NOT NULL`, which fails closed by requiring approval for every guest booking until an organiser chooses another value.
 - **Ticket types**: each `TicketType` has **`audience: TicketAudience`** (**`MEMBER`** | **`GUEST`**). Validation in the booking rules layer must prevent booking a `GUEST` type against the member line and vice versa; pricing can differ per type.
 - **Uniform guest representation**: every guest is a `BookingLine` whose ticket type has `GUEST` audience. There is no separate representation for the first guest in the redesigned contract.
+- **Dietary requirements**: every attendee's dietary note belongs to their `BookingLine`, including the member ticket. `Booking.bookerDietaryNote` is a temporary legacy read fallback only and is removed by #548.
 - **Whole-booking approval**: `Booking.approvalStatus` applies to one exact booking revision and is separate from booking lifecycle and payment state.
 - **Reapproval**: adding/removing a guest, changing guest identity/name, or changing guest ticket type is approval-relevant. Dietary-only edits and guest ordering are not.
 - **Guest removal and payment**: a member may remove a guest only when that guest place has no paid allocation. Paid guest removal is blocked until the later refund workflow is implemented.
@@ -77,7 +78,7 @@ erDiagram
     string approval_reviewed_by_user_id "nullable"
     timestamp approval_reviewed_at "nullable"
     string approval_note "nullable"
-    string booker_dietary_note "nullable"
+    string booker_dietary_note "legacy nullable fallback; removed by #548"
     string[] sit_next_to_user_ids "nullable list of user ids"
     boolean accommodation_requested "default false"
     string accommodation_note "nullable"
@@ -133,7 +134,7 @@ erDiagram
 | **Event → guest policy** | Required per-event limit on guest places that can proceed without moderator approval. |
 | **Booking** | One **booker** (`User`) for one **event/revision**; owns lifecycle and whole-revision approval state plus booker preferences. |
 | **BookingPlace** | Durable identity for one member/guest ticket within an event. It survives revisions and is the target for payment allocation and future refunds. |
-| **BookingLine** | Revision snapshot of one priced place. New lines reference `BookingPlace`; the relation is temporarily nullable only for legacy rows/write paths removed by #548. |
+| **BookingLine** | Revision snapshot of one priced place, including that attendee's dietary note. New lines reference `BookingPlace`; the relation is temporarily nullable only for legacy rows/write paths removed by #548. |
 | **BookingPlacePaymentAllocation** | Attributes an order amount directly to `BookingPlace`, so revisions never rewrite payment history and deletion/refunds are evaluated per ticket rather than by ticket-type totals. |
 | **GuestTicketRequest** | Legacy split representation only. New submission and moderation contracts use `BookingLine` and `Booking.approvalStatus`; removal is tracked by #548. |
 

--- a/docs/operations/govuk-notify-booking-templates.md
+++ b/docs/operations/govuk-notify-booking-templates.md
@@ -31,7 +31,7 @@ Also required: `GOV_NOTIFY_LIVE_API_KEY` (secret), optional `GOV_NOTIFY_EMAIL_RE
 | `eventDateTime` | Formatted start/end (en-GB) |
 | `eventLocation` | Location or `To be confirmed` |
 | `ticketLinesSummary` | Multiline bullet list of lines |
-| `bookerDietaryNote` | Booker dietary note or `None provided` |
+| `bookerDietaryNote` | Member ticket line dietary note or `None provided` (legacy variable name retained for template compatibility) |
 | `accommodationSummary` | `Not requested` or `Requested — {note}` |
 | `bookingTotalFormatted` | Sum of line prices, e.g. `£35.00` |
 | `sectionBookingsUrl` | `APP_BASE_URL/sections/{sectionId}` |

--- a/functions/src/__tests__/bookingEmailDispatcher.test.ts
+++ b/functions/src/__tests__/bookingEmailDispatcher.test.ts
@@ -21,7 +21,7 @@ const sampleLines = [
   {
     sortOrder: 0,
     guestDisplayName: null,
-    dietaryNote: null,
+    dietaryNote: "No nuts",
     ticketType: { title: "Member ticket", audience: "MEMBER", price: 25 },
   },
   {
@@ -129,6 +129,7 @@ describe("notifyBookingConfirmationEmail", () => {
         personalisation: expect.objectContaining({
           firstName: "Sam",
           eventTitle: "Annual dinner",
+          bookerDietaryNote: "No nuts",
           sectionBookingsUrl: "https://app.example/sections/sec-1",
           myPaymentsUrl: "https://app.example/payments",
         }),

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -298,4 +298,16 @@ describe("GQL schema integrity", () => {
     expect(allocationBlock).not.toContain("bookingPlaceKey");
     expect(allocationBlock).toContain("allocatedAmountMinor: Int!");
   });
+
+  it("stores dietary requirements on each attendee ticket line", () => {
+    const schema = readSchemaFile();
+    const lineStart = schema.indexOf("type BookingLine @table");
+    const lineEnd = schema.indexOf("\n}", lineStart);
+    expect(schema.slice(lineStart, lineEnd + 2)).toContain("dietaryNote: String");
+
+    const mutations = readApiFile("admin-mutations.gql");
+    const preferencesStart = mutations.indexOf("mutation UpdateBookingPreferencesFromCallable");
+    const preferencesEnd = mutations.indexOf("\n}", preferencesStart);
+    expect(mutations.slice(preferencesStart, preferencesEnd + 2)).not.toContain("bookerDietaryNote");
+  });
 });

--- a/functions/src/bookingEmailDispatcher.ts
+++ b/functions/src/bookingEmailDispatcher.ts
@@ -143,13 +143,18 @@ function buildBasePersonalisation(args: {
   const base = normaliseAppBaseUrl(appBaseUrl);
   const fn = booking.booker.firstName?.trim();
   const totalMinor = bookingTotalMinorFromLines(booking.lines);
+  const memberDietaryNote = booking.lines.find(
+    (line) => line.ticketType.audience === "MEMBER"
+  )?.dietaryNote;
   return {
     firstName: fn && fn.length > 0 ? fn : "Member",
     eventTitle: booking.event.title ?? "—",
     eventDateTime: formatBookingEventDateTime(booking.event.startDateTime, booking.event.endDateTime),
     eventLocation: booking.event.location?.trim() || "To be confirmed",
     ticketLinesSummary: buildTicketLinesSummary(booking.lines),
-    bookerDietaryNote: booking.bookerDietaryNote?.trim() || "None provided",
+    // Keep the Notify variable name stable while legacy templates are in use;
+    // the source of truth is the member ticket line.
+    bookerDietaryNote: memberDietaryNote?.trim() || booking.bookerDietaryNote?.trim() || "None provided",
     accommodationRequested: accommodationRequestedCondition(booking.accommodationRequested),
     bookingTotalFormatted: formatMinorCurrency(totalMinor, "GBP"),
     sectionBookingsUrl: `${base}/sections/${booking.event.section.id}`,

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -170,7 +170,6 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
   const baseRevisionNumber =
     baseRevisionNumberRaw == null ? undefined : Number.isInteger(Number(baseRevisionNumberRaw)) ? Number(baseRevisionNumberRaw) : undefined;
   const lines = parseBookingLines(request.data?.lines);
-  const bookerDietaryNote = parseOptionalString(request.data?.bookerDietaryNote, 500);
   const sitNextToUserIds = parseSitNextTo(request.data?.sitNextToUserIds, uid);
   const accommodationRequested = request.data?.accommodationRequested === true;
   const accommodationNote = parseOptionalString(request.data?.accommodationNote, 500);
@@ -377,7 +376,6 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
 
     await updateBookingPreferencesFromCallable({
       id: bookingId as UUIDString,
-      bookerDietaryNote,
       sitNextToUserIds,
       accommodationRequested,
       accommodationNote: accommodationRequested ? accommodationNote : null,

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -2436,6 +2436,14 @@ export interface ListEventBookingsForAdminData {
       } & GuestTicketRequest_Key)[];
       lines: ({
         id: UUIDString;
+        sortOrder: number;
+        guestDisplayName?: string | null;
+        dietaryNote?: string | null;
+        guestUser?: {
+          id: string;
+          firstName: string;
+          lastName: string;
+        } & User_Key;
         ticketType: {
           id: UUIDString;
           title: string;
@@ -3333,7 +3341,6 @@ export interface UpdateBookingPreferencesFromCallableData {
 
 export interface UpdateBookingPreferencesFromCallableVariables {
   id: UUIDString;
-  bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[] | null;
   accommodationRequested: boolean;
   accommodationNote?: string | null;

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -9046,6 +9046,14 @@ export interface ListEventBookingsForAdminData {
       } & GuestTicketRequest_Key)[];
       lines: ({
         id: UUIDString;
+        sortOrder: number;
+        guestDisplayName?: string | null;
+        dietaryNote?: string | null;
+        guestUser?: {
+          id: string;
+          firstName: string;
+          lastName: string;
+        } & User_Key;
         ticketType: {
           id: UUIDString;
           title: string;
@@ -16371,7 +16379,6 @@ The `UpdateBookingPreferencesFromCallable` mutation requires an argument of type
 ```typescript
 export interface UpdateBookingPreferencesFromCallableVariables {
   id: UUIDString;
-  bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[] | null;
   accommodationRequested: boolean;
   accommodationNote?: string | null;
@@ -16395,7 +16402,6 @@ import { connectorConfig, updateBookingPreferencesFromCallable, UpdateBookingPre
 // The `UpdateBookingPreferencesFromCallable` mutation requires an argument of type `UpdateBookingPreferencesFromCallableVariables`:
 const updateBookingPreferencesFromCallableVars: UpdateBookingPreferencesFromCallableVariables = {
   id: ..., 
-  bookerDietaryNote: ..., // optional
   sitNextToUserIds: ..., // optional
   accommodationRequested: ..., 
   accommodationNote: ..., // optional
@@ -16405,7 +16411,7 @@ const updateBookingPreferencesFromCallableVars: UpdateBookingPreferencesFromCall
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await updateBookingPreferencesFromCallable(updateBookingPreferencesFromCallableVars);
 // Variables can be defined inline as well.
-const { data } = await updateBookingPreferencesFromCallable({ id: ..., bookerDietaryNote: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
+const { data } = await updateBookingPreferencesFromCallable({ id: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -16429,7 +16435,6 @@ import { connectorConfig, updateBookingPreferencesFromCallableRef, UpdateBooking
 // The `UpdateBookingPreferencesFromCallable` mutation requires an argument of type `UpdateBookingPreferencesFromCallableVariables`:
 const updateBookingPreferencesFromCallableVars: UpdateBookingPreferencesFromCallableVariables = {
   id: ..., 
-  bookerDietaryNote: ..., // optional
   sitNextToUserIds: ..., // optional
   accommodationRequested: ..., 
   accommodationNote: ..., // optional
@@ -16438,7 +16443,7 @@ const updateBookingPreferencesFromCallableVars: UpdateBookingPreferencesFromCall
 // Call the `updateBookingPreferencesFromCallableRef()` function to get a reference to the mutation.
 const ref = updateBookingPreferencesFromCallableRef(updateBookingPreferencesFromCallableVars);
 // Variables can be defined inline as well.
-const ref = updateBookingPreferencesFromCallableRef({ id: ..., bookerDietaryNote: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
+const ref = updateBookingPreferencesFromCallableRef({ id: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -2459,6 +2459,14 @@ export interface ListEventBookingsForAdminData {
       } & GuestTicketRequest_Key)[];
       lines: ({
         id: UUIDString;
+        sortOrder: number;
+        guestDisplayName?: string | null;
+        dietaryNote?: string | null;
+        guestUser?: {
+          id: string;
+          firstName: string;
+          lastName: string;
+        } & User_Key;
         ticketType: {
           id: UUIDString;
           title: string;
@@ -3356,7 +3364,6 @@ export interface UpdateBookingPreferencesFromCallableData {
 
 export interface UpdateBookingPreferencesFromCallableVariables {
   id: UUIDString;
-  bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[] | null;
   accommodationRequested: boolean;
   accommodationNote?: string | null;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -7194,6 +7194,14 @@ export interface ListEventBookingsForAdminData {
       } & GuestTicketRequest_Key)[];
       lines: ({
         id: UUIDString;
+        sortOrder: number;
+        guestDisplayName?: string | null;
+        dietaryNote?: string | null;
+        guestUser?: {
+          id: string;
+          firstName: string;
+          lastName: string;
+        } & User_Key;
         ticketType: {
           id: UUIDString;
           title: string;
@@ -13300,7 +13308,6 @@ The `UpdateBookingPreferencesFromCallable` Mutation requires an argument of type
 ```javascript
 export interface UpdateBookingPreferencesFromCallableVariables {
   id: UUIDString;
-  bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[] | null;
   accommodationRequested: boolean;
   accommodationNote?: string | null;
@@ -13354,14 +13361,13 @@ export default function UpdateBookingPreferencesFromCallableComponent() {
   // The `useUpdateBookingPreferencesFromCallable` Mutation requires an argument of type `UpdateBookingPreferencesFromCallableVariables`:
   const updateBookingPreferencesFromCallableVars: UpdateBookingPreferencesFromCallableVariables = {
     id: ..., 
-    bookerDietaryNote: ..., // optional
     sitNextToUserIds: ..., // optional
     accommodationRequested: ..., 
     accommodationNote: ..., // optional
   };
   mutation.mutate(updateBookingPreferencesFromCallableVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ id: ..., bookerDietaryNote: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
+  mutation.mutate({ id: ..., sitNextToUserIds: ..., accommodationRequested: ..., accommodationNote: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
+++ b/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
@@ -56,6 +56,7 @@ describe("bookingWizardModel", () => {
     expect(
       buildBookingSubmissionLines({
         memberTicketTypeId: "member-ticket",
+        memberDietaryNote: "  No nuts  ",
         includeGuest: true,
         guestTicketTypeId: "guest-ticket",
         guestDisplayName: "  Guest Name  ",
@@ -67,7 +68,7 @@ describe("bookingWizardModel", () => {
         sortOrder: 0,
         guestUserId: null,
         guestDisplayName: null,
-        dietaryNote: null,
+        dietaryNote: "No nuts",
       },
       {
         ticketTypeId: "guest-ticket",

--- a/src/features/sections/hooks/bookingWizardModel.ts
+++ b/src/features/sections/hooks/bookingWizardModel.ts
@@ -93,6 +93,7 @@ export function guestDetailsValidationError(args: {
 
 export function buildBookingSubmissionLines(args: {
   memberTicketTypeId: string;
+  memberDietaryNote: string;
   includeGuest: boolean;
   guestTicketTypeId: string | null;
   guestDisplayName: string;
@@ -104,7 +105,7 @@ export function buildBookingSubmissionLines(args: {
       sortOrder: 0,
       guestUserId: null,
       guestDisplayName: null,
-      dietaryNote: null,
+      dietaryNote: args.memberDietaryNote.trim() || null,
     },
   ];
   if (args.includeGuest && args.guestTicketTypeId) {

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -348,6 +348,7 @@ export function useBookingWizardState({
 
       const lines = buildBookingSubmissionLines({
         memberTicketTypeId,
+        memberDietaryNote: bookerDietaryNote,
         includeGuest,
         guestTicketTypeId,
         guestDisplayName,
@@ -360,7 +361,6 @@ export function useBookingWizardState({
         baseBookingId: existingTerminalBooking?.id,
         baseRevisionNumber: existingTerminalBooking?.revisionNumber,
         lines,
-        bookerDietaryNote,
         sitNextToUserIds,
         accommodationRequested,
         accommodationNote: null,

--- a/src/features/sections/utils/bookingWizardHydration.ts
+++ b/src/features/sections/utils/bookingWizardHydration.ts
@@ -84,7 +84,7 @@ export function hydrateFormFromExistingBooking(booking: BookingRow): WizardFormS
     extraGuestDetails: Array.from({ length: extraCount }, (_, index) =>
       flattenedExtraGuests[index] ?? { guestDisplayName: "", dietaryNote: "" }
     ),
-    bookerDietaryNote: booking.bookerDietaryNote ?? "",
+    bookerDietaryNote: memberLine?.dietaryNote ?? booking.bookerDietaryNote ?? "",
     sitNextToUserIds: booking.sitNextToUserIds ?? [],
     accommodationRequested: booking.accommodationRequested === true,
   };

--- a/src/shared/utils/__tests__/firebaseFunctions.test.ts
+++ b/src/shared/utils/__tests__/firebaseFunctions.test.ts
@@ -358,8 +358,7 @@ describe("submitEventBooking", () => {
     const result = await submitEventBooking({
       idempotencyKey: BOOKING_UUID,
       eventId: EVENT_UUID,
-      lines: [{ ticketTypeId: TICKET_UUID, sortOrder: 1 }],
-      bookerDietaryNote: "  vegan  ",
+      lines: [{ ticketTypeId: TICKET_UUID, sortOrder: 1, dietaryNote: "  vegan  " }],
       sitNextToUserIds: ["  uid-1  ", "", "uid-2"],
       accommodationRequested: true,
       accommodationNote: "  ground floor  ",
@@ -367,7 +366,8 @@ describe("submitEventBooking", () => {
 
     expect(httpsCallable).toHaveBeenCalledWith(expect.anything(), "submitEventBooking");
     const sent = callable.mock.calls[0][0];
-    expect(sent.bookerDietaryNote).toBe("vegan");
+    expect(sent.lines[0].dietaryNote).toBe("vegan");
+    expect(sent).not.toHaveProperty("bookerDietaryNote");
     expect(sent.accommodationNote).toBe("ground floor");
     expect(sent.sitNextToUserIds).toEqual(["uid-1", "uid-2"]); // trimmed, blank filtered
     expect(result).toEqual({ bookingId: "b1", status: "CONFIRMED" });
@@ -385,7 +385,7 @@ describe("submitEventBooking", () => {
     const callable = vi.mocked(httpsCallable).mock.results[0].value;
     const sent = callable.mock.calls[0][0];
     expect(sent.accommodationRequested).toBe(false);
-    expect(sent.bookerDietaryNote).toBeNull();
+    expect(sent).not.toHaveProperty("bookerDietaryNote");
     expect(sent.accommodationNote).toBeNull();
     expect(sent.sitNextToUserIds).toEqual([]);
   });

--- a/src/shared/utils/firebaseFunctions/bookingPayments.ts
+++ b/src/shared/utils/firebaseFunctions/bookingPayments.ts
@@ -16,7 +16,6 @@ export interface SubmitEventBookingRequest {
   baseBookingId?: string;
   baseRevisionNumber?: number;
   lines: SubmitEventBookingLine[];
-  bookerDietaryNote?: string | null;
   sitNextToUserIds?: string[];
   accommodationRequested?: boolean;
   accommodationNote?: string | null;
@@ -77,8 +76,8 @@ export async function submitEventBooking(
     lines: payload.lines.map((line) => ({
       ...line,
       ticketTypeId: toCanonicalUuid(line.ticketTypeId),
+      dietaryNote: line.dietaryNote?.trim() || null,
     })),
-    bookerDietaryNote: payload.bookerDietaryNote?.trim() || null,
     sitNextToUserIds: (payload.sitNextToUserIds ?? []).map((id) => id.trim()).filter(Boolean),
     accommodationRequested: payload.accommodationRequested ?? false,
     accommodationNote: payload.accommodationNote?.trim() || null,


### PR DESCRIPTION
## Summary

- store the member's dietary requirements on their `BookingLine`, matching guest dietary storage
- stop new writes to legacy `Booking.bookerDietaryNote`
- retain a temporary read fallback for existing bookings until #548 removes the legacy field
- hydrate member dietary details from the member ticket line
- derive booking email dietary personalization from the member line, while preserving the existing Notify variable name
- expose attendee identity, ticket type, sort order, and dietary fields needed by the event-level ticket list planned in #547
- update generated Data Connect SDKs, tests, and architecture/Notify documentation

## Why

PR #551 was merged before its final dietary-note commit was included. GitHub cannot reopen a merged pull request, so this focused follow-up applies only that omitted commit to the updated epic branch.

Dietary requirements belong to the attendee ticket. Keeping both member and guest dietary notes on `BookingLine` gives every ticket a consistent attendee-level model and supports event ticket lists and dietary exports without special handling for the booker.

## Compatibility

`Booking.bookerDietaryNote` remains temporarily as a read-only fallback for legacy bookings. New submissions write dietary data only to the attendee's `BookingLine`. Issue #548 tracks removal of the fallback and legacy schema field.

## Validation

The resulting tree is identical to the previously validated post-#551 tree.

- `npm --prefix functions test` — 882 tests passed
- `npm test -- --run` — 763 tests passed
- `npm --prefix functions run build`
- `npm run build`
- `npm --prefix functions run lint`
- `npm run lint`
- `git diff --check`
- all GitHub Actions checks passed on the identical source tree

Follow-up to #551.
Part of #543 and #538.