### PR TITLE
Normalize generated Data Connect SDK bundles

### DIFF
--- a/src/dataconnect-generated/esm/index.esm.js
+++ b/src/dataconnect-generated/esm/index.esm.js
@@ -151,7 +151,7 @@ export const getGovNotifyDeliveryConfigurationRef = (dc) => {
 getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfiguration';
 
 export function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -164,7 +164,7 @@ export const listGovNotifyDeliveryModeAuditsRef = (dcOrVars, vars) => {
 listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAudits';
 
 export function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -201,7 +201,7 @@ export const getNotifyReplyToConfigurationRef = (dc) => {
 getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration';
 
 export function getNotifyReplyToConfiguration(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -214,7 +214,7 @@ export const listNotifyReplyToAuditsRef = (dcOrVars, vars) => {
 listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 
 export function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -347,7 +347,7 @@ export const getNotifyTemplateBindingsRef = (dc) => {
 getNotifyTemplateBindingsRef.operationName = 'GetNotifyTemplateBindings';
 
 export function getNotifyTemplateBindings(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyTemplateBindingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -360,7 +360,7 @@ export const listNotifyTemplateBindingAuditsRef = (dcOrVars, vars) => {
 listNotifyTemplateBindingAuditsRef.operationName = 'ListNotifyTemplateBindingAudits';
 
 export function listNotifyTemplateBindingAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyTemplateBindingAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -397,7 +397,7 @@ export const getSectionFileByIdRef = (dcOrVars, vars) => {
 getSectionFileByIdRef.operationName = 'GetSectionFileById';
 
 export function getSectionFileById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionFileByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -410,7 +410,7 @@ export const listSectionFilesByStatusRef = (dcOrVars, vars) => {
 listSectionFilesByStatusRef.operationName = 'ListSectionFilesByStatus';
 
 export function listSectionFilesByStatus(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesByStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -423,7 +423,7 @@ export const listStaleSectionFilesRef = (dcOrVars, vars) => {
 listStaleSectionFilesRef.operationName = 'ListStaleSectionFiles';
 
 export function listStaleSectionFiles(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleSectionFilesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -436,7 +436,7 @@ export const listSectionFilesForQuotaRef = (dcOrVars, vars) => {
 listSectionFilesForQuotaRef.operationName = 'ListSectionFilesForQuota';
 
 export function listSectionFilesForQuota(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesForQuotaRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -629,7 +629,7 @@ export const getLegacyUserIdentityRef = (dcOrVars, vars) => {
 getLegacyUserIdentityRef.operationName = 'GetLegacyUserIdentity';
 
 export function getLegacyUserIdentity(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLegacyUserIdentityRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -642,7 +642,7 @@ export const listLegacyUserIdentitiesByBatchRef = (dcOrVars, vars) => {
 listLegacyUserIdentitiesByBatchRef.operationName = 'ListLegacyUserIdentitiesByBatch';
 
 export function listLegacyUserIdentitiesByBatch(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesByBatchRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -655,7 +655,7 @@ export const listMigrationUsersRef = (dcOrVars, vars) => {
 listMigrationUsersRef.operationName = 'ListMigrationUsers';
 
 export function listMigrationUsers(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listMigrationUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -668,7 +668,7 @@ export const searchSectionMemberCandidatesRef = (dcOrVars, vars) => {
 searchSectionMemberCandidatesRef.operationName = 'SearchSectionMemberCandidates';
 
 export function searchSectionMemberCandidates(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(searchSectionMemberCandidatesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -681,7 +681,7 @@ export const listLegacyUserIdentitiesForMigrationRef = (dcOrVars, vars) => {
 listLegacyUserIdentitiesForMigrationRef.operationName = 'ListLegacyUserIdentitiesForMigration';
 
 export function listLegacyUserIdentitiesForMigration(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesForMigrationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -730,7 +730,7 @@ export const getUserGroupByNameRef = (dcOrVars, vars) => {
 getUserGroupByNameRef.operationName = 'GetUserGroupByName';
 
 export function getUserGroupByName(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByNameRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -743,7 +743,7 @@ export const getUserUserGroupsForAdminRef = (dcOrVars, vars) => {
 getUserUserGroupsForAdminRef.operationName = 'GetUserUserGroupsForAdmin';
 
 export function getUserUserGroupsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserUserGroupsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -756,7 +756,7 @@ export const getUserForCheckoutRef = (dcOrVars, vars) => {
 getUserForCheckoutRef.operationName = 'GetUserForCheckout';
 
 export function getUserForCheckout(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -769,7 +769,7 @@ export const getTicketTypeForCheckoutRef = (dcOrVars, vars) => {
 getTicketTypeForCheckoutRef.operationName = 'GetTicketTypeForCheckout';
 
 export function getTicketTypeForCheckout(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketTypeForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -794,7 +794,7 @@ export const getEventByIdForCallableRef = (dcOrVars, vars) => {
 getEventByIdForCallableRef.operationName = 'GetEventByIdForCallable';
 
 export function getEventByIdForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -807,7 +807,7 @@ export const getSectionByIdForCallableRef = (dcOrVars, vars) => {
 getSectionByIdForCallableRef.operationName = 'GetSectionByIdForCallable';
 
 export function getSectionByIdForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -820,7 +820,7 @@ export const getBookingReplayForBookerEventKeyRef = (dcOrVars, vars) => {
 getBookingReplayForBookerEventKeyRef.operationName = 'GetBookingReplayForBookerEventKey';
 
 export function getBookingReplayForBookerEventKey(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingReplayForBookerEventKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -833,7 +833,7 @@ export const getBookingsForBookerAndEventRef = (dcOrVars, vars) => {
 getBookingsForBookerAndEventRef.operationName = 'GetBookingsForBookerAndEvent';
 
 export function getBookingsForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingsForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -846,7 +846,7 @@ export const getBookingRevisionForApprovalFromCallableRef = (dcOrVars, vars) => 
 getBookingRevisionForApprovalFromCallableRef.operationName = 'GetBookingRevisionForApprovalFromCallable';
 
 export function getBookingRevisionForApprovalFromCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingRevisionForApprovalFromCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -859,7 +859,7 @@ export const getTicketOrdersForBookerAndEventRef = (dcOrVars, vars) => {
 getTicketOrdersForBookerAndEventRef.operationName = 'GetTicketOrdersForBookerAndEvent';
 
 export function getTicketOrdersForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrdersForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -932,7 +932,7 @@ export const getTicketOrderForWebhookRef = (dcOrVars, vars) => {
 getTicketOrderForWebhookRef.operationName = 'GetTicketOrderForWebhook';
 
 export function getTicketOrderForWebhook(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderForWebhookRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -945,7 +945,7 @@ export const getTicketOrderStripeArtifactsForCallableRef = (dcOrVars, vars) => {
 getTicketOrderStripeArtifactsForCallableRef.operationName = 'GetTicketOrderStripeArtifactsForCallable';
 
 export function getTicketOrderStripeArtifactsForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderStripeArtifactsForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -958,7 +958,7 @@ export const getPaymentWebhookEventByStripeEventIdRef = (dcOrVars, vars) => {
 getPaymentWebhookEventByStripeEventIdRef.operationName = 'GetPaymentWebhookEventByStripeEventId';
 
 export function getPaymentWebhookEventByStripeEventId(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentWebhookEventByStripeEventIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -983,7 +983,7 @@ export const getNotificationDeliveryByChannelAndKeyRef = (dcOrVars, vars) => {
 getNotificationDeliveryByChannelAndKeyRef.operationName = 'GetNotificationDeliveryByChannelAndKey';
 
 export function getNotificationDeliveryByChannelAndKey(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotificationDeliveryByChannelAndKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -996,7 +996,7 @@ export const listFailedNotificationDeliveriesForRecoveryRef = (dcOrVars, vars) =
 listFailedNotificationDeliveriesForRecoveryRef.operationName = 'ListFailedNotificationDeliveriesForRecovery';
 
 export function listFailedNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listFailedNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1009,7 +1009,7 @@ export const listStalePendingNotificationDeliveriesForRecoveryRef = (dcOrVars, v
 listStalePendingNotificationDeliveriesForRecoveryRef.operationName = 'ListStalePendingNotificationDeliveriesForRecovery';
 
 export function listStalePendingNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1142,7 +1142,7 @@ export const getPaymentReconciliationExceptionByOrderAndTypeRef = (dcOrVars, var
 getPaymentReconciliationExceptionByOrderAndTypeRef.operationName = 'GetPaymentReconciliationExceptionByOrderAndType';
 
 export function getPaymentReconciliationExceptionByOrderAndType(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentReconciliationExceptionByOrderAndTypeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1167,7 +1167,7 @@ export const getBookingForNotificationRef = (dcOrVars, vars) => {
 getBookingForNotificationRef.operationName = 'GetBookingForNotification';
 
 export function getBookingForNotification(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingForNotificationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1180,7 +1180,7 @@ export const listStaleDraftBookingsForSchedulerRef = (dcOrVars, vars) => {
 listStaleDraftBookingsForSchedulerRef.operationName = 'ListStaleDraftBookingsForScheduler';
 
 export function listStaleDraftBookingsForScheduler(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleDraftBookingsForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1193,7 +1193,7 @@ export const listStalePendingTicketOrdersForSchedulerRef = (dcOrVars, vars) => {
 listStalePendingTicketOrdersForSchedulerRef.operationName = 'ListStalePendingTicketOrdersForScheduler';
 
 export function listStalePendingTicketOrdersForScheduler(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingTicketOrdersForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1206,7 +1206,7 @@ export const getSectionAnnouncementOptOutsRef = (dcOrVars, vars) => {
 getSectionAnnouncementOptOutsRef.operationName = 'GetSectionAnnouncementOptOuts';
 
 export function getSectionAnnouncementOptOuts(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1267,7 +1267,7 @@ export const getAnnouncementRecipientProgressRef = (dcOrVars, vars) => {
 getAnnouncementRecipientProgressRef.operationName = 'GetAnnouncementRecipientProgress';
 
 export function getAnnouncementRecipientProgress(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientProgressRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1280,7 +1280,7 @@ export const getAnnouncementRecipientsForResumeRef = (dcOrVars, vars) => {
 getAnnouncementRecipientsForResumeRef.operationName = 'GetAnnouncementRecipientsForResume';
 
 export function getAnnouncementRecipientsForResume(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientsForResumeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1293,7 +1293,7 @@ export const getAnnouncementSendHistoryRef = (dcOrVars, vars) => {
 getAnnouncementSendHistoryRef.operationName = 'GetAnnouncementSendHistory';
 
 export function getAnnouncementSendHistory(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendHistoryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1306,7 +1306,7 @@ export const getAnnouncementSendRecipientsRef = (dcOrVars, vars) => {
 getAnnouncementSendRecipientsRef.operationName = 'GetAnnouncementSendRecipients';
 
 export function getAnnouncementSendRecipients(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendRecipientsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1319,7 +1319,7 @@ export const getAnnouncementSendByIdRef = (dcOrVars, vars) => {
 getAnnouncementSendByIdRef.operationName = 'GetAnnouncementSendById';
 
 export function getAnnouncementSendById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1332,7 +1332,7 @@ export const getAnnouncementRecipientBySendAndUserRef = (dcOrVars, vars) => {
 getAnnouncementRecipientBySendAndUserRef.operationName = 'GetAnnouncementRecipientBySendAndUser';
 
 export function getAnnouncementRecipientBySendAndUser(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientBySendAndUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1381,7 +1381,7 @@ export const getUserByEmailRef = (dcOrVars, vars) => {
 getUserByEmailRef.operationName = 'GetUserByEmail';
 
 export function getUserByEmail(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByEmailRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1394,7 +1394,7 @@ export const getNotifyCallbackUserByIdRef = (dcOrVars, vars) => {
 getNotifyCallbackUserByIdRef.operationName = 'GetNotifyCallbackUserById';
 
 export function getNotifyCallbackUserById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyCallbackUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1431,7 +1431,7 @@ export const getNotifyDeliveryReceiptRef = (dcOrVars, vars) => {
 getNotifyDeliveryReceiptRef.operationName = 'GetNotifyDeliveryReceipt';
 
 export function getNotifyDeliveryReceipt(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyDeliveryReceiptRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1492,7 +1492,7 @@ export const getRecentNotifyDeliveryReceiptsForUserRef = (dcOrVars, vars) => {
 getRecentNotifyDeliveryReceiptsForUserRef.operationName = 'GetRecentNotifyDeliveryReceiptsForUser';
 
 export function getRecentNotifyDeliveryReceiptsForUser(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getRecentNotifyDeliveryReceiptsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1505,7 +1505,7 @@ export const getLatestNotifyDeliveryReceiptForReferenceRef = (dcOrVars, vars) =>
 getLatestNotifyDeliveryReceiptForReferenceRef.operationName = 'GetLatestNotifyDeliveryReceiptForReference';
 
 export function getLatestNotifyDeliveryReceiptForReference(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLatestNotifyDeliveryReceiptForReferenceRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1542,7 +1542,7 @@ export const getCallableInvocationRef = (dcOrVars, vars) => {
 getCallableInvocationRef.operationName = 'GetCallableInvocation';
 
 export function getCallableInvocation(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getCallableInvocationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1627,7 +1627,7 @@ export const getCurrentUserRef = (dc) => {
 getCurrentUserRef.operationName = 'GetCurrentUser';
 
 export function getCurrentUser(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getCurrentUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1640,7 +1640,7 @@ export const getUserByIdRef = (dcOrVars, vars) => {
 getUserByIdRef.operationName = 'GetUserById';
 
 export function getUserById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1653,7 +1653,7 @@ export const listUsersRef = (dc) => {
 listUsersRef.operationName = 'ListUsers';
 
 export function listUsers(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1666,7 +1666,7 @@ export const listUserNamesByIdsRef = (dcOrVars, vars) => {
 listUserNamesByIdsRef.operationName = 'ListUserNamesByIds';
 
 export function listUserNamesByIds(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listUserNamesByIdsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1679,7 +1679,7 @@ export const listSectionsRef = (dc) => {
 listSectionsRef.operationName = 'ListSections';
 
 export function listSections(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listSectionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1692,7 +1692,7 @@ export const getSectionsForUserRef = (dc) => {
 getSectionsForUserRef.operationName = 'GetSectionsForUser';
 
 export function getSectionsForUser(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getSectionsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1705,7 +1705,7 @@ export const listUserGroupsRef = (dc) => {
 listUserGroupsRef.operationName = 'ListUserGroups';
 
 export function listUserGroups(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUserGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1718,7 +1718,7 @@ export const getUserAccessGroupsRef = (dc) => {
 getUserAccessGroupsRef.operationName = 'GetUserAccessGroups';
 
 export function getUserAccessGroups(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getUserAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1731,7 +1731,7 @@ export const checkUserProfileExistsRef = (dc) => {
 checkUserProfileExistsRef.operationName = 'CheckUserProfileExists';
 
 export function checkUserProfileExists(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(checkUserProfileExistsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1744,7 +1744,7 @@ export const getUserMembershipStatusRef = (dcOrVars, vars) => {
 getUserMembershipStatusRef.operationName = 'GetUserMembershipStatus';
 
 export function getUserMembershipStatus(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserMembershipStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1757,7 +1757,7 @@ export const getUserWithAccessGroupsRef = (dcOrVars, vars) => {
 getUserWithAccessGroupsRef.operationName = 'GetUserWithAccessGroups';
 
 export function getUserWithAccessGroups(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserWithAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1770,7 +1770,7 @@ export const getUserAccessGroupsByIdRef = (dcOrVars, vars) => {
 getUserAccessGroupsByIdRef.operationName = 'GetUserAccessGroupsById';
 
 export function getUserAccessGroupsById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserAccessGroupsByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1783,7 +1783,7 @@ export const getEventsForSectionRef = (dcOrVars, vars) => {
 getEventsForSectionRef.operationName = 'GetEventsForSection';
 
 export function getEventsForSection(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventsForSectionRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1796,7 +1796,7 @@ export const getEventByIdRef = (dcOrVars, vars) => {
 getEventByIdRef.operationName = 'GetEventById';
 
 export function getEventById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1809,7 +1809,7 @@ export const getSectionByIdRef = (dcOrVars, vars) => {
 getSectionByIdRef.operationName = 'GetSectionById';
 
 export function getSectionById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1822,7 +1822,7 @@ export const getUserGroupByIdRef = (dcOrVars, vars) => {
 getUserGroupByIdRef.operationName = 'GetUserGroupById';
 
 export function getUserGroupById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1835,7 +1835,7 @@ export const getAllUserGroupsWithStatusesRef = (dc) => {
 getAllUserGroupsWithStatusesRef.operationName = 'GetAllUserGroupsWithStatuses';
 
 export function getAllUserGroupsWithStatuses(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getAllUserGroupsWithStatusesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1848,7 +1848,7 @@ export const getSectionMembersRef = (dcOrVars, vars) => {
 getSectionMembersRef.operationName = 'GetSectionMembers';
 
 export function getSectionMembers(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionMembersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1861,7 +1861,7 @@ export const getMyBookingsForEventRef = (dcOrVars, vars) => {
 getMyBookingsForEventRef.operationName = 'GetMyBookingsForEvent';
 
 export function getMyBookingsForEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyBookingsForEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1874,7 +1874,7 @@ export const getMyBookingsRef = (dc) => {
 getMyBookingsRef.operationName = 'GetMyBookings';
 
 export function getMyBookings(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1887,7 +1887,7 @@ export const getMyTicketOrderByIdRef = (dcOrVars, vars) => {
 getMyTicketOrderByIdRef.operationName = 'GetMyTicketOrderById';
 
 export function getMyTicketOrderById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyTicketOrderByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1900,7 +1900,7 @@ export const getMyTicketOrdersRef = (dc) => {
 getMyTicketOrdersRef.operationName = 'GetMyTicketOrders';
 
 export function getMyTicketOrders(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyTicketOrdersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1913,7 +1913,7 @@ export const getMyBookingPaymentAdjustmentsRef = (dc) => {
 getMyBookingPaymentAdjustmentsRef.operationName = 'GetMyBookingPaymentAdjustments';
 
 export function getMyBookingPaymentAdjustments(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingPaymentAdjustmentsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1926,7 +1926,7 @@ export const listEventBookingsForAdminRef = (dcOrVars, vars) => {
 listEventBookingsForAdminRef.operationName = 'ListEventBookingsForAdmin';
 
 export function listEventBookingsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listEventBookingsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1939,7 +1939,7 @@ export const listTicketOrdersForAdminRef = (dcOrVars, vars) => {
 listTicketOrdersForAdminRef.operationName = 'ListTicketOrdersForAdmin';
 
 export function listTicketOrdersForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listTicketOrdersForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1952,7 +1952,7 @@ export const listBookingPaymentAdjustmentsForAdminRef = (dcOrVars, vars) => {
 listBookingPaymentAdjustmentsForAdminRef.operationName = 'ListBookingPaymentAdjustmentsForAdmin';
 
 export function listBookingPaymentAdjustmentsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listBookingPaymentAdjustmentsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1965,7 +1965,7 @@ export const listOpenPaymentReconciliationExceptionsRef = (dc) => {
 listOpenPaymentReconciliationExceptionsRef.operationName = 'ListOpenPaymentReconciliationExceptions';
 
 export function listOpenPaymentReconciliationExceptions(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listOpenPaymentReconciliationExceptionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1978,7 +1978,7 @@ export const getSectionAnnouncementOptOutRef = (dcOrVars, vars) => {
 getSectionAnnouncementOptOutRef.operationName = 'GetSectionAnnouncementOptOut';
 
 export function getSectionAnnouncementOptOut(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1991,7 +1991,7 @@ export const getMyAnnouncementPreferencesRef = (dc) => {
 getMyAnnouncementPreferencesRef.operationName = 'GetMyAnnouncementPreferences';
 
 export function getMyAnnouncementPreferences(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyAnnouncementPreferencesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }

--- a/src/dataconnect-generated/index.cjs.js
+++ b/src/dataconnect-generated/index.cjs.js
@@ -174,7 +174,7 @@ getGovNotifyDeliveryConfigurationRef.operationName = 'GetGovNotifyDeliveryConfig
 exports.getGovNotifyDeliveryConfigurationRef = getGovNotifyDeliveryConfigurationRef;
 
 exports.getGovNotifyDeliveryConfiguration = function getGovNotifyDeliveryConfiguration(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getGovNotifyDeliveryConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -189,7 +189,7 @@ listGovNotifyDeliveryModeAuditsRef.operationName = 'ListGovNotifyDeliveryModeAud
 exports.listGovNotifyDeliveryModeAuditsRef = listGovNotifyDeliveryModeAuditsRef;
 
 exports.listGovNotifyDeliveryModeAudits = function listGovNotifyDeliveryModeAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listGovNotifyDeliveryModeAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -232,7 +232,7 @@ getNotifyReplyToConfigurationRef.operationName = 'GetNotifyReplyToConfiguration'
 exports.getNotifyReplyToConfigurationRef = getNotifyReplyToConfigurationRef;
 
 exports.getNotifyReplyToConfiguration = function getNotifyReplyToConfiguration(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyReplyToConfigurationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -247,7 +247,7 @@ listNotifyReplyToAuditsRef.operationName = 'ListNotifyReplyToAudits';
 exports.listNotifyReplyToAuditsRef = listNotifyReplyToAuditsRef;
 
 exports.listNotifyReplyToAudits = function listNotifyReplyToAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyReplyToAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -402,7 +402,7 @@ getNotifyTemplateBindingsRef.operationName = 'GetNotifyTemplateBindings';
 exports.getNotifyTemplateBindingsRef = getNotifyTemplateBindingsRef;
 
 exports.getNotifyTemplateBindings = function getNotifyTemplateBindings(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getNotifyTemplateBindingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -417,7 +417,7 @@ listNotifyTemplateBindingAuditsRef.operationName = 'ListNotifyTemplateBindingAud
 exports.listNotifyTemplateBindingAuditsRef = listNotifyTemplateBindingAuditsRef;
 
 exports.listNotifyTemplateBindingAudits = function listNotifyTemplateBindingAudits(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listNotifyTemplateBindingAuditsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -460,7 +460,7 @@ getSectionFileByIdRef.operationName = 'GetSectionFileById';
 exports.getSectionFileByIdRef = getSectionFileByIdRef;
 
 exports.getSectionFileById = function getSectionFileById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionFileByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -475,7 +475,7 @@ listSectionFilesByStatusRef.operationName = 'ListSectionFilesByStatus';
 exports.listSectionFilesByStatusRef = listSectionFilesByStatusRef;
 
 exports.listSectionFilesByStatus = function listSectionFilesByStatus(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesByStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -490,7 +490,7 @@ listStaleSectionFilesRef.operationName = 'ListStaleSectionFiles';
 exports.listStaleSectionFilesRef = listStaleSectionFilesRef;
 
 exports.listStaleSectionFiles = function listStaleSectionFiles(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleSectionFilesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -505,7 +505,7 @@ listSectionFilesForQuotaRef.operationName = 'ListSectionFilesForQuota';
 exports.listSectionFilesForQuotaRef = listSectionFilesForQuotaRef;
 
 exports.listSectionFilesForQuota = function listSectionFilesForQuota(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listSectionFilesForQuotaRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -730,7 +730,7 @@ getLegacyUserIdentityRef.operationName = 'GetLegacyUserIdentity';
 exports.getLegacyUserIdentityRef = getLegacyUserIdentityRef;
 
 exports.getLegacyUserIdentity = function getLegacyUserIdentity(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLegacyUserIdentityRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -745,7 +745,7 @@ listLegacyUserIdentitiesByBatchRef.operationName = 'ListLegacyUserIdentitiesByBa
 exports.listLegacyUserIdentitiesByBatchRef = listLegacyUserIdentitiesByBatchRef;
 
 exports.listLegacyUserIdentitiesByBatch = function listLegacyUserIdentitiesByBatch(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesByBatchRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -760,7 +760,7 @@ listMigrationUsersRef.operationName = 'ListMigrationUsers';
 exports.listMigrationUsersRef = listMigrationUsersRef;
 
 exports.listMigrationUsers = function listMigrationUsers(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listMigrationUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -775,7 +775,7 @@ searchSectionMemberCandidatesRef.operationName = 'SearchSectionMemberCandidates'
 exports.searchSectionMemberCandidatesRef = searchSectionMemberCandidatesRef;
 
 exports.searchSectionMemberCandidates = function searchSectionMemberCandidates(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(searchSectionMemberCandidatesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -790,7 +790,7 @@ listLegacyUserIdentitiesForMigrationRef.operationName = 'ListLegacyUserIdentitie
 exports.listLegacyUserIdentitiesForMigrationRef = listLegacyUserIdentitiesForMigrationRef;
 
 exports.listLegacyUserIdentitiesForMigration = function listLegacyUserIdentitiesForMigration(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listLegacyUserIdentitiesForMigrationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -847,7 +847,7 @@ getUserGroupByNameRef.operationName = 'GetUserGroupByName';
 exports.getUserGroupByNameRef = getUserGroupByNameRef;
 
 exports.getUserGroupByName = function getUserGroupByName(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByNameRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -862,7 +862,7 @@ getUserUserGroupsForAdminRef.operationName = 'GetUserUserGroupsForAdmin';
 exports.getUserUserGroupsForAdminRef = getUserUserGroupsForAdminRef;
 
 exports.getUserUserGroupsForAdmin = function getUserUserGroupsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserUserGroupsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -877,7 +877,7 @@ getUserForCheckoutRef.operationName = 'GetUserForCheckout';
 exports.getUserForCheckoutRef = getUserForCheckoutRef;
 
 exports.getUserForCheckout = function getUserForCheckout(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -892,7 +892,7 @@ getTicketTypeForCheckoutRef.operationName = 'GetTicketTypeForCheckout';
 exports.getTicketTypeForCheckoutRef = getTicketTypeForCheckoutRef;
 
 exports.getTicketTypeForCheckout = function getTicketTypeForCheckout(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketTypeForCheckoutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -921,7 +921,7 @@ getEventByIdForCallableRef.operationName = 'GetEventByIdForCallable';
 exports.getEventByIdForCallableRef = getEventByIdForCallableRef;
 
 exports.getEventByIdForCallable = function getEventByIdForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -936,7 +936,7 @@ getSectionByIdForCallableRef.operationName = 'GetSectionByIdForCallable';
 exports.getSectionByIdForCallableRef = getSectionByIdForCallableRef;
 
 exports.getSectionByIdForCallable = function getSectionByIdForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -951,7 +951,7 @@ getBookingReplayForBookerEventKeyRef.operationName = 'GetBookingReplayForBookerE
 exports.getBookingReplayForBookerEventKeyRef = getBookingReplayForBookerEventKeyRef;
 
 exports.getBookingReplayForBookerEventKey = function getBookingReplayForBookerEventKey(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingReplayForBookerEventKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -966,7 +966,7 @@ getBookingsForBookerAndEventRef.operationName = 'GetBookingsForBookerAndEvent';
 exports.getBookingsForBookerAndEventRef = getBookingsForBookerAndEventRef;
 
 exports.getBookingsForBookerAndEvent = function getBookingsForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingsForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -981,7 +981,7 @@ getBookingRevisionForApprovalFromCallableRef.operationName = 'GetBookingRevision
 exports.getBookingRevisionForApprovalFromCallableRef = getBookingRevisionForApprovalFromCallableRef;
 
 exports.getBookingRevisionForApprovalFromCallable = function getBookingRevisionForApprovalFromCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingRevisionForApprovalFromCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -996,7 +996,7 @@ getTicketOrdersForBookerAndEventRef.operationName = 'GetTicketOrdersForBookerAnd
 exports.getTicketOrdersForBookerAndEventRef = getTicketOrdersForBookerAndEventRef;
 
 exports.getTicketOrdersForBookerAndEvent = function getTicketOrdersForBookerAndEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrdersForBookerAndEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1081,7 +1081,7 @@ getTicketOrderForWebhookRef.operationName = 'GetTicketOrderForWebhook';
 exports.getTicketOrderForWebhookRef = getTicketOrderForWebhookRef;
 
 exports.getTicketOrderForWebhook = function getTicketOrderForWebhook(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderForWebhookRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1096,7 +1096,7 @@ getTicketOrderStripeArtifactsForCallableRef.operationName = 'GetTicketOrderStrip
 exports.getTicketOrderStripeArtifactsForCallableRef = getTicketOrderStripeArtifactsForCallableRef;
 
 exports.getTicketOrderStripeArtifactsForCallable = function getTicketOrderStripeArtifactsForCallable(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getTicketOrderStripeArtifactsForCallableRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1111,7 +1111,7 @@ getPaymentWebhookEventByStripeEventIdRef.operationName = 'GetPaymentWebhookEvent
 exports.getPaymentWebhookEventByStripeEventIdRef = getPaymentWebhookEventByStripeEventIdRef;
 
 exports.getPaymentWebhookEventByStripeEventId = function getPaymentWebhookEventByStripeEventId(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentWebhookEventByStripeEventIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1140,7 +1140,7 @@ getNotificationDeliveryByChannelAndKeyRef.operationName = 'GetNotificationDelive
 exports.getNotificationDeliveryByChannelAndKeyRef = getNotificationDeliveryByChannelAndKeyRef;
 
 exports.getNotificationDeliveryByChannelAndKey = function getNotificationDeliveryByChannelAndKey(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotificationDeliveryByChannelAndKeyRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1155,7 +1155,7 @@ listFailedNotificationDeliveriesForRecoveryRef.operationName = 'ListFailedNotifi
 exports.listFailedNotificationDeliveriesForRecoveryRef = listFailedNotificationDeliveriesForRecoveryRef;
 
 exports.listFailedNotificationDeliveriesForRecovery = function listFailedNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listFailedNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1170,7 +1170,7 @@ listStalePendingNotificationDeliveriesForRecoveryRef.operationName = 'ListStaleP
 exports.listStalePendingNotificationDeliveriesForRecoveryRef = listStalePendingNotificationDeliveriesForRecoveryRef;
 
 exports.listStalePendingNotificationDeliveriesForRecovery = function listStalePendingNotificationDeliveriesForRecovery(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingNotificationDeliveriesForRecoveryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1325,7 +1325,7 @@ getPaymentReconciliationExceptionByOrderAndTypeRef.operationName = 'GetPaymentRe
 exports.getPaymentReconciliationExceptionByOrderAndTypeRef = getPaymentReconciliationExceptionByOrderAndTypeRef;
 
 exports.getPaymentReconciliationExceptionByOrderAndType = function getPaymentReconciliationExceptionByOrderAndType(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getPaymentReconciliationExceptionByOrderAndTypeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1354,7 +1354,7 @@ getBookingForNotificationRef.operationName = 'GetBookingForNotification';
 exports.getBookingForNotificationRef = getBookingForNotificationRef;
 
 exports.getBookingForNotification = function getBookingForNotification(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getBookingForNotificationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1369,7 +1369,7 @@ listStaleDraftBookingsForSchedulerRef.operationName = 'ListStaleDraftBookingsFor
 exports.listStaleDraftBookingsForSchedulerRef = listStaleDraftBookingsForSchedulerRef;
 
 exports.listStaleDraftBookingsForScheduler = function listStaleDraftBookingsForScheduler(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStaleDraftBookingsForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1384,7 +1384,7 @@ listStalePendingTicketOrdersForSchedulerRef.operationName = 'ListStalePendingTic
 exports.listStalePendingTicketOrdersForSchedulerRef = listStalePendingTicketOrdersForSchedulerRef;
 
 exports.listStalePendingTicketOrdersForScheduler = function listStalePendingTicketOrdersForScheduler(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listStalePendingTicketOrdersForSchedulerRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1399,7 +1399,7 @@ getSectionAnnouncementOptOutsRef.operationName = 'GetSectionAnnouncementOptOuts'
 exports.getSectionAnnouncementOptOutsRef = getSectionAnnouncementOptOutsRef;
 
 exports.getSectionAnnouncementOptOuts = function getSectionAnnouncementOptOuts(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1470,7 +1470,7 @@ getAnnouncementRecipientProgressRef.operationName = 'GetAnnouncementRecipientPro
 exports.getAnnouncementRecipientProgressRef = getAnnouncementRecipientProgressRef;
 
 exports.getAnnouncementRecipientProgress = function getAnnouncementRecipientProgress(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientProgressRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1485,7 +1485,7 @@ getAnnouncementRecipientsForResumeRef.operationName = 'GetAnnouncementRecipients
 exports.getAnnouncementRecipientsForResumeRef = getAnnouncementRecipientsForResumeRef;
 
 exports.getAnnouncementRecipientsForResume = function getAnnouncementRecipientsForResume(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientsForResumeRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1500,7 +1500,7 @@ getAnnouncementSendHistoryRef.operationName = 'GetAnnouncementSendHistory';
 exports.getAnnouncementSendHistoryRef = getAnnouncementSendHistoryRef;
 
 exports.getAnnouncementSendHistory = function getAnnouncementSendHistory(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendHistoryRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1515,7 +1515,7 @@ getAnnouncementSendRecipientsRef.operationName = 'GetAnnouncementSendRecipients'
 exports.getAnnouncementSendRecipientsRef = getAnnouncementSendRecipientsRef;
 
 exports.getAnnouncementSendRecipients = function getAnnouncementSendRecipients(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendRecipientsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1530,7 +1530,7 @@ getAnnouncementSendByIdRef.operationName = 'GetAnnouncementSendById';
 exports.getAnnouncementSendByIdRef = getAnnouncementSendByIdRef;
 
 exports.getAnnouncementSendById = function getAnnouncementSendById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementSendByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1545,7 +1545,7 @@ getAnnouncementRecipientBySendAndUserRef.operationName = 'GetAnnouncementRecipie
 exports.getAnnouncementRecipientBySendAndUserRef = getAnnouncementRecipientBySendAndUserRef;
 
 exports.getAnnouncementRecipientBySendAndUser = function getAnnouncementRecipientBySendAndUser(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getAnnouncementRecipientBySendAndUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1602,7 +1602,7 @@ getUserByEmailRef.operationName = 'GetUserByEmail';
 exports.getUserByEmailRef = getUserByEmailRef;
 
 exports.getUserByEmail = function getUserByEmail(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByEmailRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1617,7 +1617,7 @@ getNotifyCallbackUserByIdRef.operationName = 'GetNotifyCallbackUserById';
 exports.getNotifyCallbackUserByIdRef = getNotifyCallbackUserByIdRef;
 
 exports.getNotifyCallbackUserById = function getNotifyCallbackUserById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyCallbackUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1660,7 +1660,7 @@ getNotifyDeliveryReceiptRef.operationName = 'GetNotifyDeliveryReceipt';
 exports.getNotifyDeliveryReceiptRef = getNotifyDeliveryReceiptRef;
 
 exports.getNotifyDeliveryReceipt = function getNotifyDeliveryReceipt(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getNotifyDeliveryReceiptRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1731,7 +1731,7 @@ getRecentNotifyDeliveryReceiptsForUserRef.operationName = 'GetRecentNotifyDelive
 exports.getRecentNotifyDeliveryReceiptsForUserRef = getRecentNotifyDeliveryReceiptsForUserRef;
 
 exports.getRecentNotifyDeliveryReceiptsForUser = function getRecentNotifyDeliveryReceiptsForUser(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getRecentNotifyDeliveryReceiptsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1746,7 +1746,7 @@ getLatestNotifyDeliveryReceiptForReferenceRef.operationName = 'GetLatestNotifyDe
 exports.getLatestNotifyDeliveryReceiptForReferenceRef = getLatestNotifyDeliveryReceiptForReferenceRef;
 
 exports.getLatestNotifyDeliveryReceiptForReference = function getLatestNotifyDeliveryReceiptForReference(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getLatestNotifyDeliveryReceiptForReferenceRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1789,7 +1789,7 @@ getCallableInvocationRef.operationName = 'GetCallableInvocation';
 exports.getCallableInvocationRef = getCallableInvocationRef;
 
 exports.getCallableInvocation = function getCallableInvocation(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getCallableInvocationRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1888,7 +1888,7 @@ getCurrentUserRef.operationName = 'GetCurrentUser';
 exports.getCurrentUserRef = getCurrentUserRef;
 
 exports.getCurrentUser = function getCurrentUser(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getCurrentUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1903,7 +1903,7 @@ getUserByIdRef.operationName = 'GetUserById';
 exports.getUserByIdRef = getUserByIdRef;
 
 exports.getUserById = function getUserById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1918,7 +1918,7 @@ listUsersRef.operationName = 'ListUsers';
 exports.listUsersRef = listUsersRef;
 
 exports.listUsers = function listUsers(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUsersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1933,7 +1933,7 @@ listUserNamesByIdsRef.operationName = 'ListUserNamesByIds';
 exports.listUserNamesByIdsRef = listUserNamesByIdsRef;
 
 exports.listUserNamesByIds = function listUserNamesByIds(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listUserNamesByIdsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1948,7 +1948,7 @@ listSectionsRef.operationName = 'ListSections';
 exports.listSectionsRef = listSectionsRef;
 
 exports.listSections = function listSections(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listSectionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1963,7 +1963,7 @@ getSectionsForUserRef.operationName = 'GetSectionsForUser';
 exports.getSectionsForUserRef = getSectionsForUserRef;
 
 exports.getSectionsForUser = function getSectionsForUser(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getSectionsForUserRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1978,7 +1978,7 @@ listUserGroupsRef.operationName = 'ListUserGroups';
 exports.listUserGroupsRef = listUserGroupsRef;
 
 exports.listUserGroups = function listUserGroups(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listUserGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -1993,7 +1993,7 @@ getUserAccessGroupsRef.operationName = 'GetUserAccessGroups';
 exports.getUserAccessGroupsRef = getUserAccessGroupsRef;
 
 exports.getUserAccessGroups = function getUserAccessGroups(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getUserAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2008,7 +2008,7 @@ checkUserProfileExistsRef.operationName = 'CheckUserProfileExists';
 exports.checkUserProfileExistsRef = checkUserProfileExistsRef;
 
 exports.checkUserProfileExists = function checkUserProfileExists(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(checkUserProfileExistsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2023,7 +2023,7 @@ getUserMembershipStatusRef.operationName = 'GetUserMembershipStatus';
 exports.getUserMembershipStatusRef = getUserMembershipStatusRef;
 
 exports.getUserMembershipStatus = function getUserMembershipStatus(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserMembershipStatusRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2038,7 +2038,7 @@ getUserWithAccessGroupsRef.operationName = 'GetUserWithAccessGroups';
 exports.getUserWithAccessGroupsRef = getUserWithAccessGroupsRef;
 
 exports.getUserWithAccessGroups = function getUserWithAccessGroups(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserWithAccessGroupsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2053,7 +2053,7 @@ getUserAccessGroupsByIdRef.operationName = 'GetUserAccessGroupsById';
 exports.getUserAccessGroupsByIdRef = getUserAccessGroupsByIdRef;
 
 exports.getUserAccessGroupsById = function getUserAccessGroupsById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserAccessGroupsByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2068,7 +2068,7 @@ getEventsForSectionRef.operationName = 'GetEventsForSection';
 exports.getEventsForSectionRef = getEventsForSectionRef;
 
 exports.getEventsForSection = function getEventsForSection(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventsForSectionRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2083,7 +2083,7 @@ getEventByIdRef.operationName = 'GetEventById';
 exports.getEventByIdRef = getEventByIdRef;
 
 exports.getEventById = function getEventById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getEventByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2098,7 +2098,7 @@ getSectionByIdRef.operationName = 'GetSectionById';
 exports.getSectionByIdRef = getSectionByIdRef;
 
 exports.getSectionById = function getSectionById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2113,7 +2113,7 @@ getUserGroupByIdRef.operationName = 'GetUserGroupById';
 exports.getUserGroupByIdRef = getUserGroupByIdRef;
 
 exports.getUserGroupById = function getUserGroupById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getUserGroupByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2128,7 +2128,7 @@ getAllUserGroupsWithStatusesRef.operationName = 'GetAllUserGroupsWithStatuses';
 exports.getAllUserGroupsWithStatusesRef = getAllUserGroupsWithStatusesRef;
 
 exports.getAllUserGroupsWithStatuses = function getAllUserGroupsWithStatuses(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getAllUserGroupsWithStatusesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2143,7 +2143,7 @@ getSectionMembersRef.operationName = 'GetSectionMembers';
 exports.getSectionMembersRef = getSectionMembersRef;
 
 exports.getSectionMembers = function getSectionMembers(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionMembersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2158,7 +2158,7 @@ getMyBookingsForEventRef.operationName = 'GetMyBookingsForEvent';
 exports.getMyBookingsForEventRef = getMyBookingsForEventRef;
 
 exports.getMyBookingsForEvent = function getMyBookingsForEvent(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyBookingsForEventRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2173,7 +2173,7 @@ getMyBookingsRef.operationName = 'GetMyBookings';
 exports.getMyBookingsRef = getMyBookingsRef;
 
 exports.getMyBookings = function getMyBookings(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2188,7 +2188,7 @@ getMyTicketOrderByIdRef.operationName = 'GetMyTicketOrderById';
 exports.getMyTicketOrderByIdRef = getMyTicketOrderByIdRef;
 
 exports.getMyTicketOrderById = function getMyTicketOrderById(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getMyTicketOrderByIdRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2203,7 +2203,7 @@ getMyTicketOrdersRef.operationName = 'GetMyTicketOrders';
 exports.getMyTicketOrdersRef = getMyTicketOrdersRef;
 
 exports.getMyTicketOrders = function getMyTicketOrders(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyTicketOrdersRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2218,7 +2218,7 @@ getMyBookingPaymentAdjustmentsRef.operationName = 'GetMyBookingPaymentAdjustment
 exports.getMyBookingPaymentAdjustmentsRef = getMyBookingPaymentAdjustmentsRef;
 
 exports.getMyBookingPaymentAdjustments = function getMyBookingPaymentAdjustments(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyBookingPaymentAdjustmentsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2233,7 +2233,7 @@ listEventBookingsForAdminRef.operationName = 'ListEventBookingsForAdmin';
 exports.listEventBookingsForAdminRef = listEventBookingsForAdminRef;
 
 exports.listEventBookingsForAdmin = function listEventBookingsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listEventBookingsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2248,7 +2248,7 @@ listTicketOrdersForAdminRef.operationName = 'ListTicketOrdersForAdmin';
 exports.listTicketOrdersForAdminRef = listTicketOrdersForAdminRef;
 
 exports.listTicketOrdersForAdmin = function listTicketOrdersForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listTicketOrdersForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2263,7 +2263,7 @@ listBookingPaymentAdjustmentsForAdminRef.operationName = 'ListBookingPaymentAdju
 exports.listBookingPaymentAdjustmentsForAdminRef = listBookingPaymentAdjustmentsForAdminRef;
 
 exports.listBookingPaymentAdjustmentsForAdmin = function listBookingPaymentAdjustmentsForAdmin(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(listBookingPaymentAdjustmentsForAdminRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2278,7 +2278,7 @@ listOpenPaymentReconciliationExceptionsRef.operationName = 'ListOpenPaymentRecon
 exports.listOpenPaymentReconciliationExceptionsRef = listOpenPaymentReconciliationExceptionsRef;
 
 exports.listOpenPaymentReconciliationExceptions = function listOpenPaymentReconciliationExceptions(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(listOpenPaymentReconciliationExceptionsRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2293,7 +2293,7 @@ getSectionAnnouncementOptOutRef.operationName = 'GetSectionAnnouncementOptOut';
 exports.getSectionAnnouncementOptOutRef = getSectionAnnouncementOptOutRef;
 
 exports.getSectionAnnouncementOptOut = function getSectionAnnouncementOptOut(dcOrVars, varsOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrVars, varsOrOptions, options, true, true);
   return executeQuery(getSectionAnnouncementOptOutRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }
@@ -2308,7 +2308,7 @@ getMyAnnouncementPreferencesRef.operationName = 'GetMyAnnouncementPreferences';
 exports.getMyAnnouncementPreferencesRef = getMyAnnouncementPreferencesRef;
 
 exports.getMyAnnouncementPreferences = function getMyAnnouncementPreferences(dcOrOptions, options) {
-  
+
   const { dc: dcInstance, vars: inputVars, options: inputOpts } = validateArgsWithOptions(connectorConfig, dcOrOptions, options, undefined,false, false);
   return executeQuery(getMyAnnouncementPreferencesRef(dcInstance, inputVars), inputOpts && { fetchPolicy: inputOpts.fetchPolicy });
 }


### PR DESCRIPTION
## Summary

Normalize whitespace-only blank lines in the generated Data Connect ESM and CommonJS runtime bundles.

## Why

The production deployment preflight regenerates the Data Connect SDKs and then runs `scripts/normalize-generated-sdk.mjs`. The reviewed bundles on `main` still contained generator-emitted trailing whitespace, so normalization changed the checkout and the generated-drift guard stopped deployment with:

> Confirm generated SDKs match the reviewed commit failed: the checkout contains unreviewed changes.

Committing the normalized output makes regeneration plus normalization idempotent and allows the safety guard to distinguish real generated SDK drift from formatting noise.

## Impact

This is a whitespace-only generated-code change. Runtime behavior is unchanged. Production deployment remains blocked until this normalization is merged and the deploy is retried from a clean checkout.

## Validation

- `node scripts/normalize-generated-sdk.mjs` — idempotent
- `npm run test:deploy-safety -- --run scripts/deploy-environment.test.mjs scripts/deployment-check.test.mjs` — 55 tests passed
- `npm run lint` — passed
- `npm run build` — passed