### PR TITLE
Retire legacy Stripe webhook

### DIFF
--- a/config/deployment-check.json
+++ b/config/deployment-check.json
@@ -38,7 +38,6 @@
     "GOV_NOTIFY_TEST_API_KEY",
     "NOTIFY_CALLBACK_BEARER_TOKEN",
     "STRIPE_SECRET",
-    "STRIPE_WEBHOOK_SECRET",
     "STRIPE_WEBHOOK_SECRET_PAYMENTS",
     "UNSUBSCRIBE_SECRET"
   ],
@@ -103,7 +102,6 @@
     "sendSectionAnnouncement",
     "setNotifyTemplateBinding",
     "setNotifyTemplateReplyToOverride",
-    "stripeWebhook",
     "stripeWebhookPayments",
     "submitEventBooking",
     "subscribeToUserGroup",

--- a/docs/architecture/payment-state-machine.md
+++ b/docs/architecture/payment-state-machine.md
@@ -61,12 +61,11 @@ Functions maintain an explicit Stripe event allowlist in code (`SUPPORTED_STRIPE
 
 ## Endpoint Topology
 
-Stripe webhooks are split by domain starting with a dedicated payments endpoint:
+Stripe payment lifecycle events use one dedicated endpoint:
 
-- `stripeWebhookPayments` (preferred): handles payment lifecycle allowlisted events.
-- `stripeWebhook` (legacy compatibility): still accepts payment lifecycle events during cutover.
+- `stripeWebhookPayments`: handles payment lifecycle allowlisted events.
 
-See `docs/operations/stripe-webhook-endpoints.md` for endpoint URLs, Stripe dashboard setup, secret mapping, local replay/testing, and migration steps.
+See `docs/operations/stripe-webhook-endpoints.md` for endpoint URLs, Stripe dashboard setup, secret mapping, and local replay/testing.
 
 ## Refund/Dispute Persistence Model
 

--- a/docs/architecture/security-and-permissions.md
+++ b/docs/architecture/security-and-permissions.md
@@ -43,7 +43,7 @@ This document summarizes how access is enforced across Data Connect and Firebase
 | Callable | `grantAdmin` / `revokeAdmin` / `listAdminUsers` | enabled admin |
 | Callable | section-file list/download | enabled user with current section access, or enabled global admin |
 | Callable | section-file upload/manage/delete | enabled moderator of that section, or enabled global admin |
-| Webhook | `stripeWebhook` | Stripe signature-verified request |
+| Webhook | `stripeWebhookPayments` | Stripe signature-verified request |
 
 ## Function guard model
 
@@ -125,6 +125,6 @@ npm run test -- src/__tests__/users-auth/authGuards.test.ts src/__tests__/cross-
 - **Data Connect operation unexpectedly accessible/restricted**
   - Verify `@auth(...)` directive in source `.gql` and regenerate SDKs after changes.
 - **Webhook processing failures**
-  - Confirm `STRIPE_WEBHOOK_SECRET` is configured and signature header is present.
+  - Confirm `STRIPE_WEBHOOK_SECRET_PAYMENTS` is configured and signature header is present.
 - **Security tests fail in CI**
   - Usually indicates changed auth directives/guards; update code or test expectations intentionally in the same PR.

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -38,7 +38,7 @@ flowchart LR
    - Frontend calls `createTicketCheckoutSession`.
    - Function creates order + Stripe session, then browser redirects to Stripe.
 4. **Payment fulfillment**
-   - Stripe sends webhook to `stripeWebhook`.
+   - Stripe sends webhook to `stripeWebhookPayments`.
    - Function verifies signature and updates order state.
    - On applied lifecycle transitions, customer transactional email may be sent via GOV.UK Notify (idempotent ledger).
 5. **Transactional email (app-owned)**

--- a/docs/operations/environment-and-secrets.md
+++ b/docs/operations/environment-and-secrets.md
@@ -28,9 +28,8 @@ Defined via `.env*` files and read from `import.meta.env`:
 
 | Name | Type | Used by | Required |
 |---|---|---|---|
-| `STRIPE_SECRET` | Firebase secret | `createTicketCheckoutSession`, `stripeWebhook` | yes for payments |
-| `STRIPE_WEBHOOK_SECRET` | Firebase secret | `stripeWebhook` | yes for webhook processing |
-| `STRIPE_WEBHOOK_SECRET_PAYMENTS` | Firebase secret | `stripeWebhookPayments` (with legacy fallback during migration) | yes for the dedicated payments webhook |
+| `STRIPE_SECRET` | Firebase secret | `createTicketCheckoutSession`, `stripeWebhookPayments` | yes for payments |
+| `STRIPE_WEBHOOK_SECRET_PAYMENTS` | Firebase secret | `stripeWebhookPayments` | yes for webhook processing |
 | `GOV_NOTIFY_LIVE_API_KEY` | Firebase secret | GOV.UK Notify unrestricted live key | required when site/request ceiling can resolve to `LIVE` |
 | `GOV_NOTIFY_TEST_API_KEY` | Firebase secret | GOV.UK Notify test key; accepts fan-out without delivery | required when mode can resolve to `SIMULATION` |
 | `GOV_NOTIFY_TEAM_API_KEY` | Firebase secret | GOV.UK Notify team-and-guest-list key | required when mode can resolve to `TEAM_TEST` |

--- a/docs/operations/new-production-instance.md
+++ b/docs/operations/new-production-instance.md
@@ -331,7 +331,6 @@ Set secrets interactively so values do not appear in command history:
 
 ```sh
 firebase functions:secrets:set STRIPE_SECRET --project prod
-firebase functions:secrets:set STRIPE_WEBHOOK_SECRET --project prod
 firebase functions:secrets:set STRIPE_WEBHOOK_SECRET_PAYMENTS --project prod
 firebase functions:secrets:set GOV_NOTIFY_LIVE_API_KEY --project prod
 firebase functions:secrets:set GOV_NOTIFY_TEST_API_KEY --project prod
@@ -342,9 +341,8 @@ firebase functions:secrets:set NOTIFY_CALLBACK_BEARER_TOKEN --project prod
 
 Use independent, cryptographically random values for the unsubscribe and Notify
 callback bearer tokens. `STRIPE_WEBHOOK_SECRET_PAYMENTS` comes from the dedicated
-payments endpoint. Keep `STRIPE_WEBHOOK_SECRET` for the legacy endpoint/fallback
-while that endpoint remains deployed. Redeploy every Function that references a
-secret whenever its value rotates.
+payments endpoint. Redeploy every Function that references a secret whenever its
+value rotates.
 
 Before deploying, review the CLI output showing which environment file was loaded.
 Stop if it names a Dev/Beta file or if `APP_BASE_URL` is not the production origin.
@@ -362,8 +360,7 @@ Use Stripe **live mode**, not test mode:
 5. store that endpoint's signing secret as `STRIPE_WEBHOOK_SECRET_PAYMENTS`.
 
 Never reuse a Beta endpoint secret. Record the Stripe account, mode, endpoint ID,
-owner, event list, and rotation date in the private operations record. Keep the
-legacy webhook only for the documented cutover period and monitor delivery results.
+owner, event list, and rotation date in the private operations record.
 
 ## 9. Configure GOV.UK Notify
 

--- a/docs/operations/stripe-webhook-endpoints.md
+++ b/docs/operations/stripe-webhook-endpoints.md
@@ -1,11 +1,10 @@
 # Stripe Webhook Endpoints
 
-This runbook defines how Stripe webhook endpoints are configured for this project, including URL patterns, secret mapping, and migration from the legacy consolidated endpoint.
+This runbook defines how the Stripe payments webhook endpoint is configured for this project, including URL patterns, secret mapping, deployment, and replay.
 
 ## Endpoints
 
-- Preferred payments endpoint: `stripeWebhookPayments`
-- Legacy compatibility endpoint: `stripeWebhook`
+- Payments endpoint: `stripeWebhookPayments`
 
 ## URL Patterns
 
@@ -13,12 +12,8 @@ Use your Firebase project id in place of `<project-id>`.
 
 - Production payments endpoint:
   - `https://europe-west2-<project-id>.cloudfunctions.net/stripeWebhookPayments`
-- Production legacy endpoint:
-  - `https://europe-west2-<project-id>.cloudfunctions.net/stripeWebhook`
 - Local emulator payments endpoint:
   - `http://127.0.0.1:5001/<project-id>/europe-west2/stripeWebhookPayments`
-- Local emulator legacy endpoint:
-  - `http://127.0.0.1:5001/<project-id>/europe-west2/stripeWebhook`
 
 ## Stripe Dashboard Setup
 
@@ -36,21 +31,31 @@ Use your Firebase project id in place of `<project-id>`.
    - `charge.dispute.closed`
 5. Save, then reveal the signing secret for that endpoint.
 6. Store the secret for Functions:
-   - Primary: `STRIPE_WEBHOOK_SECRET_PAYMENTS`
-   - Fallback during migration: `STRIPE_WEBHOOK_SECRET`
+   - `STRIPE_WEBHOOK_SECRET_PAYMENTS`
 
 ## Secret and Endpoint Mapping
 
 - `STRIPE_WEBHOOK_SECRET_PAYMENTS`: signing secret for `stripeWebhookPayments`.
-- `STRIPE_WEBHOOK_SECRET`: legacy endpoint secret, also used as fallback if the payments-specific secret is not yet configured.
 
-## Cutover Plan
+## Retiring the Legacy Endpoint
 
-1. Deploy code with both `stripeWebhookPayments` and `stripeWebhook`.
-2. Configure Stripe to deliver payment events to `stripeWebhookPayments`.
-3. Monitor logs and payment state transitions for stable processing.
-4. Keep legacy endpoint available during transition to avoid missed events.
-5. After verification, remove payment event subscriptions from legacy endpoint.
+Before removing an existing `stripeWebhook` deployment, confirm in every Stripe
+environment that no webhook endpoint targets its URL. Deploy the current Functions
+revision, then remove the legacy function if the deploy did not prompt for deletion:
+
+```bash
+firebase functions:delete stripeWebhook --region europe-west2 --project <project-alias>
+```
+
+After all deployed Functions have stopped referencing `STRIPE_WEBHOOK_SECRET`, prune
+unused secret versions:
+
+```bash
+firebase functions:secrets:prune --project <project-alias>
+```
+
+Verify a representative payment event reaches `stripeWebhookPayments` before
+considering the retirement complete.
 
 ## Local Testing and Replay
 

--- a/functions/src/__tests__/payments/paymentWebhook.test.ts
+++ b/functions/src/__tests__/payments/paymentWebhook.test.ts
@@ -6,10 +6,7 @@ import {
 } from "@dataconnect/admin-generated";
 import * as admin from "@dataconnect/admin-generated";
 import * as logger from "firebase-functions/logger";
-import {
-  stripeWebhookPaymentsSecret,
-  stripeWebhookSecret,
-} from "../../paymentConfig";
+import { stripeWebhookPaymentsSecret } from "../../paymentConfig";
 
 const serviceMocks = vi.hoisted(() => ({
   applyTransitions: vi.fn(),
@@ -39,11 +36,10 @@ vi.mock("../../paymentOpsInternalAlerts", async (importOriginal) => ({
   notifyPaymentOpsDisputeSideState: opsMocks.notifyDispute,
 }));
 
-import { stripeWebhook, stripeWebhookPayments } from "../../paymentWebhook";
+import { stripeWebhookPayments } from "../../paymentWebhook";
 
 const ORDER_ID = "11111111-1111-4111-8111-111111111111";
 const WEBHOOK_SECRET = "whsec_payments_test";
-const LEGACY_SECRET = "whsec_legacy_test";
 
 const getWebhookEvent = vi.spyOn(admin, "getPaymentWebhookEventByStripeEventId");
 const createWebhookEvent = vi.spyOn(admin, "createPaymentWebhookEvent");
@@ -57,7 +53,6 @@ type Handler = (
 ) => Promise<void>;
 
 const handler = stripeWebhookPayments as unknown as Handler;
-const legacyHandler = stripeWebhook as unknown as Handler;
 
 function stripeEvent(args: {
   id?: string;
@@ -100,7 +95,6 @@ describe("stripe payment webhook orchestration", () => {
     vi.clearAllMocks();
     vi.stubEnv("STRIPE_SECRET", "sk_test_webhook");
     vi.stubEnv("STRIPE_WEBHOOK_SECRET_PAYMENTS", WEBHOOK_SECRET);
-    vi.stubEnv("STRIPE_WEBHOOK_SECRET", LEGACY_SECRET);
     getWebhookEvent.mockResolvedValue({
       data: { paymentWebhookEvents: [] },
     } as never);
@@ -143,12 +137,9 @@ describe("stripe payment webhook orchestration", () => {
     expect(getWebhookEvent).not.toHaveBeenCalled();
   });
 
-  it("fails closed when neither webhook secret is configured", async () => {
+  it("fails closed when the payments webhook secret is not configured", async () => {
     const paymentsSecretValue = vi
       .spyOn(stripeWebhookPaymentsSecret, "value")
-      .mockReturnValue("");
-    const legacySecretValue = vi
-      .spyOn(stripeWebhookSecret, "value")
       .mockReturnValue("");
     const response = responseHarness();
 
@@ -159,7 +150,6 @@ describe("stripe payment webhook orchestration", () => {
       );
     } finally {
       paymentsSecretValue.mockRestore();
-      legacySecretValue.mockRestore();
     }
 
     expect(response.send).toHaveBeenCalledWith(500, "Webhook secret not configured");
@@ -193,36 +183,6 @@ describe("stripe payment webhook orchestration", () => {
     expect(response.send).toHaveBeenCalledWith(200, "Ignored out-of-domain event");
     expect(getWebhookEvent).not.toHaveBeenCalled();
     expect(createWebhookEvent).not.toHaveBeenCalled();
-  });
-
-  it("uses the legacy secret only as a logged fallback", async () => {
-    const response = responseHarness();
-
-    await handler(
-      signedRequest(stripeEvent({ type: "customer.updated" }), LEGACY_SECRET),
-      response.res
-    );
-
-    expect(response.send).toHaveBeenCalledWith(200, "Ignored out-of-domain event");
-    expect(logger.warn).toHaveBeenCalledWith(
-      "stripeWebhookPayments verified with fallback webhook secret",
-      { domain: "payments", fallbackIndex: 1 }
-    );
-  });
-
-  it("keeps the legacy endpoint routed through signature verification", async () => {
-    const response = responseHarness();
-
-    await legacyHandler(
-      signedRequest(stripeEvent({ type: "customer.updated" }), LEGACY_SECRET),
-      response.res
-    );
-
-    expect(logger.warn).toHaveBeenCalledWith(
-      "stripeWebhook legacy endpoint invoked",
-      { migrationTarget: "stripeWebhookPayments" }
-    );
-    expect(response.send).toHaveBeenCalledWith(200, "Ignored out-of-domain event");
   });
 
   it("reconciles a duplicate completed checkout without appending a second ledger row", async () => {

--- a/functions/src/paymentConfig.ts
+++ b/functions/src/paymentConfig.ts
@@ -5,7 +5,6 @@ import Stripe from "stripe";
 export type StripeClient = InstanceType<typeof Stripe>;
 
 export const stripeSecret = defineSecret("STRIPE_SECRET");
-export const stripeWebhookSecret = defineSecret("STRIPE_WEBHOOK_SECRET");
 export const stripeWebhookPaymentsSecret = defineSecret("STRIPE_WEBHOOK_SECRET_PAYMENTS");
 
 export const APP_BASE_URL = (() => {

--- a/functions/src/paymentWebhook.ts
+++ b/functions/src/paymentWebhook.ts
@@ -115,11 +115,11 @@ async function appendWebhookLedgerEvent(args: {
 }
 
 async function handleStripeWebhookRequest(args: {
-  domain: "payments";
   req: { headers: Record<string, unknown>; rawBody: Buffer };
   res: { status: (code: number) => { send: (body: string) => void } };
 }): Promise<void> {
-  const { req, res, domain } = args;
+  const { req, res } = args;
+  const domain = "payments";
   const endpointName = "stripeWebhookPayments";
   try {
     const stripeClient = requireStripe(stripeSecret.value());
@@ -419,6 +419,6 @@ export const stripeWebhookPayments = onRequest(
     ],
   },
   async (req, res) => {
-    await handleStripeWebhookRequest({ domain: "payments", req, res });
+    await handleStripeWebhookRequest({ req, res });
   }
 );

--- a/functions/src/paymentWebhook.ts
+++ b/functions/src/paymentWebhook.ts
@@ -9,7 +9,6 @@ import {
   PaymentWebhookEventOutcome,
 } from "@dataconnect/admin-generated";
 import type { UUIDString } from "@dataconnect/admin-generated";
-import Stripe from "stripe";
 import { validateUUID } from "./helpers";
 import { FUNCTIONS_REGION } from "./constants";
 import {
@@ -25,7 +24,6 @@ import {
   requireStripe,
   stripeSecret,
   stripeWebhookPaymentsSecret,
-  stripeWebhookSecret,
 } from "./paymentConfig";
 import {
   applyPaymentTransitionToOrders,
@@ -116,27 +114,20 @@ async function appendWebhookLedgerEvent(args: {
   });
 }
 
-function webhookSecretCandidates(endpointName: "stripeWebhookPayments" | "stripeWebhook"): string[] {
-  const payments = stripeWebhookPaymentsSecret.value();
-  const legacy = stripeWebhookSecret.value();
-  const candidates = endpointName === "stripeWebhookPayments" ? [payments, legacy] : [legacy, payments];
-  return candidates.filter((value): value is string => Boolean(value));
-}
-
 async function handleStripeWebhookRequest(args: {
   domain: "payments";
-  endpointName: "stripeWebhookPayments" | "stripeWebhook";
   req: { headers: Record<string, unknown>; rawBody: Buffer };
   res: { status: (code: number) => { send: (body: string) => void } };
 }): Promise<void> {
-  const { req, res, domain, endpointName } = args;
+  const { req, res, domain } = args;
+  const endpointName = "stripeWebhookPayments";
   try {
     const stripeClient = requireStripe(stripeSecret.value());
-    const candidates = webhookSecretCandidates(endpointName);
-    if (candidates.length === 0) {
+    const webhookSecret = stripeWebhookPaymentsSecret.value();
+    if (!webhookSecret) {
       logger.error(`${endpointName} missing webhook secret`, {
         domain,
-        expectedSecret: "STRIPE_WEBHOOK_SECRET_PAYMENTS or STRIPE_WEBHOOK_SECRET",
+        expectedSecret: "STRIPE_WEBHOOK_SECRET_PAYMENTS",
       });
       res.status(500).send("Webhook secret not configured");
       return;
@@ -147,27 +138,7 @@ async function handleStripeWebhookRequest(args: {
       return;
     }
 
-    let event: ReturnType<InstanceType<typeof Stripe>["webhooks"]["constructEvent"]> | null = null;
-    let matchedSecretIndex = -1;
-    let constructEventError: unknown = null;
-    for (let i = 0; i < candidates.length; i += 1) {
-      try {
-        event = stripeClient.webhooks.constructEvent(req.rawBody, signature, candidates[i]);
-        matchedSecretIndex = i;
-        break;
-      } catch (err) {
-        constructEventError = err;
-      }
-    }
-    if (!event) {
-      throw constructEventError ?? new Error("Unable to verify webhook signature");
-    }
-    if (matchedSecretIndex > 0) {
-      logger.warn(`${endpointName} verified with fallback webhook secret`, {
-        domain,
-        fallbackIndex: matchedSecretIndex,
-      });
-    }
+    const event = stripeClient.webhooks.constructEvent(req.rawBody, signature, webhookSecret);
     const supportedEventType = isSupportedStripeEventType(event.type);
     const routedDomain = classifyStripeWebhookDomain(event.type);
     if (routedDomain !== domain) {
@@ -443,29 +414,11 @@ export const stripeWebhookPayments = onRequest(
     region: FUNCTIONS_REGION,
     secrets: [
       stripeSecret,
-      stripeWebhookSecret,
       stripeWebhookPaymentsSecret,
       ...govNotifySecrets,
     ],
   },
   async (req, res) => {
-    await handleStripeWebhookRequest({ domain: "payments", endpointName: "stripeWebhookPayments", req, res });
-  }
-);
-export const stripeWebhook = onRequest(
-  {
-    region: FUNCTIONS_REGION,
-    secrets: [
-      stripeSecret,
-      stripeWebhookSecret,
-      stripeWebhookPaymentsSecret,
-      ...govNotifySecrets,
-    ],
-  },
-  async (req, res) => {
-    logger.warn("stripeWebhook legacy endpoint invoked", {
-      migrationTarget: "stripeWebhookPayments",
-    });
-    await handleStripeWebhookRequest({ domain: "payments", endpointName: "stripeWebhook", req, res });
+    await handleStripeWebhookRequest({ domain: "payments", req, res });
   }
 );

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -11,4 +11,4 @@ export {
 export { getMyTicketOrderStripeArtifactsBatch } from "./paymentStripeArtifacts";
 export { reconcileMyCheckoutSessionOrders } from "./paymentReconciliationCallable";
 export { shouldSendReconciliationExceptionOpenedAlert } from "./paymentReconciliationService";
-export { stripeWebhook, stripeWebhookPayments } from "./paymentWebhook";
+export { stripeWebhookPayments } from "./paymentWebhook";


### PR DESCRIPTION
## Summary

- remove the legacy `stripeWebhook` Cloud Function export and retain only `stripeWebhookPayments`
- remove `STRIPE_WEBHOOK_SECRET` and the dual-secret signature fallback path
- update deployment validation, payment webhook tests, architecture documentation, environment setup, and the Stripe operations runbook
- document the post-deploy deletion and secret-pruning steps

## Why

Stripe has been cut over to the dedicated payments webhook and the legacy endpoint no longer receives live traffic. Keeping the compatibility endpoint and fallback secret increases deployment and operational surface without providing a current function.

## Deployment notes

Before deployment, confirm no Stripe dashboard webhook targets the legacy `stripeWebhook` URL. After deploying the new Functions revision:

1. allow Firebase deployment to delete `stripeWebhook`, or run `firebase functions:delete stripeWebhook --region europe-west2 --project <project-alias>`
2. verify a representative event reaches `stripeWebhookPayments`
3. once no deployed Function references `STRIPE_WEBHOOK_SECRET`, run `firebase functions:secrets:prune --project <project-alias>`

No deployed function or secret was deleted as part of this PR. Issue #550 should remain open until these operational steps have been completed and verified.

## Validation

- Functions webhook tests: 15 passed
- Functions full suite: 90 files, 964 tests passed
- frontend full suite: 99 files, 751 tests passed
- deployment safety: 2 files, 55 tests passed
- Functions lint and production build
- frontend lint and production build
- compiled export and stale-reference scans
- `git diff --check`

Addresses #550