### PR TITLE
Harden submitEventBooking line-count bound (#541)

### DIFF
--- a/docs/architecture/booking-submission-api.md
+++ b/docs/architecture/booking-submission-api.md
@@ -19,9 +19,13 @@ For payment lifecycle transitions and webhook semantics, see
 |--------|------|------------|-------------|
 | `idempotencyKey` | string (UUID) | yes | **Per submit attempt** — generate a new UUID (v4) when the user commits; **reuse the same value** on retries after network errors so the server returns the same booking instead of creating another |
 | `eventId` | string (UUID) | yes | Event being booked |
-| `lines` | array | yes | Complete list of 1–100 attendee line items (see below); exactly one member line and every guest line must be present |
+| `lines` | array | yes | Complete list of 1–`MAX_ATOMIC_BOOKING_LINES` (100) attendee line items (see below); exactly one member line and every guest line must be present |
 | `baseBookingId` | string (UUID) | no | Required for mutable-booking revision updates once a terminal revision exists |
 | `baseRevisionNumber` | integer | no | Required with `baseBookingId`; optimistic concurrency guard |
+
+### Line count bound
+
+`lines` is capped at `MAX_ATOMIC_BOOKING_LINES` (`functions/src/bookingSubmissionPersistence.ts`, currently 100) — the same constant the `booking-service` connector's `_Data` batch variables are `@allow(maxCount:)`-scoped to. `parseBookingLines` in `functions/src/bookings.ts` rejects an oversized array with `invalid-argument` before any Data Connect read or write. This bound exists because the whole-booking atomic model introduced by #538 commits every line of a submission (and, for amendments, of the superseded booking) in one `@transaction`; without a cap, an authenticated caller could turn one allowed callable invocation into a disproportionate amount of server-side work. `submitEventBooking`'s rate-limit cost also scales with the raw line count for the same reason — see `docs/architecture/callable-abuse-protection.md`. (#541)
 
 ### Idempotency semantics
 

--- a/docs/architecture/callable-abuse-protection.md
+++ b/docs/architecture/callable-abuse-protection.md
@@ -4,6 +4,8 @@ Firebase callable functions normally use authentication and authorization as the
 
 `CALLABLE_RATE_LIMITS` is the canonical limit configuration. Call sites must reference a named policy; do not add inline limit or window values.
 
+`enforceRateLimit` accepts an optional weighted `cost` (default 1) so a single call can consume more than one unit of its window allowance. `submitEventBooking` is the one caller that uses this: cost scales with the raw, unvalidated line count in the request (`Math.ceil(lineCount / 5)`, clamped to the policy's `limit`), so a booking at the `MAX_ATOMIC_BOOKING_LINES` (100, see `docs/architecture/booking-submission-api.md`) fan-out ceiling exhausts the caller's entire hourly allowance in one call instead of being repeatable up to 20 times an hour. Typical bookings (a handful of lines) still cost the historical flat 1 unit. See `functions/src/bookings.ts` (`submitEventBookingRateLimitCost`) and #541.
+
 ## Concurrency model
 
 `enforceRateLimit` makes two sequential Data Connect calls, not one:
@@ -34,7 +36,7 @@ Deploy Data Connect schema and connector changes before deploying Functions. Gen
 | `listUsersWithoutDataConnectProfile` | 30 | 5 minutes | Full Auth/Data Connect enumeration |
 | `listUsersPendingApproval` | 30 | 5 minutes | Full Auth/Data Connect enumeration |
 | `syncPendingUserClaims` | 10 | 1 hour | Firebase Auth read/write |
-| `submitEventBooking` | 20 | 1 hour | Mutation and transactional email |
+| `submitEventBooking` | 20 (weighted 1â€“20 by line count, see below) | 1 hour | Mutation and transactional email |
 | `reviewBookingRevision` | 30 | 1 hour | Exact-revision approval mutation and transactional email |
 | `updateMembershipStatus` | 20 | 1 hour | Auth/Data Connect writes and transactional email |
 | `resignMembership` | 3 | 1 hour | Auth/Data Connect writes and transactional email |
@@ -88,7 +90,7 @@ Risk levels are relative to other authenticated callables in this application. â
 | `getSectionForUser` | Low | Low | None | Low | Enabled + section access; bounded lookup |
 | `getSectionEventsForUser` | Low | Medium | None | Medium | Enabled + section access; bounded section query |
 | `getEventForUser` | Low | Low | None | Low | Enabled + section access; single-event query |
-| `submitEventBooking` | High | None | GOV.UK Notify | High | Enabled; validation/idempotency; 20/hour |
+| `submitEventBooking` | High | None | GOV.UK Notify | High | Enabled; validation/idempotency; 20/hour weighted by line count (#541) |
 | `reviewBookingRevision` | High | None | GOV.UK Notify | Medium | Admin + enabled; exact revision and transition checks; 30/hour |
 | `createTicketCheckoutSession` | High | None | Stripe | High | Enabled; ownership/eligibility; 10/15 minutes |
 | `createEventBookingCheckoutSession` | High | None | Stripe | High | Enabled; booking ownership; 10/15 minutes |

--- a/functions/src/__tests__/parseBookingLines.test.ts
+++ b/functions/src/__tests__/parseBookingLines.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { HttpsError } from "firebase-functions/v2/https";
+import { parseBookingLines, submitEventBookingRateLimitCost } from "../bookings";
+import { MAX_ATOMIC_BOOKING_LINES } from "../bookingSubmissionPersistence";
+import { CALLABLE_RATE_LIMITS } from "../rateLimiter";
+
+const TICKET_TYPE_ID = "10000000-0000-4000-8000-000000000001";
+
+function line(sortOrder: number) {
+  return { ticketTypeId: TICKET_TYPE_ID, sortOrder };
+}
+
+describe("parseBookingLines line-count bound (#541)", () => {
+  it("accepts exactly the maximum number of lines", () => {
+    const lines = Array.from({ length: MAX_ATOMIC_BOOKING_LINES }, (_, i) => line(i));
+    expect(parseBookingLines(lines)).toHaveLength(MAX_ATOMIC_BOOKING_LINES);
+  });
+
+  it("rejects one more than the maximum, before any per-line validation", () => {
+    const lines = Array.from({ length: MAX_ATOMIC_BOOKING_LINES + 1 }, (_, i) => line(i));
+    expect(() => parseBookingLines(lines)).toThrow(HttpsError);
+    try {
+      parseBookingLines(lines);
+      expect.unreachable("expected parseBookingLines to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpsError);
+      expect((error as HttpsError).code).toBe("invalid-argument");
+      expect((error as HttpsError).message).toBe(
+        `lines must contain no more than ${MAX_ATOMIC_BOOKING_LINES} tickets`
+      );
+    }
+  });
+
+  it("rejects an empty array", () => {
+    expect(() => parseBookingLines([])).toThrow(HttpsError);
+  });
+});
+
+describe("submitEventBookingRateLimitCost (#541)", () => {
+  const { limit } = CALLABLE_RATE_LIMITS.submitEventBooking;
+
+  it("charges the historical flat cost of 1 for a typical small booking", () => {
+    expect(submitEventBookingRateLimitCost([])).toBe(1);
+    expect(submitEventBookingRateLimitCost([{}, {}, {}])).toBe(1);
+    expect(submitEventBookingRateLimitCost(undefined)).toBe(1);
+    expect(submitEventBookingRateLimitCost(null)).toBe(1);
+  });
+
+  it("scales cost up with line count", () => {
+    expect(submitEventBookingRateLimitCost(Array.from({ length: 6 }))).toBe(2);
+    expect(submitEventBookingRateLimitCost(Array.from({ length: 10 }))).toBe(2);
+    expect(submitEventBookingRateLimitCost(Array.from({ length: 11 }))).toBe(3);
+  });
+
+  it("charges the full policy allowance at the maximum accepted line count", () => {
+    expect(submitEventBookingRateLimitCost(Array.from({ length: MAX_ATOMIC_BOOKING_LINES }))).toBe(limit);
+  });
+
+  it("clamps an oversized or malformed payload to the policy limit rather than throwing", () => {
+    expect(submitEventBookingRateLimitCost(Array.from({ length: 10_000 }))).toBe(limit);
+    expect(submitEventBookingRateLimitCost("not-an-array")).toBe(1);
+    expect(submitEventBookingRateLimitCost({ length: 10_000 })).toBe(1);
+  });
+});

--- a/functions/src/bookings.ts
+++ b/functions/src/bookings.ts
@@ -24,7 +24,7 @@ import {
   type TicketTypeForRules,
 } from "./bookingRules";
 import { requireEnabled, requireString, validateUUID, handleFunctionError, MAX_NAME_LENGTH, MAX_DESCRIPTION_LENGTH } from "./helpers";
-import { enforceRateLimit } from "./rateLimiter";
+import { CALLABLE_RATE_LIMITS, enforceRateLimit } from "./rateLimiter";
 import { FUNCTIONS_REGION } from "./constants";
 import { computeRevisionPlan, isBookingRevisionConflictError } from "./bookingRevisionEngine";
 import { computeBookingPaymentDelta, type BookingPaymentDelta } from "./bookingPaymentAdjustments";
@@ -86,7 +86,21 @@ function bookingRulesToHttps(e: BookingRulesFailure): HttpsError {
   return new HttpsError("failed-precondition", e.message, { code: e.code });
 }
 
-function parseBookingLines(raw: unknown): LineInputForRules[] {
+/** Booking lines per rate-limit unit charged to submitEventBooking (#541). Small,
+ *  typical bookings (member + a few guests) keep costing the historical flat 1 unit;
+ *  a payload at the MAX_ATOMIC_BOOKING_LINES ceiling exhausts the caller's whole
+ *  hourly allowance in one call instead of being repeatable up to `limit` times. */
+const BOOKING_LINES_PER_RATE_LIMIT_UNIT = 5;
+
+/** Cost is derived from the raw (unvalidated) line count so it applies even to
+ *  oversized or malformed payloads, not just ones that pass parseBookingLines. */
+export function submitEventBookingRateLimitCost(rawLines: unknown): number {
+  const count = Array.isArray(rawLines) ? rawLines.length : 0;
+  const { limit } = CALLABLE_RATE_LIMITS.submitEventBooking;
+  return Math.min(limit, Math.max(1, Math.ceil(count / BOOKING_LINES_PER_RATE_LIMIT_UNIT)));
+}
+
+export function parseBookingLines(raw: unknown): LineInputForRules[] {
   if (!Array.isArray(raw) || raw.length === 0) {
     throw new HttpsError("invalid-argument", "lines must be a non-empty array");
   }
@@ -225,7 +239,7 @@ function bookingSubmissionOutcome(approvalStatus: BookingApprovalStatus) {
 export const submitEventBooking = onCall({ region: FUNCTIONS_REGION, secrets: [...govNotifySecrets] }, async (request) => {
   requireEnabled(request);
   const uid = request.auth!.uid;
-  await enforceRateLimit("submitEventBooking", uid);
+  await enforceRateLimit("submitEventBooking", uid, submitEventBookingRateLimitCost(request.data?.lines));
 
   const parsedRequest = (() => {
     try {


### PR DESCRIPTION
## Summary

Addresses the remaining gaps in #541 after the atomic batch-mutation rewrite already bounded and made the booking write atomic:

- **Boundary tests** — `parseBookingLines` exported and tested directly at the `MAX_ATOMIC_BOOKING_LINES` (100) boundary: 100 accepted, 101 rejected with `invalid-argument`, plus empty-array rejection.
- **Rate limiter weighted by payload size** — `submitEventBookingRateLimitCost` computes `ceil(rawLineCount / 5)`, clamped to the policy limit, using `enforceRateLimit`'s existing (previously unused anywhere) `cost` parameter. Typical bookings (≤5 lines) still cost the historical flat 1 unit; a max-sized 100-line submission now exhausts the caller's whole hourly allowance (20) in one call instead of being repeatable 20x/hour.
- **Documentation** — new "Line count bound" section in `docs/architecture/booking-submission-api.md` covering the cap and its relationship to #538's atomic whole-booking model, plus an update to `docs/architecture/callable-abuse-protection.md` describing the weighted-cost mechanism.

All five acceptance criteria in #541 are now met.

Closes #541

## Test plan

- [x] `tsc -b` clean
- [x] `eslint` clean
- [x] Full functions test suite (936 tests) passing, including new boundary/rate-limit-cost coverage
- [x] Full frontend test suite (734 tests) passing (unaffected, included as a baseline check)