### PR TITLE
Implement atomic booking submission and amendments

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -1344,6 +1344,13 @@ query GetBookingsForBookerAndEvent($bookerId: String!, $eventId: UUID!) @auth(le
         id
         bookingPlace {
           id
+          paymentAllocations: bookingPlacePaymentAllocations_on_bookingPlace {
+            id
+            ticketOrder {
+              id
+              status
+            }
+          }
         }
         sortOrder
         guestDisplayName

--- a/dataconnect/booking-service/booking-submission.gql
+++ b/dataconnect/booking-service/booking-submission.gql
@@ -1,0 +1,86 @@
+# Dynamic batch `_Data` variables are currently unsupported by the generated
+# JavaScript SDK, so these operations live in a server-only connector without
+# SDK generation. Cloud Functions invokes the named, schema-validated operation
+# with an explicit TypeScript contract. This preserves one database transaction
+# without using the Admin SDK's generic enum-bearing insertMany path.
+
+mutation CreateCompleteBookingFromCallable(
+  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
+  $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
+) @auth(level: NO_ACCESS) @transaction {
+  booking_insert(data: $booking)
+  bookingPlace_insertMany(data: $bookingPlaces)
+  bookingLine_insertMany(data: $bookingLines)
+}
+
+mutation CreateActiveBookingRevisionFromCallable(
+  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
+  $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
+  $revisionGroupId: UUID!
+  $bookingId: UUID!
+  $supersededBookingId: UUID!
+  $deltaAmountMinor: Int!
+  $adjustmentStatus: BookingPaymentAdjustmentStatus!
+  $orchestrationKey: String!
+) @auth(level: NO_ACCESS) @transaction {
+  booking_insert(data: $booking)
+  bookingPlace_insertMany(data: $bookingPlaces)
+  bookingLine_insertMany(data: $bookingLines)
+  retired: booking_updateMany(
+    where: {
+      revisionGroupId: { eq: $revisionGroupId }
+      id: { ne: $bookingId }
+      supersededAt: { isNull: true }
+    }
+    data: {
+      supersededAt_expr: "request.time"
+      updatedAt_expr: "request.time"
+      updatedBy: "system"
+    }
+  ) @check(expr: "this >= 1", message: "BOOKING_REVISION_CONFLICT")
+  bookingPaymentAdjustment_upsert(
+    data: {
+      revisionBookingId: $bookingId
+      supersededBookingId: $supersededBookingId
+      deltaAmountMinor: $deltaAmountMinor
+      status: $adjustmentStatus
+      orchestrationKey: $orchestrationKey
+      createdBy: "system"
+      updatedBy: "system"
+    }
+  )
+}
+
+mutation CreatePendingBookingRevisionFromCallable(
+  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
+  $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
+  $supersedesBookingId: UUID!
+) @auth(level: NO_ACCESS) @transaction {
+  booking_insert(data: $booking)
+  bookingPlace_insertMany(data: $bookingPlaces)
+  bookingLine_insertMany(data: $bookingLines)
+  booking_updateMany(
+    where: {
+      id: { eq: $supersedesBookingId }
+      approvalStatus: { in: [PENDING, REJECTED] }
+      supersededAt: { isNull: true }
+    }
+    data: {
+      supersededAt_expr: "request.time"
+      updatedAt_expr: "request.time"
+      updatedBy: "system"
+    }
+  )
+}
+
+# Temporary compatibility operation for the legacy additional-guest callable.
+# It removes the production-defective generic Admin insertMany enum path while
+# #548 completes removal of the split guest-request model.
+mutation CreateLegacyGuestTicketRequestsFromCallable(
+  $requests: [GuestTicketRequest_Data!]! @allow(fields: "id bookingId status requestedGuestCount guestTicketTypeId guestDisplayName dietaryNote reviewedById reviewedAt moderatorNote createdBy updatedBy", maxCount: 20)
+) @auth(level: NO_ACCESS) @transaction {
+  guestTicketRequest_insertMany(data: $requests)
+}

--- a/dataconnect/booking-service/connector.yaml
+++ b/dataconnect/booking-service/connector.yaml
@@ -1,0 +1,1 @@
+connectorId: booking-service

--- a/dataconnect/dataconnect.yaml
+++ b/dataconnect/dataconnect.yaml
@@ -10,4 +10,4 @@ schema:
         instanceId: "sodc-web-instance"
         # schemaValidation: "STRICT"     # STRICT mode makes Postgres schema match Data Connect exactly.
         # schemaValidation: "COMPATIBLE" # COMPATIBLE mode makes Postgres schema compatible with Data Connect.
-connectorDirs: ["./api"]
+connectorDirs: ["./api", "./booking-service"]

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -468,7 +468,10 @@ type TicketType @table {
 }
 
 # Booking - one booker per event per purchase flow. Idempotent submits use clientSubmissionKey (unique per event+booker+key).
-type Booking @table @unique(fields: ["event", "booker", "clientSubmissionKey"]) {
+type Booking
+  @table
+  @unique(fields: ["event", "booker", "clientSubmissionKey"])
+  @unique(fields: ["revisionGroupId", "revisionNumber"]) {
   id: UUID! @default(expr: "uuidV4()")
   event: Event!
   booker: User!

--- a/docs/architecture/booking-data-model.md
+++ b/docs/architecture/booking-data-model.md
@@ -1,6 +1,6 @@
 # Booking data model
 
-Persistence for member ticket booking. The current redesign is tracked by epic [#538](https://github.com/rafsodc/sodc-web/issues/538) and schema issue [#543](https://github.com/rafsodc/sodc-web/issues/543). The canonical schema is in [`dataconnect/schema/schema.gql`](../../dataconnect/schema/schema.gql); update this doc when behavior or naming changes.
+Persistence for member ticket booking. The current redesign is tracked by epic [#538](https://github.com/rafsodc/sodc-web/issues/538), schema issue [#543](https://github.com/rafsodc/sodc-web/issues/543), and atomic submission issue [#544](https://github.com/rafsodc/sodc-web/issues/544). The canonical schema is in [`dataconnect/schema/schema.gql`](../../dataconnect/schema/schema.gql); update this doc when behavior or naming changes.
 
 ## Decisions (from issue discussion)
 
@@ -73,6 +73,10 @@ erDiagram
     uuid event_id FK
     string booker_user_id FK
     string client_submission_key "nullable; unique with event+booker for idempotent submit"
+    uuid revision_group_id "unique with revision_number"
+    int revision_number "monotonic within group"
+    uuid supersedes_booking_id FK "nullable on initial revision"
+    timestamp superseded_at "nullable while active or pending"
     enum status "e.g. DRAFT | SUBMITTED | CONFIRMED | CANCELLED"
     enum approval_status "NOT_REQUIRED | PENDING | APPROVED | REJECTED"
     string approval_reviewed_by_user_id "nullable"
@@ -172,6 +176,23 @@ Free bookings skip Stripe and move to `CONFIRMED` once approval is `NOT_REQUIRED
 - Review audit fields belong to the exact revision reviewed. A later approval-relevant edit cannot reuse that decision.
 - Removing an unpaid guest is allowed and follows the normal approval-reset rules. Removing a guest with a paid allocation is rejected until the refund workflow exists.
 
+## Atomic submission contract
+
+`submitEventBooking` accepts the member line, every guest line, preferences, and the revision base in one request. It validates access, the booking window, ticket eligibility, guest identity fields, the guest threshold, and revision concurrency before writing.
+
+Persistence uses a named Data Connect operation with `@transaction` to insert the `Booking`, any new stable `BookingPlace` rows, and every revision-specific `BookingLine` together. An activating revision also retires prior unsuperseded rows and records its `BookingPaymentAdjustment` in that transaction. A pending revision does not retire the last approved/payable revision.
+
+The operations live in the server-only `booking-service` connector. Firebase currently supports typed `_Data` batch variables in Data Connect operations but does not generate JavaScript SDK wrappers for them, so Functions invokes the deployed, schema-validated named mutation with an explicit TypeScript variable contract. This is deliberately distinct from the Admin SDK generic `insertMany` API: enum-bearing booking and legacy guest-request values are interpreted through declared GraphQL input types, avoiding the quoted-enum production failure tracked in #538/#544.
+
+Each booking revision is unique on `(revisionGroupId, revisionNumber)`. Together with the idempotency uniqueness on `(event, booker, clientSubmissionKey)`, this makes concurrent stale submissions fail rather than create parallel revisions. A duplicate retry refetches and returns the already-committed outcome.
+
+The callable outcome is intentionally small:
+
+- `PENDING_APPROVAL` when the whole revision is above the guest threshold and needs review;
+- `READY_FOR_PAYMENT` when approval is not required or has been carried forward.
+
+Changing an attendee identity or ticket replaces the stable place. If the replaced/removed place has a `PAID` allocation, submission fails with `PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND`; dietary-only changes reuse the place.
+
 ## Related issues
 
 | Issue | Topic |
@@ -181,9 +202,10 @@ Free bookings skip Stripe and move to `CONFIRMED` once approval is `NOT_REQUIRED
 | [#48](https://github.com/rafsodc/sodc-web/issues/48) | Moderator approval for extra guests |
 | [#49](https://github.com/rafsodc/sodc-web/issues/49) | Dietary, seating, accommodation |
 | [#52](https://github.com/rafsodc/sodc-web/issues/52) | Parent epic |
+| [#544](https://github.com/rafsodc/sodc-web/issues/544) | Atomic complete-booking submission and amendments |
 
 ## Schema source of truth
 
-Canonical definitions: [`dataconnect/schema/schema.gql`](../../dataconnect/schema/schema.gql). Operations: [`dataconnect/api/queries.gql`](../../dataconnect/api/queries.gql), [`dataconnect/api/booking-mutations.gql`](../../dataconnect/api/booking-mutations.gql), and event/ticket admin mutations in [`dataconnect/api/user-group-mutations.gql`](../../dataconnect/api/user-group-mutations.gql).
+Canonical definitions: [`dataconnect/schema/schema.gql`](../../dataconnect/schema/schema.gql). Operations: [`dataconnect/api/queries.gql`](../../dataconnect/api/queries.gql), [`dataconnect/api/booking-mutations.gql`](../../dataconnect/api/booking-mutations.gql), atomic server writes in [`dataconnect/booking-service/booking-submission.gql`](../../dataconnect/booking-service/booking-submission.gql), and event/ticket admin mutations in [`dataconnect/api/user-group-mutations.gql`](../../dataconnect/api/user-group-mutations.gql).
 
 Server-side submission (rules + persistence): see [`booking-submission-api.md`](./booking-submission-api.md) (`submitEventBooking` callable, issue **#46**).

--- a/docs/architecture/booking-submission-api.md
+++ b/docs/architecture/booking-submission-api.md
@@ -1,6 +1,6 @@
 # Submit event booking (callable API)
 
-Server-side enforcement for issue **#46**. Member UI (**#47**) should call this instead of writing bookings directly via Data Connect.
+Server-side enforcement for issues **#46** and **#544**. Member UI submits the complete member-and-guest booking through this callable instead of writing bookings directly or following with a second guest-request call.
 
 For payment lifecycle transitions and webhook semantics, see
 `docs/architecture/payment-state-machine.md`.
@@ -19,28 +19,28 @@ For payment lifecycle transitions and webhook semantics, see
 |--------|------|------------|-------------|
 | `idempotencyKey` | string (UUID) | yes | **Per submit attempt** — generate a new UUID (v4) when the user commits; **reuse the same value** on retries after network errors so the server returns the same booking instead of creating another |
 | `eventId` | string (UUID) | yes | Event being booked |
-| `lines` | array | yes | Non-empty list of line items (see below) |
+| `lines` | array | yes | Complete list of 1–100 attendee line items (see below); exactly one member line and every guest line must be present |
 | `baseBookingId` | string (UUID) | no | Required for mutable-booking revision updates once a terminal revision exists |
 | `baseRevisionNumber` | integer | no | Required with `baseBookingId`; optimistic concurrency guard |
 
 ### Idempotency semantics
 
 - The database enforces **uniqueness of `(event, booker, clientSubmissionKey)`** on `Booking` (see `dataconnect/schema/schema.gql`). The callable maps `idempotencyKey` → `clientSubmissionKey`.
-- **Replay (success, no duplicate writes):** If a **SUBMITTED** or **CONFIRMED** booking already exists for this event and booker with the same `idempotencyKey`, the callable returns **`idempotentReplay: true`** and the existing `bookingId` / `status`.
+- **Replay (success, no duplicate writes):** If a **SUBMITTED** or **CONFIRMED** booking already exists for this event and booker with the same `idempotencyKey`, the callable returns **`idempotentReplay: true`** and the existing outcome.
 - **Revision lineage:** Bookings now carry `revisionGroupId`, `revisionNumber`, and optional `supersedesBookingId`.
-- **Optimistic concurrency:** When terminal revisions already exist, caller must provide `baseBookingId` + `baseRevisionNumber` for the latest terminal revision. Stale base inputs fail with conflict semantics.
-- **Draft conflict:** If a **DRAFT** exists for this event with a **different** `clientSubmissionKey` (including legacy drafts with a null key), the call fails with `IDEMPOTENCY_DRAFT_CONFLICT` until that draft is cleared or the client retries with the matching key.
-- **Concurrent creates:** If two requests race with the same key, one insert wins; the other may hit a unique violation, refetch, and continue using the winner’s draft (or replay if already completed).
+- **Optimistic concurrency:** When terminal revisions already exist, caller must provide `baseBookingId` + `baseRevisionNumber` for the latest terminal revision. The database also enforces uniqueness of `(revisionGroupId, revisionNumber)`, so two concurrent amendments from one base cannot both commit.
+- **No partial draft:** The booking, new stable places, and all lines commit in one Data Connect transaction directly to `SUBMITTED`. A failed transaction leaves none of those rows behind.
+- **Legacy draft conflict:** Pre-redesign DRAFT rows fail with `IDEMPOTENCY_DRAFT_CONFLICT` until final migration/cleanup in #548.
 
 ### Line object
 
 | Field | Type | Required | Description |
 |--------|------|------------|-------------|
 | `ticketTypeId` | string (UUID) | yes | Must belong to the event |
-| `sortOrder` | integer | yes | Sort key; member lines should sort before guest lines |
+| `sortOrder` | integer | yes | Sort key; the member line must sort before guest lines |
 | `guestUserId` | string \| null | no | Linked guest user (Firebase UID), for guest-priced lines |
 | `guestDisplayName` | string \| null | no | Free-text guest label when not linking a user |
-| `dietaryNote` | string \| null | no | Optional note (validation expanded in #49) |
+| `dietaryNote` | string \| null | no | Optional attendee dietary requirements, stored on this exact ticket line |
 
 ## Success response
 
@@ -48,6 +48,9 @@ For payment lifecycle transitions and webhook semantics, see
 {
   "bookingId": "<uuid>",
   "status": "SUBMITTED",
+  "approvalStatus": "NOT_REQUIRED",
+  "outcome": "READY_FOR_PAYMENT",
+  "paymentReady": true,
   "idempotentReplay": false
 }
 ```
@@ -58,6 +61,9 @@ When the booking was already completed with the same idempotency key:
 {
   "bookingId": "<uuid>",
   "status": "SUBMITTED",
+  "approvalStatus": "PENDING",
+  "outcome": "PENDING_APPROVAL",
+  "paymentReady": false,
   "idempotentReplay": true
 }
 ```
@@ -76,21 +82,24 @@ Uses HTTPS callable errors. Prefer inspecting **`error.details.code`** (string) 
 | `IDEMPOTENCY_DRAFT_CONFLICT` | `failed-precondition` | Another DRAFT exists for this event (different or missing idempotency key) |
 | `TICKET_TYPE_NOT_FOUND` | `failed-precondition` | Unknown ticket type or not on this event |
 | `INELIGIBLE_TICKET_TYPE` | `failed-precondition` | User does not match the ticket type’s `userGroup` |
-| `SELF_TICKET_REQUIRED` | `failed-precondition` | No member-priced line for the booker |
+| `SELF_TICKET_REQUIRED` | `failed-precondition` | The request does not contain exactly one member-priced line for the booker |
 | `GUEST_BEFORE_SELF` | `failed-precondition` | Guest line ordered before member line |
-| `TOO_MANY_GUEST_LINES` | `failed-precondition` | More than one guest-priced line without moderation path |
 | `INVALID_GUEST_FIELDS` | `failed-precondition` | Inconsistent guest naming vs ticket audience |
+| `BOOKING_REVISION_BASE_REQUIRED` | `failed-precondition` | Amendment omitted its exact base booking/revision |
+| `BOOKING_REVISION_BASE_NOT_FOUND` | `failed-precondition` | Amendment base is no longer present |
+| `BOOKING_REVISION_CONFLICT` | `aborted` | Another revision committed first; refetch before retrying |
+| `PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND` | `failed-precondition` | Amendment removes/transfers a paid stable place; refund workflow is not implemented yet |
 
 Other `invalid-argument` / `not-found` errors apply to bad input or missing event/section.
 
 ## Post-submit email
 
-After a successful submit (`idempotentReplay: false`), Functions send a GOV.UK Notify email to the booker:
+After a successful approval-eligible submit (`idempotentReplay: false`), Functions send a GOV.UK Notify email to the booker:
 
 - **`bookingConfirmation`** — first booking for this submit (no superseded booking).
 - **`bookingRevision`** — submit supersedes a prior booking and records a payment adjustment.
 
-**No email** when the callable returns **`idempotentReplay: true`** (terminal booking already exists for the same `idempotencyKey`).
+**No email** when the callable returns **`idempotentReplay: true`**, or while a new/revised booking is `PENDING` whole-booking approval. Pending/approval/rejection notifications are added by #547.
 
 See [`docs/operations/transactional-email-workflows.md`](../operations/transactional-email-workflows.md) and [`govuk-notify-booking-templates.md`](../operations/govuk-notify-booking-templates.md).
 
@@ -98,5 +107,8 @@ See [`docs/operations/transactional-email-workflows.md`](../operations/transacti
 
 - Rules: `functions/src/bookingRules.ts`
 - Callable: `functions/src/bookings.ts` (`submitEventBooking`)
+- Stable-place planning and typed persistence contract: `functions/src/bookingSubmissionPersistence.ts`
+- Atomic Data Connect operations: `dataconnect/booking-service/booking-submission.gql`
 - Email: `functions/src/bookingEmailDispatcher.ts`
-- Draft creation for the callable: `CreateBookingDraftForUser` in `dataconnect/api/admin-mutations.gql` (explicit `bookerId`, **not** `auth.uid` from the Data Connect service account)
+
+The server-only `booking-service` connector exists because Firebase Data Connect supports `_Data` batch variables in deployed operations but its JavaScript SDK generator does not currently generate wrappers for them. Functions invokes the named, schema-validated operations using explicit TypeScript variable interfaces. It does not use Admin SDK generic `insertMany`, including for the temporary legacy guest-request compatibility path.

--- a/functions/src/__tests__/bookingRevisionEngine.test.ts
+++ b/functions/src/__tests__/bookingRevisionEngine.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { BookingStatus } from "@dataconnect/admin-generated";
 import { HttpsError } from "firebase-functions/v2/https";
-import { computeRevisionPlan } from "../bookingRevisionEngine";
+import { computeRevisionPlan, isBookingRevisionConflictError } from "../bookingRevisionEngine";
 
 describe("bookingRevisionEngine", () => {
   it("creates revision 1 for first booking submission", () => {
@@ -83,5 +83,19 @@ describe("bookingRevisionEngine", () => {
         }
       )
     ).toThrow(HttpsError);
+  });
+
+  it("recognises locally-thrown revision conflicts by stable details code", () => {
+    const error = new HttpsError(
+      "aborted",
+      "Booking revision conflict: active revision not found",
+      { code: "BOOKING_REVISION_CONFLICT" },
+    );
+    expect(isBookingRevisionConflictError(error)).toBe(true);
+  });
+
+  it("recognises Data Connect transaction check conflicts by message", () => {
+    expect(isBookingRevisionConflictError(new Error("transaction failed: BOOKING_REVISION_CONFLICT"))).toBe(true);
+    expect(isBookingRevisionConflictError(new Error("unrelated database failure"))).toBe(false);
   });
 });

--- a/functions/src/__tests__/bookingRules.test.ts
+++ b/functions/src/__tests__/bookingRules.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { BookingApprovalStatus, TicketAudience } from "@dataconnect/admin-generated";
 import {
   BOOKING_RULE_ERROR_CODES,
+  bookingApprovalAllowsPayment,
   evaluateBookingGatekeeping,
   evaluateBookingLines,
   evaluateGuestApprovalGate,
@@ -123,6 +124,20 @@ describe("bookingRules", () => {
     ];
     const r = evaluateBookingLines(lines, map, "REGULAR", explicit);
     expect(r.ok).toBe(true);
+  });
+
+  it("requires exactly one member ticket line", () => {
+    const result = evaluateBookingLines(
+      [
+        { ticketTypeId: "tt-m", sortOrder: 0 },
+        { ticketTypeId: "tt-m", sortOrder: 1 },
+      ],
+      map,
+      "REGULAR",
+      explicit,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe(BOOKING_RULE_ERROR_CODES.SELF_TICKET_REQUIRED);
   });
 
   it("rejects guest before member (ordering)", () => {
@@ -264,5 +279,12 @@ describe("bookingRules", () => {
         maxGuestsWithoutModeratorApproval: 1,
       })
     ).toBe(BookingApprovalStatus.APPROVED);
+  });
+
+  it("allows payment only for approval-eligible booking states", () => {
+    expect(bookingApprovalAllowsPayment(BookingApprovalStatus.NOT_REQUIRED)).toBe(true);
+    expect(bookingApprovalAllowsPayment(BookingApprovalStatus.APPROVED)).toBe(true);
+    expect(bookingApprovalAllowsPayment(BookingApprovalStatus.PENDING)).toBe(false);
+    expect(bookingApprovalAllowsPayment(BookingApprovalStatus.REJECTED)).toBe(false);
   });
 });

--- a/functions/src/__tests__/bookingSubmissionExecution.test.ts
+++ b/functions/src/__tests__/bookingSubmissionExecution.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BookingApprovalStatus,
+  BookingPaymentAdjustmentStatus,
+  GuestTicketRequestStatus,
+  TicketAudience,
+} from "@dataconnect/admin-generated";
+
+const mocks = vi.hoisted(() => ({ executeMutation: vi.fn() }));
+
+vi.mock("firebase-admin/data-connect", () => ({
+  getDataConnect: vi.fn(() => ({ executeMutation: mocks.executeMutation })),
+}));
+
+import {
+  persistActiveBookingRevision,
+  persistInitialBooking,
+  persistLegacyGuestTicketRequests,
+  persistPendingBookingRevision,
+  type CompleteBookingPersistenceInput,
+} from "../bookingSubmissionPersistence";
+
+const input: CompleteBookingPersistenceInput = {
+  bookingId: "10000000-0000-4000-8000-000000000001",
+  eventId: "20000000-0000-4000-8000-000000000001",
+  bookerId: "user-1",
+  idempotencyKey: "30000000-0000-4000-8000-000000000001",
+  revisionGroupId: "40000000-0000-4000-8000-000000000001",
+  revisionNumber: 1,
+  approvalStatus: BookingApprovalStatus.PENDING,
+  sitNextToUserIds: ["user-2"],
+  accommodationRequested: false,
+  accommodationNote: null,
+  placePlan: {
+    newBookingPlaceIds: ["50000000-0000-4000-8000-000000000001"],
+    removedBookingPlaceIds: [],
+    paidRemovedBookingPlaceIds: [],
+    lines: [
+      {
+        id: "60000000-0000-4000-8000-000000000001",
+        bookingPlaceId: "50000000-0000-4000-8000-000000000001",
+        ticketTypeId: "70000000-0000-4000-8000-000000000001",
+        audience: TicketAudience.MEMBER,
+        sortOrder: 0,
+        dietaryNote: "Vegetarian",
+      },
+    ],
+  },
+};
+
+describe("atomic booking submission execution", () => {
+  beforeEach(() => mocks.executeMutation.mockReset().mockResolvedValue({ data: {} }));
+
+  it("sends the booking, stable places, and lines through one named mutation", async () => {
+    await persistInitialBooking(input);
+
+    expect(mocks.executeMutation).toHaveBeenCalledOnce();
+    expect(mocks.executeMutation).toHaveBeenCalledWith(
+      "CreateCompleteBookingFromCallable",
+      expect.objectContaining({
+        booking: expect.objectContaining({
+          id: input.bookingId,
+          approvalStatus: BookingApprovalStatus.PENDING,
+          status: "SUBMITTED",
+        }),
+        bookingPlaces: [expect.objectContaining({ id: input.placePlan.newBookingPlaceIds[0] })],
+        bookingLines: [
+          expect.objectContaining({
+            bookingId: input.bookingId,
+            bookingPlaceId: input.placePlan.newBookingPlaceIds[0],
+            dietaryNote: "Vegetarian",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("keeps a pending revision on its dedicated non-activating operation", async () => {
+    await persistPendingBookingRevision({
+      ...input,
+      revisionNumber: 2,
+      supersedesBookingId: "80000000-0000-4000-8000-000000000001",
+    });
+    expect(mocks.executeMutation).toHaveBeenCalledWith(
+      "CreatePendingBookingRevisionFromCallable",
+      expect.objectContaining({
+        supersedesBookingId: "80000000-0000-4000-8000-000000000001",
+      }),
+    );
+  });
+
+  it("activates a revision and records its adjustment in the same named operation", async () => {
+    await persistActiveBookingRevision({
+      input: {
+        ...input,
+        revisionNumber: 2,
+        approvalStatus: BookingApprovalStatus.NOT_REQUIRED,
+        supersedesBookingId: "80000000-0000-4000-8000-000000000001",
+      },
+      activeBookingId: "80000000-0000-4000-8000-000000000001",
+      deltaAmountMinor: 2500,
+      adjustmentStatus: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
+    });
+    expect(mocks.executeMutation).toHaveBeenCalledWith(
+      "CreateActiveBookingRevisionFromCallable",
+      expect.objectContaining({
+        deltaAmountMinor: 2500,
+        adjustmentStatus: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
+      }),
+    );
+  });
+
+  it("routes the legacy enum batch through a declared operation, not generic insertMany", async () => {
+    await persistLegacyGuestTicketRequests([
+      {
+        id: "90000000-0000-4000-8000-000000000001",
+        bookingId: input.bookingId,
+        status: GuestTicketRequestStatus.PENDING,
+        requestedGuestCount: 1,
+        guestTicketTypeId: "70000000-0000-4000-8000-000000000002",
+        guestDisplayName: "Guest",
+        createdBy: "system",
+        updatedBy: "system",
+      },
+    ]);
+    expect(mocks.executeMutation).toHaveBeenCalledWith(
+      "CreateLegacyGuestTicketRequestsFromCallable",
+      expect.objectContaining({ requests: [expect.objectContaining({ status: "PENDING" })] }),
+    );
+  });
+});

--- a/functions/src/__tests__/bookingSubmissionPersistence.test.ts
+++ b/functions/src/__tests__/bookingSubmissionPersistence.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { TicketAudience, TicketOrderStatus } from "@dataconnect/admin-generated";
+import { planBookingPlaces } from "../bookingSubmissionPersistence";
+
+const ids = [
+  "10000000-0000-4000-8000-000000000001",
+  "10000000-0000-4000-8000-000000000002",
+  "10000000-0000-4000-8000-000000000003",
+  "10000000-0000-4000-8000-000000000004",
+];
+
+function idFactory() {
+  let index = 0;
+  return () => ids[index++];
+}
+
+describe("booking submission place planning", () => {
+  it("creates one stable place for every initial attendee", () => {
+    const plan = planBookingPlaces({
+      createId: idFactory(),
+      lines: [
+        { ticketTypeId: "member-ticket", audience: TicketAudience.MEMBER, sortOrder: 0 },
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Guest One",
+        },
+      ],
+    });
+
+    expect(plan.newBookingPlaceIds).toEqual([ids[0], ids[2]]);
+    expect(plan.lines.map((line) => line.bookingPlaceId)).toEqual([ids[0], ids[2]]);
+    expect(plan.removedBookingPlaceIds).toEqual([]);
+  });
+
+  it("reuses places across dietary-only and ordering changes", () => {
+    const plan = planBookingPlaces({
+      createId: idFactory(),
+      previousLines: [
+        {
+          ticketTypeId: "member-ticket",
+          audience: TicketAudience.MEMBER,
+          sortOrder: 0,
+          dietaryNote: "Old",
+          bookingPlaceId: "place-member",
+        },
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Guest One",
+          dietaryNote: "Old",
+          bookingPlaceId: "place-guest",
+        },
+      ],
+      lines: [
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "  guest   one ",
+          dietaryNote: "New",
+        },
+        {
+          ticketTypeId: "member-ticket",
+          audience: TicketAudience.MEMBER,
+          sortOrder: 0,
+          dietaryNote: "New",
+        },
+      ],
+    });
+
+    expect(plan.newBookingPlaceIds).toEqual([]);
+    expect(plan.lines.map((line) => line.bookingPlaceId)).toEqual(["place-member", "place-guest"]);
+    expect(plan.removedBookingPlaceIds).toEqual([]);
+  });
+
+  it("treats an attendee or ticket change as place replacement", () => {
+    const plan = planBookingPlaces({
+      createId: idFactory(),
+      previousLines: [
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Guest One",
+          bookingPlaceId: "old-place",
+        },
+      ],
+      lines: [
+        {
+          ticketTypeId: "different-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Guest Two",
+        },
+      ],
+    });
+
+    expect(plan.newBookingPlaceIds).toEqual([ids[0]]);
+    expect(plan.removedBookingPlaceIds).toEqual(["old-place"]);
+  });
+
+  it("flags removal or transfer of a paid place", () => {
+    const plan = planBookingPlaces({
+      createId: idFactory(),
+      previousLines: [
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Paid Guest",
+          bookingPlaceId: "paid-place",
+          paymentAllocationStatuses: [TicketOrderStatus.PAID],
+        },
+      ],
+      lines: [],
+    });
+
+    expect(plan.removedBookingPlaceIds).toEqual(["paid-place"]);
+    expect(plan.paidRemovedBookingPlaceIds).toEqual(["paid-place"]);
+  });
+
+  it("allows removal when an allocation has not been paid", () => {
+    const plan = planBookingPlaces({
+      previousLines: [
+        {
+          ticketTypeId: "guest-ticket",
+          audience: TicketAudience.GUEST,
+          sortOrder: 1,
+          guestDisplayName: "Unpaid Guest",
+          bookingPlaceId: "unpaid-place",
+          paymentAllocationStatuses: [TicketOrderStatus.PENDING],
+        },
+      ],
+      lines: [],
+    });
+
+    expect(plan.removedBookingPlaceIds).toEqual(["unpaid-place"]);
+    expect(plan.paidRemovedBookingPlaceIds).toEqual([]);
+  });
+});

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -12,8 +12,18 @@ function readSchemaFile(): string {
   return fs.readFileSync(p, "utf8");
 }
 
+function readBookingServiceFile(fileName: string): string {
+  const p = path.resolve(process.cwd(), "..", "dataconnect", "booking-service", fileName);
+  return fs.readFileSync(p, "utf8");
+}
+
 function readMigrationFile(fileName: string): string {
   const p = path.resolve(process.cwd(), "..", "dataconnect", "migrations", fileName);
+  return fs.readFileSync(p, "utf8");
+}
+
+function readFunctionFile(fileName: string): string {
+  const p = path.resolve(process.cwd(), "src", fileName);
   return fs.readFileSync(p, "utf8");
 }
 
@@ -228,7 +238,7 @@ describe("GQL schema integrity", () => {
       /enum BookingApprovalStatus\s*{\s*NOT_REQUIRED\s+PENDING\s+APPROVED\s+REJECTED\s*}/,
     );
 
-    const bookingStart = schema.indexOf("type Booking @table");
+    const bookingStart = schema.indexOf("type Booking\n");
     const bookingEnd = schema.indexOf("\n}", bookingStart);
     const bookingBlock = schema.slice(bookingStart, bookingEnd + 2);
     expect(bookingBlock).toContain(
@@ -309,5 +319,48 @@ describe("GQL schema integrity", () => {
     const preferencesStart = mutations.indexOf("mutation UpdateBookingPreferencesFromCallable");
     const preferencesEnd = mutations.indexOf("\n}", preferencesStart);
     expect(mutations.slice(preferencesStart, preferencesEnd + 2)).not.toContain("bookerDietaryNote");
+  });
+
+  it("persists complete booking submissions through typed atomic batch operations", () => {
+    const operations = readBookingServiceFile("booking-submission.gql");
+    for (const name of [
+      "CreateCompleteBookingFromCallable",
+      "CreateActiveBookingRevisionFromCallable",
+      "CreatePendingBookingRevisionFromCallable",
+    ]) {
+      const start = operations.indexOf(`mutation ${name}`);
+      const next = operations.indexOf("\nmutation ", start + 1);
+      const block = operations.slice(start, next < 0 ? operations.length : next);
+      expect(start).toBeGreaterThanOrEqual(0);
+      expect(block).toContain("@auth(level: NO_ACCESS) @transaction");
+      expect(block).toContain("booking_insert(data: $booking)");
+      expect(block).toContain("bookingPlace_insertMany(data: $bookingPlaces)");
+      expect(block).toContain("bookingLine_insertMany(data: $bookingLines)");
+      expect(block).toContain("@allow(");
+    }
+    expect(operations).not.toContain("GuestTicketRequestStatus");
+    const legacyBatch = operations.slice(
+      operations.indexOf("mutation CreateLegacyGuestTicketRequestsFromCallable"),
+    );
+    expect(legacyBatch).toContain("guestTicketRequest_insertMany(data: $requests)");
+    expect(legacyBatch).toContain("@auth(level: NO_ACCESS) @transaction");
+  });
+
+  it("prevents concurrent duplicate revision numbers within a booking group", () => {
+    const schema = readSchemaFile();
+    const bookingStart = schema.indexOf("type Booking\n");
+    const bookingEnd = schema.indexOf("\n}", bookingStart);
+    expect(schema.slice(bookingStart, bookingEnd + 2)).toContain(
+      "@unique(fields: [\"revisionGroupId\", \"revisionNumber\"])",
+    );
+  });
+
+  it("does not use the production-defective generic enum batch API", () => {
+    const guestRequests = readFunctionFile("guestTicketRequests.ts");
+    const persistence = readFunctionFile("bookingSubmissionPersistence.ts");
+    expect(guestRequests).not.toContain(".insertMany(\"guestTicketRequest\"");
+    expect(guestRequests).toContain("persistLegacyGuestTicketRequests(rows)");
+    expect(persistence).toContain("\"CreateLegacyGuestTicketRequestsFromCallable\"");
+    expect(persistence).not.toContain(".insertMany(\"guestTicketRequest\"");
   });
 });

--- a/functions/src/bookingRevisionEngine.ts
+++ b/functions/src/bookingRevisionEngine.ts
@@ -25,6 +25,16 @@ export interface RevisionPlan {
 
 const TERMINAL_STATUSES = new Set<BookingStatus>([BookingStatus.SUBMITTED, BookingStatus.CONFIRMED]);
 
+/** Recognises both callable domain errors and Data Connect @check failures. */
+export function isBookingRevisionConflictError(error: unknown): boolean {
+  if (error instanceof HttpsError) {
+    const details = error.details as { code?: unknown } | undefined;
+    if (details?.code === "BOOKING_REVISION_CONFLICT") return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /BOOKING_REVISION_CONFLICT/i.test(message);
+}
+
 export function computeRevisionPlan(bookings: BookingSnapshot[], request: RevisionRequest): RevisionPlan {
   const terminalBookings = bookings.filter((booking) => TERMINAL_STATUSES.has(booking.status));
   const replay = terminalBookings.find((booking) => booking.clientSubmissionKey === request.idempotencyKey);

--- a/functions/src/bookingRules.ts
+++ b/functions/src/bookingRules.ts
@@ -17,6 +17,7 @@ export const BOOKING_RULE_ERROR_CODES = {
   EVENT_GUEST_POLICY_NOT_CONFIGURED: "EVENT_GUEST_POLICY_NOT_CONFIGURED",
   BOOKING_ALREADY_SUBMITTED: "BOOKING_ALREADY_SUBMITTED",
   IDEMPOTENCY_DRAFT_CONFLICT: "IDEMPOTENCY_DRAFT_CONFLICT",
+  PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND: "PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND",
 } as const;
 
 export type BookingRuleErrorCode = (typeof BOOKING_RULE_ERROR_CODES)[keyof typeof BOOKING_RULE_ERROR_CODES];
@@ -154,8 +155,11 @@ export function evaluateBookingLines(
     }
   }
 
-  if (memberLineCount < 1) {
-    return fail(BOOKING_RULE_ERROR_CODES.SELF_TICKET_REQUIRED, "At least one member ticket line is required for the booker");
+  if (memberLineCount !== 1) {
+    return fail(
+      BOOKING_RULE_ERROR_CODES.SELF_TICKET_REQUIRED,
+      "Exactly one member ticket line is required for the booker"
+    );
   }
 
   const maxGuestLines = options?.maxGuestLines;
@@ -227,6 +231,10 @@ export function deriveBookingApprovalStatus(args: {
   return args.guestTicketCount > args.maxGuestsWithoutModeratorApproval
     ? BookingApprovalStatus.PENDING
     : BookingApprovalStatus.NOT_REQUIRED;
+}
+
+export function bookingApprovalAllowsPayment(status: BookingApprovalStatus): boolean {
+  return status === BookingApprovalStatus.NOT_REQUIRED || status === BookingApprovalStatus.APPROVED;
 }
 
 function approvalIdentityKey(guest: ApprovalRelevantGuest): string {

--- a/functions/src/bookingSubmissionPersistence.ts
+++ b/functions/src/bookingSubmissionPersistence.ts
@@ -1,0 +1,267 @@
+import { randomUUID } from "node:crypto";
+import { getDataConnect } from "firebase-admin/data-connect";
+import {
+  BookingApprovalStatus,
+  BookingPaymentAdjustmentStatus,
+  BookingStatus,
+  GuestTicketRequestStatus,
+  TicketAudience,
+  TicketOrderStatus,
+} from "@dataconnect/admin-generated";
+import type { UUIDString } from "@dataconnect/admin-generated";
+
+const connectorConfig = {
+  connector: "booking-service",
+  serviceId: "sodc-web-service",
+  location: "europe-west2",
+};
+
+export const MAX_ATOMIC_BOOKING_LINES = 100;
+
+export interface SubmissionLine {
+  ticketTypeId: UUIDString;
+  audience: TicketAudience;
+  sortOrder: number;
+  guestUserId?: string | null;
+  guestDisplayName?: string | null;
+  dietaryNote?: string | null;
+}
+
+export interface ExistingSubmissionLine extends SubmissionLine {
+  bookingPlaceId?: UUIDString | null;
+  paymentAllocationStatuses?: TicketOrderStatus[];
+}
+
+export interface PlannedSubmissionLine extends SubmissionLine {
+  id: UUIDString;
+  bookingPlaceId: UUIDString;
+}
+
+export interface BookingPlacePlan {
+  lines: PlannedSubmissionLine[];
+  newBookingPlaceIds: UUIDString[];
+  removedBookingPlaceIds: UUIDString[];
+  paidRemovedBookingPlaceIds: UUIDString[];
+}
+
+function uuidKey(value: string): string {
+  return value.trim().replace(/-/g, "").toLowerCase();
+}
+
+function normalizedName(value?: string | null): string {
+  return value?.trim().replace(/\s+/g, " ").toLocaleLowerCase("en-GB") ?? "";
+}
+
+function placeIdentityKey(line: SubmissionLine): string {
+  const ticket = uuidKey(line.ticketTypeId);
+  if (line.audience === TicketAudience.MEMBER) return `member|ticket:${ticket}`;
+  return `guest|user:${line.guestUserId?.trim() ?? ""}|name:${normalizedName(line.guestDisplayName)}|ticket:${ticket}`;
+}
+
+/**
+ * Reuses stable places only for unchanged attendee/ticket identities. A name,
+ * linked-user, audience, or ticket-type change is a place replacement; this
+ * prevents a paid entitlement being silently transferred to another guest.
+ */
+export function planBookingPlaces(args: {
+  lines: SubmissionLine[];
+  previousLines?: ExistingSubmissionLine[];
+  createId?: () => UUIDString;
+}): BookingPlacePlan {
+  const createId = args.createId ?? (() => randomUUID() as UUIDString);
+  const queues = new Map<string, ExistingSubmissionLine[]>();
+  for (const previous of args.previousLines ?? []) {
+    if (!previous.bookingPlaceId) continue;
+    const key = placeIdentityKey(previous);
+    const queue = queues.get(key) ?? [];
+    queue.push(previous);
+    queues.set(key, queue);
+  }
+
+  const reusedPlaceIds = new Set<string>();
+  const newBookingPlaceIds: UUIDString[] = [];
+  const lines = [...args.lines]
+    .sort((left, right) => left.sortOrder - right.sortOrder)
+    .map((line): PlannedSubmissionLine => {
+      const matched = queues.get(placeIdentityKey(line))?.shift();
+      const bookingPlaceId = matched?.bookingPlaceId ?? createId();
+      if (matched?.bookingPlaceId) reusedPlaceIds.add(uuidKey(matched.bookingPlaceId));
+      else newBookingPlaceIds.push(bookingPlaceId);
+      return { ...line, id: createId(), bookingPlaceId };
+    });
+
+  const removed = (args.previousLines ?? []).filter(
+    (line) => line.bookingPlaceId && !reusedPlaceIds.has(uuidKey(line.bookingPlaceId))
+  );
+  return {
+    lines,
+    newBookingPlaceIds,
+    removedBookingPlaceIds: removed.map((line) => line.bookingPlaceId!),
+    paidRemovedBookingPlaceIds: removed
+      .filter((line) => line.paymentAllocationStatuses?.includes(TicketOrderStatus.PAID))
+      .map((line) => line.bookingPlaceId!),
+  };
+}
+
+interface BookingData {
+  id: UUIDString;
+  eventId: UUIDString;
+  bookerId: string;
+  clientSubmissionKey: string;
+  revisionGroupId: UUIDString;
+  revisionNumber: number;
+  supersedesBookingId?: UUIDString | null;
+  status: BookingStatus;
+  approvalStatus: BookingApprovalStatus;
+  sitNextToUserIds: string[];
+  accommodationRequested: boolean;
+  accommodationNote?: string | null;
+  createdBy: string;
+  updatedBy: string;
+}
+
+interface BookingPlaceData {
+  id: UUIDString;
+  eventId: UUIDString;
+  bookerId: string;
+  createdBy: string;
+  updatedBy: string;
+}
+
+interface BookingLineData {
+  id: UUIDString;
+  bookingPlaceId: UUIDString;
+  bookingId: UUIDString;
+  ticketTypeId: UUIDString;
+  guestUserId?: string | null;
+  guestDisplayName?: string | null;
+  dietaryNote?: string | null;
+  sortOrder: number;
+  createdBy: string;
+  updatedBy: string;
+}
+
+interface CompleteBookingVariables {
+  booking: BookingData;
+  bookingPlaces: BookingPlaceData[];
+  bookingLines: BookingLineData[];
+}
+
+export interface CompleteBookingPersistenceInput {
+  bookingId: UUIDString;
+  eventId: UUIDString;
+  bookerId: string;
+  idempotencyKey: UUIDString;
+  revisionGroupId: UUIDString;
+  revisionNumber: number;
+  supersedesBookingId?: UUIDString | null;
+  approvalStatus: BookingApprovalStatus;
+  sitNextToUserIds: string[];
+  accommodationRequested: boolean;
+  accommodationNote?: string | null;
+  placePlan: BookingPlacePlan;
+}
+
+function completeVariables(input: CompleteBookingPersistenceInput): CompleteBookingVariables {
+  return {
+    booking: {
+      id: input.bookingId,
+      eventId: input.eventId,
+      bookerId: input.bookerId,
+      clientSubmissionKey: input.idempotencyKey,
+      revisionGroupId: input.revisionGroupId,
+      revisionNumber: input.revisionNumber,
+      supersedesBookingId: input.supersedesBookingId ?? null,
+      status: BookingStatus.SUBMITTED,
+      approvalStatus: input.approvalStatus,
+      sitNextToUserIds: input.sitNextToUserIds,
+      accommodationRequested: input.accommodationRequested,
+      accommodationNote: input.accommodationRequested ? input.accommodationNote ?? null : null,
+      createdBy: "system",
+      updatedBy: "system",
+    },
+    bookingPlaces: input.placePlan.newBookingPlaceIds.map((id) => ({
+      id,
+      eventId: input.eventId,
+      bookerId: input.bookerId,
+      createdBy: "system",
+      updatedBy: "system",
+    })),
+    bookingLines: input.placePlan.lines.map((line) => ({
+      id: line.id,
+      bookingPlaceId: line.bookingPlaceId,
+      bookingId: input.bookingId,
+      ticketTypeId: line.ticketTypeId,
+      guestUserId: line.guestUserId?.trim() || null,
+      guestDisplayName: line.guestDisplayName?.trim() || null,
+      dietaryNote: line.dietaryNote?.trim() || null,
+      sortOrder: line.sortOrder,
+      createdBy: "system",
+      updatedBy: "system",
+    })),
+  };
+}
+
+export async function persistInitialBooking(input: CompleteBookingPersistenceInput): Promise<void> {
+  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables>(
+    "CreateCompleteBookingFromCallable",
+    completeVariables(input)
+  );
+}
+
+export async function persistPendingBookingRevision(input: CompleteBookingPersistenceInput): Promise<void> {
+  if (!input.supersedesBookingId) throw new Error("Pending revision requires supersedesBookingId");
+  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables & { supersedesBookingId: UUIDString }>(
+    "CreatePendingBookingRevisionFromCallable",
+    { ...completeVariables(input), supersedesBookingId: input.supersedesBookingId }
+  );
+}
+
+export async function persistActiveBookingRevision(args: {
+  input: CompleteBookingPersistenceInput;
+  activeBookingId: UUIDString;
+  deltaAmountMinor: number;
+  adjustmentStatus: BookingPaymentAdjustmentStatus;
+}): Promise<void> {
+  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables & {
+    revisionGroupId: UUIDString;
+    bookingId: UUIDString;
+    supersededBookingId: UUIDString;
+    deltaAmountMinor: number;
+    adjustmentStatus: BookingPaymentAdjustmentStatus;
+    orchestrationKey: string;
+  }>("CreateActiveBookingRevisionFromCallable", {
+    ...completeVariables(args.input),
+    revisionGroupId: args.input.revisionGroupId,
+    bookingId: args.input.bookingId,
+    supersededBookingId: args.activeBookingId,
+    deltaAmountMinor: args.deltaAmountMinor,
+    adjustmentStatus: args.adjustmentStatus,
+    orchestrationKey: `${args.input.bookingId}:${args.input.idempotencyKey}`,
+  });
+}
+
+export interface LegacyGuestTicketRequestData {
+  id: UUIDString;
+  bookingId: UUIDString;
+  status: GuestTicketRequestStatus;
+  requestedGuestCount: number;
+  guestTicketTypeId: UUIDString;
+  guestDisplayName: string;
+  dietaryNote?: string | null;
+  reviewedById?: string | null;
+  reviewedAt?: string | null;
+  moderatorNote?: string | null;
+  createdBy: string;
+  updatedBy: string;
+}
+
+/** Compatibility only; remove with the legacy guest-request flow in #548. */
+export async function persistLegacyGuestTicketRequests(
+  requests: readonly LegacyGuestTicketRequestData[]
+): Promise<void> {
+  await getDataConnect(connectorConfig).executeMutation<unknown, { requests: readonly LegacyGuestTicketRequestData[] }>(
+    "CreateLegacyGuestTicketRequestsFromCallable",
+    { requests }
+  );
+}

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -1,26 +1,23 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import * as logger from "firebase-functions/logger";
+import { randomUUID } from "node:crypto";
 import {
-  addBookingLineFromCallable,
-  createBookingPaymentAdjustmentFromCallable,
+  BookingApprovalStatus,
   BookingStatus,
-  markBookingSupersededFromCallable,
-  createBookingDraftForUser,
-  createBookingDraftRevisionForUser,
-  deleteBookingLineFromCallable,
+  TicketAudience,
   getBookingsForBookerAndEvent,
   getEventByIdForCallable,
   getSectionByIdForCallable,
   getUserMembershipStatus,
   getUserUserGroupsForAdmin,
-  updateBookingPreferencesFromCallable,
-  updateBookingStatusFromCallable,
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
 import {
   BOOKING_RULE_ERROR_CODES,
+  bookingApprovalAllowsPayment,
+  deriveBookingApprovalStatus,
+  deriveRevisedBookingApprovalStatus,
   evaluateBookingGatekeeping,
-  evaluateGuestApprovalGate,
   evaluateBookingLines,
   type BookingRulesFailure,
   type LineInputForRules,
@@ -31,11 +28,21 @@ import { enforceRateLimit } from "./rateLimiter";
 import { FUNCTIONS_REGION } from "./constants";
 import { computeRevisionPlan } from "./bookingRevisionEngine";
 import { computeBookingPaymentDelta, type BookingPaymentDelta } from "./bookingPaymentAdjustments";
+import { bookingIdsEqual } from "./bookingCheckout";
 import { govNotifySecrets } from "./mailer";
 import {
   notifyBookingConfirmationEmail,
   notifyBookingRevisionEmail,
 } from "./bookingEmailDispatcher";
+import {
+  MAX_ATOMIC_BOOKING_LINES,
+  persistActiveBookingRevision,
+  persistInitialBooking,
+  persistPendingBookingRevision,
+  planBookingPlaces,
+  type ExistingSubmissionLine,
+  type SubmissionLine,
+} from "./bookingSubmissionPersistence";
 
 const APP_BASE_URL = (() => {
   const url = process.env.APP_BASE_URL || "http://localhost:5173";
@@ -80,6 +87,9 @@ function bookingRulesToHttps(e: BookingRulesFailure): HttpsError {
 function parseBookingLines(raw: unknown): LineInputForRules[] {
   if (!Array.isArray(raw) || raw.length === 0) {
     throw new HttpsError("invalid-argument", "lines must be a non-empty array");
+  }
+  if (raw.length > MAX_ATOMIC_BOOKING_LINES) {
+    throw new HttpsError("invalid-argument", `lines must contain no more than ${MAX_ATOMIC_BOOKING_LINES} tickets`);
   }
   const out: LineInputForRules[] = [];
   for (let i = 0; i < raw.length; i++) {
@@ -149,6 +159,15 @@ async function fetchBookingsForBookerAndEvent(bookerId: string, eventId: UUIDStr
 function isDuplicateKeyError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return /unique|duplicate|violates/i.test(msg);
+}
+
+function bookingSubmissionOutcome(approvalStatus: BookingApprovalStatus) {
+  const paymentReady = bookingApprovalAllowsPayment(approvalStatus);
+  return {
+    approvalStatus,
+    outcome: paymentReady ? "READY_FOR_PAYMENT" : "PENDING_APPROVAL",
+    paymentReady,
+  } as const;
 }
 
 /**
@@ -236,8 +255,10 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
 
     const ticketTypes = event.ticketTypes ?? [];
     const ticketTypesById = new Map<string, TicketTypeForRules>();
+    const ticketPriceById = new Map<string, number>();
     for (const tt of ticketTypes) {
       const id = validateUUID(tt.id, "ticketTypeId");
+      ticketPriceById.set(id, tt.price);
       ticketTypesById.set(id, {
         id,
         audience: tt.audience,
@@ -263,14 +284,15 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
       throw bookingRulesToHttps(lineRules);
     }
 
-    let bookings = initialBookings;
-
-    const terminalBookings = bookings.filter((b) => b.status === BookingStatus.SUBMITTED || b.status === BookingStatus.CONFIRMED);
+    const terminalBookings = initialBookings.filter(
+      (booking) => booking.status === BookingStatus.SUBMITTED || booking.status === BookingStatus.CONFIRMED
+    );
     const replayCompleted = terminalBookings.find((b) => b.clientSubmissionKey === idempotencyKey);
     if (replayCompleted) {
       return {
         bookingId: replayCompleted.id,
         status: replayCompleted.status,
+        ...bookingSubmissionOutcome(replayCompleted.approvalStatus),
         idempotentReplay: true,
       };
     }
@@ -285,144 +307,156 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
       { idempotencyKey, baseBookingId, baseRevisionNumber }
     );
 
-    if (revisionPlan.supersedesBookingId) {
-      const superseded = terminalBookings.find((b) => b.id === revisionPlan.supersedesBookingId);
-      const approvedGuestCapacity = Math.max(
-        0,
-        ...(superseded?.guestTicketRequests ?? [])
-          .filter((request) => request.status === "APPROVED")
-          .map((request) => request.requestedGuestCount)
-      );
-      const revisedGuestTicketCount = lines.reduce((count, line) => {
-        const tt = ticketTypesById.get(line.ticketTypeId);
-        return count + (tt?.audience === "GUEST" ? 1 : 0);
-      }, 0);
-      const guestApprovalGate = evaluateGuestApprovalGate({
-        guestTicketCount: revisedGuestTicketCount,
-        maxGuestsWithoutModeratorApproval: event.maxGuestsWithoutModeratorApproval ?? null,
-        approvedGuestCapacity,
-      });
-      if (!guestApprovalGate.ok) {
-        throw bookingRulesToHttps(guestApprovalGate);
-      }
-    }
-
-    const drafts = bookings.filter((b) => b.status === BookingStatus.DRAFT);
-    const matchingDraft = drafts.find((b) => b.clientSubmissionKey === idempotencyKey);
-    const otherDrafts = drafts.filter((b) => b.clientSubmissionKey !== idempotencyKey);
-    if (otherDrafts.length > 0) {
+    const legacyDrafts = initialBookings.filter((booking) => booking.status === BookingStatus.DRAFT);
+    if (legacyDrafts.length > 0) {
       throw new HttpsError(
         "failed-precondition",
-        "Another in-progress booking exists for this event. Retry with the same idempotency key as that draft, or cancel the other draft first.",
+        "A legacy in-progress booking must be cleared before the atomic booking flow can continue.",
         { code: BOOKING_RULE_ERROR_CODES.IDEMPOTENCY_DRAFT_CONFLICT }
       );
     }
 
-    let bookingId: string;
-
-    if (matchingDraft) {
-      bookingId = matchingDraft.id;
-      for (const ln of matchingDraft.lines ?? []) {
-        await deleteBookingLineFromCallable({ id: ln.id });
-      }
-    } else {
-      try {
-        const insert = revisionPlan.supersedesBookingId
-          ? await createBookingDraftRevisionForUser({
-              eventId,
-              bookerId: uid,
-              clientSubmissionKey: idempotencyKey,
-              revisionGroupId: revisionPlan.revisionGroupId,
-              revisionNumber: revisionPlan.revisionNumber,
-              supersedesBookingId: revisionPlan.supersedesBookingId,
-            })
-          : await createBookingDraftForUser({
-              eventId,
-              bookerId: uid,
-              clientSubmissionKey: idempotencyKey,
-            });
-        const key = insert.data?.booking_insert;
-        if (!key?.id) {
-          throw new HttpsError("internal", "Failed to create booking");
-        }
-        bookingId = key.id;
-      } catch (e: unknown) {
-        if (!isDuplicateKeyError(e)) {
-          throw e;
-        }
-        bookings = await fetchBookingsForBookerAndEvent(uid, eventId);
-        const replay = bookings.find(
-          (b) =>
-            b.clientSubmissionKey === idempotencyKey &&
-            (b.status === BookingStatus.SUBMITTED || b.status === BookingStatus.CONFIRMED)
-        );
-        if (replay) {
-          return { bookingId: replay.id, status: replay.status, idempotentReplay: true };
-        }
-        const racedDraft = bookings.find(
-          (b) => b.clientSubmissionKey === idempotencyKey && b.status === BookingStatus.DRAFT
-        );
-        if (racedDraft) {
-          bookingId = racedDraft.id;
-          for (const ln of racedDraft.lines ?? []) {
-            await deleteBookingLineFromCallable({ id: ln.id });
-          }
-        } else {
-          logger.error("submitEventBooking: duplicate key but no matching booking after refetch", e);
-          throw new HttpsError("aborted", "Could not complete booking after conflict; retry the request");
-        }
-      }
+    const baseBooking = revisionPlan.supersedesBookingId
+      ? terminalBookings.find((booking) => bookingIdsEqual(booking.id, revisionPlan.supersedesBookingId!))
+      : undefined;
+    if (revisionPlan.supersedesBookingId && !baseBooking) {
+      throw new HttpsError("aborted", "Booking revision conflict: base revision changed", {
+        code: "BOOKING_REVISION_CONFLICT",
+      });
     }
 
-    await updateBookingPreferencesFromCallable({
-      id: bookingId as UUIDString,
+    const submissionLines: SubmissionLine[] = lines.map((line) => ({
+      ticketTypeId: line.ticketTypeId as UUIDString,
+      audience: ticketTypesById.get(line.ticketTypeId)!.audience,
+      sortOrder: line.sortOrder,
+      guestUserId: line.guestUserId,
+      guestDisplayName: line.guestDisplayName,
+      dietaryNote: line.dietaryNote,
+    }));
+    const previousLines: ExistingSubmissionLine[] = (baseBooking?.lines ?? []).map((line) => ({
+      ticketTypeId: validateUUID(line.ticketType.id, "ticketTypeId") as UUIDString,
+      audience: line.ticketType.audience,
+      sortOrder: line.sortOrder,
+      guestUserId: line.guestUser?.id ?? null,
+      guestDisplayName: line.guestDisplayName ?? null,
+      dietaryNote: line.dietaryNote ?? null,
+      bookingPlaceId: line.bookingPlace?.id
+        ? (validateUUID(line.bookingPlace.id, "bookingPlaceId") as UUIDString)
+        : null,
+      paymentAllocationStatuses: (line.bookingPlace?.paymentAllocations ?? []).map(
+        (allocation) => allocation.ticketOrder.status
+      ),
+    }));
+    const placePlan = planBookingPlaces({ lines: submissionLines, previousLines });
+    if (placePlan.paidRemovedBookingPlaceIds.length > 0) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Paid tickets cannot be removed or transferred yet. A refund workflow is required.",
+        { code: BOOKING_RULE_ERROR_CODES.PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND }
+      );
+    }
+
+    const revisedGuests = submissionLines.filter((line) => line.audience === TicketAudience.GUEST);
+    const previousGuests = previousLines.filter((line) => line.audience === TicketAudience.GUEST);
+    const approvalStatus = baseBooking
+      ? deriveRevisedBookingApprovalStatus({
+          previousStatus: baseBooking.approvalStatus,
+          previousGuests,
+          revisedGuests,
+          maxGuestsWithoutModeratorApproval: event.maxGuestsWithoutModeratorApproval,
+        })
+      : deriveBookingApprovalStatus({
+          guestTicketCount: revisedGuests.length,
+          maxGuestsWithoutModeratorApproval: event.maxGuestsWithoutModeratorApproval,
+        });
+
+    const bookingId = randomUUID() as UUIDString;
+    const persistenceInput = {
+      bookingId,
+      eventId,
+      bookerId: uid,
+      idempotencyKey: idempotencyKey as UUIDString,
+      revisionGroupId: revisionPlan.revisionGroupId,
+      revisionNumber: revisionPlan.revisionNumber,
+      supersedesBookingId: revisionPlan.supersedesBookingId,
+      approvalStatus,
       sitNextToUserIds,
       accommodationRequested,
-      accommodationNote: accommodationRequested ? accommodationNote : null,
-    });
+      accommodationNote,
+      placePlan,
+    };
 
-    const sorted = [...lines].sort((a, b) => a.sortOrder - b.sortOrder);
-    for (const line of sorted) {
-      await addBookingLineFromCallable({
-        bookingId: bookingId as UUIDString,
-        ticketTypeId: line.ticketTypeId as UUIDString,
-        guestUserId: line.guestUserId?.trim() || null,
-        guestDisplayName: line.guestDisplayName?.trim() || null,
-        dietaryNote: line.dietaryNote?.trim() || null,
-        sortOrder: line.sortOrder,
-      });
-    }
-
-    await updateBookingStatusFromCallable({
-      id: bookingId as UUIDString,
-      status: BookingStatus.SUBMITTED,
-    });
     let paymentDelta: BookingPaymentDelta | undefined;
-    if (revisionPlan.supersedesBookingId) {
-      await markBookingSupersededFromCallable({ id: revisionPlan.supersedesBookingId });
+    try {
+      if (!revisionPlan.supersedesBookingId) {
+        await persistInitialBooking(persistenceInput);
+      } else if (!bookingApprovalAllowsPayment(approvalStatus)) {
+        await persistPendingBookingRevision(persistenceInput);
+      } else {
+        const activeBooking = terminalBookings
+          .filter(
+            (booking) =>
+              bookingIdsEqual(booking.revisionGroupId, revisionPlan.revisionGroupId) &&
+              booking.supersededAt == null &&
+              (booking.approvalStatus === BookingApprovalStatus.NOT_REQUIRED ||
+                booking.approvalStatus === BookingApprovalStatus.APPROVED)
+          )
+          .sort((left, right) => right.revisionNumber - left.revisionNumber)[0];
+        if (!activeBooking) {
+          throw new HttpsError("aborted", "Booking revision conflict: active revision not found", {
+            code: "BOOKING_REVISION_CONFLICT",
+          });
+        }
+        paymentDelta = computeBookingPaymentDelta(activeBooking, {
+          lines: submissionLines.map((line) => ({
+            ticketType: { price: ticketPriceById.get(line.ticketTypeId) ?? 0 },
+          })),
+        });
+        await persistActiveBookingRevision({
+          input: persistenceInput,
+          activeBookingId: activeBooking.id as UUIDString,
+          deltaAmountMinor: paymentDelta.deltaAmountMinor,
+          adjustmentStatus: paymentDelta.status,
+        });
+      }
+    } catch (error: unknown) {
+      if (!isDuplicateKeyError(error) && !/BOOKING_REVISION_CONFLICT/i.test(String(error))) throw error;
       const refreshed = await fetchBookingsForBookerAndEvent(uid, eventId);
-      const previousBooking = refreshed.find((booking) => booking.id === revisionPlan.supersedesBookingId);
-      const revisedBooking = refreshed.find((booking) => booking.id === bookingId);
-      paymentDelta = computeBookingPaymentDelta(previousBooking, revisedBooking);
-      await createBookingPaymentAdjustmentFromCallable({
-        revisionBookingId: bookingId as UUIDString,
-        supersededBookingId: revisionPlan.supersedesBookingId,
-        deltaAmountMinor: paymentDelta.deltaAmountMinor,
-        status: paymentDelta.status,
-        orchestrationKey: `${bookingId}:${idempotencyKey}`,
+      const replay = refreshed.find(
+        (booking) =>
+          booking.clientSubmissionKey === idempotencyKey &&
+          (booking.status === BookingStatus.SUBMITTED || booking.status === BookingStatus.CONFIRMED)
+      );
+      if (replay) {
+        return {
+          bookingId: replay.id,
+          status: replay.status,
+          ...bookingSubmissionOutcome(replay.approvalStatus),
+          idempotentReplay: true,
+        };
+      }
+      throw new HttpsError("aborted", "Booking revision conflict: retry from the latest booking", {
+        code: "BOOKING_REVISION_CONFLICT",
       });
     }
 
-    await sendBookingSubmitNotificationEmails({
-      bookingId: bookingId as UUIDString,
-      idempotencyKey,
-      appBaseUrl: APP_BASE_URL,
-      supersededBookingId: revisionPlan.supersedesBookingId,
-      paymentDelta,
-    });
+    if (bookingSubmissionOutcome(approvalStatus).paymentReady) {
+      await sendBookingSubmitNotificationEmails({
+        bookingId,
+        idempotencyKey,
+        appBaseUrl: APP_BASE_URL,
+        supersededBookingId: revisionPlan.supersedesBookingId,
+        paymentDelta,
+      });
+    }
 
     logger.info(`submitEventBooking: uid=${uid} eventId=${eventId} bookingId=${bookingId} key=${idempotencyKey}`);
-    return { bookingId, status: BookingStatus.SUBMITTED, idempotentReplay: false };
+    return {
+      bookingId,
+      status: BookingStatus.SUBMITTED,
+      ...bookingSubmissionOutcome(approvalStatus),
+      idempotentReplay: false,
+    };
   } catch (e: unknown) {
     if (e instanceof HttpsError) throw e;
     handleFunctionError(e as Error, "submitEventBooking");

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -26,7 +26,7 @@ import {
 import { requireEnabled, requireString, validateUUID, handleFunctionError, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from "./helpers";
 import { enforceRateLimit } from "./rateLimiter";
 import { FUNCTIONS_REGION } from "./constants";
-import { computeRevisionPlan } from "./bookingRevisionEngine";
+import { computeRevisionPlan, isBookingRevisionConflictError } from "./bookingRevisionEngine";
 import { computeBookingPaymentDelta, type BookingPaymentDelta } from "./bookingPaymentAdjustments";
 import { bookingIdsEqual } from "./bookingCheckout";
 import { govNotifySecrets } from "./mailer";
@@ -420,7 +420,7 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
         });
       }
     } catch (error: unknown) {
-      if (!isDuplicateKeyError(error) && !/BOOKING_REVISION_CONFLICT/i.test(String(error))) throw error;
+      if (!isDuplicateKeyError(error) && !isBookingRevisionConflictError(error)) throw error;
       const refreshed = await fetchBookingsForBookerAndEvent(uid, eventId);
       const replay = refreshed.find(
         (booking) =>

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -1169,6 +1169,13 @@ export interface GetBookingsForBookerAndEventData {
         id: UUIDString;
         bookingPlace?: {
           id: UUIDString;
+          paymentAllocations: ({
+            id: UUIDString;
+            ticketOrder: {
+              id: UUIDString;
+              status: TicketOrderStatus;
+            } & TicketOrder_Key;
+          } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;
         guestDisplayName?: string | null;

--- a/functions/src/guestTicketRequests.ts
+++ b/functions/src/guestTicketRequests.ts
@@ -7,9 +7,7 @@ import {
   getBookingForGuestTicketCallable,
   getGuestTicketRequestByIdForCallable,
   GuestTicketRequestStatus,
-  connectorConfig,
 } from "@dataconnect/admin-generated";
-import { getDataConnect } from "firebase-admin/data-connect";
 import type { UUIDString } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
 import { requireAdmin, requireEnabled, validateUUID, handleFunctionError, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from "./helpers";
@@ -30,6 +28,7 @@ import {
   guestTicketRequestId,
   runIdempotentAtomicBatch,
 } from "./guestTicketRequestIdempotency";
+import { persistLegacyGuestTicketRequests } from "./bookingSubmissionPersistence";
 
 const MAX_GUEST_REQUEST_BATCH = 20;
 
@@ -280,8 +279,7 @@ export const submitAdditionalGuestTicketRequests = onCall(
             return rows;
           },
           insertMany: async (rows) => {
-            // insertMany is one atomic bulk operation: either every missing row is committed or none is.
-            await getDataConnect(connectorConfig).insertMany("guestTicketRequest", [...rows]);
+            await persistLegacyGuestTicketRequests(rows);
           },
         });
         for (const [index, requestRow] of existing.entries()) {

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -2893,6 +2893,13 @@ export interface GetBookingsForBookerAndEventData {
         id: UUIDString;
         bookingPlace?: {
           id: UUIDString;
+          paymentAllocations: ({
+            id: UUIDString;
+            ticketOrder: {
+              id: UUIDString;
+              status: TicketOrderStatus;
+            } & TicketOrder_Key;
+          } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;
         guestDisplayName?: string | null;

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -1192,6 +1192,13 @@ export interface GetBookingsForBookerAndEventData {
         id: UUIDString;
         bookingPlace?: {
           id: UUIDString;
+          paymentAllocations: ({
+            id: UUIDString;
+            ticketOrder: {
+              id: UUIDString;
+              status: TicketOrderStatus;
+            } & TicketOrder_Key;
+          } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;
         guestDisplayName?: string | null;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2351,6 +2351,13 @@ export interface GetBookingsForBookerAndEventData {
         id: UUIDString;
         bookingPlace?: {
           id: UUIDString;
+          paymentAllocations: ({
+            id: UUIDString;
+            ticketOrder: {
+              id: UUIDString;
+              status: TicketOrderStatus;
+            } & TicketOrder_Key;
+          } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;
         guestDisplayName?: string | null;

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -244,7 +244,13 @@ describe("EventBookingWizard", () => {
     } as never);
     vi.mocked(firebaseFunctions.submitEventBooking)
       .mockRejectedValueOnce(new Error("SQL booking revision implementation detail"))
-      .mockResolvedValueOnce({ bookingId: "booking-new", status: "SUBMITTED" });
+      .mockResolvedValueOnce({
+        bookingId: "booking-new",
+        status: "SUBMITTED",
+        approvalStatus: "NOT_REQUIRED",
+        outcome: "READY_FOR_PAYMENT",
+        paymentReady: true,
+      });
 
     const user = userEvent.setup();
     render(
@@ -674,17 +680,17 @@ describe("EventBookingWizard", () => {
               guestDisplayName: "Alex Guest",
               dietaryNote: "Vegetarian",
             }),
+            expect.objectContaining({
+              ticketTypeId: "ticket-guest",
+              guestDisplayName: "Sam Extra",
+              dietaryNote: "Gluten free",
+            }),
           ]),
         })
       );
     });
 
-    expect(firebaseFunctions.submitAdditionalGuestTicketRequests).toHaveBeenCalledWith({
-      bookingId: "booking-new",
-      guestTicketTypeId: "ticket-guest",
-      idempotencyKey: expect.any(String),
-      guests: [{ guestDisplayName: "Sam Extra", dietaryNote: "Gluten free" }],
-    });
+    expect(firebaseFunctions.submitAdditionalGuestTicketRequests).not.toHaveBeenCalled();
   });
 
   it("advances to the payment step after confirming a new booking", async () => {

--- a/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
+++ b/src/features/sections/hooks/__tests__/bookingWizardModel.test.ts
@@ -61,6 +61,12 @@ describe("bookingWizardModel", () => {
         guestTicketTypeId: "guest-ticket",
         guestDisplayName: "  Guest Name  ",
         guestDietaryNote: "  Vegan  ",
+        extraGuestTicketTypeId: "extra-guest-ticket",
+        extraGuestCount: 2,
+        extraGuestDetails: [
+          { guestDisplayName: "  Guest Two  ", dietaryNote: "  Gluten free  " },
+          { guestDisplayName: "Guest Three", dietaryNote: "" },
+        ],
       })
     ).toEqual([
       {
@@ -76,6 +82,20 @@ describe("bookingWizardModel", () => {
         guestUserId: null,
         guestDisplayName: "Guest Name",
         dietaryNote: "Vegan",
+      },
+      {
+        ticketTypeId: "extra-guest-ticket",
+        sortOrder: 2,
+        guestUserId: null,
+        guestDisplayName: "Guest Two",
+        dietaryNote: "Gluten free",
+      },
+      {
+        ticketTypeId: "extra-guest-ticket",
+        sortOrder: 3,
+        guestUserId: null,
+        guestDisplayName: "Guest Three",
+        dietaryNote: null,
       },
     ]);
   });

--- a/src/features/sections/hooks/bookingWizardModel.ts
+++ b/src/features/sections/hooks/bookingWizardModel.ts
@@ -98,6 +98,9 @@ export function buildBookingSubmissionLines(args: {
   guestTicketTypeId: string | null;
   guestDisplayName: string;
   guestDietaryNote: string;
+  extraGuestTicketTypeId: string | null;
+  extraGuestDetails: ExtraGuestDetailRow[];
+  extraGuestCount: number;
 }): BookingSubmissionLine[] {
   const lines: BookingSubmissionLine[] = [
     {
@@ -116,6 +119,17 @@ export function buildBookingSubmissionLines(args: {
       guestDisplayName: args.guestDisplayName.trim(),
       dietaryNote: args.guestDietaryNote.trim() || null,
     });
+  }
+  if (args.extraGuestTicketTypeId) {
+    for (const guest of args.extraGuestDetails.slice(0, args.extraGuestCount)) {
+      lines.push({
+        ticketTypeId: args.extraGuestTicketTypeId,
+        sortOrder: lines.length,
+        guestUserId: null,
+        guestDisplayName: guest.guestDisplayName.trim(),
+        dietaryNote: guest.dietaryNote.trim() || null,
+      });
+    }
   }
   return lines;
 }

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -353,6 +353,9 @@ export function useBookingWizardState({
         guestTicketTypeId,
         guestDisplayName,
         guestDietaryNote,
+        extraGuestTicketTypeId,
+        extraGuestDetails,
+        extraGuestCount: extraGuestRequestCount,
       });
 
       const result = await submitEventBooking({
@@ -365,10 +368,6 @@ export function useBookingWizardState({
         accommodationRequested,
         accommodationNote: null,
       });
-
-      if (extraGuestRequestCount > 0) {
-        await submitAdditionalGuestRequest(result.bookingId);
-      }
 
       hydratedBookingIdRef.current = result.bookingId;
       await Promise.all([

--- a/src/shared/errors/__tests__/bookingErrors.test.ts
+++ b/src/shared/errors/__tests__/bookingErrors.test.ts
@@ -19,6 +19,7 @@ describe("booking and payment error mapping", () => {
     ["BOOKING_REVISION_BASE_REQUIRED", "Refresh your booking"],
     ["BOOKING_REVISION_BASE_NOT_FOUND", "no longer current"],
     ["BOOKING_REVISION_CONFLICT", "changed while you were editing"],
+    ["PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND", "already been paid"],
   ])("maps %s without exposing callable text", (code, expected) => {
     const mapped = toBookingUserFacingError(
       {

--- a/src/shared/errors/bookingErrors.ts
+++ b/src/shared/errors/bookingErrors.ts
@@ -103,6 +103,12 @@ const BOOKING_DOMAIN_ERRORS: Record<string, UserFacingErrorInput> = {
     message: "Your booking changed while you were editing it. Refresh and review the latest version.",
     retryable: true,
   },
+  PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND: {
+    category: "precondition",
+    title: "Paid ticket cannot be changed",
+    message: "This ticket has already been paid for. Guest refunds and ticket transfers are not available yet.",
+    retryable: false,
+  },
 };
 
 const FALLBACKS: Record<BookingErrorContext, UserFacingErrorInput> = {

--- a/src/shared/utils/firebaseFunctions/bookingPayments.ts
+++ b/src/shared/utils/firebaseFunctions/bookingPayments.ts
@@ -24,6 +24,9 @@ export interface SubmitEventBookingRequest {
 export interface SubmitEventBookingResponse {
   bookingId: string;
   status: string;
+  approvalStatus: "NOT_REQUIRED" | "PENDING" | "APPROVED" | "REJECTED";
+  outcome: "PENDING_APPROVAL" | "READY_FOR_PAYMENT";
+  paymentReady: boolean;
   idempotentReplay?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- replace the normal booking-plus-extra-guests two-call sequence with one complete `submitEventBooking` request
- persist the booking, every member/guest line, and new stable `BookingPlace` rows in one Data Connect transaction
- derive whole-booking approval for initial submissions and amendments
- return a small `PENDING_APPROVAL` or `READY_FOR_PAYMENT` outcome contract
- leave the last approved/payable revision active while an over-limit replacement is pending
- atomically retire active revisions and create payment adjustments when a replacement can proceed
- reuse stable places for unchanged attendee/ticket identities across revisions
- allow unpaid place removal and reject paid removal/transfer with `PAID_BOOKING_PLACE_REMOVAL_REQUIRES_REFUND`
- enforce unique revision-group/revision-number pairs for concurrent amendment safety
- remove the production-defective generic enum `insertMany` path, including from the temporary legacy additional-guest callable
- update generated Data Connect types, user-facing error mapping, tests, and booking architecture/API documentation

## Why

Issue #544 replaces a partial-write workflow where the main booking was submitted first and additional guests were submitted through a second callable. A failure in the second operation could leave an incomplete booking.

The production failure captured in #538 also showed that Firebase Admin's generic `insertMany` path serialized `GuestTicketRequestStatus.PENDING` incorrectly for GraphQL enum input. This change routes enum-bearing batches through declared, schema-validated Data Connect mutations.

## Atomic persistence

The new server-only `booking-service` connector contains named `@transaction` operations using constrained `_Data` batch inputs. Functions invokes those operations with explicit TypeScript variable contracts because Firebase's JavaScript SDK generator does not currently generate wrappers for dynamic `_Data` inputs.

The transaction variants cover:

- initial complete booking
- pending replacement revision without retiring the last payable revision
- approval-eligible replacement revision with supersession and payment adjustment
- temporary legacy guest-request batch compatibility until #548 removes that flow

No booking row or partial attendee collection remains when a transactional write fails.

## Approval and amendment behavior

- guest count at or below the event limit → `NOT_REQUIRED` / ready for payment
- guest count above the limit → `PENDING`
- approval-relevant over-limit changes → reset to `PENDING`
- dietary-only changes preserve the previous approval state
- pending/rejected states never activate a revision or send the existing confirmation/revision email
- duplicate idempotency retries return the committed outcome
- stale/concurrent revision submissions return a stable conflict
- changing an attendee identity or ticket replaces its stable place; a paid place cannot be removed or transferred

## Validation

- Functions full suite: 83 files, 895 tests passed
- UI full suite: 97 files, 764 tests passed
- deployment safety: 2 files, 55 tests passed
- focused atomic submission, stable-place, approval, GraphQL contract, UI, and error tests passed
- `npm --prefix functions run build`
- `npm run build`
- `npm --prefix functions run lint`
- `npm run lint`
- `npx firebase dataconnect:sdk:generate`
- `git diff --check`

Implements #544.
Part of #538.