### PR TITLE
Remove dead UI and guard event detail state

### DIFF
--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -31,7 +31,6 @@ import { useLocation } from "react-router-dom";
 import "../../../shared/components/PageContainer.css";
 import {
   AddUserToGroupDialogSurface,
-  UserDetailDialogSurface,
   UserGroupDialogSurface,
   UserGroupsListSurface,
 } from "./UserGroupsSurfaces";
@@ -85,8 +84,6 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   // All users: for merged group membership (explicit + by membership status)
   const [allUsers, setAllUsers] = useState<UserSummary[]>([]);
   const [loadingAllUsers, setLoadingAllUsers] = useState(false);
-
-  const [selectedUserDetail, setSelectedUserDetail] = useState<UserSummary | null>(null);
 
   const fetchUserGroupsList = useCallback(async () => {
     setLoading(true);
@@ -540,8 +537,6 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         onSearchTermChange={handleAddUserSearchTermChange}
         onSelectUser={handleAddUserToGroup}
       />
-
-      <UserDetailDialogSurface user={selectedUserDetail} onClose={() => setSelectedUserDetail(null)} />
 
       <SnackbarAlert snackbar={snackbar} onClose={closeSnackbar} />
     </Box>

--- a/src/features/admin/components/UserGroupsSurfaces.tsx
+++ b/src/features/admin/components/UserGroupsSurfaces.tsx
@@ -667,34 +667,3 @@ export function AddUserToGroupDialogSurface({
     </Dialog>
   );
 }
-
-interface UserDetailDialogSurfaceProps {
-  user: UserSummary | null;
-  onClose: () => void;
-}
-
-export function UserDetailDialogSurface({ user, onClose }: UserDetailDialogSurfaceProps) {
-  return (
-    <Dialog open={!!user} onClose={onClose} maxWidth="xs" fullWidth>
-      <DialogTitle>User</DialogTitle>
-      <DialogContent>
-        {user && (
-          <Box sx={{ pt: 0.5 }}>
-            <Typography variant="body2">
-              <strong>
-                {user.firstName} {user.lastName}
-              </strong>
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              {user.email || "No email"}
-            </Typography>
-            <Chip label={user.membershipStatus} size="small" variant="outlined" sx={{ mt: 1 }} />
-          </Box>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
-  );
-}

--- a/src/features/admin/components/__tests__/UserGroups.test.tsx
+++ b/src/features/admin/components/__tests__/UserGroups.test.tsx
@@ -71,7 +71,6 @@ vi.mock("../UserGroupsSurfaces", () => ({
     </div>
   ) : null,
   AddUserToGroupDialogSurface: () => null,
-  UserDetailDialogSurface: () => null,
 }));
 
 let updated = false;

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -224,8 +224,6 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
     if (!selectedEventId) {
       eventDetailRequestIdRef.current += 1;
       setEventDetailData(undefined);
-      setLoadingEventDetail(false);
-      setErrorEventDetail(false);
       return;
     }
     void refetchEventDetail();

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -198,25 +198,34 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingEventDetail, setLoadingEventDetail] = useState(false);
   const [errorEventDetail, setErrorEventDetail] = useState(false);
 
+  const eventDetailRequestIdRef = useRef(0);
   const refetchEventDetail = useCallback(async () => {
     if (!selectedEventId) return;
+    const requestId = ++eventDetailRequestIdRef.current;
     setLoadingEventDetail(true);
     setErrorEventDetail(false);
     try {
       const result = await getEventForUser(selectedEventId);
+      if (eventDetailRequestIdRef.current !== requestId) return;
       setEventDetailData({ event: result.event });
     } catch (error) {
+      if (eventDetailRequestIdRef.current !== requestId) return;
       reportError("sections.event-detail", error);
       setEventDetailData(undefined);
       setErrorEventDetail(true);
     } finally {
-      setLoadingEventDetail(false);
+      if (eventDetailRequestIdRef.current === requestId) {
+        setLoadingEventDetail(false);
+      }
     }
   }, [selectedEventId]);
 
   useEffect(() => {
     if (!selectedEventId) {
+      eventDetailRequestIdRef.current += 1;
       setEventDetailData(undefined);
+      setLoadingEventDetail(false);
+      setErrorEventDetail(false);
       return;
     }
     void refetchEventDetail();

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '../../../../test-utils';
+import { act, render, screen, waitFor } from '../../../../test-utils';
 import { MemoryRouter } from 'react-router-dom';
 import SectionDetail from '../SectionDetail';
 import * as reactGenerated from '@dataconnect/generated/react';
@@ -762,6 +762,85 @@ describe('SectionDetail', () => {
       expect(screen.queryByText('Ticket types')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument();
     });
+  });
+
+  it('does not let a stale event-detail response overwrite a newer selection', async () => {
+    const mockSectionData = {
+      section: {
+        id: sectionId,
+        name: 'Events Section',
+        type: 'EVENTS',
+        description: 'Events description',
+        purposeLinks: [],
+      },
+    };
+    const eventSummaries = [
+      {
+        id: 'event-1',
+        title: 'First Dinner',
+        ...upcomingEventTimes,
+        location: 'First Hall',
+        guestOfHonour: null,
+      },
+      {
+        id: 'event-2',
+        title: 'Second Dinner',
+        ...upcomingEventTimes,
+        location: 'Second Hall',
+        guestOfHonour: null,
+      },
+    ];
+    const eventDetail = (id: string, title: string, location: string) => ({
+      event: {
+        id,
+        section: { id: sectionId },
+        title,
+        ...upcomingEventTimes,
+        location,
+        guestOfHonour: null,
+        maxGuestsWithoutModeratorApproval: null,
+        ticketTypes: [],
+      },
+    } as unknown as Awaited<ReturnType<typeof getEventForUser>>);
+
+    let resolveFirstEvent!: (value: Awaited<ReturnType<typeof getEventForUser>>) => void;
+    const firstEventRequest = new Promise<Awaited<ReturnType<typeof getEventForUser>>>((resolve) => {
+      resolveFirstEvent = resolve;
+    });
+    vi.mocked(getEventForUser).mockImplementation((eventId: string) => {
+      if (eventId === 'event-1') return firstEventRequest;
+      return Promise.resolve(eventDetail('event-2', 'Second Dinner', 'Second Hall'));
+    });
+
+    mockGetSectionById({ data: mockSectionData, isLoading: false, isError: false });
+    mockGetUserAccessGroups({
+      data: { user: { id: 'user-1', userGroups: [] } },
+      isLoading: false,
+      isError: false,
+    });
+    mockGetEventsForSection({
+      data: { section: { id: sectionId, events: eventSummaries } },
+      isLoading: false,
+      isError: false,
+    });
+
+    const userEvent = (await import('@testing-library/user-event')).userEvent;
+    const user = userEvent.setup();
+    renderSectionDetail();
+
+    await user.click(await screen.findByRole('button', { name: /first dinner/i }));
+    await user.click(await screen.findByText('Back to events'));
+    await user.click(await screen.findByRole('button', { name: /second dinner/i }));
+
+    expect(await screen.findByRole('heading', { name: 'Second Dinner', level: 2 })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveFirstEvent(eventDetail('event-1', 'First Dinner', 'First Hall'));
+      await firstEventRequest;
+    });
+
+    expect(screen.getByRole('heading', { name: 'Second Dinner', level: 2 })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'First Dinner', level: 2 })).not.toBeInTheDocument();
   });
 
   it('should show the booking summary with pay action when payment is still due', async () => {


### PR DESCRIPTION
## Summary

- remove the unreachable user-detail state and dialog from the User Groups admin surface
- guard event-detail requests so a superseded response cannot overwrite the currently selected event
- add a regression test that switches events while the first detail request is still pending

## Context

The guest-ticket carry-forward functions originally recorded in #549 are already absent from `main` following the booking redesign. This PR completes the two findings that remain actionable.

The event-detail request was the only Section Detail fetch without the existing request-ID guard pattern. Returning to the event list and choosing another event before the first request completed could therefore display the stale first event under the newer selection.

## User impact

- administrators no longer ship permanently unreachable dialog code
- members rapidly navigating between events continue to see the event they most recently selected

## Validation

- `npm run test:run` — 98 files, 747 tests passed
- focused User Groups and Section Detail suites — 29 tests passed
- `npm run lint`
- `npm run build`
- `git diff --check`

Closes #549
