### PR TITLE
Reduce member search request volume

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,6 +13,7 @@ export const ITEMS_PER_PAGE = 25;
 
 // Debounce delays (in milliseconds)
 export const SEARCH_DEBOUNCE_MS = 500;
+export const MIN_SEARCH_CHARACTERS = 2;
 
 // UI timeouts (in milliseconds)
 export const SUCCESS_MESSAGE_TIMEOUT = 1500;

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -44,7 +44,7 @@ import type {
   UserSummary,
 } from "./userGroupsTypes";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
-import { SEARCH_DEBOUNCE_MS } from "../../../constants";
+import { MIN_SEARCH_CHARACTERS, SEARCH_DEBOUNCE_MS } from "../../../constants";
 
 interface UserGroupsProps {
   onBack: () => void;
@@ -221,7 +221,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const handleAddUserSearchTermChange = (value: string) => {
     userSearchRequestGuard.invalidate();
     setUserSearchTerm(value);
-    if (value.trim().length < 2) {
+    if (value.trim().length < MIN_SEARCH_CHARACTERS) {
       setSearchResults([]);
       setSearchingUsers(false);
     }
@@ -230,7 +230,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   const handleSearchUsers = useCallback(async (term: string) => {
     const requestToken = userSearchRequestGuard.start();
     const searchTerm = term.trim();
-    if (searchTerm.length < 2) {
+    if (searchTerm.length < MIN_SEARCH_CHARACTERS) {
       setSearchResults([]);
       setSearchingUsers(false);
       return;
@@ -286,7 +286,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   }, [userSearchRequestGuard]);
 
   useEffect(() => {
-    if (!addUserDialogOpen || userSearchTerm.trim().length < 2) return;
+    if (!addUserDialogOpen || userSearchTerm.trim().length < MIN_SEARCH_CHARACTERS) return;
     const timer = window.setTimeout(() => {
       void handleSearchUsers(userSearchTerm);
     }, SEARCH_DEBOUNCE_MS);

--- a/src/features/admin/components/UserGroups.tsx
+++ b/src/features/admin/components/UserGroups.tsx
@@ -44,6 +44,7 @@ import type {
   UserSummary,
 } from "./userGroupsTypes";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
+import { SEARCH_DEBOUNCE_MS } from "../../../constants";
 
 interface UserGroupsProps {
   onBack: () => void;
@@ -218,13 +219,18 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
   };
 
   const handleAddUserSearchTermChange = (value: string) => {
+    userSearchRequestGuard.invalidate();
     setUserSearchTerm(value);
-    handleSearchUsers(value);
+    if (value.trim().length < 2) {
+      setSearchResults([]);
+      setSearchingUsers(false);
+    }
   };
 
   const handleSearchUsers = useCallback(async (term: string) => {
     const requestToken = userSearchRequestGuard.start();
-    if (!term.trim() || term.length < 2) {
+    const searchTerm = term.trim();
+    if (searchTerm.length < 2) {
       setSearchResults([]);
       setSearchingUsers(false);
       return;
@@ -232,7 +238,7 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
 
     setSearchingUsers(true);
     try {
-      const result = await searchUsers(term, 1, 10);
+      const result = await searchUsers(searchTerm, 1, 10);
       if (result.success && result.data) {
         // Fetch full user data from DataConnect for each user to get membership status
         const usersWithData = await Promise.all(
@@ -278,6 +284,14 @@ export default function UserGroups({ onBack }: UserGroupsProps) {
       }
     }
   }, [userSearchRequestGuard]);
+
+  useEffect(() => {
+    if (!addUserDialogOpen || userSearchTerm.trim().length < 2) return;
+    const timer = window.setTimeout(() => {
+      void handleSearchUsers(userSearchTerm);
+    }, SEARCH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [addUserDialogOpen, handleSearchUsers, userSearchTerm]);
 
   const handleAddUserToGroup = async (userId: string) => {
     if (!addingToGroupId) return;

--- a/src/features/admin/components/__tests__/UserGroups.test.tsx
+++ b/src/features/admin/components/__tests__/UserGroups.test.tsx
@@ -1,10 +1,11 @@
-import { describe, beforeEach, expect, it, vi } from "vitest";
+import { describe, beforeEach, afterEach, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { executeMutation, executeQuery, QueryFetchPolicy } from "firebase/data-connect";
-import { render, screen, waitFor } from "../../../../test-utils";
+import { act, fireEvent, render, screen } from "../../../../test-utils";
 import UserGroups from "../UserGroups";
 import { searchUsers } from "../../../users/utils/searchUsers";
+import { SEARCH_DEBOUNCE_MS } from "../../../../constants";
 
 vi.mock("firebase/data-connect", () => ({
   executeQuery: vi.fn(),
@@ -142,6 +143,10 @@ describe("UserGroups", () => {
     });
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("replaces cached group details with server data after editing", async () => {
     const user = userEvent.setup();
     render(
@@ -168,22 +173,31 @@ describe("UserGroups", () => {
       success: true,
       data: { users: [], total: 0, page: 1, pageSize: 10, totalPages: 1 },
     });
-    const user = userEvent.setup();
+    const initialUser = userEvent.setup();
     render(
       <MemoryRouter>
         <UserGroups onBack={vi.fn()} />
       </MemoryRouter>
     );
 
-    await user.click(await screen.findByRole("button", { name: "Add user to Original Group" }));
+    await initialUser.click(await screen.findByRole("button", { name: "Add user to Original Group" }));
+    vi.useFakeTimers();
     const searchInput = screen.getByLabelText("Search Users");
-    await user.type(searchInput, "a");
-    await new Promise((resolve) => window.setTimeout(resolve, 550));
+    fireEvent.change(searchInput, { target: { value: "a" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SEARCH_DEBOUNCE_MS);
+    });
     expect(searchUsers).not.toHaveBeenCalled();
 
-    await user.type(searchInput, "b");
+    fireEvent.change(searchInput, { target: { value: "ab" } });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SEARCH_DEBOUNCE_MS - 1);
+    });
     expect(searchUsers).not.toHaveBeenCalled();
-    await waitFor(() => expect(searchUsers).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(searchUsers).toHaveBeenCalledTimes(1);
     expect(searchUsers).toHaveBeenCalledWith("ab", 1, 10);
   });
 });

--- a/src/features/admin/components/__tests__/UserGroups.test.tsx
+++ b/src/features/admin/components/__tests__/UserGroups.test.tsx
@@ -2,8 +2,9 @@ import { describe, beforeEach, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { executeMutation, executeQuery, QueryFetchPolicy } from "firebase/data-connect";
-import { render, screen } from "../../../../test-utils";
+import { render, screen, waitFor } from "../../../../test-utils";
 import UserGroups from "../UserGroups";
+import { searchUsers } from "../../../users/utils/searchUsers";
 
 vi.mock("firebase/data-connect", () => ({
   executeQuery: vi.fn(),
@@ -37,11 +38,13 @@ vi.mock("../UserGroupsSurfaces", () => ({
     mergedUsersForGroup,
     onExpand,
     onEdit,
+    onAddUser,
   }: {
     userGroups: Array<{ id: string; name: string }>;
     mergedUsersForGroup: Array<{ id: string; firstName: string; lastName: string }>;
     onExpand: (group: { id: string; name: string }) => void;
     onEdit: (group: { id: string; name: string }) => void;
+    onAddUser: (groupId: string) => void;
   }) => (
     <div>
       {userGroups.map((group) => (
@@ -49,6 +52,7 @@ vi.mock("../UserGroupsSurfaces", () => ({
           <span>{group.name}</span>
           <button onClick={() => onExpand(group)}>Expand {group.name}</button>
           <button onClick={() => onEdit(group)}>Edit {group.name}</button>
+          <button onClick={() => onAddUser(group.id)}>Add user to {group.name}</button>
         </div>
       ))}
       {mergedUsersForGroup.map((user) => <div key={user.id}>{user.firstName} {user.lastName}</div>)}
@@ -70,7 +74,20 @@ vi.mock("../UserGroupsSurfaces", () => ({
       <button onClick={onSubmit}>Save Group</button>
     </div>
   ) : null,
-  AddUserToGroupDialogSurface: () => null,
+  AddUserToGroupDialogSurface: ({
+    open,
+    userSearchTerm,
+    onSearchTermChange,
+  }: {
+    open: boolean;
+    userSearchTerm: string;
+    onSearchTermChange: (value: string) => void;
+  }) => open ? (
+    <label>
+      Search Users
+      <input value={userSearchTerm} onChange={(event) => onSearchTermChange(event.target.value)} />
+    </label>
+  ) : null,
 }));
 
 let updated = false;
@@ -144,5 +161,29 @@ describe("UserGroups", () => {
     expect(await screen.findByText("Updated Group")).toBeInTheDocument();
     expect(await screen.findByText("After Member")).toBeInTheDocument();
     expect(screen.queryByText("Before Member")).not.toBeInTheDocument();
+  });
+
+  it("debounces add-user searches and requires two characters", async () => {
+    vi.mocked(searchUsers).mockResolvedValue({
+      success: true,
+      data: { users: [], total: 0, page: 1, pageSize: 10, totalPages: 1 },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <UserGroups onBack={vi.fn()} />
+      </MemoryRouter>
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Add user to Original Group" }));
+    const searchInput = screen.getByLabelText("Search Users");
+    await user.type(searchInput, "a");
+    await new Promise((resolve) => window.setTimeout(resolve, 550));
+    expect(searchUsers).not.toHaveBeenCalled();
+
+    await user.type(searchInput, "b");
+    expect(searchUsers).not.toHaveBeenCalled();
+    await waitFor(() => expect(searchUsers).toHaveBeenCalledTimes(1));
+    expect(searchUsers).toHaveBeenCalledWith("ab", 1, 10);
   });
 });

--- a/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
+++ b/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
@@ -1,14 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
 import { searchSectionMembers } from "../../../shared/utils/firebaseFunctions";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
-import { SEARCH_DEBOUNCE_MS } from "../../../constants";
+import { MIN_SEARCH_CHARACTERS, SEARCH_DEBOUNCE_MS } from "../../../constants";
 
 export interface SectionMemberSeatingOption {
   id: string;
   label: string;
 }
-
-const MIN_SEARCH_CHARACTERS = 2;
 
 /**
  * Typeahead search over a section's population for the booking wizard's "sit next to" field.

--- a/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
+++ b/src/features/sections/hooks/useSectionMemberSeatingOptions.ts
@@ -1,13 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
 import { searchSectionMembers } from "../../../shared/utils/firebaseFunctions";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
+import { SEARCH_DEBOUNCE_MS } from "../../../constants";
 
 export interface SectionMemberSeatingOption {
   id: string;
   label: string;
 }
 
-const SEARCH_DEBOUNCE_MS = 300;
+const MIN_SEARCH_CHARACTERS = 2;
 
 /**
  * Typeahead search over a section's population for the booking wizard's "sit next to" field.
@@ -61,7 +62,8 @@ export function useSectionMemberSeatingSearch(
   }, [sectionId, selectedIds.join(","), selectedLabelsRequestGuard]);
 
   useEffect(() => {
-    if (!inputValue.trim()) {
+    const searchTerm = inputValue.trim();
+    if (searchTerm.length < MIN_SEARCH_CHARACTERS) {
       setSearchResults([]);
       setLoading(false);
       return;
@@ -71,7 +73,7 @@ export function useSectionMemberSeatingSearch(
     const timer = setTimeout(() => {
       void (async () => {
         try {
-          const result = await searchSectionMembers(sectionId, inputValue, selectedIds);
+          const result = await searchSectionMembers(sectionId, searchTerm, selectedIds);
           if (!searchRequestGuard.isCurrent(requestToken)) return;
           setSearchResults(
             result.members

--- a/src/features/users/hooks/__tests__/useUserSearch.test.ts
+++ b/src/features/users/hooks/__tests__/useUserSearch.test.ts
@@ -68,6 +68,19 @@ describe("useUserSearch", () => {
     expect(mockSearchUsers).not.toHaveBeenCalled();
   });
 
+  it("does not search until at least two trimmed characters are entered", async () => {
+    const { result } = renderHook(() => useUserSearch(""));
+
+    act(() => result.current.setSearchTerm(" a "));
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+      await Promise.resolve();
+    });
+
+    expect(mockSearchUsers).not.toHaveBeenCalled();
+    expect(result.current.users).toEqual([]);
+  });
+
   it("searches with initial search term after debounce", async () => {
     mockSearchUsers.mockResolvedValue(emptyResult);
 

--- a/src/features/users/hooks/useUserSearch.ts
+++ b/src/features/users/hooks/useUserSearch.ts
@@ -5,6 +5,8 @@ import { ITEMS_PER_PAGE } from "../../../constants";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 
+const MIN_SEARCH_CHARACTERS = 2;
+
 interface UseUserSearchResult {
   users: SearchUser[];
   loading: boolean;
@@ -39,7 +41,8 @@ export function useUserSearch(
 
   const performSearch = useCallback(async (term: string, pageNum: number = 1) => {
     const requestToken = searchRequestGuard.start();
-    if (!term.trim()) {
+    const searchTerm = term.trim();
+    if (searchTerm.length < MIN_SEARCH_CHARACTERS) {
       setUsers([]);
       setError(null);
       setTotalPages(1);
@@ -51,7 +54,7 @@ export function useUserSearch(
     setLoading(true);
     setError(null);
     try {
-      const result = await searchUsers(term, pageNum, ITEMS_PER_PAGE);
+      const result = await searchUsers(searchTerm, pageNum, ITEMS_PER_PAGE);
       if (!searchRequestGuard.isCurrent(requestToken)) return;
       if (result.success && result.data) {
         setUsers(result.data.users);
@@ -80,7 +83,7 @@ export function useUserSearch(
   // Debounced search - only triggers when searchTerm changes
   useEffect(() => {
     const timer = setTimeout(() => {
-      if (searchTerm.trim()) {
+      if (searchTerm.trim().length >= MIN_SEARCH_CHARACTERS) {
         performSearch(searchTerm, 1);
         setPage(1);
       } else {
@@ -101,7 +104,7 @@ export function useUserSearch(
   // Note: searchTerm is intentionally not in dependencies to avoid bypassing debounce
   // The closure will capture the current searchTerm value when this effect runs
   useEffect(() => {
-    if (searchTerm.trim()) {
+    if (searchTerm.trim().length >= MIN_SEARCH_CHARACTERS) {
       performSearch(searchTerm, page);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/features/users/hooks/useUserSearch.ts
+++ b/src/features/users/hooks/useUserSearch.ts
@@ -1,11 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { searchUsers } from "../utils/searchUsers";
 import type { SearchUser } from "../../../types";
-import { ITEMS_PER_PAGE } from "../../../constants";
+import { ITEMS_PER_PAGE, MIN_SEARCH_CHARACTERS } from "../../../constants";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
-
-const MIN_SEARCH_CHARACTERS = 2;
 
 interface UseUserSearchResult {
   users: SearchUser[];


### PR DESCRIPTION
## Summary

- use the shared 500 ms debounce for the booking seating member search
- require at least two trimmed characters across section and admin user searches
- debounce the Add User to User Group search and invalidate stale requests
- add coverage for minimum search length and admin debounce behaviour

## Why

The previous 300 ms seating debounce and immediate admin group-user search could issue multiple Firebase callable requests during ordinary typing pauses. A consistent 500 ms delay and two-character minimum reduces avoidable function traffic while keeping search responsive.

Closes #606.

## Validation

- `npm test -- --run src/features/users/hooks/__tests__/useUserSearch.test.ts src/features/admin/components/__tests__/UserGroups.test.tsx` — 14 tests passed
- `npm run build` — passed