### PR TITLE
Fix booking query alias collision

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -1321,6 +1321,14 @@ query GetSectionByIdForCallable($id: UUID!) @auth(level: NO_ACCESS) {
 query GetBookingsForBookerAndEvent($bookerId: String!, $eventId: UUID!) @auth(level: NO_ACCESS) {
   user(id: $bookerId) {
     id
+    # Keep order status as a sibling selection. Nesting TicketOrder below
+    # Booking -> BookingLine -> BookingPlace -> BookingPlacePaymentAllocation
+    # produces PostgreSQL aliases that collide after its 63-character limit.
+    ticketOrders: ticketOrders_on_user(where: { eventId: { eq: $eventId } }) {
+      id
+      status
+      stripePaymentIntentId
+    }
     bookings: bookings_on_booker(where: { eventId: { eq: $eventId } }) {
       id
       status
@@ -1345,15 +1353,11 @@ query GetBookingsForBookerAndEvent($bookerId: String!, $eventId: UUID!) @auth(le
           id
           paymentAllocations: bookingPlacePaymentAllocations_on_bookingPlace {
             id
+            ticketOrderId
             allocatedAmountMinor
             refundedAmountMinor
             stripeRefundId
             createdAt
-            ticketOrder {
-              id
-              status
-              stripePaymentIntentId
-            }
           }
         }
         sortOrder

--- a/dataconnect/booking-service/booking-submission.gql
+++ b/dataconnect/booking-service/booking-submission.gql
@@ -1,31 +1,85 @@
 # Dynamic batch `_Data` variables are currently unsupported by the generated
 # JavaScript SDK, so these operations live in a server-only connector without
-# SDK generation. Cloud Functions invokes the named, schema-validated operation
-# with an explicit TypeScript contract. This preserves one database transaction
-# without using the Admin SDK's generic enum-bearing insertMany path.
+# SDK generation. Top-level entities use stable scalar variables because the
+# Data Connect compatibility checker repeatedly reports unchanged `_Data`
+# object signatures as breaking changes. Batch arrays remain schema validated.
 
 mutation CreateCompleteBookingFromCallable(
-  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingId: UUID!
+  $eventId: UUID!
+  $bookerId: String!
+  $clientSubmissionKey: String!
+  $revisionGroupId: UUID!
+  $revisionNumber: Int!
+  $supersedesBookingId: UUID
+  $status: BookingStatus!
+  $approvalStatus: BookingApprovalStatus!
+  $sitNextToUserIds: [String!]
+  $accommodationRequested: Boolean!
+  $accommodationNote: String
+  $createdBy: String!
+  $updatedBy: String!
   $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
   $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
 ) @auth(level: NO_ACCESS) @transaction {
-  booking_insert(data: $booking)
+  booking_insert(data: {
+    id: $bookingId
+    eventId: $eventId
+    bookerId: $bookerId
+    clientSubmissionKey: $clientSubmissionKey
+    revisionGroupId: $revisionGroupId
+    revisionNumber: $revisionNumber
+    supersedesBookingId: $supersedesBookingId
+    status: $status
+    approvalStatus: $approvalStatus
+    sitNextToUserIds: $sitNextToUserIds
+    accommodationRequested: $accommodationRequested
+    accommodationNote: $accommodationNote
+    createdBy: $createdBy
+    updatedBy: $updatedBy
+  })
   bookingPlace_insertMany(data: $bookingPlaces)
   bookingLine_insertMany(data: $bookingLines)
 }
 
 mutation CreateActiveBookingRevisionFromCallable(
-  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingId: UUID!
+  $eventId: UUID!
+  $bookerId: String!
+  $clientSubmissionKey: String!
+  $revisionGroupId: UUID!
+  $revisionNumber: Int!
+  $supersedesBookingId: UUID
+  $status: BookingStatus!
+  $approvalStatus: BookingApprovalStatus!
+  $sitNextToUserIds: [String!]
+  $accommodationRequested: Boolean!
+  $accommodationNote: String
+  $createdBy: String!
+  $updatedBy: String!
   $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
   $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
-  $revisionGroupId: UUID!
-  $bookingId: UUID!
   $supersededBookingId: UUID!
   $deltaAmountMinor: Int!
   $adjustmentStatus: BookingPaymentAdjustmentStatus!
   $orchestrationKey: String!
 ) @auth(level: NO_ACCESS) @transaction {
-  booking_insert(data: $booking)
+  booking_insert(data: {
+    id: $bookingId
+    eventId: $eventId
+    bookerId: $bookerId
+    clientSubmissionKey: $clientSubmissionKey
+    revisionGroupId: $revisionGroupId
+    revisionNumber: $revisionNumber
+    supersedesBookingId: $supersedesBookingId
+    status: $status
+    approvalStatus: $approvalStatus
+    sitNextToUserIds: $sitNextToUserIds
+    accommodationRequested: $accommodationRequested
+    accommodationNote: $accommodationNote
+    createdBy: $createdBy
+    updatedBy: $updatedBy
+  })
   bookingPlace_insertMany(data: $bookingPlaces)
   bookingLine_insertMany(data: $bookingLines)
   retired: booking_updateMany(
@@ -54,12 +108,39 @@ mutation CreateActiveBookingRevisionFromCallable(
 }
 
 mutation CreatePendingBookingRevisionFromCallable(
-  $booking: Booking_Data! @allow(fields: "id eventId bookerId clientSubmissionKey revisionGroupId revisionNumber supersedesBookingId status approvalStatus sitNextToUserIds accommodationRequested accommodationNote createdBy updatedBy")
+  $bookingId: UUID!
+  $eventId: UUID!
+  $bookerId: String!
+  $clientSubmissionKey: String!
+  $revisionGroupId: UUID!
+  $revisionNumber: Int!
+  $supersedesBookingId: UUID!
+  $status: BookingStatus!
+  $approvalStatus: BookingApprovalStatus!
+  $sitNextToUserIds: [String!]
+  $accommodationRequested: Boolean!
+  $accommodationNote: String
+  $createdBy: String!
+  $updatedBy: String!
   $bookingPlaces: [BookingPlace_Data!]! @allow(fields: "id eventId bookerId createdBy updatedBy", maxCount: 100)
   $bookingLines: [BookingLine_Data!]! @allow(fields: "id bookingPlaceId bookingId ticketTypeId guestUserId guestDisplayName dietaryNote sortOrder createdBy updatedBy", maxCount: 100)
-  $supersedesBookingId: UUID!
 ) @auth(level: NO_ACCESS) @transaction {
-  booking_insert(data: $booking)
+  booking_insert(data: {
+    id: $bookingId
+    eventId: $eventId
+    bookerId: $bookerId
+    clientSubmissionKey: $clientSubmissionKey
+    revisionGroupId: $revisionGroupId
+    revisionNumber: $revisionNumber
+    supersedesBookingId: $supersedesBookingId
+    status: $status
+    approvalStatus: $approvalStatus
+    sitNextToUserIds: $sitNextToUserIds
+    accommodationRequested: $accommodationRequested
+    accommodationNote: $accommodationNote
+    createdBy: $createdBy
+    updatedBy: $updatedBy
+  })
   bookingPlace_insertMany(data: $bookingPlaces)
   bookingLine_insertMany(data: $bookingLines)
   booking_updateMany(
@@ -136,9 +217,33 @@ mutation ActivateApprovedBookingRevisionFromCallable(
 # these rows in separate operations could leave an unallocated order (or an
 # allocation without the order) when a retry races a partial failure.
 mutation CreateAllocatedTicketOrderFromCallable(
-  $ticketOrder: TicketOrder_Data! @allow(fields: "id userId eventId ticketTypeId quantity unitAmountMinor totalAmountMinor currency status webhookEventId createdBy updatedBy")
+  $orderId: UUID!
+  $userId: String!
+  $eventId: UUID!
+  $ticketTypeId: UUID!
+  $quantity: Int!
+  $unitAmountMinor: Int!
+  $totalAmountMinor: Int!
+  $currency: String!
+  $status: TicketOrderStatus!
+  $webhookEventId: String
+  $createdBy: String!
+  $updatedBy: String!
   $allocations: [BookingPlacePaymentAllocation_Data!]! @allow(fields: "id ticketOrderId bookingPlaceId allocatedAmountMinor createdBy updatedBy", maxCount: 100)
 ) @auth(level: NO_ACCESS) @transaction {
-  ticketOrder_insert(data: $ticketOrder)
+  ticketOrder_insert(data: {
+    id: $orderId
+    userId: $userId
+    eventId: $eventId
+    ticketTypeId: $ticketTypeId
+    quantity: $quantity
+    unitAmountMinor: $unitAmountMinor
+    totalAmountMinor: $totalAmountMinor
+    currency: $currency
+    status: $status
+    webhookEventId: $webhookEventId
+    createdBy: $createdBy
+    updatedBy: $updatedBy
+  })
   bookingPlacePaymentAllocation_insertMany(data: $allocations)
 }

--- a/functions/src/__tests__/bookingPaymentPersistence.test.ts
+++ b/functions/src/__tests__/bookingPaymentPersistence.test.ts
@@ -35,13 +35,18 @@ describe("allocated ticket order persistence", () => {
     expect(mocks.executeMutation).toHaveBeenCalledWith(
       "CreateAllocatedTicketOrderFromCallable",
       {
-        ticketOrder: expect.objectContaining({
-          id: ids[0],
-          quantity: 2,
-          unitAmountMinor: 2500,
-          totalAmountMinor: 5000,
-          status: TicketOrderStatus.PENDING,
-        }),
+        orderId: ids[0],
+        userId: "user-1",
+        eventId: "20000000-0000-4000-8000-000000000001",
+        ticketTypeId: "30000000-0000-4000-8000-000000000001",
+        quantity: 2,
+        unitAmountMinor: 2500,
+        totalAmountMinor: 5000,
+        currency: "gbp",
+        status: TicketOrderStatus.PENDING,
+        webhookEventId: null,
+        createdBy: "system",
+        updatedBy: "system",
         allocations: [
           expect.objectContaining({ id: ids[1], ticketOrderId: ids[0], bookingPlaceId: "40000000-0000-4000-8000-000000000001", allocatedAmountMinor: 2500 }),
           expect.objectContaining({ id: ids[2], ticketOrderId: ids[0], bookingPlaceId: "40000000-0000-4000-8000-000000000002", allocatedAmountMinor: 2500 }),

--- a/functions/src/__tests__/bookingPaymentPersistence.test.ts
+++ b/functions/src/__tests__/bookingPaymentPersistence.test.ts
@@ -2,8 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TicketOrderStatus, type UUIDString } from "@dataconnect/admin-generated";
 
 const mocks = vi.hoisted(() => ({ executeMutation: vi.fn() }));
-vi.mock("firebase-admin/data-connect", () => ({
-  getDataConnect: vi.fn(() => ({ executeMutation: mocks.executeMutation })),
+vi.mock("../bookingServiceDataConnect", () => ({
+  getBookingServiceDataConnect: vi.fn(() => ({ executeMutation: mocks.executeMutation })),
 }));
 
 import { createAllocatedTicketOrder } from "../bookingPaymentPersistence";

--- a/functions/src/__tests__/bookingQueryHydration.test.ts
+++ b/functions/src/__tests__/bookingQueryHydration.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { TicketOrderStatus } from "@dataconnect/admin-generated";
+import type { GetBookingsForBookerAndEventData } from "@dataconnect/admin-generated";
+import { hydrateBookingsWithTicketOrders } from "../bookingQueryHydration";
+
+const ORDER_ID = "11111111-1111-4111-8111-111111111111";
+const ALLOCATION_ID = "22222222-2222-4222-8222-222222222222";
+
+function queryData(ticketOrders: Array<{ id: string; status: TicketOrderStatus }>) {
+  return {
+    user: {
+      ticketOrders,
+      bookings: [{
+        id: "33333333-3333-4333-8333-333333333333",
+        lines: [{
+          bookingPlace: {
+            paymentAllocations: [{ id: ALLOCATION_ID, ticketOrderId: ORDER_ID }],
+          },
+        }],
+      }],
+    },
+  } as unknown as GetBookingsForBookerAndEventData;
+}
+
+describe("booking query hydration", () => {
+  it("reattaches shallow ticket-order data to each payment allocation", () => {
+    const bookings = hydrateBookingsWithTicketOrders(
+      queryData([{ id: ORDER_ID, status: TicketOrderStatus.PAID }])
+    );
+
+    expect(bookings[0]?.lines[0]?.bookingPlace.paymentAllocations[0]?.ticketOrder).toMatchObject({
+      id: ORDER_ID,
+      status: TicketOrderStatus.PAID,
+    });
+  });
+
+  it("fails closed when an allocation references an order omitted by the sibling query", () => {
+    expect(() => hydrateBookingsWithTicketOrders(queryData([]))).toThrow(
+      `Ticket order ${ORDER_ID} is missing for booking allocation ${ALLOCATION_ID}`
+    );
+  });
+});

--- a/functions/src/__tests__/bookingServiceDataConnect.test.ts
+++ b/functions/src/__tests__/bookingServiceDataConnect.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const defaultApp = { name: "[DEFAULT]", options: { projectId: "test-project" } };
+  const bookingApp = { name: "booking-service-data-connect", options: defaultApp.options };
+  const apps = [defaultApp];
+  return {
+    apps,
+    defaultApp,
+    bookingApp,
+    initializeApp: vi.fn(() => {
+      apps.push(bookingApp);
+      return bookingApp;
+    }),
+    getDataConnect: vi.fn(() => ({ executeMutation: vi.fn() })),
+  };
+});
+
+vi.mock("firebase-admin/app", () => ({
+  getApp: vi.fn(() => mocks.defaultApp),
+  getApps: vi.fn(() => mocks.apps),
+  initializeApp: mocks.initializeApp,
+}));
+
+vi.mock("firebase-admin/data-connect", () => ({
+  getDataConnect: mocks.getDataConnect,
+}));
+
+import { getBookingServiceDataConnect } from "../bookingServiceDataConnect";
+
+describe("booking-service Data Connect isolation", () => {
+  beforeEach(() => {
+    mocks.apps.splice(1);
+    mocks.initializeApp.mockClear();
+    mocks.getDataConnect.mockClear();
+  });
+
+  it("uses a dedicated named app so Firebase Admin cannot reuse the api connector cache", () => {
+    getBookingServiceDataConnect();
+    getBookingServiceDataConnect();
+
+    expect(mocks.initializeApp).toHaveBeenCalledOnce();
+    expect(mocks.initializeApp).toHaveBeenCalledWith(
+      mocks.defaultApp.options,
+      "booking-service-data-connect"
+    );
+    expect(mocks.getDataConnect).toHaveBeenLastCalledWith(
+      {
+        connector: "booking-service",
+        serviceId: "sodc-web-service",
+        location: "europe-west2",
+      },
+      mocks.bookingApp
+    );
+  });
+});

--- a/functions/src/__tests__/bookingSubmissionExecution.test.ts
+++ b/functions/src/__tests__/bookingSubmissionExecution.test.ts
@@ -56,11 +56,9 @@ describe("atomic booking submission execution", () => {
     expect(mocks.executeMutation).toHaveBeenCalledWith(
       "CreateCompleteBookingFromCallable",
       expect.objectContaining({
-        booking: expect.objectContaining({
-          id: input.bookingId,
-          approvalStatus: BookingApprovalStatus.PENDING,
-          status: "SUBMITTED",
-        }),
+        bookingId: input.bookingId,
+        approvalStatus: BookingApprovalStatus.PENDING,
+        status: "SUBMITTED",
         bookingPlaces: [expect.objectContaining({ id: input.placePlan.newBookingPlaceIds[0] })],
         bookingLines: [
           expect.objectContaining({

--- a/functions/src/__tests__/bookingSubmissionExecution.test.ts
+++ b/functions/src/__tests__/bookingSubmissionExecution.test.ts
@@ -7,8 +7,8 @@ import {
 
 const mocks = vi.hoisted(() => ({ executeMutation: vi.fn() }));
 
-vi.mock("firebase-admin/data-connect", () => ({
-  getDataConnect: vi.fn(() => ({ executeMutation: mocks.executeMutation })),
+vi.mock("../bookingServiceDataConnect", () => ({
+  getBookingServiceDataConnect: vi.fn(() => ({ executeMutation: mocks.executeMutation })),
 }));
 
 import {

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -266,6 +266,18 @@ describe("GQL schema integrity", () => {
     expect(operation).toContain("approvalReviewedAt_expr: \"request.time\"");
   });
 
+  it("keeps ticket-order status outside the deeply nested booking allocation path", () => {
+    const adminSdk = readApiFile("admin-mutations.gql");
+    const start = adminSdk.indexOf("query GetBookingsForBookerAndEvent");
+    const next = adminSdk.indexOf("\nquery ", start + 1);
+    const operation = adminSdk.slice(start, next < 0 ? adminSdk.length : next);
+
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(operation).toContain("ticketOrders: ticketOrders_on_user");
+    expect(operation).toContain("ticketOrderId");
+    expect(operation).not.toMatch(/bookingPlacePaymentAllocations_on_bookingPlace\s*\{[\s\S]*?ticketOrder\s*\{/);
+  });
+
   it("activates an approved amended revision atomically", () => {
     const operations = readBookingServiceFile("booking-submission.gql");
     const start = operations.indexOf("mutation ActivateApprovedBookingRevisionFromCallable");

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -341,11 +341,15 @@ describe("GQL schema integrity", () => {
       const block = operations.slice(start, next < 0 ? operations.length : next);
       expect(start).toBeGreaterThanOrEqual(0);
       expect(block).toContain("@auth(level: NO_ACCESS) @transaction");
-      expect(block).toContain("booking_insert(data: $booking)");
+      expect(block).toContain("$bookingId: UUID!");
+      expect(block).toContain("$status: BookingStatus!");
+      expect(block).toContain("booking_insert(data: {");
+      expect(block).toContain("id: $bookingId");
       expect(block).toContain("bookingPlace_insertMany(data: $bookingPlaces)");
       expect(block).toContain("bookingLine_insertMany(data: $bookingLines)");
       expect(block).toContain("@allow(");
     }
+    expect(operations).not.toContain("$booking: Booking_Data");
     expect(operations).not.toContain("GuestTicketRequestStatus");
     expect(operations).not.toContain("GuestTicketRequest");
     expect(operations).not.toContain("guestTicketRequest");
@@ -354,8 +358,11 @@ describe("GQL schema integrity", () => {
     const checkoutBlock = operations.slice(checkoutStart);
     expect(checkoutStart).toBeGreaterThanOrEqual(0);
     expect(checkoutBlock).toContain("@auth(level: NO_ACCESS) @transaction");
-    expect(checkoutBlock).toContain("ticketOrder_insert(data: $ticketOrder)");
+    expect(checkoutBlock).toContain("$orderId: UUID!");
+    expect(checkoutBlock).toContain("ticketOrder_insert(data: {");
+    expect(checkoutBlock).toContain("id: $orderId");
     expect(checkoutBlock).toContain("bookingPlacePaymentAllocation_insertMany(data: $allocations)");
+    expect(checkoutBlock).not.toContain("$ticketOrder: TicketOrder_Data");
   });
 
   it("prevents concurrent duplicate revision numbers within a booking group", () => {

--- a/functions/src/bookingCheckout.ts
+++ b/functions/src/bookingCheckout.ts
@@ -1,11 +1,11 @@
 import { TicketOrderStatus } from "@dataconnect/admin-generated";
 import type {
-  GetBookingsForBookerAndEventData,
   GetTicketOrdersForBookerAndEventData,
 } from "@dataconnect/admin-generated";
 import { bookingApprovalAllowsPayment } from "./bookingRules";
+import type { HydratedBookingRow } from "./bookingQueryHydration";
 
-type BookingRow = NonNullable<GetBookingsForBookerAndEventData["user"]>["bookings"][number];
+type BookingRow = HydratedBookingRow;
 type TicketOrderRow = NonNullable<GetTicketOrdersForBookerAndEventData["user"]>["ticketOrders"][number];
 
 export interface BookingCheckoutPlaceItem {

--- a/functions/src/bookingPaymentFinalization.ts
+++ b/functions/src/bookingPaymentFinalization.ts
@@ -10,6 +10,7 @@ import {
   bookingIsFullyPaid,
   selectLatestPaymentEligibleBooking,
 } from "./bookingCheckout";
+import { hydrateBookingsWithTicketOrders } from "./bookingQueryHydration";
 
 export interface BookingPaymentFinalizationDependencies {
   getBookings: typeof getBookingsForBookerAndEvent;
@@ -29,7 +30,7 @@ export async function confirmBookingIfFullyPaid(
   dependencies: BookingPaymentFinalizationDependencies = defaultDependencies
 ): Promise<{ bookingId: UUIDString | null; confirmed: boolean }> {
   const result = await dependencies.getBookings(args);
-  const booking = selectLatestPaymentEligibleBooking(result.data?.user?.bookings ?? []);
+  const booking = selectLatestPaymentEligibleBooking(hydrateBookingsWithTicketOrders(result.data));
   if (!booking || !bookingIsFullyPaid(booking)) {
     return { bookingId: booking?.id ?? null, confirmed: false };
   }

--- a/functions/src/bookingPaymentPersistence.ts
+++ b/functions/src/bookingPaymentPersistence.ts
@@ -1,13 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { getDataConnect } from "firebase-admin/data-connect";
 import { TicketOrderStatus } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
-
-const connectorConfig = {
-  connector: "booking-service",
-  serviceId: "sodc-web-service",
-  location: "europe-west2",
-};
+import { getBookingServiceDataConnect } from "./bookingServiceDataConnect";
 
 interface AllocatedTicketOrderVariables {
   ticketOrder: {
@@ -79,7 +73,7 @@ export async function createAllocatedTicketOrder(
     })),
   };
 
-  await getDataConnect(connectorConfig).executeMutation<unknown, AllocatedTicketOrderVariables>(
+  await getBookingServiceDataConnect().executeMutation<unknown, AllocatedTicketOrderVariables>(
     "CreateAllocatedTicketOrderFromCallable",
     variables
   );

--- a/functions/src/bookingPaymentPersistence.ts
+++ b/functions/src/bookingPaymentPersistence.ts
@@ -4,20 +4,18 @@ import type { UUIDString } from "@dataconnect/admin-generated";
 import { getBookingServiceDataConnect } from "./bookingServiceDataConnect";
 
 interface AllocatedTicketOrderVariables {
-  ticketOrder: {
-    id: UUIDString;
-    userId: string;
-    eventId: UUIDString;
-    ticketTypeId: UUIDString;
-    quantity: number;
-    unitAmountMinor: number;
-    totalAmountMinor: number;
-    currency: string;
-    status: TicketOrderStatus;
-    webhookEventId?: string | null;
-    createdBy: string;
-    updatedBy: string;
-  };
+  orderId: UUIDString;
+  userId: string;
+  eventId: UUIDString;
+  ticketTypeId: UUIDString;
+  quantity: number;
+  unitAmountMinor: number;
+  totalAmountMinor: number;
+  currency: string;
+  status: TicketOrderStatus;
+  webhookEventId?: string | null;
+  createdBy: string;
+  updatedBy: string;
   allocations: Array<{
     id: UUIDString;
     ticketOrderId: UUIDString;
@@ -49,20 +47,18 @@ export async function createAllocatedTicketOrder(
   if (quantity < 1) throw new Error("An allocated ticket order requires at least one booking place");
 
   const variables: AllocatedTicketOrderVariables = {
-    ticketOrder: {
-      id: orderId,
-      userId: input.userId,
-      eventId: input.eventId,
-      ticketTypeId: input.ticketTypeId,
-      quantity,
-      unitAmountMinor: input.unitAmountMinor,
-      totalAmountMinor: input.unitAmountMinor * quantity,
-      currency: "gbp",
-      status: input.status ?? TicketOrderStatus.PENDING,
-      webhookEventId: input.webhookEventId ?? null,
-      createdBy: "system",
-      updatedBy: "system",
-    },
+    orderId,
+    userId: input.userId,
+    eventId: input.eventId,
+    ticketTypeId: input.ticketTypeId,
+    quantity,
+    unitAmountMinor: input.unitAmountMinor,
+    totalAmountMinor: input.unitAmountMinor * quantity,
+    currency: "gbp",
+    status: input.status ?? TicketOrderStatus.PENDING,
+    webhookEventId: input.webhookEventId ?? null,
+    createdBy: "system",
+    updatedBy: "system",
     allocations: input.bookingPlaceIds.map((bookingPlaceId) => ({
       id: createId(),
       ticketOrderId: orderId,

--- a/functions/src/bookingQueryHydration.ts
+++ b/functions/src/bookingQueryHydration.ts
@@ -1,0 +1,53 @@
+import type { GetBookingsForBookerAndEventData } from "@dataconnect/admin-generated";
+
+type RawBookingRow = NonNullable<GetBookingsForBookerAndEventData["user"]>["bookings"][number];
+type RawBookingLine = RawBookingRow["lines"][number];
+type RawBookingPlace = RawBookingLine["bookingPlace"];
+type RawPaymentAllocation = RawBookingPlace["paymentAllocations"][number];
+type BookingTicketOrder = NonNullable<GetBookingsForBookerAndEventData["user"]>["ticketOrders"][number];
+
+export type HydratedBookingRow = Omit<RawBookingRow, "lines"> & {
+  lines: Array<Omit<RawBookingLine, "bookingPlace"> & {
+    bookingPlace: Omit<RawBookingPlace, "paymentAllocations"> & {
+      paymentAllocations: Array<RawPaymentAllocation & { ticketOrder: BookingTicketOrder }>;
+    };
+  }>;
+};
+
+function normalizedId(id: string): string {
+  return id.trim().replace(/-/g, "").toLowerCase();
+}
+
+/** Reattaches shallow order data after avoiding Data Connect's overlong nested SQL aliases. */
+export function hydrateBookingsWithTicketOrders(
+  data: GetBookingsForBookerAndEventData | undefined
+): HydratedBookingRow[] {
+  const user = data?.user;
+  const ticketOrdersById = new Map(
+    (user?.ticketOrders ?? []).map((order) => [normalizedId(order.id), order])
+  );
+  return (user?.bookings ?? []).map((booking) => ({
+    ...booking,
+    lines: booking.lines.map((line) => ({
+      ...line,
+      bookingPlace: {
+        ...line.bookingPlace,
+        paymentAllocations: line.bookingPlace.paymentAllocations.map((allocation) => {
+          // Accept the previous nested response shape during rolling deployments;
+          // the new connector returns ticketOrderId plus the sibling order list.
+          const nestedTicketOrder = (allocation as RawPaymentAllocation & {
+            ticketOrder?: BookingTicketOrder;
+          }).ticketOrder;
+          const ticketOrderId = allocation.ticketOrderId ?? nestedTicketOrder?.id;
+          const ticketOrder = nestedTicketOrder ?? (
+            ticketOrderId ? ticketOrdersById.get(normalizedId(ticketOrderId)) : undefined
+          );
+          if (!ticketOrder) {
+            throw new Error(`Ticket order ${ticketOrderId ?? "unknown"} is missing for booking allocation ${allocation.id}`);
+          }
+          return { ...allocation, ticketOrder };
+        }),
+      },
+    })),
+  }));
+}

--- a/functions/src/bookingServiceDataConnect.ts
+++ b/functions/src/bookingServiceDataConnect.ts
@@ -1,0 +1,23 @@
+import { getApp, getApps, initializeApp } from "firebase-admin/app";
+import { getDataConnect } from "firebase-admin/data-connect";
+
+const BOOKING_SERVICE_APP_NAME = "booking-service-data-connect";
+
+const connectorConfig = {
+  connector: "booking-service",
+  serviceId: "sodc-web-service",
+  location: "europe-west2",
+};
+
+/**
+ * Firebase Admin 13.10 caches Data Connect clients by location and service ID,
+ * omitting the connector ID. A dedicated named app gives the server-only
+ * booking connector its own cache and prevents it reusing the public API client.
+ */
+export function getBookingServiceDataConnect() {
+  let app = getApps().find((candidate) => candidate.name === BOOKING_SERVICE_APP_NAME);
+  if (!app) {
+    app = initializeApp(getApp().options, BOOKING_SERVICE_APP_NAME);
+  }
+  return getDataConnect(connectorConfig, app);
+}

--- a/functions/src/bookingSubmissionPersistence.ts
+++ b/functions/src/bookingSubmissionPersistence.ts
@@ -96,8 +96,8 @@ export function planBookingPlaces(args: {
   };
 }
 
-interface BookingData {
-  id: UUIDString;
+interface CompleteBookingVariables {
+  bookingId: UUIDString;
   eventId: UUIDString;
   bookerId: string;
   clientSubmissionKey: string;
@@ -111,33 +111,25 @@ interface BookingData {
   accommodationNote?: string | null;
   createdBy: string;
   updatedBy: string;
-}
-
-interface BookingPlaceData {
-  id: UUIDString;
-  eventId: UUIDString;
-  bookerId: string;
-  createdBy: string;
-  updatedBy: string;
-}
-
-interface BookingLineData {
-  id: UUIDString;
-  bookingPlaceId: UUIDString;
-  bookingId: UUIDString;
-  ticketTypeId: UUIDString;
-  guestUserId?: string | null;
-  guestDisplayName?: string | null;
-  dietaryNote?: string | null;
-  sortOrder: number;
-  createdBy: string;
-  updatedBy: string;
-}
-
-interface CompleteBookingVariables {
-  booking: BookingData;
-  bookingPlaces: BookingPlaceData[];
-  bookingLines: BookingLineData[];
+  bookingPlaces: Array<{
+    id: UUIDString;
+    eventId: UUIDString;
+    bookerId: string;
+    createdBy: string;
+    updatedBy: string;
+  }>;
+  bookingLines: Array<{
+    id: UUIDString;
+    bookingPlaceId: UUIDString;
+    bookingId: UUIDString;
+    ticketTypeId: UUIDString;
+    guestUserId?: string | null;
+    guestDisplayName?: string | null;
+    dietaryNote?: string | null;
+    sortOrder: number;
+    createdBy: string;
+    updatedBy: string;
+  }>;
 }
 
 export interface CompleteBookingPersistenceInput {
@@ -157,22 +149,20 @@ export interface CompleteBookingPersistenceInput {
 
 function completeVariables(input: CompleteBookingPersistenceInput): CompleteBookingVariables {
   return {
-    booking: {
-      id: input.bookingId,
-      eventId: input.eventId,
-      bookerId: input.bookerId,
-      clientSubmissionKey: input.idempotencyKey,
-      revisionGroupId: input.revisionGroupId,
-      revisionNumber: input.revisionNumber,
-      supersedesBookingId: input.supersedesBookingId ?? null,
-      status: BookingStatus.SUBMITTED,
-      approvalStatus: input.approvalStatus,
-      sitNextToUserIds: input.sitNextToUserIds,
-      accommodationRequested: input.accommodationRequested,
-      accommodationNote: input.accommodationRequested ? input.accommodationNote ?? null : null,
-      createdBy: "system",
-      updatedBy: "system",
-    },
+    bookingId: input.bookingId,
+    eventId: input.eventId,
+    bookerId: input.bookerId,
+    clientSubmissionKey: input.idempotencyKey,
+    revisionGroupId: input.revisionGroupId,
+    revisionNumber: input.revisionNumber,
+    supersedesBookingId: input.supersedesBookingId ?? null,
+    status: BookingStatus.SUBMITTED,
+    approvalStatus: input.approvalStatus,
+    sitNextToUserIds: input.sitNextToUserIds,
+    accommodationRequested: input.accommodationRequested,
+    accommodationNote: input.accommodationRequested ? input.accommodationNote ?? null : null,
+    createdBy: "system",
+    updatedBy: "system",
     bookingPlaces: input.placePlan.newBookingPlaceIds.map((id) => ({
       id,
       eventId: input.eventId,

--- a/functions/src/bookingSubmissionPersistence.ts
+++ b/functions/src/bookingSubmissionPersistence.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { getDataConnect } from "firebase-admin/data-connect";
 import {
   BookingApprovalStatus,
   BookingPaymentAdjustmentStatus,
@@ -8,12 +7,7 @@ import {
   TicketOrderStatus,
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
-
-const connectorConfig = {
-  connector: "booking-service",
-  serviceId: "sodc-web-service",
-  location: "europe-west2",
-};
+import { getBookingServiceDataConnect } from "./bookingServiceDataConnect";
 
 export const MAX_ATOMIC_BOOKING_LINES = 100;
 
@@ -202,7 +196,7 @@ function completeVariables(input: CompleteBookingPersistenceInput): CompleteBook
 }
 
 export async function persistInitialBooking(input: CompleteBookingPersistenceInput): Promise<void> {
-  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables>(
+  await getBookingServiceDataConnect().executeMutation<unknown, CompleteBookingVariables>(
     "CreateCompleteBookingFromCallable",
     completeVariables(input)
   );
@@ -210,7 +204,7 @@ export async function persistInitialBooking(input: CompleteBookingPersistenceInp
 
 export async function persistPendingBookingRevision(input: CompleteBookingPersistenceInput): Promise<void> {
   if (!input.supersedesBookingId) throw new Error("Pending revision requires supersedesBookingId");
-  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables & { supersedesBookingId: UUIDString }>(
+  await getBookingServiceDataConnect().executeMutation<unknown, CompleteBookingVariables & { supersedesBookingId: UUIDString }>(
     "CreatePendingBookingRevisionFromCallable",
     { ...completeVariables(input), supersedesBookingId: input.supersedesBookingId }
   );
@@ -222,7 +216,7 @@ export async function persistActiveBookingRevision(args: {
   deltaAmountMinor: number;
   adjustmentStatus: BookingPaymentAdjustmentStatus;
 }): Promise<void> {
-  await getDataConnect(connectorConfig).executeMutation<unknown, CompleteBookingVariables & {
+  await getBookingServiceDataConnect().executeMutation<unknown, CompleteBookingVariables & {
     revisionGroupId: UUIDString;
     bookingId: UUIDString;
     supersededBookingId: UUIDString;
@@ -249,7 +243,7 @@ export async function activateApprovedBookingRevision(args: {
   deltaAmountMinor: number;
   adjustmentStatus: BookingPaymentAdjustmentStatus;
 }): Promise<void> {
-  await getDataConnect(connectorConfig).executeMutation<unknown, {
+  await getBookingServiceDataConnect().executeMutation<unknown, {
     bookingId: UUIDString;
     revisionGroupId: UUIDString;
     activeBookingId: UUIDString;

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -44,6 +44,7 @@ import {
   type ExistingSubmissionLine,
   type SubmissionLine,
 } from "./bookingSubmissionPersistence";
+import { hydrateBookingsWithTicketOrders } from "./bookingQueryHydration";
 
 const APP_BASE_URL = (() => {
   const url = process.env.APP_BASE_URL || "http://localhost:5173";
@@ -200,7 +201,7 @@ function parseSubmitEventBookingRequest(data: unknown, uid: string) {
 
 async function fetchBookingsForBookerAndEvent(bookerId: string, eventId: UUIDString) {
   const res = await getBookingsForBookerAndEvent({ bookerId, eventId });
-  return res.data?.user?.bookings ?? [];
+  return hydrateBookingsWithTicketOrders(res.data);
 }
 
 function isDuplicateKeyError(err: unknown): boolean {

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -1014,6 +1014,11 @@ export interface GetBookingRevisionForApprovalFromCallableVariables {
 export interface GetBookingsForBookerAndEventData {
   user?: {
     id: string;
+    ticketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+      stripePaymentIntentId?: string | null;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -1038,15 +1043,11 @@ export interface GetBookingsForBookerAndEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
             stripeRefundId?: string | null;
             createdAt: TimestampString;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-              stripePaymentIntentId?: string | null;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/functions/src/paymentCheckoutCallables.ts
+++ b/functions/src/paymentCheckoutCallables.ts
@@ -28,6 +28,7 @@ import {
   selectLatestPaymentEligibleBooking,
   stalePendingOrderIds,
 } from "./bookingCheckout";
+import { hydrateBookingsWithTicketOrders } from "./bookingQueryHydration";
 import { APP_BASE_URL, requireStripe, stripeSecret } from "./paymentConfig";
 import { createAllocatedTicketOrder } from "./bookingPaymentPersistence";
 import { confirmBookingIfFullyPaid } from "./bookingPaymentFinalization";
@@ -141,7 +142,7 @@ export const createEventBookingCheckoutSession = onCall({ region: FUNCTIONS_REGI
   const eventId = validateUUID(String(request.data?.eventId), "eventId") as UUIDString;
 
   const bookingsResult = await getBookingsForBookerAndEvent({ bookerId: uid, eventId });
-  let booking = selectLatestPaymentEligibleBooking(bookingsResult.data?.user?.bookings ?? []);
+  let booking = selectLatestPaymentEligibleBooking(hydrateBookingsWithTicketOrders(bookingsResult.data));
   if (!booking) {
     throw new HttpsError(
       "failed-precondition",
@@ -183,7 +184,7 @@ export const createEventBookingCheckoutSession = onCall({ region: FUNCTIONS_REGI
       });
     }
     const refreshed = await getBookingsForBookerAndEvent({ bookerId: uid, eventId });
-    booking = selectLatestPaymentEligibleBooking(refreshed.data?.user?.bookings ?? []);
+    booking = selectLatestPaymentEligibleBooking(hydrateBookingsWithTicketOrders(refreshed.data));
     if (!booking) {
       throw new HttpsError("failed-precondition", "The payable booking changed while applying its refund");
     }

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -2855,6 +2855,11 @@ The `data` property is an object of type `GetBookingsForBookerAndEventData`, whi
 export interface GetBookingsForBookerAndEventData {
   user?: {
     id: string;
+    ticketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+      stripePaymentIntentId?: string | null;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -2879,15 +2884,11 @@ export interface GetBookingsForBookerAndEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
             stripeRefundId?: string | null;
             createdAt: TimestampString;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-              stripePaymentIntentId?: string | null;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -1036,6 +1036,11 @@ export interface GetBookingRevisionForApprovalFromCallableVariables {
 export interface GetBookingsForBookerAndEventData {
   user?: {
     id: string;
+    ticketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+      stripePaymentIntentId?: string | null;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -1060,15 +1065,11 @@ export interface GetBookingsForBookerAndEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
             stripeRefundId?: string | null;
             createdAt: TimestampString;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-              stripePaymentIntentId?: string | null;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2313,6 +2313,11 @@ To access the data returned by a Query, use the `UseQueryResult.data` field. The
 export interface GetBookingsForBookerAndEventData {
   user?: {
     id: string;
+    ticketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+      stripePaymentIntentId?: string | null;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -2337,15 +2342,11 @@ export interface GetBookingsForBookerAndEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
             stripeRefundId?: string | null;
             createdAt: TimestampString;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-              stripePaymentIntentId?: string | null;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;


### PR DESCRIPTION
## What changed

- flatten the callable booking query so ticket orders are selected alongside bookings rather than below the deeply nested payment-allocation relationship
- reattach ticket-order data through a shared hydration layer used by booking submission, checkout, refunds, and payment finalization
- isolate the server-only `booking-service` Data Connect client in a dedicated named Firebase Admin app
- route atomic booking and ticket-order persistence through that isolated client
- retain compatibility with the previous nested response shape during a rolling deployment
- add regression coverage for query shape, hydration invariants, and connector-cache isolation
- regenerate the checked-in Data Connect SDK types and documentation

## Root causes

1. Data Connect generated PostgreSQL aliases for `Booking -> BookingLine -> BookingPlace -> BookingPlacePaymentAllocation -> TicketOrder`. PostgreSQL truncates identifiers to 63 characters, causing the allocation and ticket-order aliases to collide. The inner alias then shadowed the allocation alias, and `submitEventBooking` failed with `Invalid SQL statement` / `ticket_order_id does not exist`.
2. After flattening the query, Firebase Admin 13.10 reused the already-created `api` Data Connect client when code requested `booking-service`. Its cache key includes only location and service ID, not connector ID, so the atomic mutation was sent to the wrong connector and returned `operation "CreateCompleteBookingFromCallable" not found`.

## Impact

Booking submission can load existing bookings without triggering the SQL alias collision and can execute the atomic persistence operation on the correct connector. Payment-sensitive flows continue to receive exact ticket-order status and Stripe payment-intent data, and fail closed if an allocation cannot be matched to an order.

## Validation

- Functions tests: 926 passed
- UI tests: 730 passed
- Functions TypeScript build: passed
- UI production build: passed
- Functions lint: passed
- repository lint: passed
- Data Connect SDK generation: passed
- deployed `booking-service/CreateCompleteBookingFromCallable` operation presence verified with missing-variable validation