### PR TITLE
Clarify accommodation request caption

### DIFF
--- a/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
+++ b/src/features/sections/components/wizardSteps/TicketSelectionStep.tsx
@@ -144,8 +144,9 @@ export default function TicketSelectionStep({
         disabled={!canRequestAccommodation}
       />
       <Typography variant="caption" color="text.secondary">
-        Accommodation is only available for Serving Members.
-        {canRequestAccommodation ? " Overnight accommodation at the venue, where available." : ""}
+        If you are a Serving Member, please indicate whether you would require accommodation.
+        This does not guarantee accommodation, and you will be informed if accommodation is not
+        available so that you can make your own arrangements.
       </Typography>
     </FormControl>
   );


### PR DESCRIPTION
## Summary
- The previous accommodation caption read as a hard eligibility rule and didn't explain what happens if accommodation isn't actually available.

## Test plan
- [ ] Manual review of the updated copy in the booking wizard's ticket selection step