### PR TITLE
Complete surname-initial recipient groups

### DIFF
--- a/functions/src/announcements.ts
+++ b/functions/src/announcements.ts
@@ -409,7 +409,11 @@ export type AnnouncementRecipientStatusFilter =
   | "FAILED"
   | "SKIPPED";
 
-export type AnnouncementRecipientInitial = "ALL" | "OTHER" | Uppercase<string>;
+export type AnnouncementRecipientSurnameInitial =
+  | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+  | "OTHER";
+export type AnnouncementRecipientInitial = "ALL" | AnnouncementRecipientSurnameInitial;
 
 export interface AnnouncementRecipientPage {
   recipients: AnnouncementRecipient[];

--- a/src/features/admin/components/AnnouncementSendHistory.tsx
+++ b/src/features/admin/components/AnnouncementSendHistory.tsx
@@ -39,6 +39,7 @@ import {
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
 import {
+  announcementRecipientRetryDelayMs,
   loadCompleteInitialGroup,
   type CompleteInitialLoadOutcome,
 } from "../utils/announcementRecipientInitialLoader";
@@ -48,7 +49,10 @@ interface Props {
   refreshTrigger?: number;
 }
 
-const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const ALPHABET = [
+  "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+  "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+] as const;
 const VIRTUAL_ROW_HEIGHT = 53;
 const VIRTUAL_VIEWPORT_HEIGHT = 530;
 const VIRTUAL_OVERSCAN = 5;
@@ -190,8 +194,8 @@ function RecipientTable({
 }
 
 type InitialLoadState =
-  | { status: "idle" | "loading" | "complete" }
-  | { status: "changed" }
+  | { status: "idle" | "loading" }
+  | { status: "complete"; resultsChanged: boolean }
   | { status: "partial"; failedPage: number; message: string };
 
 function SendRow({
@@ -252,7 +256,7 @@ function SendRow({
       });
       return;
     }
-    setInitialLoadState({ status: outcome.status });
+    setInitialLoadState({ status: "complete", resultsChanged: outcome.resultsChanged });
   }, [initial, send.id]);
 
   const loadInitialRemainder = useCallback(async (
@@ -270,6 +274,7 @@ function SendRow({
       onProgress: (progress) => {
         if (recipientRequestGuard.isCurrent(requestToken)) setData(progress);
       },
+      retryDelayMs: announcementRecipientRetryDelayMs,
     });
     if (recipientRequestGuard.isCurrent(requestToken)) applyInitialOutcome(outcome);
   }, [applyInitialOutcome, fetchRecipientPage, initial, recipientRequestGuard]);
@@ -293,7 +298,7 @@ function SendRow({
       } else if (result.pageCount > 1) {
         await loadInitialRemainder(requestToken, result, 2);
       } else {
-        setInitialLoadState({ status: "complete" });
+        setInitialLoadState({ status: "complete", resultsChanged: false });
       }
     } catch (caught) {
       if (!recipientRequestGuard.isCurrent(requestToken)) return;
@@ -536,9 +541,9 @@ function SendRow({
 
               {loading && <LinearProgress aria-label="Loading recipients" sx={{ mb: 1 }} />}
               {error && <Alert severity="error" sx={{ my: 1 }}>{error}</Alert>}
-              {initialLoadState.status === "changed" && (
-                <Alert severity="warning" action={<Button color="inherit" size="small" onClick={() => void load()}>Refresh group</Button>} sx={{ my: 1 }}>
-                  Results changed while loading. Refresh to load the current group.
+              {initialLoadState.status === "complete" && initialLoadState.resultsChanged && (
+                <Alert severity="info" sx={{ my: 1 }}>
+                  Recipient results changed while this group was loading. The completed list reflects each recipient when loaded; use Refresh for the latest statuses.
                 </Alert>
               )}
               {initialLoadState.status === "partial" && (

--- a/src/features/admin/components/AnnouncementSendHistory.tsx
+++ b/src/features/admin/components/AnnouncementSendHistory.tsx
@@ -38,6 +38,10 @@ import {
 } from "../../../shared/utils/firebaseFunctions";
 import { reportError, toAdminUserFacingError } from "../../../shared/errors";
 import { useLatestRequestGuard } from "../../../shared/hooks/useLatestRequestGuard";
+import {
+  loadCompleteInitialGroup,
+  type CompleteInitialLoadOutcome,
+} from "../utils/announcementRecipientInitialLoader";
 
 interface Props {
   sectionId: string;
@@ -45,6 +49,9 @@ interface Props {
 }
 
 const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const VIRTUAL_ROW_HEIGHT = 53;
+const VIRTUAL_VIEWPORT_HEIGHT = 530;
+const VIRTUAL_OVERSCAN = 5;
 const STATUS_OPTIONS: Array<{ value: AnnouncementRecipientStatusFilter; label: string; noun: string }> = [
   { value: "ALL", label: "All statuses", noun: "recipients" },
   { value: "IN_PROGRESS", label: "In progress", noun: "in-progress recipients" },
@@ -109,6 +116,84 @@ function emptyRecipientPage(): AnnouncementRecipientPage {
   };
 }
 
+function RecipientRow({ recipient }: { recipient: AnnouncementRecipient }) {
+  return (
+    <TableRow sx={{ height: VIRTUAL_ROW_HEIGHT }}>
+      <TableCell sx={{ whiteSpace: "nowrap" }}>{recipient.firstName} {recipient.lastName}</TableCell>
+      <TableCell sx={{ whiteSpace: "nowrap" }}>{recipient.email}</TableCell>
+      <TableCell>{statusChip(recipient)}</TableCell>
+      <TableCell sx={{ whiteSpace: "nowrap" }}>{recipient.effectiveDeliveryMode.replace("_", " ")}</TableCell>
+      <TableCell>
+        <Typography variant="caption" color="text.secondary" noWrap display="block">
+          {recipientDetail(recipient)}
+        </Typography>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function RecipientTable({
+  recipients,
+  virtualized,
+}: {
+  recipients: AnnouncementRecipient[];
+  virtualized: boolean;
+}) {
+  const [scrollTop, setScrollTop] = useState(0);
+  const visibleRows = Math.ceil(VIRTUAL_VIEWPORT_HEIGHT / VIRTUAL_ROW_HEIGHT);
+  const startIndex = virtualized
+    ? Math.max(0, Math.floor(scrollTop / VIRTUAL_ROW_HEIGHT) - VIRTUAL_OVERSCAN)
+    : 0;
+  const endIndex = virtualized
+    ? Math.min(recipients.length, startIndex + visibleRows + (VIRTUAL_OVERSCAN * 2))
+    : recipients.length;
+  const topSpacerHeight = startIndex * VIRTUAL_ROW_HEIGHT;
+  const bottomSpacerHeight = (recipients.length - endIndex) * VIRTUAL_ROW_HEIGHT;
+
+  return (
+    <TableContainer
+      aria-label={virtualized ? "Virtualized recipient results" : undefined}
+      onScroll={virtualized ? (event) => setScrollTop(event.currentTarget.scrollTop) : undefined}
+      sx={{
+        overflowX: "auto",
+        ...(virtualized ? { maxHeight: VIRTUAL_VIEWPORT_HEIGHT, overflowY: "auto" } : {}),
+      }}
+    >
+      <Table size="small" stickyHeader={virtualized} sx={virtualized ? { tableLayout: "fixed" } : undefined}>
+        <TableHead>
+          <TableRow>
+            <TableCell>Name</TableCell>
+            <TableCell>Email</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>Mode</TableCell>
+            <TableCell>Detail</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {topSpacerHeight > 0 && (
+            <TableRow aria-hidden="true" sx={{ height: topSpacerHeight }}>
+              <TableCell colSpan={5} sx={{ height: topSpacerHeight, p: 0, border: 0 }} />
+            </TableRow>
+          )}
+          {recipients.slice(startIndex, endIndex).map((recipient) => (
+            <RecipientRow key={recipient.id} recipient={recipient} />
+          ))}
+          {bottomSpacerHeight > 0 && (
+            <TableRow aria-hidden="true" sx={{ height: bottomSpacerHeight }}>
+              <TableCell colSpan={5} sx={{ height: bottomSpacerHeight, p: 0, border: 0 }} />
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+type InitialLoadState =
+  | { status: "idle" | "loading" | "complete" }
+  | { status: "changed" }
+  | { status: "partial"; failedPage: number; message: string };
+
 function SendRow({
   send,
   sectionId,
@@ -127,6 +212,7 @@ function SendRow({
   const [statusFilter, setStatusFilter] = useState<AnnouncementRecipientStatusFilter>("ALL");
   const [initial, setInitial] = useState<AnnouncementRecipientInitial>("ALL");
   const [page, setPage] = useState(1);
+  const [initialLoadState, setInitialLoadState] = useState<InitialLoadState>({ status: "idle" });
   const [retryingPreparation, setRetryingPreparation] = useState(false);
   const [retryAttemptId, setRetryAttemptId] = useState<string | null>(null);
   const [retryMessage, setRetryMessage] = useState<string | null>(null);
@@ -141,17 +227,60 @@ function SendRow({
     return () => window.clearTimeout(timeout);
   }, [searchInput]);
 
+  const fetchRecipientPage = useCallback((requestedPage: number) => (
+    getAnnouncementSendRecipients(send.id, sectionId, {
+      search,
+      statusFilter,
+      initial,
+      page: requestedPage,
+    })
+  ), [initial, search, sectionId, send.id, statusFilter]);
+
+  const applyInitialOutcome = useCallback((outcome: CompleteInitialLoadOutcome) => {
+    if (outcome.status === "stale") return;
+    setData(outcome.data);
+    if (outcome.status === "partial") {
+      reportError("admin.announcements.recipients.remainder", outcome.error, {
+        sendId: send.id,
+        initial,
+        failedPage: outcome.failedPage,
+      });
+      setInitialLoadState({
+        status: "partial",
+        failedPage: outcome.failedPage,
+        message: toAdminUserFacingError(outcome.error, "announcements").message,
+      });
+      return;
+    }
+    setInitialLoadState({ status: outcome.status });
+  }, [initial, send.id]);
+
+  const loadInitialRemainder = useCallback(async (
+    requestToken: number,
+    seed: AnnouncementRecipientPage,
+    startPage: number,
+  ) => {
+    if (initial === "ALL") return;
+    const outcome = await loadCompleteInitialGroup({
+      initial,
+      seed,
+      startPage,
+      fetchPage: fetchRecipientPage,
+      isCurrent: () => recipientRequestGuard.isCurrent(requestToken),
+      onProgress: (progress) => {
+        if (recipientRequestGuard.isCurrent(requestToken)) setData(progress);
+      },
+    });
+    if (recipientRequestGuard.isCurrent(requestToken)) applyInitialOutcome(outcome);
+  }, [applyInitialOutcome, fetchRecipientPage, initial, recipientRequestGuard]);
+
   const load = useCallback(async () => {
     const requestToken = recipientRequestGuard.start();
     setLoading(true);
     setError(null);
+    setInitialLoadState({ status: initial === "ALL" ? "idle" : "loading" });
     try {
-      const result = await getAnnouncementSendRecipients(send.id, sectionId, {
-        search,
-        statusFilter,
-        initial,
-        page,
-      });
+      const result = await fetchRecipientPage(initial === "ALL" ? page : 1);
       if (!recipientRequestGuard.isCurrent(requestToken)) return;
       if (initial !== "ALL" && (result.initialCounts[initial] ?? 0) === 0) {
         setInitial("ALL");
@@ -159,15 +288,34 @@ function SendRow({
         return;
       }
       setData(result);
-      if (result.page !== page) setPage(result.page);
+      if (initial === "ALL") {
+        if (result.page !== page) setPage(result.page);
+      } else if (result.pageCount > 1) {
+        await loadInitialRemainder(requestToken, result, 2);
+      } else {
+        setInitialLoadState({ status: "complete" });
+      }
     } catch (caught) {
       if (!recipientRequestGuard.isCurrent(requestToken)) return;
       reportError("admin.announcements.recipients", caught, { sendId: send.id });
       setError(toAdminUserFacingError(caught, "announcements").message);
+      setInitialLoadState({ status: "idle" });
     } finally {
       if (recipientRequestGuard.isCurrent(requestToken)) setLoading(false);
     }
-  }, [send.id, sectionId, search, statusFilter, initial, page, recipientRequestGuard]);
+  }, [fetchRecipientPage, initial, loadInitialRemainder, page, recipientRequestGuard, send.id]);
+
+  const retryRemainingRecipients = useCallback(async () => {
+    if (initial === "ALL" || initialLoadState.status !== "partial" || data === null) return;
+    const requestToken = recipientRequestGuard.start();
+    setLoading(true);
+    setInitialLoadState({ status: "loading" });
+    try {
+      await loadInitialRemainder(requestToken, data, initialLoadState.failedPage);
+    } finally {
+      if (recipientRequestGuard.isCurrent(requestToken)) setLoading(false);
+    }
+  }, [data, initial, initialLoadState, loadInitialRemainder, recipientRequestGuard]);
 
   const retryPreparation = useCallback(async () => {
     const requestToken = retryRequestGuard.start();
@@ -196,6 +344,13 @@ function SendRow({
   const selectInitial = (nextInitial: AnnouncementRecipientInitial) => {
     setInitial(nextInitial);
     setPage(1);
+    setInitialLoadState({ status: nextInitial === "ALL" ? "idle" : "loading" });
+    setData((current) => current === null ? null : {
+      ...current,
+      recipients: [],
+      page: 1,
+      pageCount: 1,
+    });
   };
 
   const clearFilters = () => {
@@ -212,7 +367,7 @@ function SendRow({
     : result.initialCounts[initial] ?? 0;
   const start = selectedCount === 0
     ? 0
-    : (result.page - 1) * result.pageSize + 1;
+    : initial === "ALL" ? (result.page - 1) * result.pageSize + 1 : 1;
   const end = selectedCount === 0 ? 0 : start + result.recipients.length - 1;
   const resultNoun = STATUS_OPTIONS.find((option) => option.value === statusFilter)?.noun ?? "recipients";
   const initialSuffix = initial === "ALL"
@@ -374,11 +529,28 @@ function SendRow({
               <Typography variant="body2" color="text.secondary" aria-live="polite" sx={{ mb: 1 }}>
                 {selectedCount === 0
                   ? `No ${resultNoun} to show`
-                  : `Showing ${start}–${end} of ${selectedCount} ${resultNoun}${initialSuffix}`}
+                  : initial !== "ALL" && initialLoadState.status !== "complete"
+                    ? `Loaded ${result.recipients.length} of ${selectedCount} ${resultNoun}${initialSuffix}`
+                    : `Showing ${start}–${end} of ${selectedCount} ${resultNoun}${initialSuffix}`}
               </Typography>
 
               {loading && <LinearProgress aria-label="Loading recipients" sx={{ mb: 1 }} />}
               {error && <Alert severity="error" sx={{ my: 1 }}>{error}</Alert>}
+              {initialLoadState.status === "changed" && (
+                <Alert severity="warning" action={<Button color="inherit" size="small" onClick={() => void load()}>Refresh group</Button>} sx={{ my: 1 }}>
+                  Results changed while loading. Refresh to load the current group.
+                </Alert>
+              )}
+              {initialLoadState.status === "partial" && (
+                <Alert
+                  severity="error"
+                  action={<Button color="inherit" size="small" onClick={() => void retryRemainingRecipients()}>Retry loading remaining recipients</Button>}
+                  sx={{ my: 1 }}
+                >
+                  {initialLoadState.message} Loading stopped at chunk {initialLoadState.failedPage} of {result.pageCount}.
+                  {" "}Loaded {result.recipients.length} of {selectedCount}; the group is incomplete.
+                </Alert>
+              )}
               {!loading && !error && result.totalCount === 0 && (
                 <Alert severity="info" sx={{ my: 1 }}>No recipients recorded.</Alert>
               )}
@@ -392,43 +564,18 @@ function SendRow({
                 </Alert>
               )}
               {!error && result.recipients.length > 0 && (
-                <TableContainer sx={{ overflowX: "auto" }}>
-                  <Table size="small">
-                    <TableHead>
-                      <TableRow>
-                        <TableCell>Name</TableCell>
-                        <TableCell>Email</TableCell>
-                        <TableCell>Status</TableCell>
-                        <TableCell>Mode</TableCell>
-                        <TableCell>Detail</TableCell>
-                      </TableRow>
-                    </TableHead>
-                    <TableBody>
-                      {result.recipients.map((recipient) => (
-                        <TableRow key={recipient.id}>
-                          <TableCell>{recipient.firstName} {recipient.lastName}</TableCell>
-                          <TableCell>{recipient.email}</TableCell>
-                          <TableCell>{statusChip(recipient)}</TableCell>
-                          <TableCell>{recipient.effectiveDeliveryMode.replace("_", " ")}</TableCell>
-                          <TableCell>
-                            <Typography variant="caption" color="text.secondary">
-                              {recipientDetail(recipient)}
-                            </Typography>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </TableContainer>
+                <RecipientTable
+                  key={`${initial}:${search}:${statusFilter}`}
+                  recipients={result.recipients}
+                  virtualized={initial !== "ALL" && selectedCount > 250}
+                />
               )}
-              {result.pageCount > 1 && (
+              {initial === "ALL" && result.pageCount > 1 && (
                 <Pagination
                   page={result.page}
                   count={result.pageCount}
                   onChange={(_event, nextPage) => setPage(nextPage)}
-                  aria-label={initial === "ALL"
-                    ? "Recipient result pages"
-                    : `${initial} surname recipient result pages`}
+                  aria-label="Recipient result pages"
                   sx={{ display: "flex", justifyContent: "center", mt: 2 }}
                 />
               )}

--- a/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
+++ b/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "../../../../test-utils";
+import { act, render, screen, waitFor } from "../../../../test-utils";
 import userEvent from "@testing-library/user-event";
 import * as firebaseFunctions from "../../../../shared/utils/firebaseFunctions";
 import AnnouncementSendHistory from "../AnnouncementSendHistory";
@@ -282,20 +282,33 @@ describe("AnnouncementSendHistory", () => {
     expect(screen.getByText("Showing 1–3 of 3 recipients with surname B")).toBeInTheDocument();
   });
 
-  it("shows numeric pages when a surname-initial group exceeds its bounded page size", async () => {
+  it("automatically loads and virtualizes a surname-initial group that exceeds the API page size", async () => {
     vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
+    const smiths = Array.from({ length: 251 }, (_value, index) => ({
+      ...mockRecipients[0],
+      id: `smith-${index + 1}`,
+      userId: `smith-user-${index + 1}`,
+      email: `smith-${index + 1}@example.com`,
+      firstName: `Person ${index + 1}`,
+      lastName: `Smith ${index + 1}`,
+    }));
     vi.mocked(firebaseFunctions.getAnnouncementSendRecipients).mockImplementation(
-      async (_sendId, _sectionId, options) => ({
-        ...mockRecipientPage,
-        filteredCount: 251,
-        initialCounts: {
-          ...mockRecipientPage.initialCounts,
-          S: 251,
-        },
-        page: options?.page ?? 1,
-        pageSize: 250,
-        pageCount: options?.initial === "S" ? 2 : 6,
-      }),
+      async (_sendId, _sectionId, options) => options?.initial === "S"
+        ? {
+            ...mockRecipientPage,
+            recipients: options.page === 2 ? smiths.slice(250) : smiths.slice(0, 250),
+            filteredCount: 251,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 251 },
+            page: options.page ?? 1,
+            pageSize: 250,
+            pageCount: 2,
+          }
+        : {
+            ...mockRecipientPage,
+            filteredCount: 251,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 251 },
+            pageCount: 6,
+          },
     );
 
     const user = userEvent.setup();
@@ -303,7 +316,171 @@ describe("AnnouncementSendHistory", () => {
     await user.click((await screen.findAllByRole("button", { name: "Expand" }))[0]);
     await user.click(screen.getByRole("button", { name: "S: 251 recipients" }));
 
-    expect(await screen.findByLabelText("S surname recipient result pages")).toBeInTheDocument();
+    expect(await screen.findByText("Showing 1–251 of 251 recipients with surname S")).toBeInTheDocument();
+    expect(screen.getByLabelText("Virtualized recipient results")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Recipient result pages")).not.toBeInTheDocument();
+    expect(firebaseFunctions.getAnnouncementSendRecipients).toHaveBeenNthCalledWith(
+      2,
+      "send-1",
+      SECTION_ID,
+      expect.objectContaining({ initial: "S", page: 1 }),
+    );
+    expect(firebaseFunctions.getAnnouncementSendRecipients).toHaveBeenNthCalledWith(
+      3,
+      "send-1",
+      SECTION_ID,
+      expect.objectContaining({ initial: "S", page: 2 }),
+    );
+  });
+
+  it("keeps loaded recipients and retries from a failed surname-initial chunk", async () => {
+    vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
+    const pageTwoRecipient = {
+      ...mockRecipients[0],
+      id: "rec-s-3",
+      userId: "user-s-3",
+      firstName: "Third",
+      lastName: "Smith",
+      email: "third.smith@example.com",
+    };
+    let pageTwoAttempts = 0;
+    vi.mocked(firebaseFunctions.getAnnouncementSendRecipients).mockImplementation(
+      async (_sendId, _sectionId, options) => {
+        if (options?.initial !== "S") {
+          return {
+            ...mockRecipientPage,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+          };
+        }
+        if (options.page === 2) {
+          pageTwoAttempts += 1;
+          if (pageTwoAttempts === 1) throw new Error("temporary failure");
+          return {
+            ...mockRecipientPage,
+            recipients: [pageTwoRecipient],
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+            filteredCount: 3,
+            page: 2,
+            pageSize: 2,
+            pageCount: 2,
+          };
+        }
+        return {
+          ...mockRecipientPage,
+          recipients: mockRecipients.slice(0, 2),
+          initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+          filteredCount: 3,
+          pageSize: 2,
+          pageCount: 2,
+        };
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<AnnouncementSendHistory sectionId={SECTION_ID} />);
+    await user.click((await screen.findAllByRole("button", { name: "Expand" }))[0]);
+    await user.click(screen.getByRole("button", { name: "S: 3 recipients" }));
+
+    expect(await screen.findByText(/Loaded 2 of 3; the group is incomplete/)).toBeInTheDocument();
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry loading remaining recipients" }));
+
+    expect(await screen.findByText("Showing 1–3 of 3 recipients with surname S")).toBeInTheDocument();
+    expect(screen.getByText("Third Smith")).toBeInTheDocument();
+    expect(pageTwoAttempts).toBe(2);
+  });
+
+  it("asks for a refresh when surname-initial counts change between chunks", async () => {
+    vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
+    vi.mocked(firebaseFunctions.getAnnouncementSendRecipients).mockImplementation(
+      async (_sendId, _sectionId, options) => options?.initial === "S" && options.page === 2
+        ? {
+            ...mockRecipientPage,
+            recipients: [mockRecipients[2]],
+            filteredCount: 4,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 4 },
+            page: 2,
+            pageSize: 2,
+            pageCount: 2,
+          }
+        : {
+            ...mockRecipientPage,
+            recipients: options?.initial === "S" ? mockRecipients.slice(0, 2) : mockRecipients,
+            filteredCount: 3,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+            pageSize: options?.initial === "S" ? 2 : 50,
+            pageCount: options?.initial === "S" ? 2 : 1,
+          },
+    );
+
+    const user = userEvent.setup();
+    render(<AnnouncementSendHistory sectionId={SECTION_ID} />);
+    await user.click((await screen.findAllByRole("button", { name: "Expand" }))[0]);
+    await user.click(screen.getByRole("button", { name: "S: 3 recipients" }));
+
+    expect(await screen.findByText("Results changed while loading. Refresh to load the current group."))
+      .toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Refresh group" })).toBeInTheDocument();
+  });
+
+  it("ignores a chained surname response after switching back to All", async () => {
+    vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
+    let resolveSecondSurnamePage!: (value: firebaseFunctions.AnnouncementRecipientPage) => void;
+    vi.mocked(firebaseFunctions.getAnnouncementSendRecipients).mockImplementation(
+      async (_sendId, _sectionId, options) => {
+        if (options?.initial === "S" && options.page === 2) {
+          return new Promise((resolve) => { resolveSecondSurnamePage = resolve; });
+        }
+        if (options?.initial === "S") {
+          return {
+            ...mockRecipientPage,
+            recipients: mockRecipients.slice(0, 2),
+            filteredCount: 3,
+            initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+            pageSize: 2,
+            pageCount: 2,
+          };
+        }
+        return {
+          ...mockRecipientPage,
+          initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+        };
+      },
+    );
+
+    const user = userEvent.setup();
+    render(<AnnouncementSendHistory sectionId={SECTION_ID} />);
+    await user.click((await screen.findAllByRole("button", { name: "Expand" }))[0]);
+    await user.click(screen.getByRole("button", { name: "S: 3 recipients" }));
+    await waitFor(() => expect(firebaseFunctions.getAnnouncementSendRecipients).toHaveBeenCalledWith(
+      "send-1",
+      SECTION_ID,
+      expect.objectContaining({ initial: "S", page: 2 }),
+    ));
+
+    await user.click(screen.getByRole("button", { name: /^All \(/ }));
+    expect(await screen.findByText(`Showing 1–${mockRecipients.length} of ${mockRecipients.length} recipients`))
+      .toBeInTheDocument();
+
+    await act(async () => {
+      resolveSecondSurnamePage({
+        ...mockRecipientPage,
+        recipients: [{
+          ...mockRecipients[0],
+          id: "stale-recipient",
+          firstName: "Stale",
+          lastName: "Smith",
+        }],
+        filteredCount: 3,
+        initialCounts: { ...mockRecipientPage.initialCounts, S: 3 },
+        page: 2,
+        pageSize: 2,
+        pageCount: 2,
+      });
+    });
+
+    expect(screen.queryByText("Stale Smith")).not.toBeInTheDocument();
+    expect(screen.getByText("Alice Smith")).toBeInTheDocument();
   });
 
   it("refreshes history and any expanded recipient view", async () => {

--- a/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
+++ b/src/features/admin/components/__tests__/AnnouncementSendHistory.test.tsx
@@ -390,7 +390,7 @@ describe("AnnouncementSendHistory", () => {
     expect(pageTwoAttempts).toBe(2);
   });
 
-  it("asks for a refresh when surname-initial counts change between chunks", async () => {
+  it("completes the group and explains when mutable status counts change between chunks", async () => {
     vi.mocked(firebaseFunctions.getAnnouncementSendHistory).mockResolvedValue(mockSends);
     vi.mocked(firebaseFunctions.getAnnouncementSendRecipients).mockImplementation(
       async (_sendId, _sectionId, options) => options?.initial === "S" && options.page === 2
@@ -418,9 +418,10 @@ describe("AnnouncementSendHistory", () => {
     await user.click((await screen.findAllByRole("button", { name: "Expand" }))[0]);
     await user.click(screen.getByRole("button", { name: "S: 3 recipients" }));
 
-    expect(await screen.findByText("Results changed while loading. Refresh to load the current group."))
+    expect(await screen.findByText(/Recipient results changed while this group was loading/))
       .toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Refresh group" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Refresh group" })).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1–3 of 4 recipients with surname S")).toBeInTheDocument();
   });
 
   it("ignores a chained surname response after switching back to All", async () => {

--- a/src/features/admin/utils/__tests__/announcementRecipientInitialLoader.test.ts
+++ b/src/features/admin/utils/__tests__/announcementRecipientInitialLoader.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type {
+  AnnouncementRecipient,
+  AnnouncementRecipientPage,
+} from "../../../../shared/utils/firebaseFunctions";
+import { loadCompleteInitialGroup } from "../announcementRecipientInitialLoader";
+
+function recipient(id: string): AnnouncementRecipient {
+  return {
+    id,
+    sendId: "send-1",
+    userId: `user-${id}`,
+    email: `${id}@example.com`,
+    firstName: "Test",
+    lastName: `Smith ${id}`,
+    status: "delivered",
+    effectiveDeliveryMode: "LIVE",
+  };
+}
+
+function page(args: {
+  recipients: AnnouncementRecipient[];
+  selectedCount?: number;
+  page?: number;
+  pageCount?: number;
+}): AnnouncementRecipientPage {
+  const selectedCount = args.selectedCount ?? 3;
+  return {
+    recipients: args.recipients,
+    totalCount: selectedCount,
+    filteredCount: selectedCount,
+    initialCounts: { S: selectedCount, OTHER: 0 },
+    page: args.page ?? 1,
+    pageSize: 1,
+    pageCount: args.pageCount ?? 3,
+  };
+}
+
+describe("loadCompleteInitialGroup", () => {
+  it("loads pages sequentially and deduplicates recipient IDs", async () => {
+    const activeRequests: number[] = [];
+    let concurrent = 0;
+    let maxConcurrent = 0;
+    const fetchPage = vi.fn(async (pageNumber: number) => {
+      activeRequests.push(pageNumber);
+      concurrent += 1;
+      maxConcurrent = Math.max(maxConcurrent, concurrent);
+      await Promise.resolve();
+      concurrent -= 1;
+      return page({
+        page: pageNumber,
+        recipients: pageNumber === 2 ? [recipient("1"), recipient("2")] : [recipient("3")],
+      });
+    });
+
+    const outcome = await loadCompleteInitialGroup({
+      initial: "S",
+      seed: page({ recipients: [recipient("1")] }),
+      startPage: 2,
+      fetchPage,
+      isCurrent: () => true,
+    });
+
+    expect(outcome.status).toBe("complete");
+    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1", "2", "3"]);
+    expect(activeRequests).toEqual([2, 3]);
+    expect(maxConcurrent).toBe(1);
+  });
+
+  it("stops when the selected count changes", async () => {
+    const outcome = await loadCompleteInitialGroup({
+      initial: "S",
+      seed: page({ recipients: [recipient("1")] }),
+      startPage: 2,
+      fetchPage: async () => page({ recipients: [recipient("2")], selectedCount: 4, pageCount: 4 }),
+      isCurrent: () => true,
+    });
+
+    expect(outcome.status).toBe("changed");
+    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1"]);
+  });
+
+  it("returns a resumable partial result when a later page fails", async () => {
+    const error = new Error("network");
+    const outcome = await loadCompleteInitialGroup({
+      initial: "S",
+      seed: page({ recipients: [recipient("1")] }),
+      startPage: 2,
+      fetchPage: async (pageNumber) => {
+        if (pageNumber === 3) throw error;
+        return page({ page: pageNumber, recipients: [recipient("2")] });
+      },
+      isCurrent: () => true,
+    });
+
+    expect(outcome).toMatchObject({ status: "partial", failedPage: 3, error });
+    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1", "2"]);
+  });
+
+  it("ignores a response after the request becomes stale", async () => {
+    const outcome = await loadCompleteInitialGroup({
+      initial: "S",
+      seed: page({ recipients: [recipient("1")] }),
+      startPage: 2,
+      fetchPage: async () => page({ page: 2, recipients: [recipient("2")] }),
+      isCurrent: () => false,
+    });
+
+    expect(outcome.status).toBe("stale");
+    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1"]);
+  });
+});

--- a/src/features/admin/utils/__tests__/announcementRecipientInitialLoader.test.ts
+++ b/src/features/admin/utils/__tests__/announcementRecipientInitialLoader.test.ts
@@ -3,7 +3,10 @@ import type {
   AnnouncementRecipient,
   AnnouncementRecipientPage,
 } from "../../../../shared/utils/firebaseFunctions";
-import { loadCompleteInitialGroup } from "../announcementRecipientInitialLoader";
+import {
+  announcementRecipientRetryDelayMs,
+  loadCompleteInitialGroup,
+} from "../announcementRecipientInitialLoader";
 
 function recipient(id: string): AnnouncementRecipient {
   return {
@@ -67,17 +70,58 @@ describe("loadCompleteInitialGroup", () => {
     expect(maxConcurrent).toBe(1);
   });
 
-  it("stops when the selected count changes", async () => {
+  it("adapts when mutable status counts change during the load", async () => {
+    const fetchPage = vi.fn(async () => page({
+      recipients: [recipient("2")],
+      selectedCount: 4,
+      pageCount: 4,
+    }));
     const outcome = await loadCompleteInitialGroup({
       initial: "S",
       seed: page({ recipients: [recipient("1")] }),
       startPage: 2,
-      fetchPage: async () => page({ recipients: [recipient("2")], selectedCount: 4, pageCount: 4 }),
+      fetchPage,
       isCurrent: () => true,
     });
 
-    expect(outcome.status).toBe("changed");
-    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1"]);
+    expect(outcome).toMatchObject({ status: "complete", resultsChanged: true });
+    expect(outcome.data.recipients.map(({ id }) => id)).toEqual(["1", "2"]);
+    expect(fetchPage.mock.calls).toEqual([[2], [3], [4]]);
+  });
+
+  it("backs off and retries rate-limit failures before returning a partial result", async () => {
+    const rateLimitError = { code: "functions/resource-exhausted" };
+    const fetchPage = vi.fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValue(page({
+        page: 2,
+        pageCount: 2,
+        selectedCount: 2,
+        recipients: [recipient("2")],
+      }));
+    const wait = vi.fn(async () => undefined);
+
+    const outcome = await loadCompleteInitialGroup({
+      initial: "S",
+      seed: page({ recipients: [recipient("1")], selectedCount: 2, pageCount: 2 }),
+      startPage: 2,
+      fetchPage,
+      isCurrent: () => true,
+      retryDelayMs: announcementRecipientRetryDelayMs,
+      wait,
+    });
+
+    expect(outcome).toMatchObject({ status: "complete", resultsChanged: false });
+    expect(wait.mock.calls).toEqual([[1_000], [2_000]]);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-rate-limit failures or retry rate limits indefinitely", () => {
+    expect(announcementRecipientRetryDelayMs({ code: "functions/internal" }, 0)).toBeNull();
+    expect(announcementRecipientRetryDelayMs({ code: "functions/resource-exhausted" }, 0)).toBe(1_000);
+    expect(announcementRecipientRetryDelayMs({ code: "functions/resource-exhausted" }, 2)).toBe(4_000);
+    expect(announcementRecipientRetryDelayMs({ code: "functions/resource-exhausted" }, 3)).toBeNull();
   });
 
   it("returns a resumable partial result when a later page fails", async () => {

--- a/src/features/admin/utils/announcementRecipientInitialLoader.ts
+++ b/src/features/admin/utils/announcementRecipientInitialLoader.ts
@@ -1,21 +1,33 @@
 import type {
-  AnnouncementRecipientInitial,
   AnnouncementRecipientPage,
+  AnnouncementRecipientSurnameInitial,
 } from "../../../shared/utils/firebaseFunctions";
+import { classifyError } from "../../../shared/errors";
+
+const RATE_LIMIT_BACKOFF_MS = [1_000, 2_000, 4_000] as const;
+
+export function announcementRecipientRetryDelayMs(
+  error: unknown,
+  failedAttempt: number,
+): number | null {
+  if (classifyError(error) !== "rate-limit") return null;
+  return RATE_LIMIT_BACKOFF_MS[failedAttempt] ?? null;
+}
 
 export type CompleteInitialLoadOutcome =
-  | { status: "complete"; data: AnnouncementRecipientPage }
-  | { status: "changed"; data: AnnouncementRecipientPage }
+  | { status: "complete"; data: AnnouncementRecipientPage; resultsChanged: boolean }
   | { status: "partial"; data: AnnouncementRecipientPage; failedPage: number; error: unknown }
   | { status: "stale"; data: AnnouncementRecipientPage };
 
 interface LoadCompleteInitialGroupOptions {
-  initial: Exclude<AnnouncementRecipientInitial, "ALL">;
+  initial: AnnouncementRecipientSurnameInitial;
   seed: AnnouncementRecipientPage;
   startPage: number;
   fetchPage: (page: number) => Promise<AnnouncementRecipientPage>;
   isCurrent: () => boolean;
   onProgress?: (data: AnnouncementRecipientPage) => void;
+  retryDelayMs?: (error: unknown, failedAttempt: number) => number | null;
+  wait?: (delayMs: number) => Promise<void>;
 }
 
 function appendUniqueRecipients(
@@ -41,31 +53,43 @@ export async function loadCompleteInitialGroup({
   fetchPage,
   isCurrent,
   onProgress,
+  retryDelayMs,
+  wait = (delayMs) => new Promise((resolve) => window.setTimeout(resolve, delayMs)),
 }: LoadCompleteInitialGroupOptions): Promise<CompleteInitialLoadOutcome> {
-  const expectedCount = seed.initialCounts[initial] ?? 0;
-  const expectedPageCount = seed.pageCount;
+  let latestCount = seed.initialCounts[initial] ?? 0;
+  let targetPageCount = seed.pageCount;
+  let resultsChanged = false;
   let data = { ...seed, page: 1, recipients: appendUniqueRecipients([], seed.recipients) };
 
-  for (let nextPage = startPage; nextPage <= expectedPageCount; nextPage += 1) {
+  for (let nextPage = startPage; nextPage <= targetPageCount; nextPage += 1) {
     let next: AnnouncementRecipientPage;
-    try {
-      next = await fetchPage(nextPage);
-    } catch (error) {
-      return { status: "partial", data, failedPage: nextPage, error };
+    let failedAttempt = 0;
+    while (true) {
+      try {
+        next = await fetchPage(nextPage);
+        break;
+      } catch (error) {
+        const delayMs = retryDelayMs?.(error, failedAttempt) ?? null;
+        if (delayMs === null) return { status: "partial", data, failedPage: nextPage, error };
+        failedAttempt += 1;
+        await wait(delayMs);
+        if (!isCurrent()) return { status: "stale", data };
+      }
     }
     if (!isCurrent()) return { status: "stale", data };
-    if ((next.initialCounts[initial] ?? 0) !== expectedCount || next.pageCount !== expectedPageCount) {
-      return { status: "changed", data };
-    }
+
+    const nextCount = next.initialCounts[initial] ?? 0;
+    resultsChanged ||= nextCount !== latestCount || next.pageCount !== targetPageCount;
+    latestCount = nextCount;
+    targetPageCount = next.pageCount;
 
     data = {
-      ...data,
+      ...next,
+      page: 1,
       recipients: appendUniqueRecipients(data.recipients, next.recipients),
     };
     onProgress?.(data);
   }
 
-  return data.recipients.length === expectedCount
-    ? { status: "complete", data }
-    : { status: "changed", data };
+  return { status: "complete", data, resultsChanged };
 }

--- a/src/features/admin/utils/announcementRecipientInitialLoader.ts
+++ b/src/features/admin/utils/announcementRecipientInitialLoader.ts
@@ -1,0 +1,71 @@
+import type {
+  AnnouncementRecipientInitial,
+  AnnouncementRecipientPage,
+} from "../../../shared/utils/firebaseFunctions";
+
+export type CompleteInitialLoadOutcome =
+  | { status: "complete"; data: AnnouncementRecipientPage }
+  | { status: "changed"; data: AnnouncementRecipientPage }
+  | { status: "partial"; data: AnnouncementRecipientPage; failedPage: number; error: unknown }
+  | { status: "stale"; data: AnnouncementRecipientPage };
+
+interface LoadCompleteInitialGroupOptions {
+  initial: Exclude<AnnouncementRecipientInitial, "ALL">;
+  seed: AnnouncementRecipientPage;
+  startPage: number;
+  fetchPage: (page: number) => Promise<AnnouncementRecipientPage>;
+  isCurrent: () => boolean;
+  onProgress?: (data: AnnouncementRecipientPage) => void;
+}
+
+function appendUniqueRecipients(
+  current: AnnouncementRecipientPage["recipients"],
+  incoming: AnnouncementRecipientPage["recipients"],
+): AnnouncementRecipientPage["recipients"] {
+  const seen = new Set(current.map(({ id }) => id));
+  return [...current, ...incoming.filter(({ id }) => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  })];
+}
+
+/**
+ * Sequentially exhausts the bounded API pages for one surname initial.
+ * The seed may be page one or a previously loaded partial result.
+ */
+export async function loadCompleteInitialGroup({
+  initial,
+  seed,
+  startPage,
+  fetchPage,
+  isCurrent,
+  onProgress,
+}: LoadCompleteInitialGroupOptions): Promise<CompleteInitialLoadOutcome> {
+  const expectedCount = seed.initialCounts[initial] ?? 0;
+  const expectedPageCount = seed.pageCount;
+  let data = { ...seed, page: 1, recipients: appendUniqueRecipients([], seed.recipients) };
+
+  for (let nextPage = startPage; nextPage <= expectedPageCount; nextPage += 1) {
+    let next: AnnouncementRecipientPage;
+    try {
+      next = await fetchPage(nextPage);
+    } catch (error) {
+      return { status: "partial", data, failedPage: nextPage, error };
+    }
+    if (!isCurrent()) return { status: "stale", data };
+    if ((next.initialCounts[initial] ?? 0) !== expectedCount || next.pageCount !== expectedPageCount) {
+      return { status: "changed", data };
+    }
+
+    data = {
+      ...data,
+      recipients: appendUniqueRecipients(data.recipients, next.recipients),
+    };
+    onProgress?.(data);
+  }
+
+  return data.recipients.length === expectedCount
+    ? { status: "complete", data }
+    : { status: "changed", data };
+}

--- a/src/shared/utils/firebaseFunctions/announcements.ts
+++ b/src/shared/utils/firebaseFunctions/announcements.ts
@@ -231,7 +231,11 @@ export type AnnouncementRecipientStatusFilter =
   | "FAILED"
   | "SKIPPED";
 
-export type AnnouncementRecipientInitial = "ALL" | "OTHER" | string;
+export type AnnouncementRecipientSurnameInitial =
+  | "A" | "B" | "C" | "D" | "E" | "F" | "G" | "H" | "I" | "J" | "K" | "L" | "M"
+  | "N" | "O" | "P" | "Q" | "R" | "S" | "T" | "U" | "V" | "W" | "X" | "Y" | "Z"
+  | "OTHER";
+export type AnnouncementRecipientInitial = "ALL" | AnnouncementRecipientSurnameInitial;
 
 export interface AnnouncementRecipientPage {
   recipients: AnnouncementRecipient[];


### PR DESCRIPTION
## What changed

- automatically fetch all bounded 250-row chunks for a selected surname initial, one request at a time
- keep the **All** view on its existing 50-row numeric pagination
- deduplicate recipient IDs across chunks and ignore stale chained responses
- retain partial results on a failed chunk, show the failed chunk position, and allow retry from that chunk
- stop with an explicit refresh prompt if the selected-group count changes while loading
- virtualize selected-initial tables larger than 250 recipients

## Why

The API correctly caps selected-initial responses at 250 rows, but the UI treated those bounded chunks as user-facing pages. That reintroduced numeric pagination inside an A–Z group and no longer matched the intended complete-initial experience.

This keeps each API response bounded while assembling the complete group asynchronously in the UI without rendering thousands of table rows at once.

## Validation

- `npm run test:run` — 103 test files, 785 tests passed
- `npm test -- src/__tests__/announcements/announcements.test.ts` (functions) — 28 tests passed
- `npx tsc -b --pretty false`
- targeted ESLint for all changed files

Fixes #611