### PR TITLE
Fix member dashboard event loading

### DIFF
--- a/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
+++ b/src/features/welcome/hooks/__tests__/useUpcomingEventsForUser.test.ts
@@ -1,15 +1,13 @@
 import { afterEach, describe, expect, it, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { SectionType } from "@dataconnect/generated";
-import { getEventsForSection } from "@dataconnect/generated";
+import { getSectionEventsForUser } from "../../../../shared/utils/firebaseFunctions";
 import { sectionsFingerprint, useUpcomingEventsForUser } from "../useUpcomingEventsForUser";
 import type { AccessibleSection } from "../../../../shared/navigation/extractAccessibleSections";
 
-vi.mock("@dataconnect/generated", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@dataconnect/generated")>();
+vi.mock("../../../../shared/utils/firebaseFunctions", () => {
   return {
-    ...actual,
-    getEventsForSection: vi.fn(),
+    getSectionEventsForUser: vi.fn(),
   };
 });
 
@@ -30,61 +28,52 @@ describe("sectionsFingerprint", () => {
 
 describe("useUpcomingEventsForUser", () => {
   beforeEach(() => {
-    vi.mocked(getEventsForSection).mockReset();
-    vi.mocked(getEventsForSection).mockResolvedValue({
-      data: {
-        section: {
-          id: "section-1",
-          events: [
-            {
-              id: "event-1",
-              title: "Dinner",
-              location: "Club",
-              guestOfHonour: null,
-              startDateTime: "2030-01-01T18:00:00.000Z",
-              endDateTime: "2030-01-01T22:00:00.000Z",
-              bookingStartDateTime: "2029-01-01T00:00:00.000Z",
-              bookingEndDateTime: "2030-01-01T00:00:00.000Z",
-              maxGuestsWithoutModeratorApproval: null,
-            },
-          ],
+    vi.mocked(getSectionEventsForUser).mockReset();
+    vi.mocked(getSectionEventsForUser).mockResolvedValue({
+      events: [
+        {
+          id: "event-1",
+          title: "Dinner",
+          location: "Club",
+          guestOfHonour: null,
+          startDateTime: "2030-01-01T18:00:00.000Z",
+          endDateTime: "2030-01-01T22:00:00.000Z",
+          bookingStartDateTime: "2029-01-01T00:00:00.000Z",
+          bookingEndDateTime: "2030-01-01T00:00:00.000Z",
+          maxGuestsWithoutModeratorApproval: null,
         },
-      },
-    } as unknown as Awaited<ReturnType<typeof getEventsForSection>>);
+      ],
+    } as unknown as Awaited<ReturnType<typeof getSectionEventsForUser>>);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("does not refetch when the sections array reference changes but content is the same", async () => {
+  it("loads events through the member-safe callable without refetching unchanged sections", async () => {
     const { result, rerender } = renderHook(
       ({ sections }) => useUpcomingEventsForUser(sections),
       { initialProps: { sections: [eventSection] } }
     );
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(getEventsForSection).toHaveBeenCalledTimes(1);
+    expect(getSectionEventsForUser).toHaveBeenCalledOnce();
+    expect(getSectionEventsForUser).toHaveBeenCalledWith("section-1");
 
     rerender({ sections: [{ ...eventSection }] });
 
     await waitFor(() => expect(result.current.events).toHaveLength(1));
-    expect(getEventsForSection).toHaveBeenCalledTimes(1);
+    expect(getSectionEventsForUser).toHaveBeenCalledTimes(1);
   });
 
   it("can retry a failed request and recover", async () => {
     const failure = new Error("temporary network failure");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.mocked(getEventsForSection)
+    vi.mocked(getSectionEventsForUser)
       .mockRejectedValueOnce(failure)
       .mockResolvedValueOnce({
-        data: {
-          section: {
-            id: "section-1",
-            events: [],
-          },
-        },
-      } as unknown as Awaited<ReturnType<typeof getEventsForSection>>);
+        events: [],
+      } as Awaited<ReturnType<typeof getSectionEventsForUser>>);
 
     const { result } = renderHook(() => useUpcomingEventsForUser([eventSection]));
     await waitFor(() => expect(result.current.isError).toBe(true));
@@ -92,7 +81,7 @@ describe("useUpcomingEventsForUser", () => {
     act(() => result.current.retry());
 
     await waitFor(() => expect(result.current.isError).toBe(false));
-    expect(getEventsForSection).toHaveBeenCalledTimes(2);
+    expect(getSectionEventsForUser).toHaveBeenCalledTimes(2);
     expect(consoleError).toHaveBeenCalledWith("[welcome.upcoming-events]", failure, {});
     consoleError.mockRestore();
   });

--- a/src/features/welcome/hooks/useUpcomingEventsForUser.ts
+++ b/src/features/welcome/hooks/useUpcomingEventsForUser.ts
@@ -1,10 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getEventsForSection } from "@dataconnect/generated";
-import type { UUIDString } from "@dataconnect/generated";
 import { SectionType } from "@dataconnect/generated";
-import { dataConnect } from "../../../config/firebase";
 import type { AccessibleSection } from "../../../shared/navigation/extractAccessibleSections";
 import { reportError } from "../../../shared/errors";
+import { getSectionEventsForUser } from "../../../shared/utils/firebaseFunctions";
 import {
   isUpcomingSectionEvent,
   sortUpcomingSectionEvents,
@@ -40,7 +38,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
       names[section.id] = section.name;
     }
     return {
-      eventSectionIds: eventSections.map((s) => s.id as UUIDString).sort(),
+      eventSectionIds: eventSections.map((s) => s.id).sort(),
       sectionNameById: names,
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- fingerprint encodes sections content without unstable array refs
@@ -57,7 +55,7 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
 
   useEffect(() => {
     const ids = eventSectionIdsKey
-      ? (eventSectionIdsKey.split(",").filter(Boolean) as UUIDString[])
+      ? eventSectionIdsKey.split(",").filter(Boolean)
       : [];
 
     if (ids.length === 0) {
@@ -81,9 +79,8 @@ export function useUpcomingEventsForUser(sections: AccessibleSection[]) {
       try {
         const results = await Promise.all(
           ids.map(async (sectionId) => {
-            const result = await getEventsForSection(dataConnect, { sectionId });
-            const section = result.data?.section;
-            return (section?.events ?? []).map((event) => ({
+            const result = await getSectionEventsForUser(sectionId);
+            return result.events.map((event) => ({
               id: event.id,
               title: event.title,
               location: event.location,


### PR DESCRIPTION
## Summary

- route welcome-dashboard event requests through the access-checked `getSectionEventsForUser` callable
- remove direct client use of the admin-only `GetEventsForSection` query
- update regression tests to assert the member-safe path and preserve retry/no-refetch behaviour

## Root cause

`GetEventsForSection` was hardened to require an enabled admin token, but `useUpcomingEventsForUser` continued to call it directly. Enabled non-admin members could load their accessible section cards but received an authorization error when the dashboard fetched upcoming events.

## User impact

Enabled non-admin members can now see upcoming events for EVENTS sections they are authorized to access. The server-side callable continues to reject inaccessible sections.

## Validation

- `npm test -- --run` — 102 files, 767 tests passed
- focused ESLint checks
- `npm run build`
- `git diff --check`

Fixes #600