### PR TITLE
Keep unsubscribe GET requests side-effect-free

### DIFF
--- a/docs/operations/firebase-hosting-security-headers.md
+++ b/docs/operations/firebase-hosting-security-headers.md
@@ -65,7 +65,8 @@ has not been duplicated or truncated. Then smoke-test:
 3. App Check/reCAPTCHA with `VITE_RECAPTCHA_SITE_KEY` configured;
 4. Analytics collection when a measurement ID is configured;
 5. Stripe Checkout redirect, return, and receipt links; and
-6. announcement unsubscribe GET redirect and one-click POST.
+6. announcement unsubscribe GET confirmation (without changing preferences), browser confirmation
+   POST, and RFC 8058 one-click POST.
 
 Use the browser console and Network panel to investigate CSP violations. Add an origin only after
 confirming which application feature requires it; do not add broad `https:` or wildcard Google

--- a/functions/src/__tests__/unsubscribe.test.ts
+++ b/functions/src/__tests__/unsubscribe.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request } from "firebase-functions/v2/https";
+import type { Response } from "express";
+import {
+  handleUnsubscribeRequest,
+  signUnsubscribeToken,
+} from "../unsubscribe";
+
+const SECRET = "unsubscribe-secret-that-is-long-enough";
+
+function token(overrides: Partial<{
+  userId: string;
+  sectionId: string;
+  sectionName: string;
+  exp: number;
+}> = {}): string {
+  return signUnsubscribeToken({
+    userId: "user-1",
+    sectionId: "section-1",
+    sectionName: "Signals & Cyber",
+    exp: Date.now() + 60_000,
+    ...overrides,
+  }, SECRET);
+}
+
+function request(overrides: Partial<{
+  method: string;
+  query: Record<string, unknown>;
+  body: Record<string, unknown>;
+}> = {}): Request {
+  return {
+    method: "GET",
+    query: { token: token() },
+    body: {},
+    ...overrides,
+  } as unknown as Request;
+}
+
+function response(): Response {
+  const res = {
+    setHeader: vi.fn(),
+    status: vi.fn(),
+    type: vi.fn(),
+    send: vi.fn(),
+    redirect: vi.fn(),
+  } as unknown as Response;
+  for (const method of ["status", "type"] as const) {
+    (res[method] as ReturnType<typeof vi.fn>).mockReturnValue(res);
+  }
+  return res;
+}
+
+describe("unsubscribeAnnouncement", () => {
+  it("renders confirmation for a valid GET without changing preferences", async () => {
+    const optOut = vi.fn();
+    const res = response();
+
+    await handleUnsubscribeRequest(request(), res, SECRET, { optOut });
+
+    expect(optOut).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.type).toHaveBeenCalledWith("html");
+    expect(res.send).toHaveBeenCalledWith(expect.stringContaining("Confirm unsubscribe"));
+    expect(res.setHeader).toHaveBeenCalledWith("Cache-Control", "no-store");
+    expect(res.setHeader).toHaveBeenCalledWith("Referrer-Policy", "no-referrer");
+  });
+
+  it("keeps an automated link-scanner GET side-effect-free", async () => {
+    const optOut = vi.fn();
+    const res = response();
+
+    await handleUnsubscribeRequest(request({ method: "GET" }), res, SECRET, { optOut });
+
+    expect(optOut).not.toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+  });
+
+  it("processes an RFC 8058 one-click POST", async () => {
+    const optOut = vi.fn().mockResolvedValue(undefined);
+    const res = response();
+
+    await handleUnsubscribeRequest(request({ method: "POST" }), res, SECRET, { optOut });
+
+    expect(optOut).toHaveBeenCalledWith({ userId: "user-1", sectionId: "section-1" });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith("OK");
+  });
+
+  it("processes browser confirmation and redirects to a token-free URL", async () => {
+    const optOut = vi.fn().mockResolvedValue(undefined);
+    const res = response();
+    const signedToken = token();
+
+    await handleUnsubscribeRequest(request({
+      method: "POST",
+      query: {},
+      body: { token: signedToken, browserConfirmation: "1" },
+    }), res, SECRET, { optOut });
+
+    expect(optOut).toHaveBeenCalledOnce();
+    expect(res.redirect).toHaveBeenCalledWith(
+      303,
+      "http://localhost:5173/unsubscribe/confirmed?section=Signals+%26+Cyber"
+    );
+    expect(String((res.redirect as ReturnType<typeof vi.fn>).mock.calls[0]?.[1])).not.toContain(signedToken);
+  });
+
+  it("rejects unsupported methods without changing preferences", async () => {
+    const optOut = vi.fn();
+    const res = response();
+
+    await handleUnsubscribeRequest(request({ method: "PUT" }), res, SECRET, { optOut });
+
+    expect(optOut).not.toHaveBeenCalled();
+    expect(res.setHeader).toHaveBeenCalledWith("Allow", "GET, POST");
+    expect(res.status).toHaveBeenCalledWith(405);
+  });
+
+  it.each([
+    ["missing", request({ query: {} })],
+    ["invalid", request({ query: { token: "not-a-valid-token" } })],
+    ["expired", request({ query: { token: token({ exp: Date.now() - 1 }) } })],
+  ])("rejects a %s token without changing preferences", async (_label, req) => {
+    const optOut = vi.fn();
+    const res = response();
+
+    await handleUnsubscribeRequest(req, res, SECRET, { optOut });
+
+    expect(optOut).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("escapes section names rendered into the confirmation page", async () => {
+    const res = response();
+
+    await handleUnsubscribeRequest(request({
+      query: { token: token({ sectionName: "<script>alert(\"x\")</script>" }) },
+    }), res, SECRET, { optOut: vi.fn() });
+
+    const html = String((res.send as ReturnType<typeof vi.fn>).mock.calls[0]?.[0]);
+    expect(html).toContain("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;");
+    expect(html).not.toContain("<script>");
+  });
+});

--- a/functions/src/unsubscribe.ts
+++ b/functions/src/unsubscribe.ts
@@ -1,7 +1,8 @@
-import { onRequest } from "firebase-functions/v2/https";
+import { onRequest, type Request } from "firebase-functions/v2/https";
 import { defineSecret } from "firebase-functions/params";
 import * as logger from "firebase-functions/logger";
 import { createHmac, timingSafeEqual } from "node:crypto";
+import type { Response } from "express";
 import { adminOptOutSectionAnnouncement } from "@dataconnect/admin-generated";
 import { FUNCTIONS_REGION } from "./constants";
 
@@ -45,46 +46,109 @@ function verifyUnsubscribeToken(token: string, secret: string): UnsubscribePaylo
   return payload;
 }
 
+function htmlEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function requestString(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function confirmationPage(token: string, sectionName: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Confirm unsubscribe</title>
+</head>
+<body>
+  <main>
+    <h1>Unsubscribe from ${htmlEscape(sectionName)}?</h1>
+    <p>You will stop receiving announcement emails for this section.</p>
+    <form method="post" action="/unsubscribe">
+      <input type="hidden" name="token" value="${htmlEscape(token)}">
+      <input type="hidden" name="browserConfirmation" value="1">
+      <button type="submit">Confirm unsubscribe</button>
+    </form>
+  </main>
+</body>
+</html>`;
+}
+
+export interface UnsubscribeHandlerDependencies {
+  optOut?: typeof adminOptOutSectionAnnouncement;
+}
+
+export async function handleUnsubscribeRequest(
+  req: Request,
+  res: Response,
+  secret: string,
+  dependencies: UnsubscribeHandlerDependencies = {}
+): Promise<void> {
+  if (req.method !== "GET" && req.method !== "POST") {
+    res.setHeader("Allow", "GET, POST");
+    res.status(405).send("Method Not Allowed");
+    return;
+  }
+
+  // Token-bearing responses must not be cached or exposed as referrers. A
+  // successful browser POST redirects to a token-free confirmation URL.
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Referrer-Policy", "no-referrer");
+
+  const token = requestString(req.query.token) ?? requestString(req.body?.token);
+  if (!token) {
+    res.status(400).send("Missing token");
+    return;
+  }
+
+  let payload: UnsubscribePayload;
+  try {
+    payload = verifyUnsubscribeToken(token, secret);
+  } catch {
+    res.status(400).send("Invalid or expired unsubscribe link");
+    return;
+  }
+
+  if (req.method === "GET") {
+    res.status(200).type("html").send(confirmationPage(token, payload.sectionName));
+    return;
+  }
+
+  try {
+    await (dependencies.optOut ?? adminOptOutSectionAnnouncement)({
+      userId: payload.userId,
+      sectionId: payload.sectionId,
+    });
+  } catch (err) {
+    logger.error("Failed to record announcement opt-out", {
+      err,
+      userId: payload.userId,
+      sectionId: payload.sectionId,
+    });
+    res.status(500).send("Unsubscribe failed — please try again later");
+    return;
+  }
+
+  if (req.body?.browserConfirmation === "1") {
+    const params = new URLSearchParams({ section: payload.sectionName });
+    res.redirect(303, `${APP_BASE_URL}/unsubscribe/confirmed?${params.toString()}`);
+    return;
+  }
+
+  // RFC 8058 one-click unsubscribe — email clients POST to the signed URL.
+  res.status(200).send("OK");
+}
+
 // ── Cloud Function ────────────────────────────────────────────────────────────
 
 export const unsubscribeAnnouncement = onRequest(
   { region: FUNCTIONS_REGION, secrets: [unsubscribeSecret], invoker: "public" },
-  async (req, res) => {
-    const token = typeof req.query.token === "string" ? req.query.token : undefined;
-
-    if (!token) {
-      res.status(400).send("Missing token");
-      return;
-    }
-
-    const secret = unsubscribeSecret.value();
-    let payload: UnsubscribePayload;
-    try {
-      payload = verifyUnsubscribeToken(token, secret);
-    } catch {
-      res.status(400).send("Invalid or expired unsubscribe link");
-      return;
-    }
-
-    try {
-      await adminOptOutSectionAnnouncement({
-        userId: payload.userId,
-        sectionId: payload.sectionId,
-      });
-    } catch (err) {
-      logger.error("Failed to record announcement opt-out", { err, userId: payload.userId, sectionId: payload.sectionId });
-      res.status(500).send("Unsubscribe failed — please try again later");
-      return;
-    }
-
-    if (req.method === "POST") {
-      // RFC 8058 one-click unsubscribe — email clients POST here
-      res.status(200).send("OK");
-      return;
-    }
-
-    // GET — redirect to confirmation page
-    const params = new URLSearchParams({ section: payload.sectionName });
-    res.redirect(302, `${APP_BASE_URL}/unsubscribe/confirmed?${params.toString()}`);
-  }
+  (req, res) => handleUnsubscribeRequest(req, res, unsubscribeSecret.value())
 );


### PR DESCRIPTION
## Summary

- keep signed unsubscribe GET requests side-effect-free
- render an explicit confirmation form for browser visits
- preserve RFC 8058 one-click POST behavior
- reject unsupported methods before token processing or mutation
- redirect browser confirmations to the existing token-free confirmation page
- prevent token-bearing responses from being cached or used as referrers

## Root cause and impact

The endpoint verified its signed token and wrote the announcement opt-out before checking the HTTP method. Email security scanners and link-preview services that followed the GET link could therefore unsubscribe a member without an intentional action.

GET now validates the signed link but only renders confirmation. The preference is changed exclusively by POST. Browser confirmation and automated one-click POST remain distinct so email-client compatibility is preserved.

Closes #540

## Validation

- Functions lint
- Functions test suite: 952 tests
- Functions TypeScript build
- Frontend lint
- Frontend test suite: 746 tests
- Frontend production build
- `git diff --check`
