### PR TITLE
Extract latest request guard hook

### DIFF
--- a/src/features/admin/components/AnnouncementSendHistory.tsx
+++ b/src/features/admin/components/AnnouncementSendHistory.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Alert,
   Box,
@@ -24,6 +24,7 @@ import {
   type AnnouncementRecipient,
 } from "../../../shared/utils/firebaseFunctions";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 interface Props {
   sectionId: string;
@@ -206,28 +207,28 @@ export default function AnnouncementSendHistory({ sectionId, refreshTrigger }: P
   const [sends, setSends] = useState<AnnouncementSend[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const historyRequestIdRef = useRef(0);
+  const historyRequestGuard = useLatestRequestGuard();
 
   useEffect(() => {
-    const requestId = ++historyRequestIdRef.current;
+    const requestToken = historyRequestGuard.start();
     setLoading(true);
     setError(null);
     getAnnouncementSendHistory(sectionId)
       .then((result) => {
-        if (historyRequestIdRef.current === requestId) setSends(result);
+        if (historyRequestGuard.isCurrent(requestToken)) setSends(result);
       })
       .catch((caught: unknown) => {
-        if (historyRequestIdRef.current !== requestId) return;
+        if (!historyRequestGuard.isCurrent(requestToken)) return;
         reportError("admin.announcements.history", caught, { sectionId });
         setError(toAdminUserFacingError(caught, "announcements").message);
       })
       .finally(() => {
-        if (historyRequestIdRef.current === requestId) setLoading(false);
+        if (historyRequestGuard.isCurrent(requestToken)) setLoading(false);
       });
     return () => {
-      if (historyRequestIdRef.current === requestId) historyRequestIdRef.current += 1;
+      if (historyRequestGuard.isCurrent(requestToken)) historyRequestGuard.invalidate();
     };
-  }, [sectionId, refreshTrigger]);
+  }, [sectionId, refreshTrigger, historyRequestGuard]);
 
   return (
     <Box sx={{ mt: 4 }}>

--- a/src/features/admin/components/AuditLogs.tsx
+++ b/src/features/admin/components/AuditLogs.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import {
   Box,
   Alert,
@@ -29,6 +29,7 @@ import {
 import PageHeader from "../../../shared/components/PageHeader";
 import "../../../shared/components/PageContainer.css";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 interface AuditLogsProps {
   onBack: () => void;
@@ -42,7 +43,7 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
   const [allUsers, setAllUsers] = useState<ListUsersData["users"]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const dataRequestIdRef = useRef(0);
+  const dataRequestGuard = useLatestRequestGuard();
 
   const fetchAllUsers = useCallback(async () => {
     try {
@@ -55,36 +56,36 @@ export default function AuditLogs({ onBack }: AuditLogsProps) {
   }, []);
 
   const fetchData = useCallback(async () => {
-    const requestId = ++dataRequestIdRef.current;
+    const requestToken = dataRequestGuard.start();
     setLoading(true);
     setError(null);
     try {
       if (tabValue === 0) {
         const ref = listUsersRef(dataConnect);
         const result = await executeDataConnectQuery(ref);
-        if (dataRequestIdRef.current !== requestId) return;
+        if (!dataRequestGuard.isCurrent(requestToken)) return;
         setUsers(result.data?.users || []);
       } else if (tabValue === 1) {
         const ref = listUserGroupsRef(dataConnect);
         const result = await executeDataConnectQuery(ref);
-        if (dataRequestIdRef.current !== requestId) return;
+        if (!dataRequestGuard.isCurrent(requestToken)) return;
         setUserGroups(result.data?.userGroups || []);
       } else if (tabValue === 2) {
         const ref = listSectionsRef(dataConnect);
         const result = await executeDataConnectQuery(ref);
-        if (dataRequestIdRef.current !== requestId) return;
+        if (!dataRequestGuard.isCurrent(requestToken)) return;
         setSections(result.data?.sections || []);
       }
     } catch (caught) {
-      if (dataRequestIdRef.current !== requestId) return;
+      if (!dataRequestGuard.isCurrent(requestToken)) return;
       reportError("admin.audit-logs.load", caught, { tab: tabValue });
       setError(toAdminUserFacingError(caught, "audit-logs").message);
     } finally {
-      if (dataRequestIdRef.current === requestId) {
+      if (dataRequestGuard.isCurrent(requestToken)) {
         setLoading(false);
       }
     }
-  }, [tabValue]);
+  }, [tabValue, dataRequestGuard]);
 
   useEffect(() => {
     void fetchAllUsers();

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -79,6 +79,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const [userSearchTerm, setUserSearchTerm] = useState("");
   const [searchResults, setSearchResults] = useState<UserSearchResult[]>([]);
   const [searchingUsers, setSearchingUsers] = useState(false);
+  const allUsersRequestGuard = useLatestRequestGuard();
   const userSearchRequestGuard = useLatestRequestGuard();
   const [addingUserId, setAddingUserId] = useState<string | null>(null);
 
@@ -158,13 +159,13 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
 
   useEffect(() => {
     if (!isAdmin) return;
-    let cancelled = false;
+    const requestToken = allUsersRequestGuard.start();
     setLoadingAllUsers(true);
     (async () => {
       try {
         const ref = listUsersRef(dataConnect);
         const result = await executeDataConnectQuery(ref);
-        if (!cancelled && result.data?.users) {
+        if (allUsersRequestGuard.isCurrent(requestToken) && result.data?.users) {
           setAllUsers(
             result.data.users.map((u) => ({
               id: u.id,
@@ -177,18 +178,18 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
         }
       } catch (caught) {
         reportError("admin.user-groups.members", caught);
-        if (!cancelled) {
+        if (allUsersRequestGuard.isCurrent(requestToken)) {
           setAllUsers([]);
           setError(toAdminUserFacingError(caught, "user-groups").message);
         }
       } finally {
-        if (!cancelled) setLoadingAllUsers(false);
+        if (allUsersRequestGuard.isCurrent(requestToken)) setLoadingAllUsers(false);
       }
     })();
     return () => {
-      cancelled = true;
+      if (allUsersRequestGuard.isCurrent(requestToken)) allUsersRequestGuard.invalidate();
     };
-  }, [isAdmin]);
+  }, [isAdmin, allUsersRequestGuard]);
 
   const handleExpand = (group: UserGroupWithDetails) => {
     if (expandedGroupId === group.id) {

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -24,6 +24,7 @@ import { MembershipStatus } from "@dataconnect/generated";
 import PageHeader from "../../../shared/components/PageHeader";
 import SnackbarAlert from "../../../shared/components/SnackbarAlert";
 import { useSnackbar } from "../../../shared/hooks/useSnackbar";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 import { searchUsers } from "../../users/utils/searchUsers";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
 import { auth } from "../../../config/firebase";
@@ -78,7 +79,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const [userSearchTerm, setUserSearchTerm] = useState("");
   const [searchResults, setSearchResults] = useState<UserSearchResult[]>([]);
   const [searchingUsers, setSearchingUsers] = useState(false);
-  const userSearchRequestIdRef = useRef(0);
+  const userSearchRequestGuard = useLatestRequestGuard();
   const [addingUserId, setAddingUserId] = useState<string | null>(null);
 
   // All users: for merged group membership (explicit + by membership status)
@@ -221,7 +222,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   };
 
   const handleSearchUsers = useCallback(async (term: string) => {
-    const requestId = ++userSearchRequestIdRef.current;
+    const requestToken = userSearchRequestGuard.start();
     if (!term.trim() || term.length < 2) {
       setSearchResults([]);
       setSearchingUsers(false);
@@ -262,20 +263,20 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
             return null;
           })
         );
-        if (userSearchRequestIdRef.current !== requestId) return;
+        if (!userSearchRequestGuard.isCurrent(requestToken)) return;
         setSearchResults(usersWithData.filter((u): u is NonNullable<typeof u> => u !== null));
       }
     } catch (caught) {
-      if (userSearchRequestIdRef.current !== requestId) return;
+      if (!userSearchRequestGuard.isCurrent(requestToken)) return;
       reportError("admin.user-groups.search", caught);
       setError(toAdminUserFacingError(caught, "users").message);
       setSearchResults([]);
     } finally {
-      if (userSearchRequestIdRef.current === requestId) {
+      if (userSearchRequestGuard.isCurrent(requestToken)) {
         setSearchingUsers(false);
       }
     }
-  }, []);
+  }, [userSearchRequestGuard]);
 
   const handleAddUserToGroup = async (userId: string) => {
     if (!addingToGroupId) return;

--- a/src/features/auth/components/AuthActionPage.tsx
+++ b/src/features/auth/components/AuthActionPage.tsx
@@ -25,6 +25,7 @@ import {
 } from "../utils/passwordValidation";
 import { reconcileMyEmail } from "../../../shared/utils/firebaseFunctions";
 import { reportError, toAuthUserFacingError } from "../../../shared/errors";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 type ActionState = "checking" | "ready" | "invalid" | "complete";
 
@@ -43,9 +44,10 @@ export default function AuthActionPage() {
   const [confirmation, setConfirmation] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const actionRequestGuard = useLatestRequestGuard();
 
   useEffect(() => {
-    let active = true;
+    const requestToken = actionRequestGuard.start();
     if (
       !["resetPassword", "verifyEmail", "verifyAndChangeEmail"].includes(mode ?? "") ||
       !oobCode
@@ -53,14 +55,14 @@ export default function AuthActionPage() {
       setState("invalid");
       setError("This email action link is invalid.");
       return () => {
-        active = false;
+        if (actionRequestGuard.isCurrent(requestToken)) actionRequestGuard.invalidate();
       };
     }
 
     const completeAction = async () => {
       if (mode === "resetPassword") {
         await verifyPasswordResetCode(auth, oobCode);
-        if (active) setState("ready");
+        if (actionRequestGuard.isCurrent(requestToken)) setState("ready");
         return;
       }
 
@@ -79,12 +81,12 @@ export default function AuthActionPage() {
           }
         }
       }
-      if (active) setState("complete");
+      if (actionRequestGuard.isCurrent(requestToken)) setState("complete");
     };
 
     void completeAction().catch((actionError: unknown) => {
       reportError("auth.action.apply", actionError, { mode: mode ?? "missing" });
-      if (active) {
+      if (actionRequestGuard.isCurrent(requestToken)) {
         const context = mode === "resetPassword" ? "password-reset" : "email-action";
         setError(toAuthUserFacingError(actionError, context).message);
         setState("invalid");
@@ -92,9 +94,9 @@ export default function AuthActionPage() {
     });
 
     return () => {
-      active = false;
+      if (actionRequestGuard.isCurrent(requestToken)) actionRequestGuard.invalidate();
     };
-  }, [mode, oobCode]);
+  }, [mode, oobCode, actionRequestGuard]);
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();

--- a/src/features/sections/components/SectionDetail.tsx
+++ b/src/features/sections/components/SectionDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useState, useMemo, useEffect, useCallback } from "react";
 import {
   Box,
   Alert,
@@ -50,6 +50,7 @@ import {
   SectionMembersView,
 } from "./SectionDetailViews";
 import { invalidateUserSectionAccess } from "../../../shared/query/invalidation";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 interface SectionDetailProps {
   sectionId: string;
@@ -88,40 +89,40 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   // manual refetchSection() from a retry/subscribe handler racing an in-flight one) overwriting
   // state with a stale response. Only the most recently started call may still be pending when
   // its own result arrives.
-  const sectionRequestIdRef = useRef(0);
+  const sectionRequestGuard = useLatestRequestGuard();
   const refetchSection = useCallback(async () => {
     if (!sectionId) return;
-    const requestId = ++sectionRequestIdRef.current;
+    const requestToken = sectionRequestGuard.start();
     setLoadingSection(true);
     setErrorSection(false);
     try {
       const result = await getSectionForUser(sectionId);
-      if (sectionRequestIdRef.current !== requestId) return;
+      if (!sectionRequestGuard.isCurrent(requestToken)) return;
       setSectionData({ section: result.section });
     } catch (error) {
-      if (sectionRequestIdRef.current !== requestId) return;
+      if (!sectionRequestGuard.isCurrent(requestToken)) return;
       reportError("sections.detail", error);
       setSectionData(undefined);
       setErrorSection(true);
     } finally {
-      if (sectionRequestIdRef.current === requestId) {
+      if (sectionRequestGuard.isCurrent(requestToken)) {
         setLoadingSection(false);
       }
     }
-  }, [sectionId]);
+  }, [sectionId, sectionRequestGuard]);
 
   useEffect(() => {
     void refetchSection();
   }, [refetchSection]);
 
-  const membersRequestIdRef = useRef(0);
+  const membersRequestGuard = useLatestRequestGuard();
   const fetchMembers = useCallback(async () => {
-    const requestId = ++membersRequestIdRef.current;
+    const requestToken = membersRequestGuard.start();
     setLoadingMembers(true);
     setErrorMembers(false);
     try {
       const res = await getSectionMembersMerged(sectionId);
-      if (membersRequestIdRef.current !== requestId) return;
+      if (!membersRequestGuard.isCurrent(requestToken)) return;
       const members: SectionMember[] = (res.members || []).map((m) => ({
         userId: m.id,
         firstName: m.firstName,
@@ -134,16 +135,16 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
       }));
       setSectionMembers(members);
     } catch (err: unknown) {
-      if (membersRequestIdRef.current !== requestId) return;
+      if (!membersRequestGuard.isCurrent(requestToken)) return;
       reportError("sections.members", err);
       setErrorMembers(true);
       setSectionMembers([]);
     } finally {
-      if (membersRequestIdRef.current === requestId) {
+      if (membersRequestGuard.isCurrent(requestToken)) {
         setLoadingMembers(false);
       }
     }
-  }, [sectionId]);
+  }, [sectionId, membersRequestGuard]);
 
   useEffect(() => {
     if (!sectionId) return;
@@ -166,27 +167,27 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingEvents, setLoadingEvents] = useState(false);
   const [errorEvents, setErrorEvents] = useState(false);
 
-  const eventsRequestIdRef = useRef(0);
+  const eventsRequestGuard = useLatestRequestGuard();
   const refetchEvents = useCallback(async () => {
     if (!sectionId) return;
-    const requestId = ++eventsRequestIdRef.current;
+    const requestToken = eventsRequestGuard.start();
     setLoadingEvents(true);
     setErrorEvents(false);
     try {
       const result = await getSectionEventsForUser(sectionId);
-      if (eventsRequestIdRef.current !== requestId) return;
+      if (!eventsRequestGuard.isCurrent(requestToken)) return;
       setEventsData({ section: { events: result.events } });
     } catch (error) {
-      if (eventsRequestIdRef.current !== requestId) return;
+      if (!eventsRequestGuard.isCurrent(requestToken)) return;
       reportError("sections.events", error);
       setEventsData(undefined);
       setErrorEvents(true);
     } finally {
-      if (eventsRequestIdRef.current === requestId) {
+      if (eventsRequestGuard.isCurrent(requestToken)) {
         setLoadingEvents(false);
       }
     }
-  }, [sectionId]);
+  }, [sectionId, eventsRequestGuard]);
 
   useEffect(() => {
     void refetchEvents();
@@ -198,36 +199,36 @@ export default function SectionDetail({ sectionId, onBack }: SectionDetailProps)
   const [loadingEventDetail, setLoadingEventDetail] = useState(false);
   const [errorEventDetail, setErrorEventDetail] = useState(false);
 
-  const eventDetailRequestIdRef = useRef(0);
+  const eventDetailRequestGuard = useLatestRequestGuard();
   const refetchEventDetail = useCallback(async () => {
     if (!selectedEventId) return;
-    const requestId = ++eventDetailRequestIdRef.current;
+    const requestToken = eventDetailRequestGuard.start();
     setLoadingEventDetail(true);
     setErrorEventDetail(false);
     try {
       const result = await getEventForUser(selectedEventId);
-      if (eventDetailRequestIdRef.current !== requestId) return;
+      if (!eventDetailRequestGuard.isCurrent(requestToken)) return;
       setEventDetailData({ event: result.event });
     } catch (error) {
-      if (eventDetailRequestIdRef.current !== requestId) return;
+      if (!eventDetailRequestGuard.isCurrent(requestToken)) return;
       reportError("sections.event-detail", error);
       setEventDetailData(undefined);
       setErrorEventDetail(true);
     } finally {
-      if (eventDetailRequestIdRef.current === requestId) {
+      if (eventDetailRequestGuard.isCurrent(requestToken)) {
         setLoadingEventDetail(false);
       }
     }
-  }, [selectedEventId]);
+  }, [selectedEventId, eventDetailRequestGuard]);
 
   useEffect(() => {
     if (!selectedEventId) {
-      eventDetailRequestIdRef.current += 1;
+      eventDetailRequestGuard.invalidate();
       setEventDetailData(undefined);
       return;
     }
     void refetchEventDetail();
-  }, [selectedEventId, refetchEventDetail]);
+  }, [selectedEventId, refetchEventDetail, eventDetailRequestGuard]);
 
   // Extract user's user group IDs
   const userUserGroupIds = useMemo(() => {

--- a/src/features/sections/components/SectionFileDownloadPage.tsx
+++ b/src/features/sections/components/SectionFileDownloadPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Alert, Box, Button, CircularProgress, Stack, Typography } from "@mui/material";
 import { Link as RouterLink } from "react-router-dom";
 import { requestSectionFileDownload } from "../../../shared/utils/firebaseFunctions";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 export default function SectionFileDownloadPage({
   sectionId,
@@ -12,21 +13,22 @@ export default function SectionFileDownloadPage({
 }) {
   const [failed, setFailed] = useState(false);
   const [attempt, setAttempt] = useState(0);
+  const downloadRequestGuard = useLatestRequestGuard();
 
   useEffect(() => {
-    let active = true;
+    const requestToken = downloadRequestGuard.start();
     setFailed(false);
     void requestSectionFileDownload(sectionId, fileId)
       .then(({ downloadUrl }) => {
-        if (active) window.location.assign(downloadUrl);
+        if (downloadRequestGuard.isCurrent(requestToken)) window.location.assign(downloadUrl);
       })
       .catch(() => {
-        if (active) setFailed(true);
+        if (downloadRequestGuard.isCurrent(requestToken)) setFailed(true);
       });
     return () => {
-      active = false;
+      if (downloadRequestGuard.isCurrent(requestToken)) downloadRequestGuard.invalidate();
     };
-  }, [sectionId, fileId, attempt]);
+  }, [sectionId, fileId, attempt, downloadRequestGuard]);
 
   return (
     <Box sx={{ maxWidth: 640, mx: "auto", py: 6 }}>

--- a/src/features/sections/hooks/useCanModerateSection.ts
+++ b/src/features/sections/hooks/useCanModerateSection.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { getSectionForUser } from "../../../shared/utils/firebaseFunctions";
 import { auth } from "../../../config/firebase";
 import { useAdminClaim } from "../../users/hooks/useAdminClaim";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 interface UseCanModerateSectionResult {
   /** True once the section access check has resolved (or failed). */
@@ -22,6 +23,7 @@ export function useCanModerateSection(sectionId: string | undefined): UseCanMode
   const isAdmin = useAdminClaim(currentUser);
   const [canModerateSection, setCanModerateSection] = useState(false);
   const [isResolved, setIsResolved] = useState(false);
+  const requestGuard = useLatestRequestGuard();
 
   useEffect(() => {
     if (!sectionId) {
@@ -29,25 +31,25 @@ export function useCanModerateSection(sectionId: string | undefined): UseCanMode
       setIsResolved(true);
       return;
     }
-    let cancelled = false;
+    const requestToken = requestGuard.start();
     setIsResolved(false);
     getSectionForUser(sectionId)
       .then((result) => {
-        if (cancelled) return;
+        if (!requestGuard.isCurrent(requestToken)) return;
         setCanModerateSection(result.canModerate);
       })
       .catch(() => {
-        if (cancelled) return;
+        if (!requestGuard.isCurrent(requestToken)) return;
         setCanModerateSection(false);
       })
       .finally(() => {
-        if (cancelled) return;
+        if (!requestGuard.isCurrent(requestToken)) return;
         setIsResolved(true);
       });
     return () => {
-      cancelled = true;
+      if (requestGuard.isCurrent(requestToken)) requestGuard.invalidate();
     };
-  }, [sectionId]);
+  }, [sectionId, requestGuard]);
 
   return {
     isResolved,

--- a/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
+++ b/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { searchSectionMembers } from "../../../shared/utils/firebaseFunctions";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 export interface SectionMemberSeatingOption {
   id: string;
@@ -27,17 +28,19 @@ export function useSectionMemberSeatingSearch(
   const [searchResults, setSearchResults] = useState<SectionMemberSeatingOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [selectedLabels, setSelectedLabels] = useState<Map<string, string>>(new Map());
+  const selectedLabelsRequestGuard = useLatestRequestGuard();
+  const searchRequestGuard = useLatestRequestGuard();
 
   // Resolve labels for already-selected ids we don't have yet (e.g. hydrated from an
   // existing booking) so their chips render correctly without waiting on a fresh search.
   useEffect(() => {
     const missing = selectedIds.filter((id) => !selectedLabels.has(id));
     if (missing.length === 0) return;
-    let active = true;
+    const requestToken = selectedLabelsRequestGuard.start();
     void (async () => {
       try {
         const result = await searchSectionMembers(sectionId, "", missing);
-        if (!active) return;
+        if (!selectedLabelsRequestGuard.isCurrent(requestToken)) return;
         setSelectedLabels((prev) => {
           const next = new Map(prev);
           for (const m of result.members) {
@@ -50,10 +53,12 @@ export function useSectionMemberSeatingSearch(
       }
     })();
     return () => {
-      active = false;
+      if (selectedLabelsRequestGuard.isCurrent(requestToken)) {
+        selectedLabelsRequestGuard.invalidate();
+      }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sectionId, selectedIds.join(",")]);
+  }, [sectionId, selectedIds.join(","), selectedLabelsRequestGuard]);
 
   useEffect(() => {
     if (!inputValue.trim()) {
@@ -61,31 +66,31 @@ export function useSectionMemberSeatingSearch(
       setLoading(false);
       return;
     }
-    let active = true;
+    const requestToken = searchRequestGuard.start();
     setLoading(true);
     const timer = setTimeout(() => {
       void (async () => {
         try {
           const result = await searchSectionMembers(sectionId, inputValue, selectedIds);
-          if (!active) return;
+          if (!searchRequestGuard.isCurrent(requestToken)) return;
           setSearchResults(
             result.members
               .filter((m) => m.id !== currentUserId)
               .map((m) => ({ id: m.id, label: `${m.firstName} ${m.lastName}` }))
           );
         } catch {
-          if (active) setSearchResults([]);
+          if (searchRequestGuard.isCurrent(requestToken)) setSearchResults([]);
         } finally {
-          if (active) setLoading(false);
+          if (searchRequestGuard.isCurrent(requestToken)) setLoading(false);
         }
       })();
     }, SEARCH_DEBOUNCE_MS);
     return () => {
-      active = false;
       clearTimeout(timer);
+      if (searchRequestGuard.isCurrent(requestToken)) searchRequestGuard.invalidate();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sectionId, inputValue, currentUserId, selectedIds.join(",")]);
+  }, [sectionId, inputValue, currentUserId, selectedIds.join(","), searchRequestGuard]);
 
   const options = useMemo(() => {
     const byId = new Map<string, SectionMemberSeatingOption>();

--- a/src/features/users/hooks/useUserSearch.ts
+++ b/src/features/users/hooks/useUserSearch.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { searchUsers } from "../utils/searchUsers";
 import type { SearchUser } from "../../../types";
 import { ITEMS_PER_PAGE } from "../../../constants";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 interface UseUserSearchResult {
   users: SearchUser[];
@@ -34,10 +35,10 @@ export function useUserSearch(
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [total, setTotal] = useState(0);
-  const searchRequestIdRef = useRef(0);
+  const searchRequestGuard = useLatestRequestGuard();
 
   const performSearch = useCallback(async (term: string, pageNum: number = 1) => {
-    const requestId = ++searchRequestIdRef.current;
+    const requestToken = searchRequestGuard.start();
     if (!term.trim()) {
       setUsers([]);
       setError(null);
@@ -51,7 +52,7 @@ export function useUserSearch(
     setError(null);
     try {
       const result = await searchUsers(term, pageNum, ITEMS_PER_PAGE);
-      if (searchRequestIdRef.current !== requestId) return;
+      if (!searchRequestGuard.isCurrent(requestToken)) return;
       if (result.success && result.data) {
         setUsers(result.data.users);
         setTotalPages(result.data.totalPages);
@@ -63,22 +64,18 @@ export function useUserSearch(
         setTotal(0);
       }
     } catch (caught) {
-      if (searchRequestIdRef.current !== requestId) return;
+      if (!searchRequestGuard.isCurrent(requestToken)) return;
       reportError("admin.users.search", caught);
       setError(toAdminUserFacingError(caught, "users").message);
       setUsers([]);
       setTotalPages(1);
       setTotal(0);
     } finally {
-      if (searchRequestIdRef.current === requestId) {
+      if (searchRequestGuard.isCurrent(requestToken)) {
         setLoading(false);
       }
     }
-  }, []);
-
-  useEffect(() => () => {
-    searchRequestIdRef.current += 1;
-  }, []);
+  }, [searchRequestGuard]);
 
   // Debounced search - only triggers when searchTerm changes
   useEffect(() => {
@@ -88,7 +85,7 @@ export function useUserSearch(
         setPage(1);
       } else {
         // Clear results when search term is empty
-        searchRequestIdRef.current += 1;
+        searchRequestGuard.invalidate();
         setUsers([]);
         setError(null);
         setTotalPages(1);
@@ -98,7 +95,7 @@ export function useUserSearch(
     }, debounceMs);
 
     return () => clearTimeout(timer);
-  }, [searchTerm, performSearch, debounceMs]);
+  }, [searchTerm, performSearch, debounceMs, searchRequestGuard]);
 
   // Handle page changes - only triggers when page changes (not searchTerm)
   // Note: searchTerm is intentionally not in dependencies to avoid bypassing debounce
@@ -111,9 +108,9 @@ export function useUserSearch(
   }, [page, performSearch]); // searchTerm intentionally omitted to prevent immediate searches on typing
 
   const setSearchTerm = useCallback((term: string) => {
-    searchRequestIdRef.current += 1;
+    searchRequestGuard.invalidate();
     setSearchTermState(term);
-  }, []);
+  }, [searchRequestGuard]);
 
   const refetch = useCallback(() => {
     performSearch(searchTerm, page);

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -9,6 +9,7 @@ import {
   isUpcomingSectionEvent,
   sortUpcomingSectionEvents,
 } from "../../../shared/utils/sectionEventDisplay";
+import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
 export interface UpcomingEventRow {
   id: string;
@@ -52,6 +53,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
   const [isError, setIsError] = useState(false);
   const [retryAttempt, setRetryAttempt] = useState(0);
   const lastFetchedKeyRef = useRef<string | null>(null);
+  const requestGuard = useLatestRequestGuard();
 
   useEffect(() => {
     const ids = eventSectionIdsKey
@@ -66,7 +68,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
       return;
     }
 
-    let alive = true;
+    const requestToken = requestGuard.start();
     const isNewFetch = lastFetchedKeyRef.current !== eventSectionIdsKey;
     lastFetchedKeyRef.current = eventSectionIdsKey;
 
@@ -99,27 +101,27 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
           results.flat().filter((event) => isUpcomingSectionEvent(event, now))
         );
 
-        if (alive) {
+        if (requestGuard.isCurrent(requestToken)) {
           setEvents(upcoming);
           setIsError(false);
         }
       } catch (error) {
-        if (alive) {
+        if (requestGuard.isCurrent(requestToken)) {
           reportError("welcome.upcoming-events", error);
           setIsError(true);
           // Keep any previously loaded events visible while the retry option is shown.
         }
       } finally {
-        if (alive) {
+        if (requestGuard.isCurrent(requestToken)) {
           setLoading(false);
         }
       }
     })();
 
     return () => {
-      alive = false;
+      if (requestGuard.isCurrent(requestToken)) requestGuard.invalidate();
     };
-  }, [eventSectionIdsKey, sectionNameById, retryAttempt]);
+  }, [eventSectionIdsKey, sectionNameById, retryAttempt, requestGuard]);
 
   return {
     events,

--- a/src/shared/hooks/__tests__/useLatestRequestGuard.test.ts
+++ b/src/shared/hooks/__tests__/useLatestRequestGuard.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useLatestRequestGuard } from "../useLatestRequestGuard";
+
+describe("useLatestRequestGuard", () => {
+  it("keeps its API stable across rerenders", () => {
+    const { result, rerender } = renderHook(() => useLatestRequestGuard());
+    const initialGuard = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialGuard);
+  });
+
+  it("supersedes an older request when a newer request starts", () => {
+    const { result } = renderHook(() => useLatestRequestGuard());
+    let firstToken = 0;
+    let secondToken = 0;
+
+    act(() => {
+      firstToken = result.current.start();
+      secondToken = result.current.start();
+    });
+
+    expect(result.current.isCurrent(firstToken)).toBe(false);
+    expect(result.current.isCurrent(secondToken)).toBe(true);
+  });
+
+  it("invalidates the current request explicitly", () => {
+    const { result } = renderHook(() => useLatestRequestGuard());
+    let token = 0;
+
+    act(() => {
+      token = result.current.start();
+      result.current.invalidate();
+    });
+
+    expect(result.current.isCurrent(token)).toBe(false);
+  });
+
+  it("invalidates the current request on unmount", () => {
+    const { result, unmount } = renderHook(() => useLatestRequestGuard());
+    const guard = result.current;
+    let token = 0;
+
+    act(() => {
+      token = guard.start();
+    });
+    unmount();
+
+    expect(guard.isCurrent(token)).toBe(false);
+  });
+});

--- a/src/shared/hooks/useLatestRequestGuard.ts
+++ b/src/shared/hooks/useLatestRequestGuard.ts
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+export interface LatestRequestGuard {
+  start: () => number;
+  isCurrent: (token: number) => boolean;
+  invalidate: () => void;
+}
+
+/**
+ * Prevents an obsolete asynchronous request from committing state after a
+ * newer request, explicit invalidation, or component unmount.
+ *
+ * Callers continue to own request execution and all data/loading/error state.
+ */
+export function useLatestRequestGuard(): LatestRequestGuard {
+  const latestTokenRef = useRef(0);
+
+  const start = useCallback(() => {
+    latestTokenRef.current += 1;
+    return latestTokenRef.current;
+  }, []);
+
+  const isCurrent = useCallback(
+    (token: number) => latestTokenRef.current === token,
+    [],
+  );
+
+  const invalidate = useCallback(() => {
+    latestTokenRef.current += 1;
+  }, []);
+
+  useEffect(() => () => {
+    invalidate();
+  }, [invalidate]);
+
+  return useMemo(
+    () => ({ start, isCurrent, invalidate }),
+    [start, isCurrent, invalidate],
+  );
+}


### PR DESCRIPTION
## Summary

- add a shared `useLatestRequestGuard` hook with stable `start`, `isCurrent`, and `invalidate` operations
- invalidate outstanding requests automatically when the owning component unmounts
- replace all eight hand-rolled latest-request guards while preserving each caller's loading, error, and pagination behaviour
- add focused tests for API stability, request supersession, manual invalidation, and unmount invalidation

## Why

The same request-token pattern had been copied across multiple UI components and hooks. Centralising it removes duplication and gives stale async responses consistent handling without introducing shared loading or error state.

## Validation

- `npm run lint`
- `npm run test:run` — 99 files, 751 tests passed
- `npm run test:coverage` — statements 76.34%, branches 71.52%, functions 73.89%, lines 77.36%
- `npm run build`
- `git diff --check`

Closes #591