### PR TITLE
Fix booking UI refresh and loading failures

### DIFF
--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -607,14 +607,15 @@ query ListEventBookingsForAdmin($eventId: UUID!) @auth(expr: "auth.token.admin =
         dietaryNote
         bookingPlace {
           id
+          # Keep order status as a sibling selection (see ListTicketOrdersForAdmin,
+          # fetched alongside this query). Nesting TicketOrder below
+          # Booking -> BookingLine -> BookingPlace -> BookingPlacePaymentAllocation
+          # produces PostgreSQL aliases that collide after its 63-character limit.
           paymentAllocations: bookingPlacePaymentAllocations_on_bookingPlace {
             id
             allocatedAmountMinor
             refundedAmountMinor
-            ticketOrder {
-              id
-              status
-            }
+            ticketOrderId
           }
         }
         guestUser {

--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -393,6 +393,13 @@ query GetSectionMembers($sectionId: UUID!) @auth(level: NO_ACCESS) {
 query GetMyBookingsForEvent($eventId: UUID!) @auth(expr: "auth.token.enabled == true") {
   user(key: { id_expr: "auth.uid" }) {
     id
+    # Keep order status as a sibling selection. Nesting TicketOrder below
+    # Booking -> BookingLine -> BookingPlace -> BookingPlacePaymentAllocation
+    # produces PostgreSQL aliases that collide after its 63-character limit.
+    bookingTicketOrders: ticketOrders_on_user(where: { eventId: { eq: $eventId } }) {
+      id
+      status
+    }
     bookings: bookings_on_booker(where: { eventId: { eq: $eventId } }) {
       id
       status
@@ -413,11 +420,8 @@ query GetMyBookingsForEvent($eventId: UUID!) @auth(expr: "auth.token.enabled == 
           id
           paymentAllocations: bookingPlacePaymentAllocations_on_bookingPlace {
             id
+            ticketOrderId
             refundedAmountMinor
-            ticketOrder {
-              id
-              status
-            }
           }
         }
         sortOrder

--- a/functions/email-templates/bookingRevision.md
+++ b/functions/email-templates/bookingRevision.md
@@ -11,10 +11,9 @@ variables:
   - bookingTotalFormatted
   - sectionBookingsUrl
   - myPaymentsUrl
-  - paymentAdjustmentStatus
   - previousTotalFormatted
   - revisedTotalFormatted
-  - deltaAmountFormatted
+  - paymentRemainingFormatted
 ---
 Hello ((firstName)),
 
@@ -40,9 +39,7 @@ Previous total: ((previousTotalFormatted))
 
 Revised total: ((revisedTotalFormatted))
 
-Payment difference: ((deltaAmountFormatted))
-
-Payment status: ((paymentAdjustmentStatus))
+Payment remaining: ((paymentRemainingFormatted))
 
 ---
 

--- a/functions/src/__tests__/bookingApprovals.test.ts
+++ b/functions/src/__tests__/bookingApprovals.test.ts
@@ -7,12 +7,12 @@ import {
 } from "@dataconnect/admin-generated";
 import type {
   GetBookingRevisionForApprovalFromCallableData,
-  GetBookingsForBookerAndEventData,
 } from "@dataconnect/admin-generated";
 import { resolveBookingApprovalReview } from "../bookingApprovals";
+import type { HydratedBookingRow } from "../bookingQueryHydration";
 
 type Target = NonNullable<GetBookingRevisionForApprovalFromCallableData["booking"]>;
-type Revision = NonNullable<GetBookingsForBookerAndEventData["user"]>["bookings"][number];
+type Revision = HydratedBookingRow;
 
 function target(overrides: Partial<Target> = {}): Target {
   return {
@@ -41,7 +41,7 @@ function revision(overrides: Partial<Revision> = {}): Revision {
     revisionGroupId: "20000000-0000-4000-8000-000000000001",
     revisionNumber: 1,
     supersededAt: null,
-    lines: [{ id: "line-old", sortOrder: 0, guestDisplayName: null, dietaryNote: null, ticketType: { id: "ticket", title: "Ticket", audience: "MEMBER", price: 20 }, bookingPlace: { id: "place-old", paymentAllocations: [] }, guestUser: null }],
+    lines: [{ id: "line-old", sortOrder: 0, guestDisplayName: null, dietaryNote: null, ticketType: { id: "ticket", title: "Ticket", audience: "MEMBER", price: 20 }, bookingPlace: { id: "place-old", paymentAllocations: [{ id: "allocation-old", allocatedAmountMinor: 2000, refundedAmountMinor: 0, ticketOrderId: "order-old", ticketOrder: { id: "order-old", status: "PAID", stripePaymentIntentId: "pi_old" } }] }, guestUser: null }],
     ...overrides,
   } as unknown as Revision;
 }

--- a/functions/src/__tests__/bookingApprovals.test.ts
+++ b/functions/src/__tests__/bookingApprovals.test.ts
@@ -59,6 +59,7 @@ describe("whole-booking approval review", () => {
       previousTotalMinor: 2000,
       revisedTotalMinor: 3000,
       deltaAmountMinor: 1000,
+      paymentRemainingMinor: 1000,
       status: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
     });
   });

--- a/functions/src/__tests__/bookingEmailDispatcher.test.ts
+++ b/functions/src/__tests__/bookingEmailDispatcher.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
 import * as admin from "@dataconnect/admin-generated";
 import {
   accommodationRequestedCondition,
@@ -12,9 +11,7 @@ import {
   bookingTotalMinorFromLines,
   buildTicketLinesSummary,
   formatBookingEventDateTime,
-  formatSignedDeltaAmount,
   notifyBookingConfirmationEmail,
-  paymentAdjustmentStatusLabel,
 } from "../bookingEmailDispatcher";
 import * as notificationDelivery from "../notificationDelivery";
 
@@ -63,14 +60,6 @@ describe("bookingEmailDispatcher helpers", () => {
     );
     expect(bookingChangesRequestedDeliveryKey("b1")).toBe("booking-changes-requested:b1");
     expect(bookingApprovedDeliveryKey("b1")).toBe("booking-approved:b1");
-  });
-
-  it("labels payment adjustment status", () => {
-    expect(paymentAdjustmentStatusLabel(BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE)).toBe(
-      "Additional payment due"
-    );
-    expect(formatSignedDeltaAmount(1500)).toBe("+£15.00");
-    expect(formatSignedDeltaAmount(-500)).toBe("-£5.00");
   });
 
   it("accommodationRequestedCondition returns GOV.UK Notify's literal yes/no condition value", () => {

--- a/functions/src/__tests__/bookingPaymentAdjustments.test.ts
+++ b/functions/src/__tests__/bookingPaymentAdjustments.test.ts
@@ -3,9 +3,18 @@ import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
 import { computeBookingPaymentDelta } from "../bookingPaymentAdjustments";
 
 describe("bookingPaymentAdjustments", () => {
+  const settledAllocation = {
+    allocatedAmountMinor: 3000,
+    refundedAmountMinor: 0,
+    ticketOrder: { status: "PAID" },
+  };
+
   it("marks refund path when revised booking total decreases", () => {
     const result = computeBookingPaymentDelta(
-      { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] },
+      { lines: [
+        { ticketType: { price: 30 }, bookingPlace: { paymentAllocations: [settledAllocation] } },
+        { ticketType: { price: 20 } },
+      ] },
       { lines: [{ ticketType: { price: 30 } }] }
     );
     expect(result.deltaAmountMinor).toBe(-2000);
@@ -14,7 +23,10 @@ describe("bookingPaymentAdjustments", () => {
 
   it("marks charge path when revised booking total increases", () => {
     const result = computeBookingPaymentDelta(
-      { lines: [{ ticketType: { price: 30 } }] },
+      { lines: [{
+        ticketType: { price: 30 },
+        bookingPlace: { paymentAllocations: [settledAllocation] },
+      }] },
       { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] }
     );
     expect(result.deltaAmountMinor).toBe(2000);
@@ -30,6 +42,35 @@ describe("bookingPaymentAdjustments", () => {
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 
+  it("keeps an amended unpaid booking wholly unpaid", () => {
+    const result = computeBookingPaymentDelta(
+      { lines: [{ ticketType: { price: 30 }, bookingPlace: { paymentAllocations: [] } }] },
+      { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] }
+    );
+
+    expect(result.previousTotalMinor).toBe(3000);
+    expect(result.revisedTotalMinor).toBe(5000);
+    expect(result.deltaAmountMinor).toBe(0);
+    expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
+  });
+
+  it("does not treat an uncompleted checkout as settled payment", () => {
+    const result = computeBookingPaymentDelta(
+      { lines: [{
+        ticketType: { price: 30 },
+        bookingPlace: { paymentAllocations: [{
+          allocatedAmountMinor: 3000,
+          refundedAmountMinor: 0,
+          ticketOrder: { status: "PENDING" },
+        }] },
+      }] },
+      { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] }
+    );
+
+    expect(result.deltaAmountMinor).toBe(0);
+    expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
+  });
+
   it("treats a missing previous booking as having no payable lines", () => {
     const result = computeBookingPaymentDelta(
       undefined,
@@ -37,6 +78,7 @@ describe("bookingPaymentAdjustments", () => {
     );
 
     expect(result.previousTotalMinor).toBe(0);
-    expect(result.deltaAmountMinor).toBe(3000);
+    expect(result.deltaAmountMinor).toBe(0);
+    expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 });

--- a/functions/src/__tests__/bookingPaymentAdjustments.test.ts
+++ b/functions/src/__tests__/bookingPaymentAdjustments.test.ts
@@ -18,6 +18,7 @@ describe("bookingPaymentAdjustments", () => {
       { lines: [{ ticketType: { price: 30 } }] }
     );
     expect(result.deltaAmountMinor).toBe(-2000);
+    expect(result.paymentRemainingMinor).toBe(0);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND);
   });
 
@@ -30,6 +31,7 @@ describe("bookingPaymentAdjustments", () => {
       { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] }
     );
     expect(result.deltaAmountMinor).toBe(2000);
+    expect(result.paymentRemainingMinor).toBe(2000);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE);
   });
 
@@ -39,10 +41,11 @@ describe("bookingPaymentAdjustments", () => {
       { lines: [{ ticketType: { price: 30 } }] }
     );
     expect(result.deltaAmountMinor).toBe(0);
+    expect(result.paymentRemainingMinor).toBe(3000);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 
-  it("keeps an amended unpaid booking wholly unpaid", () => {
+  it("keeps an amended unpaid booking wholly unpaid, with the full revised total still owed", () => {
     const result = computeBookingPaymentDelta(
       { lines: [{ ticketType: { price: 30 }, bookingPlace: { paymentAllocations: [] } }] },
       { lines: [{ ticketType: { price: 30 } }, { ticketType: { price: 20 } }] }
@@ -51,6 +54,7 @@ describe("bookingPaymentAdjustments", () => {
     expect(result.previousTotalMinor).toBe(3000);
     expect(result.revisedTotalMinor).toBe(5000);
     expect(result.deltaAmountMinor).toBe(0);
+    expect(result.paymentRemainingMinor).toBe(5000);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 
@@ -68,10 +72,32 @@ describe("bookingPaymentAdjustments", () => {
     );
 
     expect(result.deltaAmountMinor).toBe(0);
+    expect(result.paymentRemainingMinor).toBe(5000);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 
-  it("treats a missing previous booking as having no payable lines", () => {
+  it("keeps an earlier unpaid line owed when a further revision is submitted before it was ever settled", () => {
+    // Paid for ticket A (£10). Added ticket B (£10) — that revision's extra £10 was
+    // never paid. Now a third ticket C (£10) is added on top, before B was settled.
+    const result = computeBookingPaymentDelta(
+      { lines: [
+        { ticketType: { price: 10 }, bookingPlace: { paymentAllocations: [{
+          allocatedAmountMinor: 1000,
+          refundedAmountMinor: 0,
+          ticketOrder: { status: "PAID" },
+        }] } }, // ticket A: settled
+        { ticketType: { price: 10 }, bookingPlace: { paymentAllocations: [] } }, // ticket B: still unpaid
+      ] },
+      { lines: [{ ticketType: { price: 10 } }, { ticketType: { price: 10 } }, { ticketType: { price: 10 } }] }
+    );
+
+    expect(result.previousTotalMinor).toBe(2000);
+    expect(result.revisedTotalMinor).toBe(3000);
+    // Only A is settled, so B's unpaid £10 must not be dropped: £20 remains (B + C), not £10.
+    expect(result.paymentRemainingMinor).toBe(2000);
+  });
+
+  it("treats a missing previous booking as having no payable lines, so the revised total is fully owed", () => {
     const result = computeBookingPaymentDelta(
       undefined,
       { lines: [{ ticketType: { price: 30 } }] }
@@ -79,6 +105,7 @@ describe("bookingPaymentAdjustments", () => {
 
     expect(result.previousTotalMinor).toBe(0);
     expect(result.deltaAmountMinor).toBe(0);
+    expect(result.paymentRemainingMinor).toBe(3000);
     expect(result.status).toBe(BookingPaymentAdjustmentStatus.NOT_REQUIRED);
   });
 });

--- a/functions/src/__tests__/bookingsEmailWiring.test.ts
+++ b/functions/src/__tests__/bookingsEmailWiring.test.ts
@@ -64,6 +64,7 @@ describe("sendBookingSubmitNotificationEmails", () => {
         previousTotalMinor: 1000,
         revisedTotalMinor: 1500,
         deltaAmountMinor: 500,
+        paymentRemainingMinor: 500,
         status: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
       },
     });

--- a/functions/src/__tests__/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/gqlSchemaIntegrity.test.ts
@@ -40,6 +40,18 @@ function extractAllOperationHeaders(source: string): Array<{ name: string; heade
 }
 
 describe("GQL schema integrity", () => {
+  it("keeps member ticket-order status outside the deeply nested booking allocation path", () => {
+    const queries = readApiFile("queries.gql");
+    const start = queries.indexOf("query GetMyBookingsForEvent");
+    const end = queries.indexOf("\nquery GetMyBookings", start + 1);
+    const query = queries.slice(start, end);
+
+    expect(start, "GetMyBookingsForEvent must exist").toBeGreaterThanOrEqual(0);
+    expect(query).toContain("bookingTicketOrders: ticketOrders_on_user");
+    expect(query).toContain("ticketOrderId");
+    expect(query).not.toMatch(/paymentAllocations:[\s\S]*?ticketOrder\s*\{/);
+  });
+
   it("user-facing mutation files only use NO_ACCESS for explicitly server-migrated operations", () => {
     // Operations listed here have been deliberately moved to server-only callable
     // paths and must NOT appear as client-callable in future.

--- a/functions/src/__tests__/notificationRecoveryPayload.test.ts
+++ b/functions/src/__tests__/notificationRecoveryPayload.test.ts
@@ -18,6 +18,7 @@ describe("notification recovery payloads", () => {
         previousTotalMinor: 2_000,
         revisedTotalMinor: 2_500,
         deltaAmountMinor: 500,
+        paymentRemainingMinor: 500,
         status: BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE,
       },
     };

--- a/functions/src/bookingApprovals.ts
+++ b/functions/src/bookingApprovals.ts
@@ -10,7 +10,6 @@ import {
 import type { UUIDString } from "@dataconnect/admin-generated";
 import type {
   GetBookingRevisionForApprovalFromCallableData,
-  GetBookingsForBookerAndEventData,
 } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
 import { enforceRateLimit } from "./rateLimiter";
@@ -22,6 +21,7 @@ import {
   validateUUID,
 } from "./helpers";
 import { bookingIdsEqual } from "./bookingCheckout";
+import { hydrateBookingsWithTicketOrders, type HydratedBookingRow } from "./bookingQueryHydration";
 import { computeBookingPaymentDelta, type BookingPaymentDelta } from "./bookingPaymentAdjustments";
 import { activateApprovedBookingRevision } from "./bookingSubmissionPersistence";
 import {
@@ -80,7 +80,7 @@ function isApprovalConflict(error: unknown): boolean {
 }
 
 type ApprovalTarget = NonNullable<GetBookingRevisionForApprovalFromCallableData["booking"]>;
-type BookerBooking = NonNullable<GetBookingsForBookerAndEventData["user"]>["bookings"][number];
+type BookerBooking = HydratedBookingRow;
 
 export function resolveBookingApprovalReview(args: {
   target: ApprovalTarget;
@@ -151,7 +151,7 @@ export const reviewBookingRevision = onCall(
       });
       const review = resolveBookingApprovalReview({
         target,
-        revisions: allResult.data?.user?.bookings ?? [],
+        revisions: hydrateBookingsWithTicketOrders(allResult.data),
         expectedRevisionNumber,
         decision,
       });

--- a/functions/src/bookingEmailDispatcher.ts
+++ b/functions/src/bookingEmailDispatcher.ts
@@ -1,6 +1,5 @@
 import * as logger from "firebase-functions/logger";
 import {
-  BookingPaymentAdjustmentStatus,
   getBookingForNotification,
   NotificationChannel,
 } from "@dataconnect/admin-generated";
@@ -84,10 +83,9 @@ export type BookingEmailPersonalisation = {
 };
 
 export type BookingRevisionEmailPersonalisation = BookingEmailPersonalisation & {
-  paymentAdjustmentStatus: string;
   previousTotalFormatted: string;
   revisedTotalFormatted: string;
-  deltaAmountFormatted: string;
+  paymentRemainingFormatted: string;
 };
 
 export type BookingChangesRequestedEmailPersonalisation = BookingEmailPersonalisation & {
@@ -137,33 +135,6 @@ export function buildTicketLinesSummary(lines: BookingLineRow[]): string {
 /** GOV.UK Notify optional-content conditions must be the literal string "yes"/"no". */
 export function accommodationRequestedCondition(requested: boolean): "yes" | "no" {
   return requested ? "yes" : "no";
-}
-
-export function paymentAdjustmentStatusLabel(status: BookingPaymentAdjustmentStatus): string {
-  switch (status) {
-    case BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE:
-      return "Additional payment due";
-    case BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND:
-      return "Refund due";
-    case BookingPaymentAdjustmentStatus.NOT_REQUIRED:
-      return "No payment change required";
-    case BookingPaymentAdjustmentStatus.SETTLED:
-      return "Payment change completed";
-    default:
-      return String(status);
-  }
-}
-
-export function formatSignedDeltaAmount(deltaAmountMinor: number): string {
-  const abs = Math.abs(deltaAmountMinor);
-  const formatted = formatMinorCurrency(abs, "GBP");
-  if (deltaAmountMinor > 0) {
-    return `+${formatted}`;
-  }
-  if (deltaAmountMinor < 0) {
-    return `-${formatted}`;
-  }
-  return formatted;
 }
 
 function buildBasePersonalisation(args: {
@@ -308,10 +279,9 @@ export async function notifyBookingRevisionEmail(args: {
     const base = buildBasePersonalisation({ booking, appBaseUrl: args.appBaseUrl });
     const personalisation: BookingRevisionEmailPersonalisation = {
       ...base,
-      paymentAdjustmentStatus: paymentAdjustmentStatusLabel(args.paymentDelta.status),
       previousTotalFormatted: formatMinorCurrency(args.paymentDelta.previousTotalMinor, "GBP"),
       revisedTotalFormatted: formatMinorCurrency(args.paymentDelta.revisedTotalMinor, "GBP"),
-      deltaAmountFormatted: formatSignedDeltaAmount(args.paymentDelta.deltaAmountMinor),
+      paymentRemainingFormatted: formatMinorCurrency(args.paymentDelta.paymentRemainingMinor, "GBP"),
     };
     const reference = `BOOKING_REVISION:${args.bookingId}:${args.idempotencyKey}`;
     const deliveryKey = bookingRevisionDeliveryKey(args.bookingId, args.idempotencyKey);

--- a/functions/src/bookingPaymentAdjustments.ts
+++ b/functions/src/bookingPaymentAdjustments.ts
@@ -24,6 +24,9 @@ export interface BookingPaymentDelta {
   previousTotalMinor: number;
   revisedTotalMinor: number;
   deltaAmountMinor: number;
+  /** What's still owed on the revised total: the full total if nothing is settled
+   *  yet, or just the net increase over an already-settled previous total. */
+  paymentRemainingMinor: number;
   status: BookingPaymentAdjustmentStatus;
 }
 
@@ -35,15 +38,26 @@ function bookingTotalMinor(booking?: BookingSnapshot | null): number {
   return (booking?.lines ?? []).reduce((acc, line) => acc + toMinorUnits(line.ticketType.price), 0);
 }
 
+function lineIsSettled(line: BookingLineSnapshot): boolean {
+  return (line.bookingPlace?.paymentAllocations ?? []).some((allocation) => {
+    const status = allocation.ticketOrder?.status;
+    const settled = status === TicketOrderStatus.PAID || status === TicketOrderStatus.REFUNDED;
+    const netPaidMinor = (allocation.allocatedAmountMinor ?? 0) - (allocation.refundedAmountMinor ?? 0);
+    return settled && netPaidMinor > 0;
+  });
+}
+
 function bookingHasSettledPayment(booking?: BookingSnapshot | null): boolean {
-  return (booking?.lines ?? []).some((line) =>
-    (line.bookingPlace?.paymentAllocations ?? []).some((allocation) => {
-      const status = allocation.ticketOrder?.status;
-      const settled = status === TicketOrderStatus.PAID || status === TicketOrderStatus.REFUNDED;
-      const netPaidMinor =
-        (allocation.allocatedAmountMinor ?? 0) - (allocation.refundedAmountMinor ?? 0);
-      return settled && netPaidMinor > 0;
-    })
+  return (booking?.lines ?? []).some(lineIsSettled);
+}
+
+/** Sum of previous-booking lines that are individually settled — not just "some line is
+ *  paid" — so a still-unpaid line from an earlier, unresolved revision isn't dropped
+ *  when a later revision is submitted on top of it. */
+function settledTotalMinor(booking?: BookingSnapshot | null): number {
+  return (booking?.lines ?? []).reduce(
+    (acc, line) => acc + (lineIsSettled(line) ? toMinorUnits(line.ticketType.price) : 0),
+    0
   );
 }
 
@@ -53,17 +67,21 @@ export function computeBookingPaymentDelta(
 ): BookingPaymentDelta {
   const previousTotalMinor = bookingTotalMinor(previousBooking);
   const revisedTotalMinor = bookingTotalMinor(revisedBooking);
+  const hasSettledPayment = bookingHasSettledPayment(previousBooking);
   // An unpaid booking has no payment position to adjust. Its revised total is
   // collected by normal checkout, rather than presented as an incremental
   // charge/refund against money that was never received.
-  const deltaAmountMinor = bookingHasSettledPayment(previousBooking)
-    ? revisedTotalMinor - previousTotalMinor
-    : 0;
+  const deltaAmountMinor = hasSettledPayment ? revisedTotalMinor - previousTotalMinor : 0;
   const status =
     deltaAmountMinor < 0
       ? BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND
       : deltaAmountMinor > 0
         ? BookingPaymentAdjustmentStatus.PENDING_AUTO_CHARGE
         : BookingPaymentAdjustmentStatus.NOT_REQUIRED;
-  return { previousTotalMinor, revisedTotalMinor, deltaAmountMinor, status };
+  // What's actually been settled carries forward per line, not per booking — an
+  // earlier revision's still-unpaid line stays owed even once a different line on
+  // the same booking is paid, and even across a further revision submitted on top
+  // of it before that earlier amount was ever resolved.
+  const paymentRemainingMinor = Math.max(revisedTotalMinor - settledTotalMinor(previousBooking), 0);
+  return { previousTotalMinor, revisedTotalMinor, deltaAmountMinor, paymentRemainingMinor, status };
 }

--- a/functions/src/bookingPaymentAdjustments.ts
+++ b/functions/src/bookingPaymentAdjustments.ts
@@ -1,9 +1,19 @@
-import { BookingPaymentAdjustmentStatus } from "@dataconnect/admin-generated";
+import {
+  BookingPaymentAdjustmentStatus,
+  TicketOrderStatus,
+} from "@dataconnect/admin-generated";
 
 interface BookingLineSnapshot {
   ticketType: {
     price: number;
   };
+  bookingPlace?: {
+    paymentAllocations?: Array<{
+      allocatedAmountMinor?: number;
+      refundedAmountMinor?: number;
+      ticketOrder?: { status?: TicketOrderStatus | string | null } | null;
+    }> | null;
+  } | null;
 }
 
 interface BookingSnapshot {
@@ -25,13 +35,30 @@ function bookingTotalMinor(booking?: BookingSnapshot | null): number {
   return (booking?.lines ?? []).reduce((acc, line) => acc + toMinorUnits(line.ticketType.price), 0);
 }
 
+function bookingHasSettledPayment(booking?: BookingSnapshot | null): boolean {
+  return (booking?.lines ?? []).some((line) =>
+    (line.bookingPlace?.paymentAllocations ?? []).some((allocation) => {
+      const status = allocation.ticketOrder?.status;
+      const settled = status === TicketOrderStatus.PAID || status === TicketOrderStatus.REFUNDED;
+      const netPaidMinor =
+        (allocation.allocatedAmountMinor ?? 0) - (allocation.refundedAmountMinor ?? 0);
+      return settled && netPaidMinor > 0;
+    })
+  );
+}
+
 export function computeBookingPaymentDelta(
   previousBooking?: BookingSnapshot | null,
   revisedBooking?: BookingSnapshot | null
 ): BookingPaymentDelta {
   const previousTotalMinor = bookingTotalMinor(previousBooking);
   const revisedTotalMinor = bookingTotalMinor(revisedBooking);
-  const deltaAmountMinor = revisedTotalMinor - previousTotalMinor;
+  // An unpaid booking has no payment position to adjust. Its revised total is
+  // collected by normal checkout, rather than presented as an incremental
+  // charge/refund against money that was never received.
+  const deltaAmountMinor = bookingHasSettledPayment(previousBooking)
+    ? revisedTotalMinor - previousTotalMinor
+    : 0;
   const status =
     deltaAmountMinor < 0
       ? BookingPaymentAdjustmentStatus.PENDING_AUTO_REFUND

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -1340,6 +1340,10 @@ export interface GetMyBookingsData {
 export interface GetMyBookingsForEventData {
   user?: {
     id: string;
+    bookingTicketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -1360,11 +1364,8 @@ export interface GetMyBookingsForEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -2231,10 +2231,7 @@ export interface ListEventBookingsForAdminData {
             id: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
+            ticketOrderId: UUIDString;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         guestUser?: {

--- a/functions/src/generatedEmailTemplateManifest.ts
+++ b/functions/src/generatedEmailTemplateManifest.ts
@@ -87,12 +87,11 @@ export const EMAIL_TEMPLATE_MANIFEST: Record<string, EmailTemplateDefinition> = 
     "bookingTotalFormatted",
     "sectionBookingsUrl",
     "myPaymentsUrl",
-    "paymentAdjustmentStatus",
     "previousTotalFormatted",
     "revisedTotalFormatted",
-    "deltaAmountFormatted"
+    "paymentRemainingFormatted"
     ],
-    body: "Hello ((firstName)),\n\nYour booking for ((eventTitle)) has been updated.\n\n---\n\n# Event details\n\nDate and time: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your updated booking\n\n((ticketLinesSummary))\n\n((accommodationRequested??Accommodation requested — see your booking for details.))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nPayment difference: ((deltaAmountFormatted))\n\nPayment status: ((paymentAdjustmentStatus))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nView your payments:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
+    body: "Hello ((firstName)),\n\nYour booking for ((eventTitle)) has been updated.\n\n---\n\n# Event details\n\nDate and time: ((eventDateTime))\n\nWhere: ((eventLocation))\n\n---\n\n# Your updated booking\n\n((ticketLinesSummary))\n\n((accommodationRequested??Accommodation requested — see your booking for details.))\n\nPrevious total: ((previousTotalFormatted))\n\nRevised total: ((revisedTotalFormatted))\n\nPayment remaining: ((paymentRemainingFormatted))\n\n---\n\nView your booking:\n\n((sectionBookingsUrl))\n\nView your payments:\n\n((myPaymentsUrl))\n\nKind regards,\n\nSODC Admin",
   },
   emailChangeVerification: {
     subject: "Confirm your new SODC email address",

--- a/functions/src/notificationRecoveryPayload.ts
+++ b/functions/src/notificationRecoveryPayload.ts
@@ -36,6 +36,7 @@ export type NotificationRecoveryPayload =
         previousTotalMinor: number;
         revisedTotalMinor: number;
         deltaAmountMinor: number;
+        paymentRemainingMinor: number;
         status: BookingPaymentAdjustmentStatus;
       };
     })
@@ -223,6 +224,7 @@ export function parseNotificationRecoveryPayload(
           previousTotalMinor: finiteNumber(paymentDelta.previousTotalMinor, "previousTotalMinor"),
           revisedTotalMinor: finiteNumber(paymentDelta.revisedTotalMinor, "revisedTotalMinor"),
           deltaAmountMinor: finiteNumber(paymentDelta.deltaAmountMinor, "deltaAmountMinor"),
+          paymentRemainingMinor: finiteNumber(paymentDelta.paymentRemainingMinor, "paymentRemainingMinor"),
           status: enumValue(
             paymentDelta.status,
             Object.values(BookingPaymentAdjustmentStatus),

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -8768,10 +8768,7 @@ export interface ListEventBookingsForAdminData {
             id: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
+            ticketOrderId: UUIDString;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         guestUser?: {

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -8089,6 +8089,10 @@ The `data` property is an object of type `GetMyBookingsForEventData`, which is d
 export interface GetMyBookingsForEventData {
   user?: {
     id: string;
+    bookingTicketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -8109,11 +8113,8 @@ export interface GetMyBookingsForEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/src/dataconnect-generated/esm/index.esm.js
+++ b/src/dataconnect-generated/esm/index.esm.js
@@ -151,7 +151,7 @@ export const getGovNotifyDeliveryConfigurationRef = (dc) => {
 getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfiguration';
 
 export function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -164,7 +164,7 @@ export const listGovNotifyDeliveryModeAuditsRef = (dcOrVars, vars) => {
 listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAudits';
 
 export function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -201,7 +201,7 @@ export const getNotifyReplyToConfigurationRef = (dc) => {
 getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration';
 
 export function getNotifyReplyToConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -214,7 +214,7 @@ export const listNotifyReplyToAuditsRef = (dcOrVars, vars) => {
 listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 
 export function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -347,7 +347,7 @@ export const getNotifyTemplateBindingsRef = (dc) => {
 getNotifyTemplateBindingsRef.operationName = 'GetNotifyTemplateBindings';
 
 export function getNotifyTemplateBindings(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyTemplateBindingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -360,7 +360,7 @@ export const listNotifyTemplateBindingAuditsRef = (dcOrVars, vars) => {
 listNotifyTemplateBindingAuditsRef.operationName = 'ListNotifyTemplateBindingAudits';
 
 export function listNotifyTemplateBindingAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyTemplateBindingAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -397,7 +397,7 @@ export const getSectionFileByIdRef = (dcOrVars, vars) => {
 getSectionFileByIdRef.operationName = 'GetSectionFileById';
 
 export function getSectionFileById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionFileByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -410,7 +410,7 @@ export const listSectionFilesByStatusRef = (dcOrVars, vars) => {
 listSectionFilesByStatusRef.operationName = 'ListSectionFilesByStatus';
 
 export function listSectionFilesByStatus(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesByStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -423,7 +423,7 @@ export const listStaleSectionFilesRef = (dcOrVars, vars) => {
 listStaleSectionFilesRef.operationName = 'ListStaleSectionFiles';
 
 export function listStaleSectionFiles(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleSectionFilesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -436,7 +436,7 @@ export const listSectionFilesForQuotaRef = (dcOrVars, vars) => {
 listSectionFilesForQuotaRef.operationName = 'ListSectionFilesForQuota';
 
 export function listSectionFilesForQuota(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesForQuotaRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -629,7 +629,7 @@ export const getLegacyUserIdentityRef = (dcOrVars, vars) => {
 getLegacyUserIdentityRef.operationName = 'GetLegacyUserIdentity';
 
 export function getLegacyUserIdentity(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLegacyUserIdentityRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -642,7 +642,7 @@ export const listLegacyUserIdentitiesByBatchRef = (dcOrVars, vars) => {
 listLegacyUserIdentitiesByBatchRef.operationName = 'ListLegacyUserIdentitiesByBatch';
 
 export function listLegacyUserIdentitiesByBatch(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesByBatchRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -655,7 +655,7 @@ export const listMigrationUsersRef = (dcOrVars, vars) => {
 listMigrationUsersRef.operationName = 'ListMigrationUsers';
 
 export function listMigrationUsers(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listMigrationUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -668,7 +668,7 @@ export const searchSectionMemberCandidatesRef = (dcOrVars, vars) => {
 searchSectionMemberCandidatesRef.operationName = 'SearchSectionMemberCandidates';
 
 export function searchSectionMemberCandidates(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(searchSectionMemberCandidatesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -681,7 +681,7 @@ export const listLegacyUserIdentitiesForMigrationRef = (dcOrVars, vars) => {
 listLegacyUserIdentitiesForMigrationRef.operationName = 'ListLegacyUserIdentitiesForMigration';
 
 export function listLegacyUserIdentitiesForMigration(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesForMigrationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -730,7 +730,7 @@ export const getUserGroupByNameRef = (dcOrVars, vars) => {
 getUserGroupByNameRef.operationName = 'GetUserGroupByName';
 
 export function getUserGroupByName(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByNameRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -743,7 +743,7 @@ export const getUserUserGroupsForAdminRef = (dcOrVars, vars) => {
 getUserUserGroupsForAdminRef.operationName = 'GetUserUserGroupsForAdmin';
 
 export function getUserUserGroupsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserUserGroupsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -756,7 +756,7 @@ export const getUserForCheckoutRef = (dcOrVars, vars) => {
 getUserForCheckoutRef.operationName = 'GetUserForCheckout';
 
 export function getUserForCheckout(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -769,7 +769,7 @@ export const getTicketTypeForCheckoutRef = (dcOrVars, vars) => {
 getTicketTypeForCheckoutRef.operationName = 'GetTicketTypeForCheckout';
 
 export function getTicketTypeForCheckout(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketTypeForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -794,7 +794,7 @@ export const getEventByIdForCallableRef = (dcOrVars, vars) => {
 getEventByIdForCallableRef.operationName = 'GetEventByIdForCallable';
 
 export function getEventByIdForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -807,7 +807,7 @@ export const getSectionByIdForCallableRef = (dcOrVars, vars) => {
 getSectionByIdForCallableRef.operationName = 'GetSectionByIdForCallable';
 
 export function getSectionByIdForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -820,7 +820,7 @@ export const getBookingsForBookerAndEventRef = (dcOrVars, vars) => {
 getBookingsForBookerAndEventRef.operationName = 'GetBookingsForBookerAndEvent';
 
 export function getBookingsForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingsForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -833,7 +833,7 @@ export const getBookingRevisionForApprovalFromCallableRef = (dcOrVars, vars) => 
 getBookingRevisionForApprovalFromCallableRef.operationName = 'GetBookingRevisionForApprovalFromCallable';
 
 export function getBookingRevisionForApprovalFromCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingRevisionForApprovalFromCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -846,7 +846,7 @@ export const getTicketOrdersForBookerAndEventRef = (dcOrVars, vars) => {
 getTicketOrdersForBookerAndEventRef.operationName = 'GetTicketOrdersForBookerAndEvent';
 
 export function getTicketOrdersForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrdersForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -919,7 +919,7 @@ export const getTicketOrderForWebhookRef = (dcOrVars, vars) => {
 getTicketOrderForWebhookRef.operationName = 'GetTicketOrderForWebhook';
 
 export function getTicketOrderForWebhook(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderForWebhookRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -932,7 +932,7 @@ export const getTicketOrderStripeArtifactsForCallableRef = (dcOrVars, vars) => {
 getTicketOrderStripeArtifactsForCallableRef.operationName = 'GetTicketOrderStripeArtifactsForCallable';
 
 export function getTicketOrderStripeArtifactsForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderStripeArtifactsForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -945,7 +945,7 @@ export const getPaymentWebhookEventByStripeEventIdRef = (dcOrVars, vars) => {
 getPaymentWebhookEventByStripeEventIdRef.operationName = 'GetPaymentWebhookEventByStripeEventId';
 
 export function getPaymentWebhookEventByStripeEventId(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentWebhookEventByStripeEventIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -970,7 +970,7 @@ export const getNotificationDeliveryByChannelAndKeyRef = (dcOrVars, vars) => {
 getNotificationDeliveryByChannelAndKeyRef.operationName = 'GetNotificationDeliveryByChannelAndKey';
 
 export function getNotificationDeliveryByChannelAndKey(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotificationDeliveryByChannelAndKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -983,7 +983,7 @@ export const listFailedNotificationDeliveriesForRecoveryRef = (dcOrVars, vars) =
 listFailedNotificationDeliveriesForRecoveryRef.operationName = 'ListFailedNotificationDeliveriesForRecovery';
 
 export function listFailedNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listFailedNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -996,7 +996,7 @@ export const listStalePendingNotificationDeliveriesForRecoveryRef = (dcOrVars, v
 listStalePendingNotificationDeliveriesForRecoveryRef.operationName = 'ListStalePendingNotificationDeliveriesForRecovery';
 
 export function listStalePendingNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1129,7 +1129,7 @@ export const getPaymentReconciliationExceptionByOrderAndTypeRef = (dcOrVars, var
 getPaymentReconciliationExceptionByOrderAndTypeRef.operationName = 'GetPaymentReconciliationExceptionByOrderAndType';
 
 export function getPaymentReconciliationExceptionByOrderAndType(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentReconciliationExceptionByOrderAndTypeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1154,7 +1154,7 @@ export const getBookingForNotificationRef = (dcOrVars, vars) => {
 getBookingForNotificationRef.operationName = 'GetBookingForNotification';
 
 export function getBookingForNotification(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingForNotificationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1167,7 +1167,7 @@ export const listStaleDraftBookingsForSchedulerRef = (dcOrVars, vars) => {
 listStaleDraftBookingsForSchedulerRef.operationName = 'ListStaleDraftBookingsForScheduler';
 
 export function listStaleDraftBookingsForScheduler(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleDraftBookingsForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1180,7 +1180,7 @@ export const listStalePendingTicketOrdersForSchedulerRef = (dcOrVars, vars) => {
 listStalePendingTicketOrdersForSchedulerRef.operationName = 'ListStalePendingTicketOrdersForScheduler';
 
 export function listStalePendingTicketOrdersForScheduler(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingTicketOrdersForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1193,7 +1193,7 @@ export const getSectionAnnouncementOptOutsRef = (dcOrVars, vars) => {
 getSectionAnnouncementOptOutsRef.operationName = 'GetSectionAnnouncementOptOuts';
 
 export function getSectionAnnouncementOptOuts(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1254,7 +1254,7 @@ export const getAnnouncementRecipientProgressRef = (dcOrVars, vars) => {
 getAnnouncementRecipientProgressRef.operationName = 'GetAnnouncementRecipientProgress';
 
 export function getAnnouncementRecipientProgress(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientProgressRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1267,7 +1267,7 @@ export const getAnnouncementRecipientsForResumeRef = (dcOrVars, vars) => {
 getAnnouncementRecipientsForResumeRef.operationName = 'GetAnnouncementRecipientsForResume';
 
 export function getAnnouncementRecipientsForResume(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientsForResumeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1280,7 +1280,7 @@ export const getAnnouncementSendHistoryRef = (dcOrVars, vars) => {
 getAnnouncementSendHistoryRef.operationName = 'GetAnnouncementSendHistory';
 
 export function getAnnouncementSendHistory(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendHistoryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1293,7 +1293,7 @@ export const getAnnouncementSendRecipientsRef = (dcOrVars, vars) => {
 getAnnouncementSendRecipientsRef.operationName = 'GetAnnouncementSendRecipients';
 
 export function getAnnouncementSendRecipients(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendRecipientsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1306,7 +1306,7 @@ export const getAnnouncementSendByIdRef = (dcOrVars, vars) => {
 getAnnouncementSendByIdRef.operationName = 'GetAnnouncementSendById';
 
 export function getAnnouncementSendById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1319,7 +1319,7 @@ export const getAnnouncementRecipientBySendAndUserRef = (dcOrVars, vars) => {
 getAnnouncementRecipientBySendAndUserRef.operationName = 'GetAnnouncementRecipientBySendAndUser';
 
 export function getAnnouncementRecipientBySendAndUser(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientBySendAndUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1368,7 +1368,7 @@ export const getUserByEmailRef = (dcOrVars, vars) => {
 getUserByEmailRef.operationName = 'GetUserByEmail';
 
 export function getUserByEmail(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByEmailRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1381,7 +1381,7 @@ export const getNotifyCallbackUserByIdRef = (dcOrVars, vars) => {
 getNotifyCallbackUserByIdRef.operationName = 'GetNotifyCallbackUserById';
 
 export function getNotifyCallbackUserById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyCallbackUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1418,7 +1418,7 @@ export const getNotifyDeliveryReceiptRef = (dcOrVars, vars) => {
 getNotifyDeliveryReceiptRef.operationName = 'GetNotifyDeliveryReceipt';
 
 export function getNotifyDeliveryReceipt(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyDeliveryReceiptRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1479,7 +1479,7 @@ export const getRecentNotifyDeliveryReceiptsForUserRef = (dcOrVars, vars) => {
 getRecentNotifyDeliveryReceiptsForUserRef.operationName = 'GetRecentNotifyDeliveryReceiptsForUser';
 
 export function getRecentNotifyDeliveryReceiptsForUser(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getRecentNotifyDeliveryReceiptsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1492,7 +1492,7 @@ export const getLatestNotifyDeliveryReceiptForReferenceRef = (dcOrVars, vars) =>
 getLatestNotifyDeliveryReceiptForReferenceRef.operationName = 'GetLatestNotifyDeliveryReceiptForReference';
 
 export function getLatestNotifyDeliveryReceiptForReference(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLatestNotifyDeliveryReceiptForReferenceRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1529,7 +1529,7 @@ export const getCallableInvocationRef = (dcOrVars, vars) => {
 getCallableInvocationRef.operationName = 'GetCallableInvocation';
 
 export function getCallableInvocation(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getCallableInvocationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1614,7 +1614,7 @@ export const getCurrentUserRef = (dc) => {
 getCurrentUserRef.operationName = 'GetCurrentUser';
 
 export function getCurrentUser(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getCurrentUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1627,7 +1627,7 @@ export const getUserByIdRef = (dcOrVars, vars) => {
 getUserByIdRef.operationName = 'GetUserById';
 
 export function getUserById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1640,7 +1640,7 @@ export const listUsersRef = (dc) => {
 listUsersRef.operationName = 'ListUsers';
 
 export function listUsers(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1653,7 +1653,7 @@ export const listSectionsRef = (dc) => {
 listSectionsRef.operationName = 'ListSections';
 
 export function listSections(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listSectionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1666,7 +1666,7 @@ export const getSectionsForUserRef = (dc) => {
 getSectionsForUserRef.operationName = 'GetSectionsForUser';
 
 export function getSectionsForUser(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getSectionsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1679,7 +1679,7 @@ export const listUserGroupsRef = (dc) => {
 listUserGroupsRef.operationName = 'ListUserGroups';
 
 export function listUserGroups(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUserGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1692,7 +1692,7 @@ export const getUserAccessGroupsRef = (dc) => {
 getUserAccessGroupsRef.operationName = 'GetUserAccessGroups';
 
 export function getUserAccessGroups(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getUserAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1705,7 +1705,7 @@ export const checkUserProfileExistsRef = (dc) => {
 checkUserProfileExistsRef.operationName = 'CheckUserProfileExists';
 
 export function checkUserProfileExists(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(checkUserProfileExistsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1718,7 +1718,7 @@ export const getUserMembershipStatusRef = (dcOrVars, vars) => {
 getUserMembershipStatusRef.operationName = 'GetUserMembershipStatus';
 
 export function getUserMembershipStatus(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserMembershipStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1731,7 +1731,7 @@ export const getUserWithAccessGroupsRef = (dcOrVars, vars) => {
 getUserWithAccessGroupsRef.operationName = 'GetUserWithAccessGroups';
 
 export function getUserWithAccessGroups(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserWithAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1744,7 +1744,7 @@ export const getUserAccessGroupsByIdRef = (dcOrVars, vars) => {
 getUserAccessGroupsByIdRef.operationName = 'GetUserAccessGroupsById';
 
 export function getUserAccessGroupsById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserAccessGroupsByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1757,7 +1757,7 @@ export const getEventsForSectionRef = (dcOrVars, vars) => {
 getEventsForSectionRef.operationName = 'GetEventsForSection';
 
 export function getEventsForSection(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventsForSectionRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1770,7 +1770,7 @@ export const getEventByIdRef = (dcOrVars, vars) => {
 getEventByIdRef.operationName = 'GetEventById';
 
 export function getEventById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1783,7 +1783,7 @@ export const getSectionByIdRef = (dcOrVars, vars) => {
 getSectionByIdRef.operationName = 'GetSectionById';
 
 export function getSectionById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1796,7 +1796,7 @@ export const getUserGroupByIdRef = (dcOrVars, vars) => {
 getUserGroupByIdRef.operationName = 'GetUserGroupById';
 
 export function getUserGroupById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1809,7 +1809,7 @@ export const getAllUserGroupsWithStatusesRef = (dc) => {
 getAllUserGroupsWithStatusesRef.operationName = 'GetAllUserGroupsWithStatuses';
 
 export function getAllUserGroupsWithStatuses(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getAllUserGroupsWithStatusesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1822,7 +1822,7 @@ export const getSectionMembersRef = (dcOrVars, vars) => {
 getSectionMembersRef.operationName = 'GetSectionMembers';
 
 export function getSectionMembers(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionMembersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1835,7 +1835,7 @@ export const getMyBookingsForEventRef = (dcOrVars, vars) => {
 getMyBookingsForEventRef.operationName = 'GetMyBookingsForEvent';
 
 export function getMyBookingsForEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyBookingsForEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1848,7 +1848,7 @@ export const getMyBookingsRef = (dc) => {
 getMyBookingsRef.operationName = 'GetMyBookings';
 
 export function getMyBookings(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1861,7 +1861,7 @@ export const getMyTicketOrderByIdRef = (dcOrVars, vars) => {
 getMyTicketOrderByIdRef.operationName = 'GetMyTicketOrderById';
 
 export function getMyTicketOrderById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyTicketOrderByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1874,7 +1874,7 @@ export const getMyTicketOrdersRef = (dc) => {
 getMyTicketOrdersRef.operationName = 'GetMyTicketOrders';
 
 export function getMyTicketOrders(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyTicketOrdersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1887,7 +1887,7 @@ export const getMyBookingPaymentAdjustmentsRef = (dc) => {
 getMyBookingPaymentAdjustmentsRef.operationName = 'GetMyBookingPaymentAdjustments';
 
 export function getMyBookingPaymentAdjustments(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingPaymentAdjustmentsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1900,7 +1900,7 @@ export const listEventBookingsForAdminRef = (dcOrVars, vars) => {
 listEventBookingsForAdminRef.operationName = 'ListEventBookingsForAdmin';
 
 export function listEventBookingsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listEventBookingsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1913,7 +1913,7 @@ export const listTicketOrdersForAdminRef = (dcOrVars, vars) => {
 listTicketOrdersForAdminRef.operationName = 'ListTicketOrdersForAdmin';
 
 export function listTicketOrdersForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listTicketOrdersForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1926,7 +1926,7 @@ export const listBookingPaymentAdjustmentsForAdminRef = (dcOrVars, vars) => {
 listBookingPaymentAdjustmentsForAdminRef.operationName = 'ListBookingPaymentAdjustmentsForAdmin';
 
 export function listBookingPaymentAdjustmentsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listBookingPaymentAdjustmentsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1939,7 +1939,7 @@ export const listOpenPaymentReconciliationExceptionsRef = (dc) => {
 listOpenPaymentReconciliationExceptionsRef.operationName = 'ListOpenPaymentReconciliationExceptions';
 
 export function listOpenPaymentReconciliationExceptions(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listOpenPaymentReconciliationExceptionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1952,7 +1952,7 @@ export const getSectionAnnouncementOptOutRef = (dcOrVars, vars) => {
 getSectionAnnouncementOptOutRef.operationName = 'GetSectionAnnouncementOptOut';
 
 export function getSectionAnnouncementOptOut(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1965,7 +1965,7 @@ export const getMyAnnouncementPreferencesRef = (dc) => {
 getMyAnnouncementPreferencesRef.operationName = 'GetMyAnnouncementPreferences';
 
 export function getMyAnnouncementPreferences(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyAnnouncementPreferencesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }

--- a/src/dataconnect-generated/index.cjs.js
+++ b/src/dataconnect-generated/index.cjs.js
@@ -174,7 +174,7 @@ getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfig
 exports.getGovNotifyDeliveryConfigurationRef = getGovNotifyDeliveryConfigurationRef;
 
 exports.getGovNotifyDeliveryConfiguration = function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -189,7 +189,7 @@ listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAud
 exports.listGovNotifyDeliveryModeAuditsRef = listGovNotifyDeliveryModeAuditsRef;
 
 exports.listGovNotifyDeliveryModeAudits = function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -232,7 +232,7 @@ getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration'
 exports.getNotifyReplyToConfigurationRef = getNotifyReplyToConfigurationRef;
 
 exports.getNotifyReplyToConfiguration = function getNotifyReplyToConfiguration(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -247,7 +247,7 @@ listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 exports.listNotifyReplyToAuditsRef = listNotifyReplyToAuditsRef;
 
 exports.listNotifyReplyToAudits = function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -402,7 +402,7 @@ getNotifyTemplateBindingsRef.operationName = 'GetNotifyTemplateBindings';
 exports.getNotifyTemplateBindingsRef = getNotifyTemplateBindingsRef;
 
 exports.getNotifyTemplateBindings = function getNotifyTemplateBindings(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyTemplateBindingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -417,7 +417,7 @@ listNotifyTemplateBindingAuditsRef.operationName = 'ListNotifyTemplateBindingAud
 exports.listNotifyTemplateBindingAuditsRef = listNotifyTemplateBindingAuditsRef;
 
 exports.listNotifyTemplateBindingAudits = function listNotifyTemplateBindingAudits(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyTemplateBindingAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -460,7 +460,7 @@ getSectionFileByIdRef.operationName = 'GetSectionFileById';
 exports.getSectionFileByIdRef = getSectionFileByIdRef;
 
 exports.getSectionFileById = function getSectionFileById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionFileByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -475,7 +475,7 @@ listSectionFilesByStatusRef.operationName = 'ListSectionFilesByStatus';
 exports.listSectionFilesByStatusRef = listSectionFilesByStatusRef;
 
 exports.listSectionFilesByStatus = function listSectionFilesByStatus(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesByStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -490,7 +490,7 @@ listStaleSectionFilesRef.operationName = 'ListStaleSectionFiles';
 exports.listStaleSectionFilesRef = listStaleSectionFilesRef;
 
 exports.listStaleSectionFiles = function listStaleSectionFiles(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleSectionFilesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -505,7 +505,7 @@ listSectionFilesForQuotaRef.operationName = 'ListSectionFilesForQuota';
 exports.listSectionFilesForQuotaRef = listSectionFilesForQuotaRef;
 
 exports.listSectionFilesForQuota = function listSectionFilesForQuota(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesForQuotaRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -730,7 +730,7 @@ getLegacyUserIdentityRef.operationName = 'GetLegacyUserIdentity';
 exports.getLegacyUserIdentityRef = getLegacyUserIdentityRef;
 
 exports.getLegacyUserIdentity = function getLegacyUserIdentity(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLegacyUserIdentityRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -745,7 +745,7 @@ listLegacyUserIdentitiesByBatchRef.operationName = 'ListLegacyUserIdentitiesByBa
 exports.listLegacyUserIdentitiesByBatchRef = listLegacyUserIdentitiesByBatchRef;
 
 exports.listLegacyUserIdentitiesByBatch = function listLegacyUserIdentitiesByBatch(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesByBatchRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -760,7 +760,7 @@ listMigrationUsersRef.operationName = 'ListMigrationUsers';
 exports.listMigrationUsersRef = listMigrationUsersRef;
 
 exports.listMigrationUsers = function listMigrationUsers(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listMigrationUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -775,7 +775,7 @@ searchSectionMemberCandidatesRef.operationName = 'SearchSectionMemberCandidates'
 exports.searchSectionMemberCandidatesRef = searchSectionMemberCandidatesRef;
 
 exports.searchSectionMemberCandidates = function searchSectionMemberCandidates(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(searchSectionMemberCandidatesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -790,7 +790,7 @@ listLegacyUserIdentitiesForMigrationRef.operationName = 'ListLegacyUserIdentitie
 exports.listLegacyUserIdentitiesForMigrationRef = listLegacyUserIdentitiesForMigrationRef;
 
 exports.listLegacyUserIdentitiesForMigration = function listLegacyUserIdentitiesForMigration(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesForMigrationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -847,7 +847,7 @@ getUserGroupByNameRef.operationName = 'GetUserGroupByName';
 exports.getUserGroupByNameRef = getUserGroupByNameRef;
 
 exports.getUserGroupByName = function getUserGroupByName(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByNameRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -862,7 +862,7 @@ getUserUserGroupsForAdminRef.operationName = 'GetUserUserGroupsForAdmin';
 exports.getUserUserGroupsForAdminRef = getUserUserGroupsForAdminRef;
 
 exports.getUserUserGroupsForAdmin = function getUserUserGroupsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserUserGroupsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -877,7 +877,7 @@ getUserForCheckoutRef.operationName = 'GetUserForCheckout';
 exports.getUserForCheckoutRef = getUserForCheckoutRef;
 
 exports.getUserForCheckout = function getUserForCheckout(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -892,7 +892,7 @@ getTicketTypeForCheckoutRef.operationName = 'GetTicketTypeForCheckout';
 exports.getTicketTypeForCheckoutRef = getTicketTypeForCheckoutRef;
 
 exports.getTicketTypeForCheckout = function getTicketTypeForCheckout(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketTypeForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -921,7 +921,7 @@ getEventByIdForCallableRef.operationName = 'GetEventByIdForCallable';
 exports.getEventByIdForCallableRef = getEventByIdForCallableRef;
 
 exports.getEventByIdForCallable = function getEventByIdForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -936,7 +936,7 @@ getSectionByIdForCallableRef.operationName = 'GetSectionByIdForCallable';
 exports.getSectionByIdForCallableRef = getSectionByIdForCallableRef;
 
 exports.getSectionByIdForCallable = function getSectionByIdForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -951,7 +951,7 @@ getBookingsForBookerAndEventRef.operationName = 'GetBookingsForBookerAndEvent';
 exports.getBookingsForBookerAndEventRef = getBookingsForBookerAndEventRef;
 
 exports.getBookingsForBookerAndEvent = function getBookingsForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingsForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -966,7 +966,7 @@ getBookingRevisionForApprovalFromCallableRef.operationName = 'GetBookingRevision
 exports.getBookingRevisionForApprovalFromCallableRef = getBookingRevisionForApprovalFromCallableRef;
 
 exports.getBookingRevisionForApprovalFromCallable = function getBookingRevisionForApprovalFromCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingRevisionForApprovalFromCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -981,7 +981,7 @@ getTicketOrdersForBookerAndEventRef.operationName = 'GetTicketOrdersForBookerAnd
 exports.getTicketOrdersForBookerAndEventRef = getTicketOrdersForBookerAndEventRef;
 
 exports.getTicketOrdersForBookerAndEvent = function getTicketOrdersForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrdersForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1066,7 +1066,7 @@ getTicketOrderForWebhookRef.operationName = 'GetTicketOrderForWebhook';
 exports.getTicketOrderForWebhookRef = getTicketOrderForWebhookRef;
 
 exports.getTicketOrderForWebhook = function getTicketOrderForWebhook(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderForWebhookRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1081,7 +1081,7 @@ getTicketOrderStripeArtifactsForCallableRef.operationName = 'GetTicketOrderStrip
 exports.getTicketOrderStripeArtifactsForCallableRef = getTicketOrderStripeArtifactsForCallableRef;
 
 exports.getTicketOrderStripeArtifactsForCallable = function getTicketOrderStripeArtifactsForCallable(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderStripeArtifactsForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1096,7 +1096,7 @@ getPaymentWebhookEventByStripeEventIdRef.operationName = 'GetPaymentWebhookEvent
 exports.getPaymentWebhookEventByStripeEventIdRef = getPaymentWebhookEventByStripeEventIdRef;
 
 exports.getPaymentWebhookEventByStripeEventId = function getPaymentWebhookEventByStripeEventId(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentWebhookEventByStripeEventIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1125,7 +1125,7 @@ getNotificationDeliveryByChannelAndKeyRef.operationName = 'GetNotificationDelive
 exports.getNotificationDeliveryByChannelAndKeyRef = getNotificationDeliveryByChannelAndKeyRef;
 
 exports.getNotificationDeliveryByChannelAndKey = function getNotificationDeliveryByChannelAndKey(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotificationDeliveryByChannelAndKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1140,7 +1140,7 @@ listFailedNotificationDeliveriesForRecoveryRef.operationName = 'ListFailedNotifi
 exports.listFailedNotificationDeliveriesForRecoveryRef = listFailedNotificationDeliveriesForRecoveryRef;
 
 exports.listFailedNotificationDeliveriesForRecovery = function listFailedNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listFailedNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1155,7 +1155,7 @@ listStalePendingNotificationDeliveriesForRecoveryRef.operationName = 'ListStaleP
 exports.listStalePendingNotificationDeliveriesForRecoveryRef = listStalePendingNotificationDeliveriesForRecoveryRef;
 
 exports.listStalePendingNotificationDeliveriesForRecovery = function listStalePendingNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1310,7 +1310,7 @@ getPaymentReconciliationExceptionByOrderAndTypeRef.operationName = 'GetPaymentRe
 exports.getPaymentReconciliationExceptionByOrderAndTypeRef = getPaymentReconciliationExceptionByOrderAndTypeRef;
 
 exports.getPaymentReconciliationExceptionByOrderAndType = function getPaymentReconciliationExceptionByOrderAndType(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentReconciliationExceptionByOrderAndTypeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1339,7 +1339,7 @@ getBookingForNotificationRef.operationName = 'GetBookingForNotification';
 exports.getBookingForNotificationRef = getBookingForNotificationRef;
 
 exports.getBookingForNotification = function getBookingForNotification(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingForNotificationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1354,7 +1354,7 @@ listStaleDraftBookingsForSchedulerRef.operationName = 'ListStaleDraftBookingsFor
 exports.listStaleDraftBookingsForSchedulerRef = listStaleDraftBookingsForSchedulerRef;
 
 exports.listStaleDraftBookingsForScheduler = function listStaleDraftBookingsForScheduler(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleDraftBookingsForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1369,7 +1369,7 @@ listStalePendingTicketOrdersForSchedulerRef.operationName = 'ListStalePendingTic
 exports.listStalePendingTicketOrdersForSchedulerRef = listStalePendingTicketOrdersForSchedulerRef;
 
 exports.listStalePendingTicketOrdersForScheduler = function listStalePendingTicketOrdersForScheduler(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingTicketOrdersForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1384,7 +1384,7 @@ getSectionAnnouncementOptOutsRef.operationName = 'GetSectionAnnouncementOptOuts'
 exports.getSectionAnnouncementOptOutsRef = getSectionAnnouncementOptOutsRef;
 
 exports.getSectionAnnouncementOptOuts = function getSectionAnnouncementOptOuts(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1455,7 +1455,7 @@ getAnnouncementRecipientProgressRef.operationName = 'GetAnnouncementRecipientPro
 exports.getAnnouncementRecipientProgressRef = getAnnouncementRecipientProgressRef;
 
 exports.getAnnouncementRecipientProgress = function getAnnouncementRecipientProgress(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientProgressRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1470,7 +1470,7 @@ getAnnouncementRecipientsForResumeRef.operationName = 'GetAnnouncementRecipients
 exports.getAnnouncementRecipientsForResumeRef = getAnnouncementRecipientsForResumeRef;
 
 exports.getAnnouncementRecipientsForResume = function getAnnouncementRecipientsForResume(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientsForResumeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1485,7 +1485,7 @@ getAnnouncementSendHistoryRef.operationName = 'GetAnnouncementSendHistory';
 exports.getAnnouncementSendHistoryRef = getAnnouncementSendHistoryRef;
 
 exports.getAnnouncementSendHistory = function getAnnouncementSendHistory(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendHistoryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1500,7 +1500,7 @@ getAnnouncementSendRecipientsRef.operationName = 'GetAnnouncementSendRecipients'
 exports.getAnnouncementSendRecipientsRef = getAnnouncementSendRecipientsRef;
 
 exports.getAnnouncementSendRecipients = function getAnnouncementSendRecipients(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendRecipientsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1515,7 +1515,7 @@ getAnnouncementSendByIdRef.operationName = 'GetAnnouncementSendById';
 exports.getAnnouncementSendByIdRef = getAnnouncementSendByIdRef;
 
 exports.getAnnouncementSendById = function getAnnouncementSendById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1530,7 +1530,7 @@ getAnnouncementRecipientBySendAndUserRef.operationName = 'GetAnnouncementRecipie
 exports.getAnnouncementRecipientBySendAndUserRef = getAnnouncementRecipientBySendAndUserRef;
 
 exports.getAnnouncementRecipientBySendAndUser = function getAnnouncementRecipientBySendAndUser(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientBySendAndUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1587,7 +1587,7 @@ getUserByEmailRef.operationName = 'GetUserByEmail';
 exports.getUserByEmailRef = getUserByEmailRef;
 
 exports.getUserByEmail = function getUserByEmail(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByEmailRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1602,7 +1602,7 @@ getNotifyCallbackUserByIdRef.operationName = 'GetNotifyCallbackUserById';
 exports.getNotifyCallbackUserByIdRef = getNotifyCallbackUserByIdRef;
 
 exports.getNotifyCallbackUserById = function getNotifyCallbackUserById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyCallbackUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1645,7 +1645,7 @@ getNotifyDeliveryReceiptRef.operationName = 'GetNotifyDeliveryReceipt';
 exports.getNotifyDeliveryReceiptRef = getNotifyDeliveryReceiptRef;
 
 exports.getNotifyDeliveryReceipt = function getNotifyDeliveryReceipt(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyDeliveryReceiptRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1716,7 +1716,7 @@ getRecentNotifyDeliveryReceiptsForUserRef.operationName = 'GetRecentNotifyDelive
 exports.getRecentNotifyDeliveryReceiptsForUserRef = getRecentNotifyDeliveryReceiptsForUserRef;
 
 exports.getRecentNotifyDeliveryReceiptsForUser = function getRecentNotifyDeliveryReceiptsForUser(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getRecentNotifyDeliveryReceiptsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1731,7 +1731,7 @@ getLatestNotifyDeliveryReceiptForReferenceRef.operationName = 'GetLatestNotifyDe
 exports.getLatestNotifyDeliveryReceiptForReferenceRef = getLatestNotifyDeliveryReceiptForReferenceRef;
 
 exports.getLatestNotifyDeliveryReceiptForReference = function getLatestNotifyDeliveryReceiptForReference(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLatestNotifyDeliveryReceiptForReferenceRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1774,7 +1774,7 @@ getCallableInvocationRef.operationName = 'GetCallableInvocation';
 exports.getCallableInvocationRef = getCallableInvocationRef;
 
 exports.getCallableInvocation = function getCallableInvocation(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getCallableInvocationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1873,7 +1873,7 @@ getCurrentUserRef.operationName = 'GetCurrentUser';
 exports.getCurrentUserRef = getCurrentUserRef;
 
 exports.getCurrentUser = function getCurrentUser(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getCurrentUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1888,7 +1888,7 @@ getUserByIdRef.operationName = 'GetUserById';
 exports.getUserByIdRef = getUserByIdRef;
 
 exports.getUserById = function getUserById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1903,7 +1903,7 @@ listUsersRef.operationName = 'ListUsers';
 exports.listUsersRef = listUsersRef;
 
 exports.listUsers = function listUsers(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1918,7 +1918,7 @@ listSectionsRef.operationName = 'ListSections';
 exports.listSectionsRef = listSectionsRef;
 
 exports.listSections = function listSections(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listSectionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1933,7 +1933,7 @@ getSectionsForUserRef.operationName = 'GetSectionsForUser';
 exports.getSectionsForUserRef = getSectionsForUserRef;
 
 exports.getSectionsForUser = function getSectionsForUser(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getSectionsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1948,7 +1948,7 @@ listUserGroupsRef.operationName = 'ListUserGroups';
 exports.listUserGroupsRef = listUserGroupsRef;
 
 exports.listUserGroups = function listUserGroups(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUserGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1963,7 +1963,7 @@ getUserAccessGroupsRef.operationName = 'GetUserAccessGroups';
 exports.getUserAccessGroupsRef = getUserAccessGroupsRef;
 
 exports.getUserAccessGroups = function getUserAccessGroups(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getUserAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1978,7 +1978,7 @@ checkUserProfileExistsRef.operationName = 'CheckUserProfileExists';
 exports.checkUserProfileExistsRef = checkUserProfileExistsRef;
 
 exports.checkUserProfileExists = function checkUserProfileExists(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(checkUserProfileExistsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1993,7 +1993,7 @@ getUserMembershipStatusRef.operationName = 'GetUserMembershipStatus';
 exports.getUserMembershipStatusRef = getUserMembershipStatusRef;
 
 exports.getUserMembershipStatus = function getUserMembershipStatus(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserMembershipStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2008,7 +2008,7 @@ getUserWithAccessGroupsRef.operationName = 'GetUserWithAccessGroups';
 exports.getUserWithAccessGroupsRef = getUserWithAccessGroupsRef;
 
 exports.getUserWithAccessGroups = function getUserWithAccessGroups(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserWithAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2023,7 +2023,7 @@ getUserAccessGroupsByIdRef.operationName = 'GetUserAccessGroupsById';
 exports.getUserAccessGroupsByIdRef = getUserAccessGroupsByIdRef;
 
 exports.getUserAccessGroupsById = function getUserAccessGroupsById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserAccessGroupsByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2038,7 +2038,7 @@ getEventsForSectionRef.operationName = 'GetEventsForSection';
 exports.getEventsForSectionRef = getEventsForSectionRef;
 
 exports.getEventsForSection = function getEventsForSection(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventsForSectionRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2053,7 +2053,7 @@ getEventByIdRef.operationName = 'GetEventById';
 exports.getEventByIdRef = getEventByIdRef;
 
 exports.getEventById = function getEventById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2068,7 +2068,7 @@ getSectionByIdRef.operationName = 'GetSectionById';
 exports.getSectionByIdRef = getSectionByIdRef;
 
 exports.getSectionById = function getSectionById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2083,7 +2083,7 @@ getUserGroupByIdRef.operationName = 'GetUserGroupById';
 exports.getUserGroupByIdRef = getUserGroupByIdRef;
 
 exports.getUserGroupById = function getUserGroupById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2098,7 +2098,7 @@ getAllUserGroupsWithStatusesRef.operationName = 'GetAllUserGroupsWithStatuses';
 exports.getAllUserGroupsWithStatusesRef = getAllUserGroupsWithStatusesRef;
 
 exports.getAllUserGroupsWithStatuses = function getAllUserGroupsWithStatuses(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getAllUserGroupsWithStatusesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2113,7 +2113,7 @@ getSectionMembersRef.operationName = 'GetSectionMembers';
 exports.getSectionMembersRef = getSectionMembersRef;
 
 exports.getSectionMembers = function getSectionMembers(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionMembersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2128,7 +2128,7 @@ getMyBookingsForEventRef.operationName = 'GetMyBookingsForEvent';
 exports.getMyBookingsForEventRef = getMyBookingsForEventRef;
 
 exports.getMyBookingsForEvent = function getMyBookingsForEvent(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyBookingsForEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2143,7 +2143,7 @@ getMyBookingsRef.operationName = 'GetMyBookings';
 exports.getMyBookingsRef = getMyBookingsRef;
 
 exports.getMyBookings = function getMyBookings(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2158,7 +2158,7 @@ getMyTicketOrderByIdRef.operationName = 'GetMyTicketOrderById';
 exports.getMyTicketOrderByIdRef = getMyTicketOrderByIdRef;
 
 exports.getMyTicketOrderById = function getMyTicketOrderById(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyTicketOrderByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2173,7 +2173,7 @@ getMyTicketOrdersRef.operationName = 'GetMyTicketOrders';
 exports.getMyTicketOrdersRef = getMyTicketOrdersRef;
 
 exports.getMyTicketOrders = function getMyTicketOrders(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyTicketOrdersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2188,7 +2188,7 @@ getMyBookingPaymentAdjustmentsRef.operationName = 'GetMyBookingPaymentAdjustment
 exports.getMyBookingPaymentAdjustmentsRef = getMyBookingPaymentAdjustmentsRef;
 
 exports.getMyBookingPaymentAdjustments = function getMyBookingPaymentAdjustments(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingPaymentAdjustmentsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2203,7 +2203,7 @@ listEventBookingsForAdminRef.operationName = 'ListEventBookingsForAdmin';
 exports.listEventBookingsForAdminRef = listEventBookingsForAdminRef;
 
 exports.listEventBookingsForAdmin = function listEventBookingsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listEventBookingsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2218,7 +2218,7 @@ listTicketOrdersForAdminRef.operationName = 'ListTicketOrdersForAdmin';
 exports.listTicketOrdersForAdminRef = listTicketOrdersForAdminRef;
 
 exports.listTicketOrdersForAdmin = function listTicketOrdersForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listTicketOrdersForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2233,7 +2233,7 @@ listBookingPaymentAdjustmentsForAdminRef.operationName = 'ListBookingPaymentAdju
 exports.listBookingPaymentAdjustmentsForAdminRef = listBookingPaymentAdjustmentsForAdminRef;
 
 exports.listBookingPaymentAdjustmentsForAdmin = function listBookingPaymentAdjustmentsForAdmin(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listBookingPaymentAdjustmentsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2248,7 +2248,7 @@ listOpenPaymentReconciliationExceptionsRef.operationName = 'ListOpenPaymentRecon
 exports.listOpenPaymentReconciliationExceptionsRef = listOpenPaymentReconciliationExceptionsRef;
 
 exports.listOpenPaymentReconciliationExceptions = function listOpenPaymentReconciliationExceptions(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listOpenPaymentReconciliationExceptionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2263,7 +2263,7 @@ getSectionAnnouncementOptOutRef.operationName = 'GetSectionAnnouncementOptOut';
 exports.getSectionAnnouncementOptOutRef = getSectionAnnouncementOptOutRef;
 
 exports.getSectionAnnouncementOptOut = function getSectionAnnouncementOptOut(dcOrVars, varsOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2278,7 +2278,7 @@ getMyAnnouncementPreferencesRef.operationName = 'GetMyAnnouncementPreferences';
 exports.getMyAnnouncementPreferencesRef = getMyAnnouncementPreferencesRef;
 
 exports.getMyAnnouncementPreferences = function getMyAnnouncementPreferences(dcOrOptions, options) {
-
+  
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyAnnouncementPreferencesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -1362,6 +1362,10 @@ export interface GetMyBookingsData {
 export interface GetMyBookingsForEventData {
   user?: {
     id: string;
+    bookingTicketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -1382,11 +1386,8 @@ export interface GetMyBookingsForEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -2253,10 +2253,7 @@ export interface ListEventBookingsForAdminData {
             id: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
+            ticketOrderId: UUIDString;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         guestUser?: {

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -6411,6 +6411,10 @@ To access the data returned by a Query, use the `UseQueryResult.data` field. The
 export interface GetMyBookingsForEventData {
   user?: {
     id: string;
+    bookingTicketOrders: ({
+      id: UUIDString;
+      status: TicketOrderStatus;
+    } & TicketOrder_Key)[];
     bookings: ({
       id: UUIDString;
       status: BookingStatus;
@@ -6431,11 +6435,8 @@ export interface GetMyBookingsForEventData {
           id: UUIDString;
           paymentAllocations: ({
             id: UUIDString;
+            ticketOrderId: UUIDString;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         sortOrder: number;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -6970,10 +6970,7 @@ export interface ListEventBookingsForAdminData {
             id: UUIDString;
             allocatedAmountMinor: number;
             refundedAmountMinor: number;
-            ticketOrder: {
-              id: UUIDString;
-              status: TicketOrderStatus;
-            } & TicketOrder_Key;
+            ticketOrderId: UUIDString;
           } & BookingPlacePaymentAllocation_Key)[];
         } & BookingPlace_Key;
         guestUser?: {

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -421,8 +421,18 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       )
       .sort((left, right) => new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime());
   }, [approvalStatusFilter, eventBookings]);
-  const attendeeTickets = useMemo(() => activeEventTicketRows(eventBookings), [eventBookings]);
-  const ticketOrders: TicketOrderAdminRow[] = ticketOrdersData?.event?.ticketOrders ?? [];
+  const ticketOrders = useMemo<TicketOrderAdminRow[]>(
+    () => ticketOrdersData?.event?.ticketOrders ?? [],
+    [ticketOrdersData]
+  );
+  const ticketOrdersById = useMemo(
+    () => new Map(ticketOrders.map((order) => [order.id, order])),
+    [ticketOrders]
+  );
+  const attendeeTickets = useMemo(
+    () => activeEventTicketRows(eventBookings, ticketOrdersById),
+    [eventBookings, ticketOrdersById]
+  );
   const bookingPaymentAdjustments: BookingPaymentAdjustmentAdminRow[] = paymentAdjustmentsData?.event?.bookings ?? [];
 
   const handleReviewBooking = async (
@@ -499,6 +509,7 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           onApprovalStatusFilterChange={setApprovalStatusFilter}
           approvalBookings={approvalBookings}
           allEventBookings={eventBookings}
+          ticketOrdersById={ticketOrdersById}
           attendeeTickets={attendeeTickets}
           moderatorNoteDraft={moderatorNoteDraft}
           onModeratorNoteChange={(bookingId, value) =>

--- a/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
@@ -33,7 +33,7 @@ import type {
   TicketOrderAdminRow,
   TicketTypeRow,
 } from "../sectionEventsManagerTypes";
-import type { EventAttendeeTicketRow } from "../../utils/bookingApprovalsAdmin";
+import type { EventAttendeeTicketRow, TicketOrdersById } from "../../utils/bookingApprovalsAdmin";
 import {
   attendeePaymentState,
   eventTicketRowsCsv,
@@ -58,6 +58,7 @@ interface TicketAdminSurfaceProps {
   onApprovalStatusFilterChange: (value: BookingApprovalStatusFilter) => void;
   approvalBookings: EventBookingAdminRow[];
   allEventBookings: EventBookingAdminRow[];
+  ticketOrdersById: TicketOrdersById;
   attendeeTickets: EventAttendeeTicketRow[];
   moderatorNoteDraft: Record<string, string>;
   onModeratorNoteChange: (bookingId: string, value: string) => void;
@@ -90,6 +91,7 @@ export function TicketAdminSurface({
   onApprovalStatusFilterChange,
   approvalBookings,
   allEventBookings,
+  ticketOrdersById,
   attendeeTickets,
   moderatorNoteDraft,
   onModeratorNoteChange,
@@ -132,6 +134,7 @@ export function TicketAdminSurface({
           loading={loadingEventBookings}
           bookings={approvalBookings}
           allBookings={allEventBookings}
+          ticketOrdersById={ticketOrdersById}
           moderatorNoteDraft={moderatorNoteDraft}
           onModeratorNoteChange={onModeratorNoteChange}
           reviewingBookingId={reviewingBookingId}
@@ -297,6 +300,7 @@ function BookingApprovalsSection({
   loading,
   bookings,
   allBookings,
+  ticketOrdersById,
   moderatorNoteDraft,
   onModeratorNoteChange,
   reviewingBookingId,
@@ -307,6 +311,7 @@ function BookingApprovalsSection({
   loading: boolean;
   bookings: EventBookingAdminRow[];
   allBookings: EventBookingAdminRow[];
+  ticketOrdersById: TicketOrdersById;
   moderatorNoteDraft: Record<string, string>;
   onModeratorNoteChange: (bookingId: string, value: string) => void;
   reviewingBookingId: string | null;
@@ -401,7 +406,7 @@ function BookingApprovalsSection({
                           <strong>{line.guestDisplayName || (line.ticketType.audience === "MEMBER" ? "Member" : "Guest")}</strong>
                           {` — ${line.ticketType.title}`}
                           {line.dietaryNote ? ` · Dietary: ${line.dietaryNote}` : ""}
-                          {` · Payment: ${attendeePaymentState(line).replaceAll("_", " ").toLowerCase()}`}
+                          {` · Payment: ${attendeePaymentState(line, ticketOrdersById).replaceAll("_", " ").toLowerCase()}`}
                         </Box>
                       ))}
                     </Box>

--- a/src/features/admin/utils/__tests__/bookingApprovalsAdmin.test.ts
+++ b/src/features/admin/utils/__tests__/bookingApprovalsAdmin.test.ts
@@ -5,7 +5,7 @@ import {
   TicketAudience,
   TicketOrderStatus,
 } from "@dataconnect/generated";
-import type { EventBookingAdminRow } from "../../components/sectionEventsManagerTypes";
+import type { EventBookingAdminRow, TicketOrderAdminRow } from "../../components/sectionEventsManagerTypes";
 import {
   activeEventTicketRows,
   currentActiveBookings,
@@ -13,7 +13,12 @@ import {
   type EventAttendeeTicketRow,
   pendingBookingRevisions,
   previousActiveBooking,
+  type TicketOrdersById,
 } from "../bookingApprovalsAdmin";
+
+function ticketOrdersById(orders: Array<Partial<TicketOrderAdminRow> & { id: string }>): TicketOrdersById {
+  return new Map(orders.map((order) => [order.id, order as TicketOrderAdminRow]));
+}
 
 function booking(overrides: Partial<EventBookingAdminRow> = {}): EventBookingAdminRow {
   return {
@@ -68,7 +73,7 @@ describe("booking approval admin model", () => {
               id: "allocation-member",
               allocatedAmountMinor: 2000,
               refundedAmountMinor: 0,
-              ticketOrder: { id: "order-member", status: TicketOrderStatus.PAID },
+              ticketOrderId: "order-member",
             }],
           },
         },
@@ -83,7 +88,10 @@ describe("booking approval admin model", () => {
       ] as EventBookingAdminRow["lines"],
     });
 
-    const rows = activeEventTicketRows([active]);
+    const rows = activeEventTicketRows(
+      [active],
+      ticketOrdersById([{ id: "order-member", status: TicketOrderStatus.PAID }])
+    );
     expect(rows).toEqual([
       expect.objectContaining({ attendeeName: "Alex Member", dietaryNote: "Vegetarian", paymentState: "PAID" }),
       expect.objectContaining({ attendeeName: "Jamie Guest", dietaryNote: "No nuts", paymentState: "UNPAID" }),
@@ -92,11 +100,14 @@ describe("booking approval admin model", () => {
   });
 
   it("does not include superseded, rejected, or pending revisions in the active ticket roster", () => {
-    expect(activeEventTicketRows([
-      booking({ supersededAt: "2026-08-11T11:00:00Z" }),
-      booking({ id: "pending", approvalStatus: BookingApprovalStatus.PENDING }),
-      booking({ id: "rejected", approvalStatus: BookingApprovalStatus.REJECTED }),
-    ])).toEqual([]);
+    expect(activeEventTicketRows(
+      [
+        booking({ supersededAt: "2026-08-11T11:00:00Z" }),
+        booking({ id: "pending", approvalStatus: BookingApprovalStatus.PENDING }),
+        booking({ id: "rejected", approvalStatus: BookingApprovalStatus.REJECTED }),
+      ],
+      ticketOrdersById([])
+    )).toEqual([]);
   });
 
   it("neutralizes spreadsheet formulas in exported attendee-controlled cells", () => {

--- a/src/features/admin/utils/bookingApprovalsAdmin.ts
+++ b/src/features/admin/utils/bookingApprovalsAdmin.ts
@@ -4,7 +4,9 @@ import {
   TicketAudience,
   TicketOrderStatus,
 } from "@dataconnect/generated";
-import type { EventBookingAdminRow } from "../components/sectionEventsManagerTypes";
+import type { EventBookingAdminRow, TicketOrderAdminRow } from "../components/sectionEventsManagerTypes";
+
+export type TicketOrdersById = ReadonlyMap<string, TicketOrderAdminRow>;
 
 export type AttendeePaymentState = "FREE" | "UNPAID" | "PAYMENT_PENDING" | "PAID" | "REFUNDED";
 
@@ -69,23 +71,26 @@ export function previousActiveBooking(
 }
 
 export function attendeePaymentState(
-  line: EventBookingAdminRow["lines"][number]
+  line: EventBookingAdminRow["lines"][number],
+  ticketOrdersById: TicketOrdersById
 ): AttendeePaymentState {
   if (line.ticketType.price <= 0) return "FREE";
   const allocations = line.bookingPlace.paymentAllocations ?? [];
-  if (allocations.some((allocation) => allocation.ticketOrder.status === TicketOrderStatus.PAID)) {
+  const statuses = allocations.map((allocation) => ticketOrdersById.get(allocation.ticketOrderId)?.status);
+  if (statuses.some((status) => status === TicketOrderStatus.PAID)) {
     const allocated = allocations.reduce((total, allocation) => total + allocation.allocatedAmountMinor, 0);
     const refunded = allocations.reduce((total, allocation) => total + allocation.refundedAmountMinor, 0);
     return allocated > 0 && refunded >= allocated ? "REFUNDED" : "PAID";
   }
-  if (allocations.some((allocation) => allocation.ticketOrder.status === TicketOrderStatus.PENDING)) {
+  if (statuses.some((status) => status === TicketOrderStatus.PENDING)) {
     return "PAYMENT_PENDING";
   }
   return "UNPAID";
 }
 
 export function activeEventTicketRows(
-  bookings: readonly EventBookingAdminRow[]
+  bookings: readonly EventBookingAdminRow[],
+  ticketOrdersById: TicketOrdersById
 ): EventAttendeeTicketRow[] {
   return currentActiveBookings(bookings).flatMap((booking) =>
     [...booking.lines]
@@ -107,7 +112,7 @@ export function activeEventTicketRows(
           ticketType: line.ticketType.title,
           dietaryNote: line.dietaryNote?.trim() || null,
           approvalStatus: booking.approvalStatus,
-          paymentState: attendeePaymentState(line),
+          paymentState: attendeePaymentState(line, ticketOrdersById),
         };
       })
   );

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -1,6 +1,7 @@
 import { Alert, Box, Button, CircularProgress, Paper, Step, StepLabel, Stepper, Typography } from "@mui/material";
 import type { GetEventByIdData, GetSectionByIdData } from "@dataconnect/generated";
 import { getBookingStatusLabel } from "../../../shared/utils/paymentStatusLabels";
+import FailureState from "../../../shared/components/FailureState";
 import { useBookingWizardState } from "../hooks/useBookingWizardState";
 import EventBookingStatusSummary from "./EventBookingStatusSummary";
 import TicketSelectionStep from "./wizardSteps/TicketSelectionStep";
@@ -38,6 +39,15 @@ export default function EventBookingWizard({
 
   if (wizard.loadingProfile || wizard.loadingBookings) {
     return <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}><CircularProgress size={28} /></Box>;
+  }
+  if (wizard.bookingsError) {
+    return (
+      <FailureState
+        title="Booking unavailable"
+        message="We could not load your booking. Please try again."
+        onRetry={() => void wizard.refetchMyBookings()}
+      />
+    );
   }
   if (!wizard.membershipStatus) {
     return <Alert severity="warning" sx={{ mt: 2 }}>Complete your membership profile before booking events.</Alert>;

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -88,9 +88,21 @@ export default function EventBookingWizard({
       ) : null}
 
       {wizard.lastSubmission && !wizard.existingTerminalBooking ? (
-        <Alert severity={wizard.lastSubmission.paymentReady ? "success" : "warning"} sx={{ mt: 2 }}>
+        <Alert
+          severity={wizard.lastSubmission.paymentReady ? "success" : "warning"}
+          sx={{ mt: 2 }}
+          action={wizard.lastSubmission.paymentReady ? (
+            <Button
+              color="inherit"
+              disabled={wizard.payingAllTickets}
+              onClick={() => void wizard.handlePayAllTickets()}
+            >
+              {wizard.payingAllTickets ? "Starting checkout…" : "Continue to payment"}
+            </Button>
+          ) : undefined}
+        >
           {wizard.lastSubmission.paymentReady
-            ? "Your booking has been submitted. Payment is available next."
+            ? "Your booking has been submitted and is ready for payment."
             : "Your booking has been submitted and is awaiting organiser approval. Payment will become available after approval."}
         </Alert>
       ) : null}

--- a/src/features/sections/components/MyPayments.tsx
+++ b/src/features/sections/components/MyPayments.tsx
@@ -15,7 +15,7 @@ import {
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useGetMyBookingPaymentAdjustments, useGetMyTicketOrders } from "@dataconnect/generated/react";
-import { TicketOrderStatus } from "@dataconnect/generated";
+import { BookingPaymentAdjustmentStatus, TicketOrderStatus } from "@dataconnect/generated";
 import { dataConnect } from "../../../config/firebase";
 import PageHeader from "../../../shared/components/PageHeader";
 import "../../../shared/components/PageContainer.css";
@@ -58,12 +58,14 @@ export default function MyPayments({ onBack }: MyPaymentsProps) {
   const orders = useMemo(() => data?.user?.ticketOrders ?? [], [data?.user?.ticketOrders]);
   const paymentGroups = useMemo(() => groupTicketOrdersForDisplay(orders), [orders]);
   const bookingAdjustments = (adjustmentsData?.user?.bookings ?? []).flatMap((booking) =>
-    (booking.adjustments ?? []).map((adjustment) => ({
+    (booking.adjustments ?? [])
+      .filter((adjustment) => adjustment.status !== BookingPaymentAdjustmentStatus.NOT_REQUIRED)
+      .map((adjustment) => ({
       bookingId: booking.id,
       eventTitle: booking.event?.title ?? "Event",
       revisionNumber: booking.revisionNumber,
       ...adjustment,
-    }))
+      }))
   );
 
   useEffect(() => {

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from "../../../../test-utils";
 import { BookingStatus, TicketAudience, TicketOrderStatus } from "@dataconnect/generated";
 import * as reactGenerated from "@dataconnect/generated/react";
 import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
+import * as bookingInvalidation from "../../../../shared/query/invalidation";
 import EventBookingWizard from "../EventBookingWizard";
 
 vi.mock("@dataconnect/generated/react", () => ({
@@ -16,7 +17,7 @@ vi.mock("@dataconnect/generated/react", () => ({
 }));
 vi.mock("../../../../config/firebase", () => ({ dataConnect: {} }));
 vi.mock("../../../../shared/query/invalidation", () => ({
-  invalidateMyBookings: vi.fn().mockResolvedValue(undefined),
+  refreshMyBookingsFromServer: vi.fn().mockResolvedValue({ user: { bookings: [] } }),
 }));
 vi.mock("../../../../shared/utils/firebaseFunctions", () => ({
   getSectionMembersMerged: vi.fn().mockResolvedValue({ members: [] }),
@@ -63,6 +64,8 @@ const event = {
   ],
 } as never;
 
+const refetchMyBookings = vi.fn().mockResolvedValue({ data: { user: { bookings: [] } } });
+
 function bookingWithGuest(paid: boolean) {
   return {
     id: "booking-1",
@@ -90,7 +93,7 @@ function bookingWithGuest(paid: boolean) {
         bookingPlace: {
           id: "guest-place",
           paymentAllocations: paid
-            ? [{ id: "allocation-1", ticketOrder: { id: "order-1", status: TicketOrderStatus.PAID } }]
+            ? [{ id: "allocation-1", ticketOrderId: "order-1" }]
             : [],
         },
         ticketType: { id: "ticket-guest", title: "Guest standard", audience: TicketAudience.GUEST, price: 25 },
@@ -99,11 +102,30 @@ function bookingWithGuest(paid: boolean) {
   };
 }
 
-function renderWizard(props: { bookings?: unknown[]; wizardOpen?: boolean } = {}) {
+function renderWizard(props: {
+  bookings?: unknown[];
+  bookingTicketOrders?: unknown[];
+  bookingsError?: boolean;
+  wizardOpen?: boolean;
+} = {}) {
   vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
-    data: { user: { bookings: props.bookings ?? [] } },
+    data: {
+      user: {
+        bookings: props.bookings ?? [],
+        bookingTicketOrders: props.bookingTicketOrders ?? [],
+      },
+    },
     isLoading: false,
-    refetch: vi.fn().mockResolvedValue({ data: { user: { bookings: props.bookings ?? [] } } }),
+    isError: props.bookingsError ?? false,
+    error: props.bookingsError ? new Error("Query failed") : null,
+    refetch: refetchMyBookings.mockResolvedValue({
+      data: {
+        user: {
+          bookings: props.bookings ?? [],
+          bookingTicketOrders: props.bookingTicketOrders ?? [],
+        },
+      },
+    }),
   } as never);
   return render(
     <MemoryRouter>
@@ -162,11 +184,26 @@ describe("EventBookingWizard", () => {
     await user.click(screen.getByRole("button", { name: "Submit booking" }));
 
     await waitFor(() => expect(firebaseFunctions.submitEventBooking).toHaveBeenCalledTimes(1));
+    expect(bookingInvalidation.refreshMyBookingsFromServer).toHaveBeenCalledWith(
+      expect.anything(),
+      "event-1",
+    );
     expect(vi.mocked(firebaseFunctions.submitEventBooking).mock.calls[0]?.[0].lines).toEqual([
       expect.objectContaining({ ticketTypeId: "ticket-member", dietaryNote: "Vegetarian" }),
       expect.objectContaining({ guestDisplayName: "Alex Guest", dietaryNote: "Vegan" }),
       expect.objectContaining({ guestDisplayName: "Sam Guest", dietaryNote: "Gluten free" }),
     ]);
+  });
+
+  it("shows a retryable error instead of an empty booking page when loading fails", async () => {
+    const user = userEvent.setup();
+    renderWizard({ bookingsError: true });
+
+    expect(screen.getByRole("heading", { name: "Booking unavailable" })).toBeInTheDocument();
+    expect(screen.getByText("We could not load your booking. Please try again.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(refetchMyBookings).toHaveBeenCalledOnce();
   });
 
   it("allows an unpaid guest to be removed while editing", async () => {
@@ -182,7 +219,10 @@ describe("EventBookingWizard", () => {
 
   it("blocks removal or transfer of a paid guest and explains the future refund route", async () => {
     const user = userEvent.setup();
-    renderWizard({ bookings: [bookingWithGuest(true)] });
+    renderWizard({
+      bookings: [bookingWithGuest(true)],
+      bookingTicketOrders: [{ id: "order-1", status: TicketOrderStatus.PAID }],
+    });
     await user.click(screen.getByRole("button", { name: "Edit booking" }));
     await user.click(screen.getByRole("button", { name: "Next" }));
 

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -137,6 +137,13 @@ function renderWizard(props: {
 describe("EventBookingWizard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(firebaseFunctions.submitEventBooking).mockResolvedValue({
+      bookingId: "booking-new",
+      status: "SUBMITTED",
+      approvalStatus: "PENDING",
+      outcome: "PENDING_APPROVAL",
+      paymentReady: false,
+    });
     vi.mocked(reactGenerated.useGetCurrentUser).mockReturnValue({
       data: { user: { id: "user-1", membershipStatus: "REGULAR" } },
       isLoading: false,
@@ -193,6 +200,34 @@ describe("EventBookingWizard", () => {
       expect.objectContaining({ guestDisplayName: "Alex Guest", dietaryNote: "Vegan" }),
       expect.objectContaining({ guestDisplayName: "Sam Guest", dietaryNote: "Gluten free" }),
     ]);
+    expect(screen.queryByRole("button", { name: "Continue to payment" })).not.toBeInTheDocument();
+  });
+
+  it("offers payment immediately after a booking that does not require approval", async () => {
+    vi.mocked(firebaseFunctions.submitEventBooking).mockResolvedValue({
+      bookingId: "booking-new",
+      status: "SUBMITTED",
+      approvalStatus: "NOT_REQUIRED",
+      outcome: "READY_FOR_PAYMENT",
+      paymentReady: true,
+    });
+    vi.mocked(firebaseFunctions.createEventBookingCheckoutSession).mockResolvedValue({
+      url: null,
+      orderIds: [],
+      confirmed: true,
+    });
+    const user = userEvent.setup();
+    renderWizard();
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await user.click(screen.getByRole("button", { name: "Submit booking" }));
+
+    const paymentButton = await screen.findByRole("button", { name: "Continue to payment" });
+    expect(screen.getByText("Your booking has been submitted and is ready for payment.")).toBeInTheDocument();
+    await user.click(paymentButton);
+
+    expect(firebaseFunctions.createEventBookingCheckoutSession).toHaveBeenCalledWith({ eventId: "event-1" });
   });
 
   it("shows a retryable error instead of an empty booking page when loading fails", async () => {

--- a/src/features/sections/components/__tests__/MyPayments.test.tsx
+++ b/src/features/sections/components/__tests__/MyPayments.test.tsx
@@ -213,6 +213,45 @@ describe("MyPayments", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not present an unpaid booking amendment as a payment adjustment", () => {
+    vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({
+        data: { user: { id: "u-1", ticketOrders: [] } },
+        isLoading: false,
+        isError: false,
+      })
+    );
+    vi.mocked(reactGenerated.useGetMyBookingPaymentAdjustments).mockReturnValue(
+      dataConnectQueryResult<typeof reactGenerated.useGetMyBookingPaymentAdjustments>({
+        data: {
+          user: {
+            id: "u-1",
+            bookings: [{
+              id: "booking-2",
+              revisionNumber: 2,
+              event: { id: "event-1", title: "Spring Ball" },
+              adjustments: [{
+                id: "adj-1",
+                deltaAmountMinor: 0,
+                status: "NOT_REQUIRED",
+                orchestrationKey: "booking-2:adj-1",
+                createdAt: "2026-04-01T12:05:00Z",
+                updatedAt: "2026-04-01T12:06:00Z",
+                supersededBooking: { id: "booking-1", revisionNumber: 1 },
+              }],
+            }],
+          },
+        },
+        isLoading: false,
+        isError: false,
+      })
+    );
+
+    render(<MyPayments onBack={() => undefined} />);
+
+    expect(screen.queryByText(/Booking changes/)).not.toBeInTheDocument();
+  });
+
   it("auto-loads receipt links and renders View receipt", async () => {
     vi.mocked(reactGenerated.useGetMyTicketOrders).mockReturnValue(
       dataConnectQueryResult<typeof reactGenerated.useGetMyTicketOrders>({

--- a/src/features/sections/hooks/useBookingWizardData.ts
+++ b/src/features/sections/hooks/useBookingWizardData.ts
@@ -31,6 +31,8 @@ export function useBookingWizardData(args: {
   const {
     data: myBookingsData,
     isLoading: loadingBookings,
+    isError: bookingsError,
+    error: bookingsQueryError,
     refetch: refetchMyBookings,
   } = useGetMyBookingsForEvent(dataConnect, { eventId: event.id as UUIDString });
   const membershipStatus = currentUserData?.user?.membershipStatus;
@@ -154,6 +156,9 @@ export function useBookingWizardData(args: {
     paymentSummaryForBooking != null && isBookingPaymentComplete(paymentSummaryForBooking);
 
   return {
+    bookingTicketOrders: myBookingsData?.user?.bookingTicketOrders ?? [],
+    bookingsError,
+    bookingsQueryError,
     bookingPaymentAdjustments,
     canProceedToConfirmation,
     currentUserData,

--- a/src/features/sections/hooks/useBookingWizardData.ts
+++ b/src/features/sections/hooks/useBookingWizardData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import type { GetEventByIdData, GetSectionByIdData, UUIDString } from "@dataconnect/generated";
-import { BookingStatus, TicketAudience } from "@dataconnect/generated";
+import { BookingPaymentAdjustmentStatus, BookingStatus, TicketAudience } from "@dataconnect/generated";
 import {
   useGetCurrentUser,
   useGetMyBookingPaymentAdjustments,
@@ -130,7 +130,9 @@ export function useBookingWizardData(args: {
     const booking = paymentAdjustmentsData?.user?.bookings?.find(
       (row) => row.id === paymentEligibleBooking.id
     );
-    return booking?.adjustments ?? [];
+    return (booking?.adjustments ?? []).filter(
+      (adjustment) => adjustment.status !== BookingPaymentAdjustmentStatus.NOT_REQUIRED
+    );
   }, [paymentEligibleBooking, paymentAdjustmentsData]);
 
   const paymentSummaryForBooking = useMemo(() => {

--- a/src/features/sections/hooks/useBookingWizardState.ts
+++ b/src/features/sections/hooks/useBookingWizardState.ts
@@ -8,7 +8,7 @@ import {
   type SubmitEventBookingResponse,
 } from "../../../shared/utils/firebaseFunctions";
 import { toCanonicalUuid } from "../../../shared/utils/uuid";
-import { invalidateMyBookings } from "../../../shared/query/invalidation";
+import { refreshMyBookingsFromServer } from "../../../shared/query/invalidation";
 import {
   extractDomainErrorCode,
   reportError,
@@ -66,6 +66,9 @@ export function useBookingWizardState({
   const hydratedBookingVersionRef = useRef<string | null>(null);
 
   const {
+    bookingTicketOrders,
+    bookingsError,
+    bookingsQueryError,
     bookingPaymentAdjustments,
     currentUserData,
     existingDraft,
@@ -93,15 +96,19 @@ export function useBookingWizardState({
     loading: seatingOptionsLoading,
   } = useSectionMemberSeatingSearch(section.id, currentUserData?.user?.id, sitNextToUserIds);
 
+  useEffect(() => {
+    if (bookingsError) reportError("booking.load", bookingsQueryError);
+  }, [bookingsError, bookingsQueryError]);
+
   const applyBookingSnapshot = useCallback((booking: NonNullable<typeof existingTerminalBooking>) => {
-    const snapshot = hydrateFormFromExistingBooking(booking);
+    const snapshot = hydrateFormFromExistingBooking(booking, bookingTicketOrders);
     setMemberTicketTypeId(snapshot.memberTicketTypeId);
     setGuests(snapshot.guests);
     setGuestCountInput(String(snapshot.guests.length));
     setMemberDietaryNote(snapshot.memberDietaryNote);
     setSitNextToUserIds(snapshot.sitNextToUserIds);
     setAccommodationRequested(snapshot.accommodationRequested);
-  }, []);
+  }, [bookingTicketOrders]);
 
   useEffect(() => {
     onHasExistingBookingChange?.(Boolean(existingTerminalBooking));
@@ -123,11 +130,15 @@ export function useBookingWizardState({
       return;
     }
     if (isEditingBooking) return;
-    const version = `${existingTerminalBooking.id}:${existingTerminalBooking.updatedAt}`;
+    const orderVersion = bookingTicketOrders
+      .map((order) => `${order.id}:${order.status}`)
+      .sort()
+      .join(",");
+    const version = `${existingTerminalBooking.id}:${existingTerminalBooking.updatedAt}:${orderVersion}`;
     if (hydratedBookingVersionRef.current === version) return;
     hydratedBookingVersionRef.current = version;
     applyBookingSnapshot(existingTerminalBooking);
-  }, [applyBookingSnapshot, existingTerminalBooking, isEditingBooking]);
+  }, [applyBookingSnapshot, bookingTicketOrders, existingTerminalBooking, isEditingBooking]);
 
   useEffect(() => {
     if (!memberTicketTypes.length) {
@@ -260,19 +271,24 @@ export function useBookingWizardState({
       setLastSubmission(result);
       setIsEditingBooking(false);
       setActiveStep(0);
-      await Promise.all([refetchMyBookings(), invalidateMyBookings(queryClient)]);
+      try {
+        await refreshMyBookingsFromServer(queryClient, event.id);
+      } catch (refreshError) {
+        reportError("booking.refresh-after-submit", refreshError);
+        setSubmitError("Your booking was saved, but the latest details could not be loaded. Please try refreshing.");
+      }
       onBookingComplete?.();
     } catch (error: unknown) {
       reportError("booking.submit", error);
       const code = extractDomainErrorCode(error);
       if (code === "BOOKING_ALREADY_SUBMITTED") {
         setSubmitError("You already have a submitted booking for this event.");
-        await refetchMyBookings();
+        await refreshMyBookingsFromServer(queryClient, event.id);
       } else if (code === "OUTSIDE_BOOKING_WINDOW") {
         setSubmitError("The booking window is closed.");
       } else if (code === "IDEMPOTENCY_DRAFT_CONFLICT") {
-        const refreshed = await refetchMyBookings();
-        const draft = refreshed.data?.user?.bookings?.find((booking) => booking.status === BookingStatus.DRAFT);
+        const refreshed = await refreshMyBookingsFromServer(queryClient, event.id);
+        const draft = refreshed.user?.bookings?.find((booking) => booking.status === BookingStatus.DRAFT);
         const raw = draft?.clientSubmissionKey?.trim();
         if (raw) {
           try {
@@ -298,7 +314,14 @@ export function useBookingWizardState({
     try {
       const { url, confirmed } = await createEventBookingCheckoutSession({ eventId: event.id });
       if (url) window.location.assign(url);
-      else if (confirmed) await Promise.all([refetchMyBookings(), invalidateMyBookings(queryClient)]);
+      else if (confirmed) {
+        try {
+          await refreshMyBookingsFromServer(queryClient, event.id);
+        } catch (refreshError) {
+          reportError("booking.refresh-after-checkout", refreshError);
+          setSubmitError("Payment completed, but the latest booking details could not be loaded. Please try refreshing.");
+        }
+      }
       else throw new Error("Checkout completed without a payment URL or booking confirmation");
     } catch (error: unknown) {
       reportError("booking.checkout-start", error);
@@ -372,8 +395,11 @@ export function useBookingWizardState({
     lastSubmission,
     ticketOrdersData,
     bookingPaymentAdjustments,
+    bookingsError,
+    bookingsQueryError,
     loadingProfile,
     loadingBookings,
+    refetchMyBookings,
     membershipStatus,
     gate,
     handleNext,

--- a/src/features/sections/utils/bookingWizardHydration.ts
+++ b/src/features/sections/utils/bookingWizardHydration.ts
@@ -14,7 +14,7 @@ type BookingRow = {
     id?: string | null;
     bookingPlace: {
       id: string;
-      paymentAllocations?: Array<{ ticketOrder?: { status?: string | null } | null }> | null;
+      paymentAllocations?: Array<{ ticketOrderId?: string | null }> | null;
     };
     ticketType?: { id?: string | null; audience?: string | null } | null;
     guestDisplayName?: string | null;
@@ -24,13 +24,29 @@ type BookingRow = {
   accommodationRequested?: boolean | null;
 };
 
-function lineIsPaid(line: NonNullable<BookingRow["lines"]>[number]): boolean {
+type BookingTicketOrder = {
+  id: string;
+  status?: string | null;
+};
+
+function lineIsPaid(
+  line: NonNullable<BookingRow["lines"]>[number],
+  paidTicketOrderIds: ReadonlySet<string>
+): boolean {
   return (line.bookingPlace.paymentAllocations ?? []).some(
-    (allocation) => allocation.ticketOrder?.status === TicketOrderStatus.PAID
+    (allocation) => allocation.ticketOrderId != null && paidTicketOrderIds.has(allocation.ticketOrderId)
   );
 }
 
-export function hydrateFormFromExistingBooking(booking: BookingRow): WizardFormSnapshot {
+export function hydrateFormFromExistingBooking(
+  booking: BookingRow,
+  ticketOrders: BookingTicketOrder[] = []
+): WizardFormSnapshot {
+  const paidTicketOrderIds = new Set(
+    ticketOrders
+      .filter((order) => order.status === TicketOrderStatus.PAID)
+      .map((order) => order.id)
+  );
   const memberLine = (booking.lines ?? []).find(
     (line) => line.ticketType?.audience === TicketAudience.MEMBER
   );
@@ -42,7 +58,7 @@ export function hydrateFormFromExistingBooking(booking: BookingRow): WizardFormS
       ticketTypeId: line.ticketType?.id ?? null,
       guestDisplayName: line.guestDisplayName ?? "",
       dietaryNote: line.dietaryNote ?? "",
-      paid: lineIsPaid(line),
+      paid: lineIsPaid(line, paidTicketOrderIds),
     }));
 
   return {

--- a/src/shared/query/__tests__/invalidation.test.ts
+++ b/src/shared/query/__tests__/invalidation.test.ts
@@ -1,10 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryObserver } from "@tanstack/react-query";
+
+const bookingQueryMocks = vi.hoisted(() => ({
+  getMyBookingsForEvent: vi.fn(),
+  getMyBookings: vi.fn(),
+  getMyTicketOrders: vi.fn(),
+  getMyBookingPaymentAdjustments: vi.fn(),
+}));
+
+vi.mock("@dataconnect/generated", () => bookingQueryMocks);
+vi.mock("../../../config/firebase", () => ({ dataConnect: { mocked: true } }));
+vi.mock("firebase/data-connect", () => ({
+  QueryFetchPolicy: { SERVER_ONLY: "SERVER_ONLY" },
+}));
+
 import {
   invalidateAnnouncementPreferences,
   invalidateMyBookings,
   invalidateSectionsForUser,
   invalidateUserSectionAccess,
+  refreshMyBookingsFromServer,
 } from "../invalidation";
 
 function queryClientWithInvalidateSpy() {
@@ -16,6 +31,10 @@ function queryClientWithInvalidateSpy() {
 }
 
 describe("cross-view query invalidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("invalidates aggregate and section announcement preferences", async () => {
     const { queryClient, invalidateQueries } = queryClientWithInvalidateSpy();
 
@@ -74,5 +93,38 @@ describe("cross-view query invalidation", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetMyBookingsForEvent"] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetMyTicketOrders"] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["GetMyBookingPaymentAdjustments"] });
+  });
+
+  it("bypasses the Data Connect cache after a callable booking write", async () => {
+    const queryClient = new QueryClient();
+    const eventBookings = { user: { bookings: [{ id: "booking-1" }], bookingTicketOrders: [] } };
+    const allBookings = { user: { bookings: [{ id: "booking-1" }] } };
+    const ticketOrders = { user: { ticketOrders: [{ id: "order-1" }] } };
+    const paymentAdjustments = { user: { bookings: [] } };
+    bookingQueryMocks.getMyBookingsForEvent.mockResolvedValue({ data: eventBookings });
+    bookingQueryMocks.getMyBookings.mockResolvedValue({ data: allBookings });
+    bookingQueryMocks.getMyTicketOrders.mockResolvedValue({ data: ticketOrders });
+    bookingQueryMocks.getMyBookingPaymentAdjustments.mockResolvedValue({ data: paymentAdjustments });
+
+    const result = await refreshMyBookingsFromServer(queryClient, "event-1");
+
+    expect(result).toEqual(eventBookings);
+    expect(bookingQueryMocks.getMyBookingsForEvent).toHaveBeenCalledWith(
+      { mocked: true },
+      { eventId: "event-1" },
+      { fetchPolicy: "SERVER_ONLY" },
+    );
+    for (const query of [
+      bookingQueryMocks.getMyBookings,
+      bookingQueryMocks.getMyTicketOrders,
+      bookingQueryMocks.getMyBookingPaymentAdjustments,
+    ]) {
+      expect(query).toHaveBeenCalledWith({ mocked: true }, { fetchPolicy: "SERVER_ONLY" });
+    }
+    expect(queryClient.getQueryData(["GetMyBookingsForEvent", { eventId: "event-1" }])).toEqual(eventBookings);
+    expect(queryClient.getQueryData(["GetMyBookings", null])).toEqual(allBookings);
+    expect(queryClient.getQueryData(["GetMyTicketOrders", null])).toEqual(ticketOrders);
+    expect(queryClient.getQueryData(["GetMyBookingPaymentAdjustments", null])).toEqual(paymentAdjustments);
+    queryClient.clear();
   });
 });

--- a/src/shared/query/invalidation.ts
+++ b/src/shared/query/invalidation.ts
@@ -1,4 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query";
+import type { UUIDString } from "@dataconnect/generated";
+import {
+  getMyBookingPaymentAdjustments,
+  getMyBookings,
+  getMyBookingsForEvent,
+  getMyTicketOrders,
+} from "@dataconnect/generated";
+import { QueryFetchPolicy } from "firebase/data-connect";
+import { dataConnect } from "../../config/firebase";
 
 /**
  * Data Connect's generated React mutations do not know which other generated
@@ -30,4 +39,33 @@ export async function invalidateMyBookings(queryClient: QueryClient) {
     queryClient.invalidateQueries({ queryKey: ["GetMyTicketOrders"] }),
     queryClient.invalidateQueries({ queryKey: ["GetMyBookingPaymentAdjustments"] }),
   ]);
+}
+
+/**
+ * Callable booking writes bypass the browser Data Connect client. Refresh both
+ * Data Connect's internal cache and TanStack Query from the server so a normal
+ * refetch cannot return the pre-callable cached result.
+ */
+export async function refreshMyBookingsFromServer(
+  queryClient: QueryClient,
+  eventId: UUIDString
+) {
+  const serverOnly = { fetchPolicy: QueryFetchPolicy.SERVER_ONLY } as const;
+  const eventBookings = await getMyBookingsForEvent(dataConnect, { eventId }, serverOnly);
+  queryClient.setQueryData(["GetMyBookingsForEvent", { eventId }], { ...eventBookings.data });
+
+  const [allBookings, ticketOrders, paymentAdjustments] = await Promise.all([
+    getMyBookings(dataConnect, serverOnly),
+    getMyTicketOrders(dataConnect, serverOnly),
+    getMyBookingPaymentAdjustments(dataConnect, serverOnly),
+  ]);
+
+  queryClient.setQueryData(["GetMyBookings", null], { ...allBookings.data });
+  queryClient.setQueryData(["GetMyTicketOrders", null], { ...ticketOrders.data });
+  queryClient.setQueryData(
+    ["GetMyBookingPaymentAdjustments", null],
+    { ...paymentAdjustments.data }
+  );
+
+  return eventBookings.data;
 }


### PR DESCRIPTION
Closes #565.

## What changed

- flatten `GetMyBookingsForEvent` so ticket-order status is selected alongside bookings rather than through the deeply nested allocation path
- join allocation IDs to sibling ticket orders when determining whether a booking line is paid
- force server-only Data Connect reads after callable booking and payment writes, then update the corresponding TanStack Query caches
- show a retryable error state when the member booking query fails instead of leaving the Book tab blank
- regenerate the Data Connect SDKs and add regression coverage for the query shape, refresh policy, paid-line hydration, and loading error state

## Root cause

The member booking query nested `TicketOrder` through `Booking -> BookingLine -> BookingPlace -> BookingPlacePaymentAllocation`. Generated PostgreSQL aliases could collide after PostgreSQL's 63-character identifier limit, causing the query to fail. When callable writes succeeded, ordinary generated-query refetches also used Data Connect's default cache-preferred policy, so the UI could retain the pre-write result.

## User impact

After a successful booking submission or payment update, the latest booking is loaded into the UI immediately. Existing bookings load reliably after refresh, paid ticket lines remain protected, and query failures provide a clear retry action.

## Validation

- frontend: 97 files / 732 tests passed
- Functions: 84 files / 927 tests passed
- frontend build and lint passed
- Functions build and lint passed

## Deployment

Deploy Data Connect before the updated frontend so the generated client query matches the deployed connector.