### PR TITLE
Mark Data Connect SDKs as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+# Data Connect SDKs are generated from the schema and connector sources but
+# remain committed so installs and builds do not require the generator.
+src/dataconnect-generated/** linguist-generated=true
+functions/src/dataconnect-admin-generated/** linguist-generated=true
+
 # The Data Connect SDK generator emits example placeholders with trailing spaces.
 # Keep generated documentation reproducible while excluding that generator-owned
 # formatting from Git's whitespace error checks.

--- a/dataconnect/README.md
+++ b/dataconnect/README.md
@@ -114,6 +114,12 @@ All auth patterns are documented in `AUTH_EXPRESSIONS.md`. Key patterns:
 
 ## Deployment
 
+The frontend SDK in `src/dataconnect-generated` and Admin SDK in
+`functions/src/dataconnect-admin-generated` are generated output that remains
+committed to the repository. Do not edit these files directly; regenerate both
+SDKs from the schema and connector sources under `dataconnect/` whenever those
+sources change.
+
 After making changes, generate and compile against the SDKs **before** changing a remote environment:
 
 1. Run `npx firebase dataconnect:sdk:generate` from the repository root.


### PR DESCRIPTION
## Summary

- classify both committed Data Connect SDK trees as generated code for GitHub Linguist
- preserve the generated README whitespace attributes
- document that SDK output remains committed and must be regenerated from schema and connector sources

## Why

Generated SDK files currently dominate repository language and review statistics even though they are generator-owned output. Marking them as generated keeps GitHub reviews focused on maintained source without changing how the SDKs are committed or deployed.

Closes #580
Part of #539
Part of #575

## Validation

- `git check-attr linguist-generated` returns `true` for representative frontend, admin, and nested SDK files
- generated README files retain `whitespace: -trailing-space`
- no generated SDK content changed
- `git diff --check` passed
