### PR TITLE
Fix booking seating preference selection

### DIFF
--- a/functions/src/__tests__/bookingsEmailWiring.test.ts
+++ b/functions/src/__tests__/bookingsEmailWiring.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
-import { sendBookingSubmitNotificationEmails } from "../bookings";
+import { parseSitNextToUserIds, sendBookingSubmitNotificationEmails } from "../bookings";
 import {
   notifyBookingConfirmationEmail,
   notifyBookingRevisionEmail,
@@ -10,6 +10,28 @@ vi.mock("../bookingEmailDispatcher", () => ({
   notifyBookingConfirmationEmail: vi.fn(),
   notifyBookingRevisionEmail: vi.fn(),
 }));
+
+describe("booking request seating preferences", () => {
+  it("accepts opaque Firebase Auth UIDs and preserves their values", () => {
+    expect(parseSitNextToUserIds([" user-2 ", "cGqrtuZyUBcXfz9pbSC9Jb8QE4u1"], "user-1")).toEqual([
+      "user-2",
+      "cGqrtuZyUBcXfz9pbSC9Jb8QE4u1",
+    ]);
+  });
+
+  it("removes duplicate and blank selections", () => {
+    expect(parseSitNextToUserIds(["user-2", " ", "user-2"], "user-1")).toEqual(["user-2"]);
+  });
+
+  it("rejects self-selection and oversized UIDs", () => {
+    expect(() => parseSitNextToUserIds(["user-1"], "user-1")).toThrow(
+      "You cannot select yourself"
+    );
+    expect(() => parseSitNextToUserIds(["x".repeat(129)], "user-1")).toThrow(
+      "must be no more than 128 characters"
+    );
+  });
+});
 
 describe("sendBookingSubmitNotificationEmails", () => {
   beforeEach(() => {

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -134,7 +134,10 @@ function parseOptionalString(value: unknown, maxLen: number): string | null {
   return trimmed.slice(0, maxLen);
 }
 
-function parseSitNextTo(raw: unknown, uid: string): string[] {
+const MAX_FIREBASE_UID_LENGTH = 128;
+
+/** Firebase Auth UIDs are opaque strings, not Data Connect UUID scalars. */
+export function parseSitNextToUserIds(raw: unknown, uid: string): string[] {
   if (!Array.isArray(raw)) return [];
   const out: string[] = [];
   for (const v of raw) {
@@ -143,13 +146,56 @@ function parseSitNextTo(raw: unknown, uid: string): string[] {
     }
     const trimmed = v.trim();
     if (!trimmed) continue;
-    const id = validateUUID(trimmed, "sitNextToUserIds");
-    if (id === uid) {
+    if (trimmed.length > MAX_FIREBASE_UID_LENGTH) {
+      throw new HttpsError(
+        "invalid-argument",
+        `sitNextToUserIds entries must be no more than ${MAX_FIREBASE_UID_LENGTH} characters`
+      );
+    }
+    if (trimmed === uid) {
       throw new HttpsError("invalid-argument", "You cannot select yourself in sit-next-to preferences");
     }
-    if (!out.includes(id)) out.push(id);
+    if (!out.includes(trimmed)) out.push(trimmed);
   }
   return out.slice(0, 10);
+}
+
+function logBookingRejection(error: HttpsError): void {
+  const details = error.details as { code?: unknown } | undefined;
+  logger.warn("submitEventBooking rejected", {
+    errorCode: error.code,
+    domainCode: typeof details?.code === "string" ? details.code : undefined,
+    validationMessage: error.code === "invalid-argument" ? error.message : undefined,
+  });
+}
+
+function parseSubmitEventBookingRequest(data: unknown, uid: string) {
+  const input = data && typeof data === "object" ? (data as Record<string, unknown>) : {};
+  const idempotencyKey = validateUUID(
+    requireString(input.idempotencyKey, "idempotencyKey"),
+    "idempotencyKey"
+  );
+  const eventId = validateUUID(input.eventId as string, "eventId") as UUIDString;
+  const baseBookingId = input.baseBookingId
+    ? (validateUUID(String(input.baseBookingId), "baseBookingId") as UUIDString)
+    : undefined;
+  const baseRevisionNumberRaw = input.baseRevisionNumber;
+  const baseRevisionNumber =
+    baseRevisionNumberRaw == null
+      ? undefined
+      : Number.isInteger(Number(baseRevisionNumberRaw))
+        ? Number(baseRevisionNumberRaw)
+        : undefined;
+  return {
+    idempotencyKey,
+    eventId,
+    baseBookingId,
+    baseRevisionNumber,
+    lines: parseBookingLines(input.lines),
+    sitNextToUserIds: parseSitNextToUserIds(input.sitNextToUserIds, uid),
+    accommodationRequested: input.accommodationRequested === true,
+    accommodationNote: parseOptionalString(input.accommodationNote, 500),
+  };
 }
 
 async function fetchBookingsForBookerAndEvent(bookerId: string, eventId: UUIDString) {
@@ -180,19 +226,24 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
   const uid = request.auth!.uid;
   await enforceRateLimit("submitEventBooking", uid);
 
-  const idempotencyKey = validateUUID(
-    requireString(request.data?.idempotencyKey, "idempotencyKey"),
-    "idempotencyKey"
-  );
-  const eventId = validateUUID(request.data?.eventId as string, "eventId") as UUIDString;
-  const baseBookingId = request.data?.baseBookingId ? (validateUUID(String(request.data.baseBookingId), "baseBookingId") as UUIDString) : undefined;
-  const baseRevisionNumberRaw = request.data?.baseRevisionNumber;
-  const baseRevisionNumber =
-    baseRevisionNumberRaw == null ? undefined : Number.isInteger(Number(baseRevisionNumberRaw)) ? Number(baseRevisionNumberRaw) : undefined;
-  const lines = parseBookingLines(request.data?.lines);
-  const sitNextToUserIds = parseSitNextTo(request.data?.sitNextToUserIds, uid);
-  const accommodationRequested = request.data?.accommodationRequested === true;
-  const accommodationNote = parseOptionalString(request.data?.accommodationNote, 500);
+  const parsedRequest = (() => {
+    try {
+      return parseSubmitEventBookingRequest(request.data, uid);
+    } catch (error: unknown) {
+      if (error instanceof HttpsError) logBookingRejection(error);
+      throw error;
+    }
+  })();
+  const {
+    idempotencyKey,
+    eventId,
+    baseBookingId,
+    baseRevisionNumber,
+    lines,
+    sitNextToUserIds,
+    accommodationRequested,
+    accommodationNote,
+  } = parsedRequest;
 
   try {
     const [eventResult, userStatusResult, userGroupsResult, initialBookings] = await Promise.all([
@@ -463,7 +514,10 @@ export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [.
       idempotentReplay: false,
     };
   } catch (e: unknown) {
-    if (e instanceof HttpsError) throw e;
+    if (e instanceof HttpsError) {
+      logBookingRejection(e);
+      throw e;
+    }
     handleFunctionError(e as Error, "submitEventBooking");
   }
 });

--- a/src/features/sections/components/__tests__/TicketSelectionStep.test.tsx
+++ b/src/features/sections/components/__tests__/TicketSelectionStep.test.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "../../../../test-utils";
+import TicketSelectionStep from "../wizardSteps/TicketSelectionStep";
+
+function SeatingPickerHarness() {
+  const [inputValue, setInputValue] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  return (
+    <TicketSelectionStep
+      memberTicketTypes={[]}
+      memberTicketTypeId={null}
+      onMemberTicketTypeChange={() => undefined}
+      memberDietaryNote=""
+      onMemberDietaryNoteChange={() => undefined}
+      seatingOptions={[{ id: "firebase-user-2", label: "Alex Member" }]}
+      seatingSearchInputValue={inputValue}
+      onSeatingSearchInputValueChange={setInputValue}
+      seatingOptionsLoading={false}
+      sitNextToUserIds={selectedIds}
+      onSitNextToUserIdsChange={setSelectedIds}
+      accommodationRequested={false}
+      onAccommodationRequestedChange={() => undefined}
+      canRequestAccommodation={false}
+    />
+  );
+}
+
+describe("TicketSelectionStep seating picker", () => {
+  it("clears search text after selecting a member while retaining the selected chip", async () => {
+    const user = userEvent.setup();
+    render(<SeatingPickerHarness />);
+
+    const input = screen.getByLabelText("Sit next to (optional)");
+    await user.type(input, "Alex");
+    await user.click(screen.getByRole("option", { name: "Alex Member" }));
+
+    expect(input).toHaveValue("");
+    expect(screen.getByText("Alex Member")).toBeInTheDocument();
+  });
+});

--- a/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
+++ b/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
@@ -97,7 +97,10 @@ export default function TicketSelectionStep({
         filterOptions={(x) => x}
         options={seatingOptions}
         value={seatingOptions.filter((o) => sitNextToUserIds.includes(o.id))}
-        onChange={(_, next) => onSitNextToUserIdsChange(next.map((n) => n.id))}
+        onChange={(_, next) => {
+          onSitNextToUserIdsChange(next.map((n) => n.id));
+          onSeatingSearchInputValueChange("");
+        }}
         inputValue={seatingSearchInputValue}
         onInputChange={(_, next, reason) => {
           if (reason === "input") onSeatingSearchInputValueChange(next);


### PR DESCRIPTION
## Summary

- accepts Firebase Auth UIDs in booking `sitNextToUserIds` instead of incorrectly requiring UUIDs
- preserves trimming, deduplication, self-selection prevention, UID length limits, and the ten-member cap
- records safe callable rejection metadata for future handled validation failures
- clears the controlled “Sit next to” search text after selecting a member while retaining the selected chip
- adds backend and component regressions for both behaviours

## Root cause

A Dev booking attempt at 22:39:12 UTC returned HTTP 400 immediately after callable authentication. The member picker supplies Firebase Auth user IDs, and the Data Connect `User.id` plus `Booking.sitNextToUserIds` contract stores those IDs as strings. The callable nevertheless passed every seating ID through UUID validation, rejecting normal Firebase UIDs before any Data Connect write.

Separately, the picker ignored MUI Autocomplete's reset input event because its search text is controlled, leaving the completed search query visible after selection.

## User impact

Members can submit bookings with seating preferences selected, and selecting a member now clears the search box ready for another name.

No booking was persisted by the observed failed request because validation rejected it before persistence.

## Validation

- Functions: 82 test files, 922 tests
- UI: 97 test files, 730 tests
- Functions and UI lint
- Functions and UI production builds
- `git diff --check`