### PR TITLE
Fix FK violation when logging order_not_found webhook events

### DIFF
--- a/functions/src/__tests__/paymentWebhook.test.ts
+++ b/functions/src/__tests__/paymentWebhook.test.ts
@@ -441,7 +441,7 @@ describe("stripe payment webhook orchestration", () => {
         stripeEventId: "evt_unknown_order",
         outcome: PaymentWebhookEventOutcome.IGNORED,
         reason: "order_not_found",
-        ticketOrderId: ORDER_ID,
+        ticketOrderId: null,
       })
     );
     expect(serviceMocks.applyTransitions).not.toHaveBeenCalled();

--- a/functions/src/paymentWebhook.ts
+++ b/functions/src/paymentWebhook.ts
@@ -265,7 +265,6 @@ async function handleStripeWebhookRequest(args: {
         eventType: event.type,
         outcome: PaymentWebhookEventOutcome.IGNORED,
         reason: "order_not_found",
-        ticketOrderId: canonicalOrderId,
         stripeObjectId,
         livemode: event.livemode,
       });


### PR DESCRIPTION
## Summary
- `handleStripeWebhookRequest`'s `order_not_found` branch passed `ticketOrderId` for an order that, by definition, doesn't exist in the database — violating `payment_webhook_event_ticket_order_id_fkey` and turning an ignorable event into a 400 that Stripe retries forever.
- Omits `ticketOrderId` in that branch, matching the existing `missing_order_metadata` branch's pattern.

Fixes #585

## Test plan
- [x] `npx vitest run src/__tests__/paymentWebhook.test.ts` — 17/17 passing
- [x] `npm run build` (tsc) succeeds