### PR TITLE
Add event sponsors and Markdown details

### DIFF
--- a/dataconnect/api/admin-mutations.gql
+++ b/dataconnect/api/admin-mutations.gql
@@ -1275,6 +1275,8 @@ query GetEventByIdForCallable($id: UUID!) @auth(level: NO_ACCESS) {
     title
     location
     guestOfHonour
+    sponsors
+    details
     startDateTime
     endDateTime
     bookingStartDateTime

--- a/dataconnect/api/queries.gql
+++ b/dataconnect/api/queries.gql
@@ -249,6 +249,8 @@ query GetEventsForSection($sectionId: UUID!) @auth(expr: "auth.token.admin == tr
       title
       location
       guestOfHonour
+      sponsors
+      details
       startDateTime
       endDateTime
       bookingStartDateTime
@@ -268,6 +270,8 @@ query GetEventById($id: UUID!) @auth(expr: "auth.token.admin == true && auth.tok
     title
     location
     guestOfHonour
+    sponsors
+    details
     startDateTime
     endDateTime
     bookingStartDateTime

--- a/dataconnect/api/user-group-mutations.gql
+++ b/dataconnect/api/user-group-mutations.gql
@@ -153,6 +153,8 @@ mutation CreateEvent(
   $title: String!
   $location: String
   $guestOfHonour: String
+  $sponsors: String
+  $details: String
   $startDateTime: Timestamp!
   $endDateTime: Timestamp!
   $bookingStartDateTime: Timestamp!
@@ -165,6 +167,8 @@ mutation CreateEvent(
       title: $title
       location: $location
       guestOfHonour: $guestOfHonour
+      sponsors: $sponsors
+      details: $details
       startDateTime: $startDateTime
       endDateTime: $endDateTime
       bookingStartDateTime: $bookingStartDateTime
@@ -179,6 +183,8 @@ mutation UpdateEvent(
   $title: String!
   $location: String
   $guestOfHonour: String
+  $sponsors: String
+  $details: String
   $startDateTime: Timestamp!
   $endDateTime: Timestamp!
   $bookingStartDateTime: Timestamp!
@@ -191,6 +197,8 @@ mutation UpdateEvent(
       title: $title
       location: $location
       guestOfHonour: $guestOfHonour
+      sponsors: $sponsors
+      details: $details
       startDateTime: $startDateTime
       endDateTime: $endDateTime
       bookingStartDateTime: $bookingStartDateTime

--- a/dataconnect/schema/schema.gql
+++ b/dataconnect/schema/schema.gql
@@ -431,6 +431,8 @@ type Event @table {
   title: String!
   location: String
   guestOfHonour: String
+  sponsors: String
+  details: String
   startDateTime: Timestamp!
   endDateTime: Timestamp!
   bookingStartDateTime: Timestamp!

--- a/functions/src/__tests__/cross-cutting/contracts/gqlSchemaIntegrity.test.ts
+++ b/functions/src/__tests__/cross-cutting/contracts/gqlSchemaIntegrity.test.ts
@@ -250,6 +250,30 @@ describe("GQL schema integrity", () => {
     expect(eventMutations.match(/\$maxGuestsWithoutModeratorApproval: Int!/g)).toHaveLength(2);
   });
 
+  it("threads optional event sponsors and details through the event connector operations", () => {
+    const schema = readSchemaFile();
+    const eventStart = schema.indexOf("type Event @table");
+    const eventEnd = schema.indexOf("\n}", eventStart);
+    const eventBlock = schema.slice(eventStart, eventEnd + 2);
+    expect(eventBlock).toContain("sponsors: String");
+    expect(eventBlock).toContain("details: String");
+
+    const eventMutations = readApiFile("user-group-mutations.gql");
+    expect(eventMutations.match(/\$sponsors: String/g)).toHaveLength(2);
+    expect(eventMutations.match(/\$details: String/g)).toHaveLength(2);
+    expect(eventMutations.match(/sponsors: \$sponsors/g)).toHaveLength(2);
+    expect(eventMutations.match(/details: \$details/g)).toHaveLength(2);
+
+    const memberQueries = readApiFile("queries.gql");
+    expect(memberQueries.match(/^\s+sponsors$/gm)).toHaveLength(2);
+    expect(memberQueries.match(/^\s+details$/gm)).toHaveLength(2);
+
+    const callableQueries = readApiFile("admin-mutations.gql");
+    expect(callableQueries).toMatch(
+      /query GetEventByIdForCallable[\s\S]*?guestOfHonour\s+sponsors\s+details\s+startDateTime/,
+    );
+  });
+
   it("backfills legacy null guest limits before applying the non-null constraint", () => {
     const migration = readMigrationFile(
       "2026-08-11-issue-543-required-guest-approval-limit.sql",

--- a/functions/src/dataconnect-admin-generated/index.d.ts
+++ b/functions/src/dataconnect-admin-generated/index.d.ts
@@ -470,6 +470,8 @@ export interface CreateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -1150,6 +1152,8 @@ export interface GetEventByIdData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -1180,6 +1184,8 @@ export interface GetEventByIdForCallableData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -1217,6 +1223,8 @@ export interface GetEventsForSectionData {
       title: string;
       location?: string | null;
       guestOfHonour?: string | null;
+      sponsors?: string | null;
+      details?: string | null;
       startDateTime: TimestampString;
       endDateTime: TimestampString;
       bookingStartDateTime: TimestampString;
@@ -3156,6 +3164,8 @@ export interface UpdateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^12.15.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.2"
       },
       "devDependencies": {
@@ -141,6 +142,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -490,6 +492,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -533,6 +536,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -605,6 +609,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -648,6 +653,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1373,6 +1379,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.0.tgz",
       "integrity": "sha512-soIskolmGgbpi0K/MfrjtdpO1220qRCbXA4Z8Qx3lM+fVwA3q40m+OM+7zBHd2nuQCrLXb33L6Oc1aBH3Y26AQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.3",
         "@firebase/logger": "0.5.1",
@@ -1439,6 +1446,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.14.tgz",
       "integrity": "sha512-rgFmiofYsdS9ZG/Bht3OBxJtPD3zWE1cffShWubEm+4+qZeyzCbmtb1q6jOEjN9fB7uufe4rQmWOPXouR3758Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.15.0",
         "@firebase/component": "0.7.3",
@@ -1455,6 +1463,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
       "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/logger": "0.5.1"
       }
@@ -1909,6 +1918,7 @@
       "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2092,6 +2102,7 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.6.tgz",
       "integrity": "sha512-R4DaYF3dgCQCUAkr4wW1w26GHXcf5rCmBRHVBuuvJvaGLmZdD8EjatP80Nz5JCw0KxORAzwftnHzXVnjR8HnFw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -2727,6 +2738,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack-query-firebase/react/-/react-2.1.1.tgz",
       "integrity": "sha512-1hOEcfxLgorg0TwadBJeeEvoD7P4JMCJLhdO1doUQWZRs83WmwTlBJGv8GiO1y2KWaKjQh+JdgsuYCqG2dPXcA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@tanstack/react-query": "^5",
         "firebase": "^11.3.0 || ^12.0.0"
@@ -2747,6 +2759,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
       "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.16"
       },
@@ -2853,8 +2866,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2912,6 +2924,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2923,14 +2944,46 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2959,6 +3012,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2969,6 +3023,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2981,6 +3036,12 @@
       "peerDependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.50.1",
@@ -3027,6 +3088,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -3251,6 +3313,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -3278,6 +3346,7 @@
       "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.9",
@@ -3407,6 +3476,7 @@
       "integrity": "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.9",
         "fflate": "^0.8.2",
@@ -3444,6 +3514,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3573,6 +3644,16 @@
         "npm": ">=6"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3634,6 +3715,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3678,6 +3760,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3703,6 +3795,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/cliui": {
@@ -3745,6 +3877,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3904,6 +4046,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3915,10 +4070,22 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/dom-accessibility-api": {
@@ -3926,8 +4093,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4050,6 +4216,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4218,6 +4385,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4247,6 +4424,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4347,6 +4530,7 @@
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.15.0.tgz",
       "integrity": "sha512-p0YTLcRSTiBXMx9sGr4ZNSfLjc/RVBEw4C/TXjVMtw65+6E1Pbm47UY3F4/AqRoDobEcNX3gsbPGy7jPjxbgSQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/ai": "2.13.1",
         "@firebase/analytics": "0.10.22",
@@ -4490,6 +4674,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4541,6 +4765,16 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
@@ -4628,6 +4862,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4647,6 +4911,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -4679,6 +4953,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4769,6 +5065,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -4920,6 +5217,16 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4948,7 +5255,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5004,12 +5310,607 @@
         "node": ">=10"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
@@ -5168,6 +6069,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5253,6 +6179,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5305,7 +6232,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5321,7 +6247,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5334,8 +6259,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -5353,6 +6277,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/protobufjs": {
       "version": "7.6.5",
@@ -5398,6 +6332,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5407,6 +6342,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5419,6 +6355,33 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
       "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
       "license": "MIT"
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -5496,6 +6459,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-directory": {
@@ -5710,6 +6706,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -5736,6 +6742,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -5774,6 +6794,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/stylis": {
@@ -5914,6 +6952,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5952,6 +7010,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5989,6 +7048,93 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -6031,12 +7177,41 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -6112,6 +7287,7 @@
       "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.9",
         "@vitest/mocker": "4.1.9",
@@ -6433,6 +7609,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -6448,6 +7625,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "src/dataconnect-generated": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "firebase": "^12.15.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.2"
   },
   "devDependencies": {

--- a/src/dataconnect-generated/README.md
+++ b/src/dataconnect-generated/README.md
@@ -2600,6 +2600,8 @@ export interface GetEventByIdForCallableData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -7481,6 +7483,8 @@ export interface GetEventsForSectionData {
       title: string;
       location?: string | null;
       guestOfHonour?: string | null;
+      sponsors?: string | null;
+      details?: string | null;
       startDateTime: TimestampString;
       endDateTime: TimestampString;
       bookingStartDateTime: TimestampString;
@@ -7604,6 +7608,8 @@ export interface GetEventByIdData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -19577,6 +19583,8 @@ export interface CreateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -19605,6 +19613,8 @@ const createEventVars: CreateEventVariables = {
   title: ..., 
   location: ..., // optional
   guestOfHonour: ..., // optional
+  sponsors: ..., // optional
+  details: ..., // optional
   startDateTime: ..., 
   endDateTime: ..., 
   bookingStartDateTime: ..., 
@@ -19616,7 +19626,7 @@ const createEventVars: CreateEventVariables = {
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await createEvent(createEventVars);
 // Variables can be defined inline as well.
-const { data } = await createEvent({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+const { data } = await createEvent({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -19643,6 +19653,8 @@ const createEventVars: CreateEventVariables = {
   title: ..., 
   location: ..., // optional
   guestOfHonour: ..., // optional
+  sponsors: ..., // optional
+  details: ..., // optional
   startDateTime: ..., 
   endDateTime: ..., 
   bookingStartDateTime: ..., 
@@ -19653,7 +19665,7 @@ const createEventVars: CreateEventVariables = {
 // Call the `createEventRef()` function to get a reference to the mutation.
 const ref = createEventRef(createEventVars);
 // Variables can be defined inline as well.
-const ref = createEventRef({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+const ref = createEventRef({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -19710,6 +19722,8 @@ export interface UpdateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -19738,6 +19752,8 @@ const updateEventVars: UpdateEventVariables = {
   title: ..., 
   location: ..., // optional
   guestOfHonour: ..., // optional
+  sponsors: ..., // optional
+  details: ..., // optional
   startDateTime: ..., 
   endDateTime: ..., 
   bookingStartDateTime: ..., 
@@ -19749,7 +19765,7 @@ const updateEventVars: UpdateEventVariables = {
 // You can use the `await` keyword to wait for the promise to resolve.
 const { data } = await updateEvent(updateEventVars);
 // Variables can be defined inline as well.
-const { data } = await updateEvent({ id: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+const { data } = await updateEvent({ id: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
 // You can also pass in a `DataConnect` instance to the action shortcut function.
 const dataConnect = getDataConnect(connectorConfig);
@@ -19776,6 +19792,8 @@ const updateEventVars: UpdateEventVariables = {
   title: ..., 
   location: ..., // optional
   guestOfHonour: ..., // optional
+  sponsors: ..., // optional
+  details: ..., // optional
   startDateTime: ..., 
   endDateTime: ..., 
   bookingStartDateTime: ..., 
@@ -19786,7 +19804,7 @@ const updateEventVars: UpdateEventVariables = {
 // Call the `updateEventRef()` function to get a reference to the mutation.
 const ref = updateEventRef(updateEventVars);
 // Variables can be defined inline as well.
-const ref = updateEventRef({ id: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+const ref = updateEventRef({ id: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
 // You can also pass in a `DataConnect` instance to the `MutationRef` function.
 const dataConnect = getDataConnect(connectorConfig);

--- a/src/dataconnect-generated/index.d.ts
+++ b/src/dataconnect-generated/index.d.ts
@@ -492,6 +492,8 @@ export interface CreateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -1172,6 +1174,8 @@ export interface GetEventByIdData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -1202,6 +1206,8 @@ export interface GetEventByIdForCallableData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -1239,6 +1245,8 @@ export interface GetEventsForSectionData {
       title: string;
       location?: string | null;
       guestOfHonour?: string | null;
+      sponsors?: string | null;
+      details?: string | null;
       startDateTime: TimestampString;
       endDateTime: TimestampString;
       bookingStartDateTime: TimestampString;
@@ -3178,6 +3186,8 @@ export interface UpdateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;

--- a/src/dataconnect-generated/react/README.md
+++ b/src/dataconnect-generated/react/README.md
@@ -2112,6 +2112,8 @@ export interface GetEventByIdForCallableData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -5931,6 +5933,8 @@ export interface GetEventsForSectionData {
       title: string;
       location?: string | null;
       guestOfHonour?: string | null;
+      sponsors?: string | null;
+      details?: string | null;
       startDateTime: TimestampString;
       endDateTime: TimestampString;
       bookingStartDateTime: TimestampString;
@@ -6027,6 +6031,8 @@ export interface GetEventByIdData {
     title: string;
     location?: string | null;
     guestOfHonour?: string | null;
+    sponsors?: string | null;
+    details?: string | null;
     startDateTime: TimestampString;
     endDateTime: TimestampString;
     bookingStartDateTime: TimestampString;
@@ -16014,6 +16020,8 @@ export interface CreateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -16072,6 +16080,8 @@ export default function CreateEventComponent() {
     title: ..., 
     location: ..., // optional
     guestOfHonour: ..., // optional
+    sponsors: ..., // optional
+    details: ..., // optional
     startDateTime: ..., 
     endDateTime: ..., 
     bookingStartDateTime: ..., 
@@ -16080,7 +16090,7 @@ export default function CreateEventComponent() {
   };
   mutation.mutate(createEventVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+  mutation.mutate({ sectionId: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {
@@ -16124,6 +16134,8 @@ export interface UpdateEventVariables {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: TimestampString;
   endDateTime: TimestampString;
   bookingStartDateTime: TimestampString;
@@ -16182,6 +16194,8 @@ export default function UpdateEventComponent() {
     title: ..., 
     location: ..., // optional
     guestOfHonour: ..., // optional
+    sponsors: ..., // optional
+    details: ..., // optional
     startDateTime: ..., 
     endDateTime: ..., 
     bookingStartDateTime: ..., 
@@ -16190,7 +16204,7 @@ export default function UpdateEventComponent() {
   };
   mutation.mutate(updateEventVars);
   // Variables can be defined inline as well.
-  mutation.mutate({ id: ..., title: ..., location: ..., guestOfHonour: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
+  mutation.mutate({ id: ..., title: ..., location: ..., guestOfHonour: ..., sponsors: ..., details: ..., startDateTime: ..., endDateTime: ..., bookingStartDateTime: ..., bookingEndDateTime: ..., maxGuestsWithoutModeratorApproval: ..., });
 
   // You can also pass in a `useDataConnectMutationOptions` object to `UseMutationResult.mutate()`.
   const options = {

--- a/src/features/admin/components/SectionEventsManager.tsx
+++ b/src/features/admin/components/SectionEventsManager.tsx
@@ -76,6 +76,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
   const [title, setTitle] = useState("");
   const [location, setLocation] = useState("");
   const [guestOfHonour, setGuestOfHonour] = useState("");
+  const [sponsors, setSponsors] = useState("");
+  const [details, setDetails] = useState("");
   const [startDateTime, setStartDateTime] = useState("");
   const [endDateTime, setEndDateTime] = useState("");
   const [bookingStartDateTime, setBookingStartDateTime] = useState("");
@@ -204,6 +206,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       setTitle(event.title);
       setLocation(event.location ?? "");
       setGuestOfHonour(event.guestOfHonour ?? "");
+      setSponsors(event.sponsors ?? "");
+      setDetails(event.details ?? "");
       setStartDateTime(toDatetimeLocal(event.startDateTime));
       setEndDateTime(toDatetimeLocal(event.endDateTime));
       setBookingStartDateTime(toDatetimeLocal(event.bookingStartDateTime));
@@ -216,6 +220,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
       setTitle("");
       setLocation("");
       setGuestOfHonour("");
+      setSponsors("");
+      setDetails("");
       const now = new Date();
       setStartDateTime(toDatetimeLocal(now.toISOString()));
       setEndDateTime(toDatetimeLocal(now.toISOString()));
@@ -250,6 +256,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
             title: title.trim(),
             location: location.trim() || null,
             guestOfHonour: guestOfHonour.trim() || null,
+            sponsors: sponsors.trim() || null,
+            details: details.trim() || null,
             startDateTime: fromDatetimeLocal(startDateTime),
             endDateTime: fromDatetimeLocal(endDateTime),
             bookingStartDateTime: fromDatetimeLocal(bookingStartDateTime),
@@ -264,6 +272,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
             title: title.trim(),
             location: location.trim() || null,
             guestOfHonour: guestOfHonour.trim() || null,
+            sponsors: sponsors.trim() || null,
+            details: details.trim() || null,
             startDateTime: fromDatetimeLocal(startDateTime),
             endDateTime: fromDatetimeLocal(endDateTime),
             bookingStartDateTime: fromDatetimeLocal(bookingStartDateTime),
@@ -482,6 +492,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           title: eventDetailData.event.title,
           location: eventDetailData.event.location,
           guestOfHonour: eventDetailData.event.guestOfHonour,
+          sponsors: eventDetailData.event.sponsors,
+          details: eventDetailData.event.details,
           startDateTime: eventDetailData.event.startDateTime,
           endDateTime: eventDetailData.event.endDateTime,
           bookingStartDateTime: eventDetailData.event.bookingStartDateTime,
@@ -553,6 +565,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           title={title}
           location={location}
           guestOfHonour={guestOfHonour}
+          sponsors={sponsors}
+          details={details}
           startDateTime={startDateTime}
           endDateTime={endDateTime}
           bookingStartDateTime={bookingStartDateTime}
@@ -564,6 +578,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
           onTitleChange={setTitle}
           onLocationChange={setLocation}
           onGuestOfHonourChange={setGuestOfHonour}
+          onSponsorsChange={setSponsors}
+          onDetailsChange={setDetails}
           onStartDateTimeChange={setStartDateTime}
           onEndDateTimeChange={setEndDateTime}
           onBookingStartDateTimeChange={setBookingStartDateTime}
@@ -599,6 +615,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
         title={title}
         location={location}
         guestOfHonour={guestOfHonour}
+        sponsors={sponsors}
+        details={details}
         startDateTime={startDateTime}
         endDateTime={endDateTime}
         bookingStartDateTime={bookingStartDateTime}
@@ -610,6 +628,8 @@ export default function SectionEventsManager({ sectionId, sectionName, initialEv
         onTitleChange={setTitle}
         onLocationChange={setLocation}
         onGuestOfHonourChange={setGuestOfHonour}
+        onSponsorsChange={setSponsors}
+        onDetailsChange={setDetails}
         onStartDateTimeChange={setStartDateTime}
         onEndDateTimeChange={setEndDateTime}
         onBookingStartDateTimeChange={setBookingStartDateTime}

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "../../../../test-utils";
+import { fireEvent, render, screen, waitFor } from "../../../../test-utils";
 import SectionEventsManager from "../SectionEventsManager";
 import * as reactGenerated from "@dataconnect/generated/react";
 import * as generated from "@dataconnect/generated";
@@ -197,6 +197,22 @@ describe("SectionEventsManager", () => {
       })
     );
     expect(firebaseDataConnect.executeMutation).toHaveBeenCalled();
+  });
+
+  it("uses the safe Markdown renderer for the admin preview", async () => {
+    const user = userEvent.setup();
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+
+    await user.click(screen.getByRole("button", { name: /add event/i }));
+    fireEvent.change(screen.getByLabelText(/^event details$/i), {
+      target: {
+        value: '<script>alert("preview unsafe")</script>\n\n[Unsafe preview](javascript:alert(1))',
+      },
+    });
+
+    expect(screen.queryByText('alert("preview unsafe")')).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Unsafe preview" })).not.toBeInTheDocument();
+    expect(screen.getByText("Unsafe preview")).toBeInTheDocument();
   });
 
   it("renders a complete pending booking and approves its exact revision", async () => {

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "../../../../test-utils";
 import SectionEventsManager from "../SectionEventsManager";
 import * as reactGenerated from "@dataconnect/generated/react";
+import * as generated from "@dataconnect/generated";
+import * as firebaseDataConnect from "firebase/data-connect";
 import userEvent from "@testing-library/user-event";
 import {
   dataConnectQueryResult,
@@ -68,6 +70,7 @@ vi.mock("@dataconnect/generated", async () => {
   const actual = await vi.importActual("@dataconnect/generated");
   return {
     ...actual,
+    createEventRef: vi.fn((_dc: unknown, vars: unknown) => ({ type: "mutation", vars })),
     updateEventRef: vi.fn((_dc: unknown, vars: unknown) => ({ type: "mutation", vars })),
   };
 });
@@ -170,6 +173,32 @@ describe("SectionEventsManager", () => {
     });
   });
 
+  it("creates an event with sponsors and Markdown details and previews the details", async () => {
+    const user = userEvent.setup();
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+
+    await user.click(screen.getByRole("button", { name: /add event/i }));
+    await user.type(screen.getByLabelText(/title/i), "Sponsored dinner");
+    await user.type(screen.getByLabelText(/^sponsors$/i), "Example Ltd");
+    await user.type(screen.getByLabelText(/^event details$/i), "# Welcome\n\nPlease read **carefully**.");
+
+    expect(screen.getByRole("heading", { name: "Welcome", level: 3 })).toBeInTheDocument();
+    expect(screen.getByText("carefully").tagName).toBe("STRONG");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(generated.createEventRef).toHaveBeenCalled());
+    expect(generated.createEventRef).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: "Sponsored dinner",
+        sponsors: "Example Ltd",
+        details: "# Welcome\n\nPlease read **carefully**.",
+      })
+    );
+    expect(firebaseDataConnect.executeMutation).toHaveBeenCalled();
+  });
+
   it("renders a complete pending booking and approves its exact revision", async () => {
     const user = userEvent.setup();
     mockGetEventsForSection({
@@ -241,6 +270,8 @@ describe("SectionEventsManager", () => {
               bookingEndDateTime: "2025-02-28T23:59:59Z",
               location: "Main Hall",
               guestOfHonour: "Jane Doe",
+              sponsors: "Example Ltd",
+              details: "## Evening programme\n\nDinner and dancing.",
               maxGuestsWithoutModeratorApproval: 2,
             },
           ],
@@ -260,6 +291,8 @@ describe("SectionEventsManager", () => {
           bookingEndDateTime: "2025-02-28T23:59:59Z",
           location: "Main Hall",
           guestOfHonour: "Jane Doe",
+          sponsors: "Example Ltd",
+          details: "## Evening programme\n\nDinner and dancing.",
           maxGuestsWithoutModeratorApproval: 2,
           ticketTypes: [],
         },
@@ -276,7 +309,43 @@ describe("SectionEventsManager", () => {
     expect(screen.getByRole("dialog", { name: /edit event/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/title/i)).toHaveValue("Annual Dinner");
     expect(screen.getByLabelText(/location/i)).toHaveValue("Main Hall");
+    expect(screen.getByLabelText(/^sponsors$/i)).toHaveValue("Example Ltd");
+    expect(screen.getByLabelText(/^event details$/i)).toHaveValue("## Evening programme\n\nDinner and dancing.");
+    expect(screen.getByRole("heading", { name: "Evening programme", level: 4 })).toBeInTheDocument();
     expect(screen.getByLabelText(/max guests without moderator approval/i)).toHaveValue(2);
+  });
+
+  it("persists cleared optional event content as null", async () => {
+    const user = userEvent.setup();
+    const event = {
+      id: "ev-1",
+      title: "Annual Dinner",
+      startDateTime: "2025-03-01T18:00:00Z",
+      endDateTime: "2025-03-01T22:00:00Z",
+      bookingStartDateTime: "2025-02-01T00:00:00Z",
+      bookingEndDateTime: "2025-02-28T23:59:59Z",
+      location: "Main Hall",
+      guestOfHonour: "Jane Doe",
+      sponsors: "Example Ltd",
+      details: "Existing details",
+      maxGuestsWithoutModeratorApproval: 2,
+    };
+    mockGetEventsForSection({ data: { section: { id: sectionId, events: [event] } }, isLoading: false, isError: false });
+    mockGetEventById({ data: { event: { ...event, ticketTypes: [] } }, isLoading: false, isError: false });
+
+    render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
+    await user.click(screen.getByRole("button", { name: /event admin/i }));
+    await user.click(screen.getByRole("button", { name: /^event details$/i }));
+    await user.click(screen.getByRole("button", { name: /edit event details/i }));
+    await user.clear(screen.getByLabelText(/^sponsors$/i));
+    await user.clear(screen.getByLabelText(/^event details$/i));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(generated.updateEventRef).toHaveBeenCalled());
+    expect(generated.updateEventRef).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ sponsors: null, details: null })
+    );
   });
 
   it("renders refreshed selected-event details after editing", async () => {

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -355,8 +355,8 @@ describe("SectionEventsManager", () => {
     await user.click(screen.getByRole("button", { name: /event admin/i }));
     await user.click(screen.getByRole("button", { name: /^event details$/i }));
     await user.click(screen.getByRole("button", { name: /edit event details/i }));
-    await user.clear(screen.getByLabelText(/^sponsors$/i));
-    await user.clear(screen.getByLabelText(/^event details$/i));
+    fireEvent.change(screen.getByLabelText(/^sponsors$/i), { target: { value: "" } });
+    fireEvent.change(screen.getByLabelText(/^event details$/i), { target: { value: "" } });
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => expect(generated.updateEventRef).toHaveBeenCalled());
@@ -415,8 +415,7 @@ describe("SectionEventsManager", () => {
     await user.click(screen.getByRole("button", { name: /event admin/i }));
     await user.click(screen.getByRole("button", { name: /^event details$/i }));
     await user.click(screen.getByRole("button", { name: /edit event details/i }));
-    await user.clear(screen.getByLabelText(/title/i));
-    await user.type(screen.getByLabelText(/title/i), "Updated Dinner");
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Updated Dinner" } });
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {

--- a/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
+++ b/src/features/admin/components/__tests__/SectionEventsManager.test.tsx
@@ -178,9 +178,11 @@ describe("SectionEventsManager", () => {
     render(<SectionEventsManager sectionId={sectionId} sectionName={sectionName} onBack={onBack} />);
 
     await user.click(screen.getByRole("button", { name: /add event/i }));
-    await user.type(screen.getByLabelText(/title/i), "Sponsored dinner");
-    await user.type(screen.getByLabelText(/^sponsors$/i), "Example Ltd");
-    await user.type(screen.getByLabelText(/^event details$/i), "# Welcome\n\nPlease read **carefully**.");
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Sponsored dinner" } });
+    fireEvent.change(screen.getByLabelText(/^sponsors$/i), { target: { value: "Example Ltd" } });
+    fireEvent.change(screen.getByLabelText(/^event details$/i), {
+      target: { value: "# Welcome\n\nPlease read **carefully**." },
+    });
 
     expect(screen.getByRole("heading", { name: "Welcome", level: 3 })).toBeInTheDocument();
     expect(screen.getByText("carefully").tagName).toBe("STRONG");

--- a/src/features/admin/components/sectionEventsManagerSurfaces/EventDialogSurface.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/EventDialogSurface.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   CircularProgress,
   Dialog,
@@ -6,7 +7,9 @@ import {
   DialogContent,
   DialogTitle,
   TextField,
+  Typography,
 } from "@mui/material";
+import SafeMarkdown from "../../../../shared/components/SafeMarkdown";
 import type { EventRow } from "../sectionEventsManagerTypes";
 
 interface EventDialogSurfaceProps {
@@ -15,6 +18,8 @@ interface EventDialogSurfaceProps {
   title: string;
   location: string;
   guestOfHonour: string;
+  sponsors: string;
+  details: string;
   startDateTime: string;
   endDateTime: string;
   bookingStartDateTime: string;
@@ -26,6 +31,8 @@ interface EventDialogSurfaceProps {
   onTitleChange: (value: string) => void;
   onLocationChange: (value: string) => void;
   onGuestOfHonourChange: (value: string) => void;
+  onSponsorsChange: (value: string) => void;
+  onDetailsChange: (value: string) => void;
   onStartDateTimeChange: (value: string) => void;
   onEndDateTimeChange: (value: string) => void;
   onBookingStartDateTimeChange: (value: string) => void;
@@ -38,6 +45,8 @@ export function EventDialogSurface({
   title,
   location,
   guestOfHonour,
+  sponsors,
+  details,
   startDateTime,
   endDateTime,
   bookingStartDateTime,
@@ -49,6 +58,8 @@ export function EventDialogSurface({
   onTitleChange,
   onLocationChange,
   onGuestOfHonourChange,
+  onSponsorsChange,
+  onDetailsChange,
   onStartDateTimeChange,
   onEndDateTimeChange,
   onBookingStartDateTimeChange,
@@ -56,7 +67,7 @@ export function EventDialogSurface({
   onMaxGuestsChange,
 }: EventDialogSurfaceProps) {
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>{editingEvent ? "Edit event" : "Add event"}</DialogTitle>
       <DialogContent>
         <TextField label="Title" fullWidth value={title} onChange={(event) => onTitleChange(event.target.value)} margin="dense" required />
@@ -68,6 +79,36 @@ export function EventDialogSurface({
           onChange={(event) => onGuestOfHonourChange(event.target.value)}
           margin="dense"
         />
+        <TextField
+          label="Sponsors"
+          fullWidth
+          multiline
+          minRows={2}
+          value={sponsors}
+          onChange={(event) => onSponsorsChange(event.target.value)}
+          margin="dense"
+          helperText="Enter one or more sponsor names. Line breaks are preserved."
+        />
+        <TextField
+          label="Event details"
+          fullWidth
+          multiline
+          minRows={6}
+          value={details}
+          onChange={(event) => onDetailsChange(event.target.value)}
+          margin="dense"
+          helperText="Supports Markdown headings, paragraphs, emphasis, lists, links, quotes, and inline code. Raw HTML is ignored."
+        />
+        <Typography variant="subtitle2" sx={{ mt: 2 }}>
+          Event details preview
+        </Typography>
+        <Box sx={{ mt: 1, mb: 1, p: 2, minHeight: 64, border: 1, borderColor: "divider", borderRadius: 1 }}>
+          {details.trim() ? (
+            <SafeMarkdown>{details}</SafeMarkdown>
+          ) : (
+            <Typography variant="body2" color="text.secondary">Nothing to preview.</Typography>
+          )}
+        </Box>
         <TextField
           label="Start date/time"
           type="datetime-local"

--- a/src/features/admin/components/sectionEventsManagerSurfaces/EventDialogSurface.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/EventDialogSurface.tsx
@@ -66,6 +66,7 @@ export function EventDialogSurface({
   onBookingEndDateTimeChange,
   onMaxGuestsChange,
 }: EventDialogSurfaceProps) {
+  const previewDetails = details.trim();
   return (
     <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
       <DialogTitle>{editingEvent ? "Edit event" : "Add event"}</DialogTitle>
@@ -103,8 +104,8 @@ export function EventDialogSurface({
           Event details preview
         </Typography>
         <Box sx={{ mt: 1, mb: 1, p: 2, minHeight: 64, border: 1, borderColor: "divider", borderRadius: 1 }}>
-          {details.trim() ? (
-            <SafeMarkdown>{details}</SafeMarkdown>
+          {previewDetails ? (
+            <SafeMarkdown>{previewDetails}</SafeMarkdown>
           ) : (
             <Typography variant="body2" color="text.secondary">Nothing to preview.</Typography>
           )}

--- a/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
@@ -33,6 +33,7 @@ import type {
   TicketOrderAdminRow,
   TicketTypeRow,
 } from "../sectionEventsManagerTypes";
+import SafeMarkdown from "../../../../shared/components/SafeMarkdown";
 import type { EventAttendeeTicketRow, TicketOrdersById } from "../../utils/bookingApprovalsAdmin";
 import {
   attendeePaymentState,
@@ -202,6 +203,16 @@ function EventDetailsSection({
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>Guest of honour</TableCell>
               <TableCell>{event.guestOfHonour ?? "—"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Sponsors</TableCell>
+              <TableCell sx={{ whiteSpace: "pre-line" }}>{event.sponsors?.trim() || "—"}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 600 }}>Details</TableCell>
+              <TableCell>
+                {event.details?.trim() ? <SafeMarkdown>{event.details}</SafeMarkdown> : "—"}
+              </TableCell>
             </TableRow>
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>Booking window</TableCell>

--- a/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
+++ b/src/features/admin/components/sectionEventsManagerSurfaces/TicketAdminSurface.tsx
@@ -175,6 +175,7 @@ function EventDetailsSection({
   if (!event) {
     return <Alert severity="info">Event details are not available.</Alert>;
   }
+  const details = event.details?.trim();
 
   return (
     <Box>
@@ -211,7 +212,7 @@ function EventDetailsSection({
             <TableRow>
               <TableCell sx={{ fontWeight: 600 }}>Details</TableCell>
               <TableCell>
-                {event.details?.trim() ? <SafeMarkdown>{event.details}</SafeMarkdown> : "—"}
+                {details ? <SafeMarkdown>{details}</SafeMarkdown> : "—"}
               </TableCell>
             </TableRow>
             <TableRow>

--- a/src/features/admin/components/sectionEventsManagerTypes.ts
+++ b/src/features/admin/components/sectionEventsManagerTypes.ts
@@ -10,6 +10,8 @@ export interface EventRow {
   title: string;
   location?: string | null;
   guestOfHonour?: string | null;
+  sponsors?: string | null;
+  details?: string | null;
   startDateTime: string;
   endDateTime: string;
   bookingStartDateTime: string;

--- a/src/features/sections/components/EventDetailHero.tsx
+++ b/src/features/sections/components/EventDetailHero.tsx
@@ -38,6 +38,11 @@ export default function EventDetailHero({ event }: EventDetailHeroProps) {
             Guest of honour: {event.guestOfHonour}
           </Typography>
         ) : null}
+        {event.sponsors?.trim() ? (
+          <Typography variant="body2" fontWeight={500} sx={{ whiteSpace: "pre-line" }}>
+            Sponsored by: {event.sponsors.trim()}
+          </Typography>
+        ) : null}
         <Typography variant="body2" color="text.secondary">
           {formatBookingWindow(event.bookingStartDateTime, event.bookingEndDateTime)}
         </Typography>

--- a/src/features/sections/components/EventDetailHero.tsx
+++ b/src/features/sections/components/EventDetailHero.tsx
@@ -1,7 +1,15 @@
-import { Box, Chip, Paper, Stack, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+import {
+  AccessTimeOutlined,
+  BusinessOutlined,
+  CalendarMonthOutlined,
+  EventAvailableOutlined,
+  GroupOutlined,
+  LocationOnOutlined,
+  PersonOutline,
+} from "@mui/icons-material";
+import { Box, Paper, Typography } from "@mui/material";
 import type { GetEventByIdData } from "@dataconnect/generated";
-import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
-import { formatGbpMajorAmount } from "../../../shared/utils/currencyDisplay";
 import { formatEventGuestPolicy } from "../utils/eventGuestPolicy";
 
 type EventDetail = NonNullable<GetEventByIdData["event"]>;
@@ -10,63 +18,137 @@ export interface EventDetailHeroProps {
   event: EventDetail;
 }
 
-function formatBookingWindow(start: string, end: string): string {
-  const opts: Intl.DateTimeFormatOptions = { day: "numeric", month: "long", year: "numeric" };
-  const s = new Date(start).toLocaleDateString(undefined, opts);
-  const e = new Date(end).toLocaleDateString(undefined, opts);
-  return `Bookings open ${s} – ${e}`;
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+const timeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function sameCalendarDay(start: Date, end: Date): boolean {
+  return (
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate()
+  );
+}
+
+function formatEventDate(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  return sameCalendarDay(start, end)
+    ? dateFormatter.format(start)
+    : `${dateFormatter.format(start)} – ${dateFormatter.format(end)}`;
+}
+
+function formatEventTime(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  return sameCalendarDay(start, end)
+    ? `${timeFormatter.format(start)} – ${timeFormatter.format(end)}`
+    : `Starts ${timeFormatter.format(start)} · Ends ${timeFormatter.format(end)}`;
+}
+
+function formatBookingWindow(startDateTime: string, endDateTime: string): string {
+  return `${shortDateFormatter.format(new Date(startDateTime))} to ${shortDateFormatter.format(new Date(endDateTime))}`;
+}
+
+function EventMetaItem({
+  icon,
+  label,
+  children,
+  fullWidth = false,
+}: {
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+  fullWidth?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: 1.25,
+        p: 1.5,
+        borderRadius: 1.5,
+        bgcolor: "action.hover",
+        gridColumn: fullWidth ? "1 / -1" : undefined,
+      }}
+    >
+      <Box sx={{ color: "primary.main", display: "flex", mt: 0.25 }} aria-hidden="true">
+        {icon}
+      </Box>
+      <Box>
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+          fontWeight={700}
+          sx={{ letterSpacing: "0.04em", textTransform: "uppercase" }}
+        >
+          {label}
+        </Typography>
+        <Typography variant="body2" component="div" sx={{ mt: 0.25, whiteSpace: "pre-line" }}>
+          {children}
+        </Typography>
+      </Box>
+    </Box>
+  );
 }
 
 export default function EventDetailHero({ event }: EventDetailHeroProps) {
   return (
-    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
-      <Typography variant="h5" component="h2" fontWeight={600} sx={{ mb: 1 }}>
+    <Paper variant="outlined" sx={{ p: { xs: 2, sm: 3 }, mb: 2 }}>
+      <Typography variant="h5" component="h2" fontWeight={600} sx={{ mb: 2 }}>
         {event.title}
       </Typography>
 
-      <Stack spacing={0.75} sx={{ mb: 2 }}>
-        <Typography variant="body2" color="text.secondary">
-          {formatSectionEventWhen(event.startDateTime, event.endDateTime)}
-        </Typography>
-        {event.location ? (
-          <Typography variant="body2" color="text.secondary">
-            {event.location}
-          </Typography>
+      <Box
+        aria-label="Event information"
+        sx={{
+          display: "grid",
+          gridTemplateColumns: { xs: "1fr", sm: "repeat(2, minmax(0, 1fr))" },
+          gap: 1.25,
+        }}
+      >
+        <EventMetaItem icon={<CalendarMonthOutlined fontSize="small" />} label="Date">
+          {formatEventDate(event.startDateTime, event.endDateTime)}
+        </EventMetaItem>
+        <EventMetaItem icon={<AccessTimeOutlined fontSize="small" />} label="Time">
+          {formatEventTime(event.startDateTime, event.endDateTime)}
+        </EventMetaItem>
+        {event.location?.trim() ? (
+          <EventMetaItem icon={<LocationOnOutlined fontSize="small" />} label="Location">
+            {event.location.trim()}
+          </EventMetaItem>
         ) : null}
-        {event.guestOfHonour ? (
-          <Typography variant="body2" fontWeight={500}>
-            Guest of honour: {event.guestOfHonour}
-          </Typography>
+        {event.guestOfHonour?.trim() ? (
+          <EventMetaItem icon={<PersonOutline fontSize="small" />} label="Guest of honour">
+            {event.guestOfHonour.trim()}
+          </EventMetaItem>
         ) : null}
         {event.sponsors?.trim() ? (
-          <Typography variant="body2" fontWeight={500} sx={{ whiteSpace: "pre-line" }}>
-            Sponsored by: {event.sponsors.trim()}
-          </Typography>
+          <EventMetaItem icon={<BusinessOutlined fontSize="small" />} label="Sponsored by">
+            {event.sponsors.trim()}
+          </EventMetaItem>
         ) : null}
-        <Typography variant="body2" color="text.secondary">
+        <EventMetaItem icon={<EventAvailableOutlined fontSize="small" />} label="Booking window">
           {formatBookingWindow(event.bookingStartDateTime, event.bookingEndDateTime)}
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
+        </EventMetaItem>
+        <EventMetaItem icon={<GroupOutlined fontSize="small" />} label="Guest bookings" fullWidth>
           {formatEventGuestPolicy(event.maxGuestsWithoutModeratorApproval)}
-        </Typography>
-      </Stack>
-
-      {(event.ticketTypes ?? []).length > 0 ? (
-        <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
-          {event.ticketTypes!.map((ticketType) => (
-            <Chip
-              key={ticketType.id}
-              size="small"
-              variant="outlined"
-              label={`${ticketType.title}${ticketType.price != null ? ` · ${formatGbpMajorAmount(ticketType.price)}` : ""}`}
-            />
-          ))}
-        </Box>
-      ) : (
-        <Typography variant="body2" color="text.secondary">
-          Ticket types will be published soon.
-        </Typography>
-      )}
+        </EventMetaItem>
+      </Box>
     </Paper>
   );
 }

--- a/src/features/sections/components/EventDetailHero.tsx
+++ b/src/features/sections/components/EventDetailHero.tsx
@@ -34,6 +34,10 @@ const timeFormatter = new Intl.DateTimeFormat(undefined, {
   minute: "2-digit",
 });
 
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime());
+}
+
 function sameCalendarDay(start: Date, end: Date): boolean {
   return (
     start.getFullYear() === end.getFullYear() &&
@@ -45,6 +49,9 @@ function sameCalendarDay(start: Date, end: Date): boolean {
 function formatEventDate(startDateTime: string, endDateTime: string): string {
   const start = new Date(startDateTime);
   const end = new Date(endDateTime);
+  if (!isValidDate(start) || !isValidDate(end)) {
+    return "Date unavailable";
+  }
   return sameCalendarDay(start, end)
     ? dateFormatter.format(start)
     : `${dateFormatter.format(start)} – ${dateFormatter.format(end)}`;
@@ -53,13 +60,21 @@ function formatEventDate(startDateTime: string, endDateTime: string): string {
 function formatEventTime(startDateTime: string, endDateTime: string): string {
   const start = new Date(startDateTime);
   const end = new Date(endDateTime);
+  if (!isValidDate(start) || !isValidDate(end)) {
+    return "Time unavailable";
+  }
   return sameCalendarDay(start, end)
     ? `${timeFormatter.format(start)} – ${timeFormatter.format(end)}`
     : `Starts ${timeFormatter.format(start)} · Ends ${timeFormatter.format(end)}`;
 }
 
 function formatBookingWindow(startDateTime: string, endDateTime: string): string {
-  return `${shortDateFormatter.format(new Date(startDateTime))} to ${shortDateFormatter.format(new Date(endDateTime))}`;
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  if (!isValidDate(start) || !isValidDate(end)) {
+    return "Booking dates unavailable";
+  }
+  return `${shortDateFormatter.format(start)} to ${shortDateFormatter.format(end)}`;
 }
 
 function EventMetaItem({

--- a/src/features/sections/components/EventDetailHero.tsx
+++ b/src/features/sections/components/EventDetailHero.tsx
@@ -10,6 +10,10 @@ import {
 } from "@mui/icons-material";
 import { Box, Paper, Typography } from "@mui/material";
 import type { GetEventByIdData } from "@dataconnect/generated";
+import {
+  formatSectionEventDate,
+  formatSectionEventTime,
+} from "../../../shared/utils/sectionEventDisplay";
 import { formatEventGuestPolicy } from "../utils/eventGuestPolicy";
 
 type EventDetail = NonNullable<GetEventByIdData["event"]>;
@@ -18,54 +22,13 @@ export interface EventDetailHeroProps {
   event: EventDetail;
 }
 
-const dateFormatter = new Intl.DateTimeFormat(undefined, {
-  weekday: "long",
-  day: "numeric",
-  month: "long",
-  year: "numeric",
-});
 const shortDateFormatter = new Intl.DateTimeFormat(undefined, {
   day: "numeric",
   month: "long",
   year: "numeric",
 });
-const timeFormatter = new Intl.DateTimeFormat(undefined, {
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
 function isValidDate(value: Date): boolean {
   return !Number.isNaN(value.getTime());
-}
-
-function sameCalendarDay(start: Date, end: Date): boolean {
-  return (
-    start.getFullYear() === end.getFullYear() &&
-    start.getMonth() === end.getMonth() &&
-    start.getDate() === end.getDate()
-  );
-}
-
-function formatEventDate(startDateTime: string, endDateTime: string): string {
-  const start = new Date(startDateTime);
-  const end = new Date(endDateTime);
-  if (!isValidDate(start) || !isValidDate(end)) {
-    return "Date unavailable";
-  }
-  return sameCalendarDay(start, end)
-    ? dateFormatter.format(start)
-    : `${dateFormatter.format(start)} – ${dateFormatter.format(end)}`;
-}
-
-function formatEventTime(startDateTime: string, endDateTime: string): string {
-  const start = new Date(startDateTime);
-  const end = new Date(endDateTime);
-  if (!isValidDate(start) || !isValidDate(end)) {
-    return "Time unavailable";
-  }
-  return sameCalendarDay(start, end)
-    ? `${timeFormatter.format(start)} – ${timeFormatter.format(end)}`
-    : `Starts ${timeFormatter.format(start)} · Ends ${timeFormatter.format(end)}`;
 }
 
 function formatBookingWindow(startDateTime: string, endDateTime: string): string {
@@ -137,10 +100,10 @@ export default function EventDetailHero({ event }: EventDetailHeroProps) {
         }}
       >
         <EventMetaItem icon={<CalendarMonthOutlined fontSize="small" />} label="Date">
-          {formatEventDate(event.startDateTime, event.endDateTime)}
+          {formatSectionEventDate(event.startDateTime, event.endDateTime)}
         </EventMetaItem>
         <EventMetaItem icon={<AccessTimeOutlined fontSize="small" />} label="Time">
-          {formatEventTime(event.startDateTime, event.endDateTime)}
+          {formatSectionEventTime(event.startDateTime, event.endDateTime)}
         </EventMetaItem>
         {event.location?.trim() ? (
           <EventMetaItem icon={<LocationOnOutlined fontSize="small" />} label="Location">

--- a/src/features/sections/components/EventDetailsContent.tsx
+++ b/src/features/sections/components/EventDetailsContent.tsx
@@ -1,0 +1,20 @@
+import { Paper, Typography } from "@mui/material";
+import SafeMarkdown from "../../../shared/components/SafeMarkdown";
+
+export interface EventDetailsContentProps {
+  details?: string | null;
+}
+
+export default function EventDetailsContent({ details }: EventDetailsContentProps) {
+  const content = details?.trim();
+  if (!content) return null;
+
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 2 }}>
+      <Typography variant="h6" component="h2" sx={{ mb: 1 }}>
+        Event details
+      </Typography>
+      <SafeMarkdown>{content}</SafeMarkdown>
+    </Paper>
+  );
+}

--- a/src/features/sections/components/SectionDetailViews.tsx
+++ b/src/features/sections/components/SectionDetailViews.tsx
@@ -27,6 +27,7 @@ import { eventDetailTabLabel, type EventDetailTab } from "../utils/sectionDetail
 import ContactDetailsDialog from "./ContactDetailsDialog";
 import EventBookingWizard from "./EventBookingWizard";
 import EventDetailHero from "./EventDetailHero";
+import EventDetailsContent from "./EventDetailsContent";
 import SectionEventCard from "./SectionEventCard";
 import SectionMemberCard from "./SectionMemberCard";
 import SectionMemberListItem from "./SectionMemberListItem";
@@ -367,6 +368,7 @@ export function SectionEventDetailView({
           {activeTab === "about" || !hasCurrentUser ? (
             <>
               <EventDetailHero event={event} />
+              <EventDetailsContent details={event.details} />
               {hasCurrentUser ? (
                 <Box sx={{ mt: 2 }}>
                   <Button

--- a/src/features/sections/components/SectionEventCard.tsx
+++ b/src/features/sections/components/SectionEventCard.tsx
@@ -1,4 +1,11 @@
+import type { ReactNode } from "react";
 import {
+  AccessTimeOutlined,
+  CalendarMonthOutlined,
+  LocationOnOutlined,
+} from "@mui/icons-material";
+import {
+  Box,
   Card,
   CardActionArea,
   CardContent,
@@ -6,12 +13,39 @@ import {
   Typography,
 } from "@mui/material";
 import type { SectionEventListItem } from "../../../shared/utils/sectionEventDisplay";
-import { formatSectionEventWhen } from "../../../shared/utils/sectionEventDisplay";
+import {
+  formatSectionEventDate,
+  formatSectionEventTime,
+} from "../../../shared/utils/sectionEventDisplay";
 
 export interface SectionEventCardProps {
   event: SectionEventListItem;
   variant?: "upcoming" | "past";
   onSelect: (eventId: string) => void;
+}
+
+function EventCardMeta({ icon, label, children }: { icon: ReactNode; label: string; children: ReactNode }) {
+  return (
+    <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1 }}>
+      <Box sx={{ color: "primary.main", display: "flex", mt: 0.25 }} aria-hidden="true">
+        {icon}
+      </Box>
+      <Box sx={{ minWidth: 0 }}>
+        <Typography
+          variant="caption"
+          component="div"
+          color="text.secondary"
+          fontWeight={700}
+          sx={{ letterSpacing: "0.04em", textTransform: "uppercase" }}
+        >
+          {label}
+        </Typography>
+        <Typography variant="body2" component="div" sx={{ mt: 0.125 }}>
+          {children}
+        </Typography>
+      </Box>
+    </Box>
+  );
 }
 
 export default function SectionEventCard({
@@ -53,19 +87,19 @@ export default function SectionEventCard({
           <Typography variant="subtitle1" component="h3" fontWeight={600} gutterBottom>
             {event.title}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {formatSectionEventWhen(event.startDateTime, event.endDateTime)}
-          </Typography>
-          {event.location ? (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              {event.location}
-            </Typography>
-          ) : null}
-          {event.guestOfHonour ? (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              Guest of honour: {event.guestOfHonour}
-            </Typography>
-          ) : null}
+          <Box aria-label="Event information" sx={{ display: "grid", gap: 1.25, mt: 1.5 }}>
+            <EventCardMeta icon={<CalendarMonthOutlined fontSize="small" />} label="Date">
+              {formatSectionEventDate(event.startDateTime, event.endDateTime)}
+            </EventCardMeta>
+            <EventCardMeta icon={<AccessTimeOutlined fontSize="small" />} label="Time">
+              {formatSectionEventTime(event.startDateTime, event.endDateTime)}
+            </EventCardMeta>
+            {event.location?.trim() ? (
+              <EventCardMeta icon={<LocationOnOutlined fontSize="small" />} label="Location">
+                {event.location.trim()}
+              </EventCardMeta>
+            ) : null}
+          </Box>
         </CardContent>
       </CardActionArea>
     </Card>

--- a/src/features/sections/components/__tests__/EventContent.test.tsx
+++ b/src/features/sections/components/__tests__/EventContent.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "../../../../test-utils";
+import EventDetailHero from "../EventDetailHero";
+import EventDetailsContent from "../EventDetailsContent";
+
+const event = {
+  id: "event-1",
+  title: "Annual Dinner",
+  location: "Main Hall",
+  guestOfHonour: "Alex Example",
+  sponsors: "Example Ltd\nPartner Org",
+  details: "## Programme\n\nWelcome **everyone**.\n\n[More information](https://example.com/event)",
+  startDateTime: "2026-10-01T18:00:00Z",
+  endDateTime: "2026-10-01T22:00:00Z",
+  bookingStartDateTime: "2026-08-01T00:00:00Z",
+  bookingEndDateTime: "2026-09-20T23:59:59Z",
+  maxGuestsWithoutModeratorApproval: 1,
+  ticketTypes: [],
+} as never;
+
+describe("event content", () => {
+  it("shows sponsors and safely rendered Markdown details", () => {
+    render(
+      <>
+        <EventDetailHero event={event} />
+        <EventDetailsContent details={(event as { details: string }).details} />
+      </>
+    );
+
+    expect(screen.getByText(/Sponsored by:/)).toHaveTextContent("Example Ltd Partner Org");
+    expect(screen.getByRole("heading", { name: "Event details", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Programme", level: 4 })).toBeInTheDocument();
+    expect(screen.getByText("everyone").tagName).toBe("STRONG");
+    expect(screen.getByRole("link", { name: "More information" })).toHaveAttribute(
+      "href",
+      "https://example.com/event"
+    );
+  });
+
+  it("renders no details surface for empty content", () => {
+    const { container } = render(<EventDetailsContent details="   " />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/features/sections/components/__tests__/EventContent.test.tsx
+++ b/src/features/sections/components/__tests__/EventContent.test.tsx
@@ -15,7 +15,9 @@ const event = {
   bookingStartDateTime: "2026-08-01T00:00:00Z",
   bookingEndDateTime: "2026-09-20T23:59:59Z",
   maxGuestsWithoutModeratorApproval: 1,
-  ticketTypes: [],
+  ticketTypes: [
+    { id: "ticket-1", title: "Dinner ticket", price: 50 },
+  ],
 } as never;
 
 describe("event content", () => {
@@ -27,7 +29,15 @@ describe("event content", () => {
       </>
     );
 
-    expect(screen.getByText(/Sponsored by:/)).toHaveTextContent("Example Ltd Partner Org");
+    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Time")).toBeInTheDocument();
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Guest of honour")).toBeInTheDocument();
+    expect(screen.getByText("Sponsored by")).toBeInTheDocument();
+    expect(screen.getByText(/Example Ltd/)).toHaveTextContent("Example Ltd Partner Org");
+    expect(screen.getByText("Booking window")).toBeInTheDocument();
+    expect(screen.getByText("Guest bookings")).toBeInTheDocument();
+    expect(screen.queryByText(/Dinner ticket/)).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Event details", level: 2 })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Programme", level: 4 })).toBeInTheDocument();
     expect(screen.getByText("everyone").tagName).toBe("STRONG");
@@ -35,6 +45,23 @@ describe("event content", () => {
       "href",
       "https://example.com/event"
     );
+  });
+
+  it("omits optional metadata when it is not configured", () => {
+    render(
+      <EventDetailHero
+        event={{
+          ...(event as object),
+          location: null,
+          guestOfHonour: null,
+          sponsors: null,
+        } as never}
+      />
+    );
+
+    expect(screen.queryByText("Location")).not.toBeInTheDocument();
+    expect(screen.queryByText("Guest of honour")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sponsored by")).not.toBeInTheDocument();
   });
 
   it("renders no details surface for empty content", () => {

--- a/src/features/sections/components/__tests__/EventContent.test.tsx
+++ b/src/features/sections/components/__tests__/EventContent.test.tsx
@@ -64,6 +64,24 @@ describe("event content", () => {
     expect(screen.queryByText("Sponsored by")).not.toBeInTheDocument();
   });
 
+  it("shows friendly fallbacks when event dates are invalid", () => {
+    render(
+      <EventDetailHero
+        event={{
+          ...(event as object),
+          startDateTime: "invalid-start",
+          endDateTime: "invalid-end",
+          bookingStartDateTime: "invalid-booking-start",
+          bookingEndDateTime: "invalid-booking-end",
+        } as never}
+      />
+    );
+
+    expect(screen.getByText("Date unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Time unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Booking dates unavailable")).toBeInTheDocument();
+  });
+
   it("renders no details surface for empty content", () => {
     const { container } = render(<EventDetailsContent details="   " />);
     expect(container).toBeEmptyDOMElement();

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -1280,7 +1280,11 @@ describe('SectionDetail', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Old Dinner')).toBeInTheDocument();
-      expect(screen.getByText('Guest of honour: Guest')).toBeInTheDocument();
+      expect(screen.getByText('Date')).toBeInTheDocument();
+      expect(screen.getByText('Time')).toBeInTheDocument();
+      expect(screen.getByText('Location')).toBeInTheDocument();
+      expect(screen.getByText('Hall')).toBeInTheDocument();
+      expect(screen.queryByText(/Guest of honour/)).not.toBeInTheDocument();
     });
   });
 

--- a/src/features/sections/components/__tests__/SectionDetail.test.tsx
+++ b/src/features/sections/components/__tests__/SectionDetail.test.tsx
@@ -755,9 +755,12 @@ describe('SectionDetail', () => {
     await waitFor(() => {
       expect(screen.getByText('Back to events')).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: 'Annual Dinner', level: 2 })).toBeInTheDocument();
+      expect(screen.getByText('Location')).toBeInTheDocument();
       expect(screen.getByText('Main Hall')).toBeInTheDocument();
-      expect(screen.getByText(/Guest of honour: Jane Doe/)).toBeInTheDocument();
-      expect(screen.getByText(/Standard · £25\.00/)).toBeInTheDocument();
+      expect(screen.getByText('Guest of honour')).toBeInTheDocument();
+      expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+      expect(screen.queryByText(/Standard/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/£25\.00/)).not.toBeInTheDocument();
       expect(screen.getByRole('button', { name: 'Book this event' })).toBeInTheDocument();
       expect(screen.queryByText('Ticket types')).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Pay' })).not.toBeInTheDocument();
@@ -1312,7 +1315,7 @@ describe('SectionDetail', () => {
     });
   });
 
-  it('should show ticket type without price on the About tab', async () => {
+  it('does not show ticket types on the About tab', async () => {
     const eventId = 'event-1';
     const mockSectionData = {
       section: {
@@ -1369,8 +1372,8 @@ describe('SectionDetail', () => {
     await waitFor(() => expect(screen.getByText('Annual Dinner')).toBeInTheDocument());
     await user.click(screen.getByRole('button', { name: /annual dinner/i }));
 
-    // About tab is default — EventDetailHero shows with no price on ticket chip
-    await waitFor(() => expect(screen.getByText('Standard')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Booking window')).toBeInTheDocument());
+    expect(screen.queryByText('Standard')).not.toBeInTheDocument();
     expect(screen.queryByText(/£/)).not.toBeInTheDocument();
   });
 

--- a/src/shared/components/SafeMarkdown.tsx
+++ b/src/shared/components/SafeMarkdown.tsx
@@ -1,0 +1,69 @@
+import { Box, Divider, Link, Typography } from "@mui/material";
+import ReactMarkdown, { defaultUrlTransform, type Components } from "react-markdown";
+
+const ALLOWED_ELEMENTS = [
+  "h1",
+  "h2",
+  "h3",
+  "p",
+  "em",
+  "strong",
+  "ul",
+  "ol",
+  "li",
+  "a",
+  "blockquote",
+  "code",
+  "hr",
+  "br",
+] as const;
+
+const components: Components = {
+  h1: ({ children }) => <Typography component="h3" variant="h5" sx={{ mt: 2, mb: 1 }}>{children}</Typography>,
+  h2: ({ children }) => <Typography component="h4" variant="h6" sx={{ mt: 2, mb: 1 }}>{children}</Typography>,
+  h3: ({ children }) => <Typography component="h5" variant="subtitle1" fontWeight={600} sx={{ mt: 2, mb: 1 }}>{children}</Typography>,
+  p: ({ children }) => <Typography component="p" variant="body1" sx={{ my: 1 }}>{children}</Typography>,
+  ul: ({ children }) => <Box component="ul" sx={{ my: 1, pl: 3 }}>{children}</Box>,
+  ol: ({ children }) => <Box component="ol" sx={{ my: 1, pl: 3 }}>{children}</Box>,
+  li: ({ children }) => <Box component="li" sx={{ mb: 0.5 }}>{children}</Box>,
+  a: ({ href, children }) => {
+    if (!href) return <Typography component="span">{children}</Typography>;
+    const external = href?.startsWith("http://") || href?.startsWith("https://");
+    return (
+      <Link href={href} target={external ? "_blank" : undefined} rel={external ? "noreferrer noopener" : undefined}>
+        {children}
+      </Link>
+    );
+  },
+  blockquote: ({ children }) => (
+    <Box component="blockquote" sx={{ my: 1.5, mx: 0, pl: 2, borderLeft: 4, borderColor: "divider", color: "text.secondary" }}>
+      {children}
+    </Box>
+  ),
+  code: ({ children }) => (
+    <Box component="code" sx={{ px: 0.5, py: 0.25, borderRadius: 0.5, bgcolor: "action.hover", fontFamily: "monospace" }}>
+      {children}
+    </Box>
+  ),
+  hr: () => <Divider sx={{ my: 2 }} />,
+};
+
+export interface SafeMarkdownProps {
+  children: string;
+}
+
+export default function SafeMarkdown({ children }: SafeMarkdownProps) {
+  return (
+    <Box sx={{ overflowWrap: "anywhere", color: "text.primary" }}>
+      <ReactMarkdown
+        allowedElements={[...ALLOWED_ELEMENTS]}
+        components={components}
+        skipHtml
+        unwrapDisallowed
+        urlTransform={defaultUrlTransform}
+      >
+        {children}
+      </ReactMarkdown>
+    </Box>
+  );
+}

--- a/src/shared/components/__tests__/SafeMarkdown.test.tsx
+++ b/src/shared/components/__tests__/SafeMarkdown.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "../../../test-utils";
+import SafeMarkdown from "../SafeMarkdown";
+
+describe("SafeMarkdown", () => {
+  it("renders the supported CommonMark content with accessible structure", () => {
+    render(
+      <SafeMarkdown>{`# Welcome
+
+This is *important* and **strong**.
+
+- First item
+- Second item
+
+[SODC website](https://example.com)`}</SafeMarkdown>
+    );
+
+    expect(screen.getByRole("heading", { name: "Welcome", level: 3 })).toBeInTheDocument();
+    expect(screen.getByText("important").tagName).toBe("EM");
+    expect(screen.getByText("strong").tagName).toBe("STRONG");
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "SODC website" })).toHaveAttribute("href", "https://example.com");
+    expect(screen.getByRole("link", { name: "SODC website" })).toHaveAttribute("rel", "noreferrer noopener");
+  });
+
+  it("drops raw HTML and prevents unsafe link schemes", () => {
+    render(
+      <SafeMarkdown>{`<script>alert("unsafe")</script>
+
+<img src=x onerror=alert(1)>
+
+[Unsafe link](javascript:alert(1))`}</SafeMarkdown>
+    );
+
+    expect(screen.queryByText('alert("unsafe")')).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Unsafe link" })).not.toBeInTheDocument();
+    expect(screen.getByText("Unsafe link")).toBeInTheDocument();
+  });
+});

--- a/src/shared/utils/__tests__/sectionEventDisplay.test.ts
+++ b/src/shared/utils/__tests__/sectionEventDisplay.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatSectionEventDate,
+  formatSectionEventTime,
   formatSectionEventWhen,
   isUpcomingSectionEvent,
   partitionSectionEventsByTiming,
@@ -65,5 +67,12 @@ describe("sectionEventDisplay", () => {
     );
     expect(formatted).toContain("–");
     expect(formatted.length).toBeGreaterThan(10);
+  });
+
+  it("formats event dates and times separately with safe fallbacks", () => {
+    expect(formatSectionEventDate("2026-07-01T18:00:00.000Z", "2026-07-01T22:00:00.000Z")).not.toContain("–");
+    expect(formatSectionEventTime("2026-07-01T18:00:00.000Z", "2026-07-01T22:00:00.000Z")).toContain("–");
+    expect(formatSectionEventDate("invalid", "invalid")).toBe("Date unavailable");
+    expect(formatSectionEventTime("invalid", "invalid")).toBe("Time unavailable");
   });
 });

--- a/src/shared/utils/sectionEventDisplay.ts
+++ b/src/shared/utils/sectionEventDisplay.ts
@@ -9,6 +9,47 @@ export interface SectionEventListItem {
   imageUrl?: string | null;
 }
 
+const eventDateFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+const eventTimeFormatter = new Intl.DateTimeFormat(undefined, {
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+function isValidDate(value: Date): boolean {
+  return !Number.isNaN(value.getTime());
+}
+
+function isSameCalendarDay(start: Date, end: Date): boolean {
+  return (
+    start.getFullYear() === end.getFullYear() &&
+    start.getMonth() === end.getMonth() &&
+    start.getDate() === end.getDate()
+  );
+}
+
+export function formatSectionEventDate(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  if (!isValidDate(start) || !isValidDate(end)) return "Date unavailable";
+  return isSameCalendarDay(start, end)
+    ? eventDateFormatter.format(start)
+    : `${eventDateFormatter.format(start)} – ${eventDateFormatter.format(end)}`;
+}
+
+export function formatSectionEventTime(startDateTime: string, endDateTime: string): string {
+  const start = new Date(startDateTime);
+  const end = new Date(endDateTime);
+  if (!isValidDate(start) || !isValidDate(end)) return "Time unavailable";
+  return isSameCalendarDay(start, end)
+    ? `${eventTimeFormatter.format(start)} – ${eventTimeFormatter.format(end)}`
+    : `Starts ${eventTimeFormatter.format(start)} · Ends ${eventTimeFormatter.format(end)}`;
+}
+
 /**
  * Upcoming events: endDateTime is still in the future (includes events currently in progress).
  * Matches the welcome dashboard rule in useUpcomingEventsForUser (#232).


### PR DESCRIPTION
## Summary

- add optional sponsors and Markdown details fields to the Event schema and Data Connect operations
- regenerate the frontend and Functions Data Connect SDKs
- add sponsors and event-details inputs to the event admin dialog with a live preview
- render sponsors and safe, theme-aware Markdown on member event pages and in event administration
- add a shared CommonMark renderer that ignores raw HTML and disables unsafe links
- add persistence, rendering, empty-state, connector-contract, and Markdown security coverage

## Why

Event organisers need to acknowledge sponsors and publish richer event information without introducing a separate sponsor-management model or allowing arbitrary HTML.

## User impact

Administrators can create, edit, preview, and clear sponsor and event-details content. Members see sponsor names and formatted details only when those fields are populated. Existing events remain valid because both fields are nullable.

## Deployment

This is an additive Data Connect schema change. Deploy Data Connect before the updated Functions and Hosting artifacts. No data backfill is required.

## Validation

- frontend suite: 762 tests passed
- Functions suite: 970 tests passed
- deployment safety suite: 55 tests passed
- app and Functions builds passed
- app and Functions lint passed
- Data Connect SDK generation passed
- dependency audit findings are the same two pre-existing development-tool advisories on main; react-markdown is not in either dependency path

Closes #597