### PR TITLE
Allow section moderators to book outside the event window

### DIFF
--- a/functions/src/__tests__/bookings/bookingRules.test.ts
+++ b/functions/src/__tests__/bookings/bookingRules.test.ts
@@ -130,7 +130,7 @@ describe("bookingRules", () => {
       nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
     });
 
-    expect(result).toEqual({ ok: true, moderatorLateBooking: true });
+    expect(result).toEqual({ ok: true, moderatorWindowOverride: true });
   });
 
   it("does not allow an ordinary booker or another section's moderator after closing", () => {
@@ -150,7 +150,7 @@ describe("bookingRules", () => {
     if (!result.ok) expect(result.code).toBe(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW);
   });
 
-  it("does not let a moderator book before the published opening time", () => {
+  it("allows a matching section moderator to book before the published opening time", () => {
     const result = evaluateBookingGatekeeping({
       purposeLinks: [
         { purposes: ["ACCESS", "BOOKER", "MODERATOR"], userGroup: group("g1", ["REGULAR"]) },
@@ -162,8 +162,7 @@ describe("bookingRules", () => {
       nowMs: Date.parse("2024-12-31T23:59:59.000Z"),
     });
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.code).toBe(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW);
+    expect(result).toEqual({ ok: true, moderatorWindowOverride: true });
   });
 
   it("evaluateBookingLines accepts member-only then guest", () => {

--- a/functions/src/__tests__/bookings/bookingRules.test.ts
+++ b/functions/src/__tests__/bookings/bookingRules.test.ts
@@ -117,6 +117,55 @@ describe("bookingRules", () => {
     expect(isWithinBookingWindow(start, end, Date.now() - 400_000)).toBe(false);
   });
 
+  it("allows a matching section moderator to book after the window closes", () => {
+    const result = evaluateBookingGatekeeping({
+      purposeLinks: [
+        { purposes: ["ACCESS", "BOOKER"], userGroup: group("g1", ["REGULAR"]) },
+        { purpose: "MODERATOR", userGroup: group("moderators") },
+      ],
+      membershipStatus: "REGULAR",
+      explicitGroupIds: new Set(["g1", "moderators"]),
+      bookingStartDateTime: "2025-01-01T00:00:00.000Z",
+      bookingEndDateTime: "2025-12-31T23:59:59.000Z",
+      nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual({ ok: true, moderatorLateBooking: true });
+  });
+
+  it("does not allow an ordinary booker or another section's moderator after closing", () => {
+    const result = evaluateBookingGatekeeping({
+      purposeLinks: [
+        { purposes: ["ACCESS", "BOOKER"], userGroup: group("g1", ["REGULAR"]) },
+        { purpose: "MODERATOR", userGroup: group("other-section-moderators") },
+      ],
+      membershipStatus: "REGULAR",
+      explicitGroupIds: new Set(["g1", "my-other-moderator-group"]),
+      bookingStartDateTime: "2025-01-01T00:00:00.000Z",
+      bookingEndDateTime: "2025-12-31T23:59:59.000Z",
+      nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW);
+  });
+
+  it("does not let a moderator book before the published opening time", () => {
+    const result = evaluateBookingGatekeeping({
+      purposeLinks: [
+        { purposes: ["ACCESS", "BOOKER", "MODERATOR"], userGroup: group("g1", ["REGULAR"]) },
+      ],
+      membershipStatus: "REGULAR",
+      explicitGroupIds: new Set(["g1"]),
+      bookingStartDateTime: "2025-01-01T00:00:00.000Z",
+      bookingEndDateTime: "2025-12-31T23:59:59.000Z",
+      nowMs: Date.parse("2024-12-31T23:59:59.000Z"),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW);
+  });
+
   it("evaluateBookingLines accepts member-only then guest", () => {
     const lines: LineInputForRules[] = [
       { ticketTypeId: "tt-m", sortOrder: 0 },

--- a/functions/src/__tests__/payments/paymentCheckoutCallables.test.ts
+++ b/functions/src/__tests__/payments/paymentCheckoutCallables.test.ts
@@ -176,10 +176,24 @@ describe("payment checkout callables", () => {
     expect(result).toEqual({ url: "https://checkout.stripe.test/session", orderIds: [ORDER_ID], confirmed: false });
   });
 
-  it("allows a matching section moderator to pay for a booking after closing", async () => {
+  it("allows an eligible member with a payment-ready booking to pay after closing", async () => {
     const closedTicketType = ticketType();
     closedTicketType.event.bookingEndDateTime = "2021-01-01T00:00:00.000Z";
     getTicketType.mockResolvedValue({ data: { ticketType: closedTicketType } } as never);
+    getBookings.mockResolvedValue({ data: { user: { bookings: [booking(BookingApprovalStatus.NOT_REQUIRED)] } } } as never);
+    const stripe = stripeClient();
+    mocks.requireStripe.mockReturnValue(stripe);
+
+    await expect(eventHandler(enabledRequest({ eventId: EVENT_ID }))).resolves.toMatchObject({
+      url: "https://checkout.stripe.test/session",
+    });
+  });
+
+  it("allows a matching section moderator to pay before bookings open", async () => {
+    const futureTicketType = ticketType();
+    futureTicketType.event.bookingStartDateTime = "2101-01-01T00:00:00.000Z";
+    futureTicketType.event.bookingEndDateTime = "2102-01-01T00:00:00.000Z";
+    getTicketType.mockResolvedValue({ data: { ticketType: futureTicketType } } as never);
     getSection.mockResolvedValue({ data: { section: { id: SECTION_ID, purposeLinks: [
       { purposes: [SectionUserGroupPurpose.BOOKER], userGroup: { id: GROUP_ID, membershipStatuses: null } },
       { purposes: [SectionUserGroupPurpose.MODERATOR], userGroup: { id: GROUP_ID, membershipStatuses: null } },
@@ -193,10 +207,11 @@ describe("payment checkout callables", () => {
     });
   });
 
-  it("rejects late checkout when the moderator group belongs to another section", async () => {
-    const closedTicketType = ticketType();
-    closedTicketType.event.bookingEndDateTime = "2021-01-01T00:00:00.000Z";
-    getTicketType.mockResolvedValue({ data: { ticketType: closedTicketType } } as never);
+  it("rejects checkout before opening when the moderator group belongs to another section", async () => {
+    const futureTicketType = ticketType();
+    futureTicketType.event.bookingStartDateTime = "2101-01-01T00:00:00.000Z";
+    futureTicketType.event.bookingEndDateTime = "2102-01-01T00:00:00.000Z";
+    getTicketType.mockResolvedValue({ data: { ticketType: futureTicketType } } as never);
     getSection.mockResolvedValue({ data: { section: { id: SECTION_ID, purposeLinks: [
       { purposes: [SectionUserGroupPurpose.BOOKER], userGroup: { id: GROUP_ID, membershipStatuses: null } },
       { purposes: [SectionUserGroupPurpose.MODERATOR], userGroup: { id: OTHER_GROUP_ID, membershipStatuses: null } },

--- a/functions/src/__tests__/payments/paymentCheckoutCallables.test.ts
+++ b/functions/src/__tests__/payments/paymentCheckoutCallables.test.ts
@@ -43,6 +43,7 @@ const USER_ID = "user-1";
 const EVENT_ID = "11111111-1111-4111-8111-111111111111";
 const SECTION_ID = "22222222-2222-4222-8222-222222222222";
 const GROUP_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_GROUP_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const TICKET_TYPE_ID = "44444444-4444-4444-8444-444444444444";
 const ORDER_ID = "55555555-5555-4555-8555-555555555555";
 const STALE_ORDER_ID = "66666666-6666-4666-8666-666666666666";
@@ -173,6 +174,39 @@ describe("payment checkout callables", () => {
       { idempotencyKey: bookingCheckoutIdempotencyKey(BOOKING_ID, [ORDER_ID]) }
     );
     expect(result).toEqual({ url: "https://checkout.stripe.test/session", orderIds: [ORDER_ID], confirmed: false });
+  });
+
+  it("allows a matching section moderator to pay for a booking after closing", async () => {
+    const closedTicketType = ticketType();
+    closedTicketType.event.bookingEndDateTime = "2021-01-01T00:00:00.000Z";
+    getTicketType.mockResolvedValue({ data: { ticketType: closedTicketType } } as never);
+    getSection.mockResolvedValue({ data: { section: { id: SECTION_ID, purposeLinks: [
+      { purposes: [SectionUserGroupPurpose.BOOKER], userGroup: { id: GROUP_ID, membershipStatuses: null } },
+      { purposes: [SectionUserGroupPurpose.MODERATOR], userGroup: { id: GROUP_ID, membershipStatuses: null } },
+    ] } } } as never);
+    getBookings.mockResolvedValue({ data: { user: { bookings: [booking(BookingApprovalStatus.NOT_REQUIRED)] } } } as never);
+    const stripe = stripeClient();
+    mocks.requireStripe.mockReturnValue(stripe);
+
+    await expect(eventHandler(enabledRequest({ eventId: EVENT_ID }))).resolves.toMatchObject({
+      url: "https://checkout.stripe.test/session",
+    });
+  });
+
+  it("rejects late checkout when the moderator group belongs to another section", async () => {
+    const closedTicketType = ticketType();
+    closedTicketType.event.bookingEndDateTime = "2021-01-01T00:00:00.000Z";
+    getTicketType.mockResolvedValue({ data: { ticketType: closedTicketType } } as never);
+    getSection.mockResolvedValue({ data: { section: { id: SECTION_ID, purposeLinks: [
+      { purposes: [SectionUserGroupPurpose.BOOKER], userGroup: { id: GROUP_ID, membershipStatuses: null } },
+      { purposes: [SectionUserGroupPurpose.MODERATOR], userGroup: { id: OTHER_GROUP_ID, membershipStatuses: null } },
+    ] } } } as never);
+    getBookings.mockResolvedValue({ data: { user: { bookings: [booking(BookingApprovalStatus.NOT_REQUIRED)] } } } as never);
+
+    await expect(eventHandler(enabledRequest({ eventId: EVENT_ID }))).rejects.toMatchObject({
+      code: "failed-precondition",
+    });
+    expect(mocks.requireStripe).not.toHaveBeenCalled();
   });
 
   it("reuses only an exactly allocated pending order and fails stale pending orders", async () => {

--- a/functions/src/bookingRules.ts
+++ b/functions/src/bookingRules.ts
@@ -25,7 +25,7 @@ export type BookingRuleErrorCode = (typeof BOOKING_RULE_ERROR_CODES)[keyof typeo
 export type BookingRulesFailure = { ok: false; code: BookingRuleErrorCode; message: string };
 export type BookingRulesSuccess = { ok: true };
 export type BookingRulesResult = BookingRulesFailure | BookingRulesSuccess;
-export type BookingGatekeepingResult = BookingRulesFailure | { ok: true; moderatorLateBooking: boolean };
+export type BookingGatekeepingResult = BookingRulesFailure | { ok: true; moderatorWindowOverride: boolean };
 
 function fail(code: BookingRuleErrorCode, message: string): BookingRulesFailure {
   return { ok: false, code, message };
@@ -324,11 +324,11 @@ export function evaluateBookingGatekeeping(args: {
     args.bookingEndDateTime,
     args.nowMs
   );
-  const moderatorLateBooking =
-    bookingWindowState === "AFTER" &&
+  const moderatorWindowOverride =
+    (bookingWindowState === "BEFORE" || bookingWindowState === "AFTER") &&
     userHasModeratorPurpose(args.purposeLinks, args.explicitGroupIds, args.membershipStatus);
-  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
+  if (bookingWindowState !== "OPEN" && !moderatorWindowOverride) {
     return fail(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW, "Booking is only allowed during the published booking window");
   }
-  return { ok: true, moderatorLateBooking };
+  return { ok: true, moderatorWindowOverride };
 }

--- a/functions/src/bookingRules.ts
+++ b/functions/src/bookingRules.ts
@@ -25,6 +25,7 @@ export type BookingRuleErrorCode = (typeof BOOKING_RULE_ERROR_CODES)[keyof typeo
 export type BookingRulesFailure = { ok: false; code: BookingRuleErrorCode; message: string };
 export type BookingRulesSuccess = { ok: true };
 export type BookingRulesResult = BookingRulesFailure | BookingRulesSuccess;
+export type BookingGatekeepingResult = BookingRulesFailure | { ok: true; moderatorLateBooking: boolean };
 
 function fail(code: BookingRuleErrorCode, message: string): BookingRulesFailure {
   return { ok: false, code, message };
@@ -74,15 +75,39 @@ export function userHasBookerPurpose(
   return bookerLinks.some((l) => userMatchesUserGroup(membershipStatus, l.userGroup, explicitGroupIds));
 }
 
+export function userHasModeratorPurpose(
+  purposeLinks: { purpose?: string; purposes?: string[] | null; userGroup: { id: string; membershipStatuses?: string[] | null } }[],
+  explicitGroupIds: Set<string>,
+  membershipStatus: string
+): boolean {
+  return purposeLinks.some(
+    (link) =>
+      linkHasPurpose(link, "MODERATOR") &&
+      userMatchesUserGroup(membershipStatus, link.userGroup, explicitGroupIds)
+  );
+}
+
+export type BookingWindowState = "BEFORE" | "OPEN" | "AFTER" | "INVALID";
+
+export function getBookingWindowState(
+  bookingStartDateTime: string,
+  bookingEndDateTime: string,
+  nowMs: number = Date.now()
+): BookingWindowState {
+  const start = Date.parse(bookingStartDateTime);
+  const end = Date.parse(bookingEndDateTime);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) return "INVALID";
+  if (nowMs < start) return "BEFORE";
+  if (nowMs > end) return "AFTER";
+  return "OPEN";
+}
+
 export function isWithinBookingWindow(
   bookingStartDateTime: string,
   bookingEndDateTime: string,
   nowMs: number = Date.now()
 ): boolean {
-  const start = Date.parse(bookingStartDateTime);
-  const end = Date.parse(bookingEndDateTime);
-  if (Number.isNaN(start) || Number.isNaN(end)) return false;
-  return nowMs >= start && nowMs <= end;
+  return getBookingWindowState(bookingStartDateTime, bookingEndDateTime, nowMs) === "OPEN";
 }
 
 export interface TicketTypeForRules {
@@ -284,7 +309,7 @@ export function evaluateBookingGatekeeping(args: {
   bookingStartDateTime: string;
   bookingEndDateTime: string;
   nowMs?: number;
-}): BookingRulesResult {
+}): BookingGatekeepingResult {
   if (!userHasSectionAccess(args.purposeLinks, args.explicitGroupIds, args.membershipStatus)) {
     return fail(BOOKING_RULE_ERROR_CODES.NO_SECTION_ACCESS, "You do not have permission to access this section");
   }
@@ -294,8 +319,16 @@ export function evaluateBookingGatekeeping(args: {
   if (!userHasBookerPurpose(args.purposeLinks, args.explicitGroupIds, args.membershipStatus)) {
     return fail(BOOKING_RULE_ERROR_CODES.NOT_AUTHORIZED_BOOKER, "You are not in a group allowed to book for this section");
   }
-  if (!isWithinBookingWindow(args.bookingStartDateTime, args.bookingEndDateTime, args.nowMs)) {
+  const bookingWindowState = getBookingWindowState(
+    args.bookingStartDateTime,
+    args.bookingEndDateTime,
+    args.nowMs
+  );
+  const moderatorLateBooking =
+    bookingWindowState === "AFTER" &&
+    userHasModeratorPurpose(args.purposeLinks, args.explicitGroupIds, args.membershipStatus);
+  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
     return fail(BOOKING_RULE_ERROR_CODES.OUTSIDE_BOOKING_WINDOW, "Booking is only allowed during the published booking window");
   }
-  return { ok: true };
+  return { ok: true, moderatorLateBooking };
 }

--- a/functions/src/paymentCheckoutCallables.ts
+++ b/functions/src/paymentCheckoutCallables.ts
@@ -101,10 +101,13 @@ async function ensureTicketCheckoutEligibility(args: {
     ticketType.event.bookingStartDateTime,
     ticketType.event.bookingEndDateTime
   );
-  const moderatorLateBooking =
-    bookingWindowState === "AFTER" &&
+  const moderatorEarlyCheckout =
+    bookingWindowState === "BEFORE" &&
     userHasModeratorPurpose(purposeLinks, explicitGroupIds, membershipStatus);
-  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
+  if (
+    bookingWindowState === "INVALID" ||
+    (bookingWindowState === "BEFORE" && !moderatorEarlyCheckout)
+  ) {
     throw new HttpsError("failed-precondition", "Ticket sales are not open for this event");
   }
   return { membershipStatus, explicitGroupIds };

--- a/functions/src/paymentCheckoutCallables.ts
+++ b/functions/src/paymentCheckoutCallables.ts
@@ -18,7 +18,12 @@ import { createHash } from "node:crypto";
 import { requireEnabled, validateUUID } from "./helpers";
 import { enforceRateLimit } from "./rateLimiter";
 import { FUNCTIONS_REGION } from "./constants";
-import { userMatchesUserGroup, userHasBookerPurpose } from "./bookingRules";
+import {
+  getBookingWindowState,
+  userMatchesUserGroup,
+  userHasBookerPurpose,
+  userHasModeratorPurpose,
+} from "./bookingRules";
 import {
   bookingIdsEqual,
   bookingIsFullyPaid,
@@ -56,22 +61,11 @@ export function buildStripeCheckoutReturnUrls(
   };
 }
 
-function ensureBookingWindow(start: string, end: string): void {
-  const now = Date.now();
-  const s = Date.parse(start);
-  const e = Date.parse(end);
-  if (!Number.isFinite(s) || !Number.isFinite(e) || now < s || now > e) {
-    throw new HttpsError("failed-precondition", "Ticket sales are not open for this event");
-  }
-}
-
 async function ensureTicketCheckoutEligibility(args: {
   uid: string;
   ticketType: NonNullable<Awaited<ReturnType<typeof getTicketTypeForCheckout>>["data"]["ticketType"]>;
 }): Promise<{ membershipStatus: string; explicitGroupIds: Set<string> }> {
   const { uid, ticketType } = args;
-  ensureBookingWindow(ticketType.event.bookingStartDateTime, ticketType.event.bookingEndDateTime);
-
   const section = await getSectionByIdForCallable({ id: ticketType.event.section.id as UUIDString });
   const sectionData = section.data?.section;
   if (!sectionData) throw new HttpsError("not-found", "Section not found");
@@ -81,12 +75,13 @@ async function ensureTicketCheckoutEligibility(args: {
   const user = dcUser.data?.user;
   if (!user) throw new HttpsError("failed-precondition", "User profile is required");
   const membershipStatus = user.membershipStatus;
+  const purposeLinks = (sectionData.purposeLinks ?? []).map((l) => ({
+    purposes: l.purposes ?? [],
+    userGroup: { id: validateUUID(l.userGroup.id), membershipStatuses: l.userGroup.membershipStatuses ?? null },
+  }));
   if (
     !userHasBookerPurpose(
-      (sectionData.purposeLinks ?? []).map((l) => ({
-        purposes: l.purposes ?? [],
-        userGroup: { id: validateUUID(l.userGroup.id), membershipStatuses: l.userGroup.membershipStatuses ?? null },
-      })),
+      purposeLinks,
       explicitGroupIds,
       membershipStatus
     )
@@ -101,6 +96,16 @@ async function ensureTicketCheckoutEligibility(args: {
     )
   ) {
     throw new HttpsError("permission-denied", "You are not eligible for this ticket type");
+  }
+  const bookingWindowState = getBookingWindowState(
+    ticketType.event.bookingStartDateTime,
+    ticketType.event.bookingEndDateTime
+  );
+  const moderatorLateBooking =
+    bookingWindowState === "AFTER" &&
+    userHasModeratorPurpose(purposeLinks, explicitGroupIds, membershipStatus);
+  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
+    throw new HttpsError("failed-precondition", "Ticket sales are not open for this event");
   }
   return { membershipStatus, explicitGroupIds };
 }

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -66,6 +66,11 @@ export default function EventBookingWizard({
 
   return (
     <Box sx={{ mt: 1 }}>
+      {wizard.gate.moderatorLateBooking ? (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Bookings are closed to members. As a moderator for this section, you can create or amend your own booking.
+        </Alert>
+      ) : null}
       {wizard.showBookingSummary && wizard.existingTerminalBooking ? (
         <>
           <EventBookingStatusSummary

--- a/src/features/sections/components/EventBookingWizard.tsx
+++ b/src/features/sections/components/EventBookingWizard.tsx
@@ -66,9 +66,12 @@ export default function EventBookingWizard({
 
   return (
     <Box sx={{ mt: 1 }}>
-      {wizard.gate.moderatorLateBooking ? (
+      {wizard.gate.moderatorWindowOverride ? (
         <Alert severity="info" sx={{ mb: 2 }}>
-          Bookings are closed to members. As a moderator for this section, you can create or amend your own booking.
+          {wizard.gate.moderatorWindowOverride === "BEFORE"
+            ? "Bookings are not yet open to members."
+            : "Bookings are closed to members."}{" "}
+          As a moderator for this section, you can create or amend your own booking.
         </Alert>
       ) : null}
       {wizard.showBookingSummary && wizard.existingTerminalBooking ? (

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -107,6 +107,8 @@ function renderWizard(props: {
   bookingTicketOrders?: unknown[];
   bookingsError?: boolean;
   wizardOpen?: boolean;
+  sectionOverride?: unknown;
+  eventOverride?: unknown;
 } = {}) {
   vi.mocked(reactGenerated.useGetMyBookingsForEvent).mockReturnValue({
     data: {
@@ -129,7 +131,11 @@ function renderWizard(props: {
   } as never);
   return render(
     <MemoryRouter>
-      <EventBookingWizard section={section} event={event} wizardOpen={props.wizardOpen ?? true} />
+      <EventBookingWizard
+        section={(props.sectionOverride ?? section) as never}
+        event={(props.eventOverride ?? event) as never}
+        wizardOpen={props.wizardOpen ?? true}
+      />
     </MemoryRouter>
   );
 }
@@ -167,6 +173,40 @@ describe("EventBookingWizard", () => {
     expect(screen.getByText("Guests")).toBeInTheDocument();
     expect(screen.getByText("Review and submit")).toBeInTheDocument();
     expect(screen.queryByText("Pay")).not.toBeInTheDocument();
+  });
+
+  it("explains the late-booking exception to an authorised section moderator", () => {
+    renderWizard({
+      sectionOverride: {
+        id: "section-1",
+        name: "Events",
+        type: "EVENTS",
+        purposeLinks: [
+          { purposes: ["ACCESS", "BOOKER"], userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] } },
+          { purposes: ["MODERATOR"], userGroup: { id: "group-1", membershipStatuses: null } },
+        ],
+      },
+      eventOverride: {
+        id: "event-1",
+        title: "Annual Dinner",
+        bookingStartDateTime: "2019-01-01T00:00:00Z",
+        bookingEndDateTime: "2020-01-01T00:00:00Z",
+        maxGuestsWithoutModeratorApproval: 1,
+        ticketTypes: [
+          {
+            id: "ticket-member",
+            title: "Member standard",
+            audience: TicketAudience.MEMBER,
+            price: 50,
+            userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByText(/bookings are closed to members/i)).toBeInTheDocument();
+    expect(screen.getByText(/as a moderator for this section/i)).toBeInTheDocument();
+    expect(screen.getByText("Your details")).toBeInTheDocument();
   });
 
   it("submits member and all guest dietary details atomically and explains over-limit approval", async () => {

--- a/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
+++ b/src/features/sections/components/__tests__/EventBookingWizard.test.tsx
@@ -209,6 +209,31 @@ describe("EventBookingWizard", () => {
     expect(screen.getByText("Your details")).toBeInTheDocument();
   });
 
+  it("keeps the booking interface closed for an ordinary member after the booking window", () => {
+    renderWizard({
+      eventOverride: {
+        id: "event-1",
+        title: "Annual Dinner",
+        bookingStartDateTime: "2019-01-01T00:00:00Z",
+        bookingEndDateTime: "2020-01-01T00:00:00Z",
+        maxGuestsWithoutModeratorApproval: 1,
+        ticketTypes: [
+          {
+            id: "ticket-member",
+            title: "Member standard",
+            audience: TicketAudience.MEMBER,
+            price: 50,
+            userGroup: { id: "group-1", membershipStatuses: ["REGULAR"] },
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Bookings for this event are closed.");
+    expect(screen.queryByText(/as a moderator for this section/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Your details")).not.toBeInTheDocument();
+  });
+
   it("submits member and all guest dietary details atomically and explains over-limit approval", async () => {
     const user = userEvent.setup();
     renderWizard();

--- a/src/features/sections/utils/__tests__/bookingEligibility.test.ts
+++ b/src/features/sections/utils/__tests__/bookingEligibility.test.ts
@@ -88,6 +88,56 @@ describe("bookingEligibility", () => {
       if (!r.ok) expect(r.code).toBe("OUTSIDE_BOOKING_WINDOW");
     });
 
+    it("allows a matching section moderator after bookings close", () => {
+      const r = evaluateBookingGatePreview({
+        purposeLinks: [
+          ...baseLinks,
+          { purpose: "MODERATOR", userGroup: { id: "moderators" } },
+        ],
+        membershipStatus: MembershipStatus.REGULAR,
+        explicitGroupIds: new Set(["moderators"]),
+        ...window,
+        nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
+      });
+
+      expect(r).toEqual({ ok: true, moderatorLateBooking: true });
+    });
+
+    it("keeps an ordinary booker and another section's moderator closed out", () => {
+      const r = evaluateBookingGatePreview({
+        purposeLinks: [
+          ...baseLinks,
+          { purpose: "MODERATOR", userGroup: { id: "other-section-moderators" } },
+        ],
+        membershipStatus: MembershipStatus.REGULAR,
+        explicitGroupIds: new Set(["my-other-moderator-group"]),
+        ...window,
+        nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
+      });
+
+      expect(r.ok).toBe(false);
+      if (!r.ok) {
+        expect(r.code).toBe("OUTSIDE_BOOKING_WINDOW");
+        expect(r.message).toBe("Bookings for this event are closed.");
+      }
+    });
+
+    it("does not open bookings early for moderators", () => {
+      const r = evaluateBookingGatePreview({
+        purposeLinks: [
+          ...baseLinks,
+          { purpose: "MODERATOR", userGroup: { id: "moderators" } },
+        ],
+        membershipStatus: MembershipStatus.REGULAR,
+        explicitGroupIds: new Set(["moderators"]),
+        ...window,
+        nowMs: Date.parse("2024-12-31T23:59:59.000Z"),
+      });
+
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.code).toBe("OUTSIDE_BOOKING_WINDOW");
+    });
+
     it("fails without BOOKER purpose", () => {
       const r = evaluateBookingGatePreview({
         purposeLinks: [{ purpose: "ACCESS", userGroup: { id: "ag", membershipStatuses: ["REGULAR"] } }],

--- a/src/features/sections/utils/__tests__/bookingEligibility.test.ts
+++ b/src/features/sections/utils/__tests__/bookingEligibility.test.ts
@@ -100,7 +100,7 @@ describe("bookingEligibility", () => {
         nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
       });
 
-      expect(r).toEqual({ ok: true, moderatorLateBooking: true });
+      expect(r).toEqual({ ok: true, moderatorWindowOverride: "AFTER" });
     });
 
     it("keeps an ordinary booker and another section's moderator closed out", () => {
@@ -122,7 +122,7 @@ describe("bookingEligibility", () => {
       }
     });
 
-    it("does not open bookings early for moderators", () => {
+    it("allows a matching section moderator before bookings open", () => {
       const r = evaluateBookingGatePreview({
         purposeLinks: [
           ...baseLinks,
@@ -134,8 +134,7 @@ describe("bookingEligibility", () => {
         nowMs: Date.parse("2024-12-31T23:59:59.000Z"),
       });
 
-      expect(r.ok).toBe(false);
-      if (!r.ok) expect(r.code).toBe("OUTSIDE_BOOKING_WINDOW");
+      expect(r).toEqual({ ok: true, moderatorWindowOverride: "BEFORE" });
     });
 
     it("fails without BOOKER purpose", () => {

--- a/src/features/sections/utils/bookingEligibility.ts
+++ b/src/features/sections/utils/bookingEligibility.ts
@@ -41,15 +41,39 @@ export function userHasBookerPurpose(
   return bookerLinks.some((l) => userMatchesUserGroup(membershipStatus, l.userGroup, explicitGroupIds));
 }
 
+export function userHasModeratorPurpose(
+  purposeLinks: { purpose?: string; purposes?: string[] | null; userGroup: { id: string; membershipStatuses?: string[] | null } }[],
+  explicitGroupIds: Set<string>,
+  membershipStatus: string
+): boolean {
+  return purposeLinks.some(
+    (link) =>
+      linkHasPurpose(link, "MODERATOR") &&
+      userMatchesUserGroup(membershipStatus, link.userGroup, explicitGroupIds)
+  );
+}
+
+export type BookingWindowState = "BEFORE" | "OPEN" | "AFTER" | "INVALID";
+
+export function getBookingWindowState(
+  bookingStartDateTime: string,
+  bookingEndDateTime: string,
+  nowMs: number = Date.now()
+): BookingWindowState {
+  const start = Date.parse(bookingStartDateTime);
+  const end = Date.parse(bookingEndDateTime);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start > end) return "INVALID";
+  if (nowMs < start) return "BEFORE";
+  if (nowMs > end) return "AFTER";
+  return "OPEN";
+}
+
 export function isWithinBookingWindow(
   bookingStartDateTime: string,
   bookingEndDateTime: string,
   nowMs: number = Date.now()
 ): boolean {
-  const start = Date.parse(bookingStartDateTime);
-  const end = Date.parse(bookingEndDateTime);
-  if (Number.isNaN(start) || Number.isNaN(end)) return false;
-  return nowMs >= start && nowMs <= end;
+  return getBookingWindowState(bookingStartDateTime, bookingEndDateTime, nowMs) === "OPEN";
 }
 
 export type BookingGateFailureCode =
@@ -59,7 +83,7 @@ export type BookingGateFailureCode =
   | "OUTSIDE_BOOKING_WINDOW";
 
 export type BookingGateResult =
-  | { ok: true }
+  | { ok: true; moderatorLateBooking: boolean }
   | { ok: false; code: BookingGateFailureCode; message: string };
 
 /**
@@ -97,12 +121,19 @@ export function evaluateBookingGatePreview(args: {
       message: "You are not in a group allowed to book for this section.",
     };
   }
-  if (!isWithinBookingWindow(bookingStartDateTime, bookingEndDateTime, nowMs)) {
+  const bookingWindowState = getBookingWindowState(bookingStartDateTime, bookingEndDateTime, nowMs);
+  const moderatorLateBooking =
+    bookingWindowState === "AFTER" &&
+    userHasModeratorPurpose(purposeLinks, explicitGroupIds, membershipStatus);
+  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
     return {
       ok: false,
       code: "OUTSIDE_BOOKING_WINDOW",
-      message: "Booking is only open during the published booking window.",
+      message:
+        bookingWindowState === "AFTER"
+          ? "Bookings for this event are closed."
+          : "Booking is only open during the published booking window.",
     };
   }
-  return { ok: true };
+  return { ok: true, moderatorLateBooking };
 }

--- a/src/features/sections/utils/bookingEligibility.ts
+++ b/src/features/sections/utils/bookingEligibility.ts
@@ -83,7 +83,7 @@ export type BookingGateFailureCode =
   | "OUTSIDE_BOOKING_WINDOW";
 
 export type BookingGateResult =
-  | { ok: true; moderatorLateBooking: boolean }
+  | { ok: true; moderatorWindowOverride: "BEFORE" | "AFTER" | null }
   | { ok: false; code: BookingGateFailureCode; message: string };
 
 /**
@@ -122,10 +122,12 @@ export function evaluateBookingGatePreview(args: {
     };
   }
   const bookingWindowState = getBookingWindowState(bookingStartDateTime, bookingEndDateTime, nowMs);
-  const moderatorLateBooking =
-    bookingWindowState === "AFTER" &&
-    userHasModeratorPurpose(purposeLinks, explicitGroupIds, membershipStatus);
-  if (bookingWindowState !== "OPEN" && !moderatorLateBooking) {
+  const moderatorWindowOverride =
+    (bookingWindowState === "BEFORE" || bookingWindowState === "AFTER") &&
+    userHasModeratorPurpose(purposeLinks, explicitGroupIds, membershipStatus)
+      ? bookingWindowState
+      : null;
+  if (bookingWindowState !== "OPEN" && !moderatorWindowOverride) {
     return {
       ok: false,
       code: "OUTSIDE_BOOKING_WINDOW",
@@ -135,5 +137,5 @@ export function evaluateBookingGatePreview(args: {
           : "Booking is only open during the published booking window.",
     };
   }
-  return { ok: true, moderatorLateBooking };
+  return { ok: true, moderatorWindowOverride };
 }


### PR DESCRIPTION
## Summary

- allow eligible moderators for the event section to create or amend their own booking before the booking window opens and after it closes
- verify the moderator exception server-side against the event section and the caller membership
- keep ordinary members and moderators for other sections from creating or amending bookings outside the published window
- allow any otherwise eligible member to pay after closing when they already have a submitted, payment-eligible booking
- distinguish the pre-opening and post-closing moderator exception in the booking UI

## Why

Section moderators sometimes need to add or amend their own booking outside the public booking window. Separately, closing the booking window should prevent new member booking changes, but should not strand a member who already has a valid submitted booking awaiting payment.

## User impact

Matching section moderators can complete the normal booking journey before opening or after closing. Ordinary members remain unable to create or amend bookings outside the window, but can settle an existing payment-eligible booking after closing. All ticket, guest, approval, membership, and payment eligibility rules continue to apply.

## Validation

- focused booking eligibility and booking wizard tests pass
- focused booking rules and payment checkout tests pass
- added component coverage confirming ordinary members see the closed state without the moderator override
- app and Functions builds pass
- app and Functions lint pass
- deployment safety suite: 55 passed

Closes #588